### PR TITLE
Treat client timeouts during watches similarly to other http errors

### DIFF
--- a/kopf/clients/watching.py
+++ b/kopf/clients/watching.py
@@ -226,7 +226,7 @@ async def watch_objs(
             async for line in _iter_jsonlines(response.content):
                 raw_input = cast(bodies.RawInput, json.loads(line.decode("utf-8")))
                 yield raw_input
-    except (aiohttp.ClientConnectionError, aiohttp.ClientPayloadError):
+    except (aiohttp.ClientConnectionError, aiohttp.ClientPayloadError, asyncio.TimeoutError):
         pass
     finally:
         freeze_waiter.remove_done_callback(response_close_callback)


### PR DESCRIPTION
## What do these changes do?

`asyncio.TimeoutError` is caught and ignored like other http errors

## Description

Currently, if `connect_timeout` or `client_timeout` is reached, the error is not caught and is effectively fatal; the operator needs to be restarted. However, some other http errors are ignored and the watch is resumed by `infinite_watch()`. I believe this may have been an oversight as I can see no reason why a timeout should be considered a fatal exception when other http errors are not.

## Issues/PRs
#391

## Type of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
   - There were no existing unit tests for the silent error handling as noted in the comment to infinite_watch()
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`