### PR TITLE
Catch extra exceptions when server connection closes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,3 +15,4 @@ and [Historic GitHub Contributors](https://github.com/zalando-incubator/kopf/gra
 - [Soroosh Sarabadani](https://github.com/psycho-ir)
 - [Trond Hindenes](https://github.com/trondhindenes)
 - [Vennamaneni Sai Narasimha](https://github.com/thevennamaneni)
+- [Cliff Burdick](https://github.com/cliffburdick)

--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -94,3 +94,4 @@ async def post_event(
     except aiohttp.ClientOSError as e:
         logger.warning(f"Failed to post an event. Ignoring and continuing. "
                        f"Event: type={type!r}, reason={reason!r}, message={message!r}.")
+                       

--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -81,9 +81,16 @@ async def post_event(
         )
         response.raise_for_status()
 
-    except (aiohttp.ClientResponseError, aiohttp.client_exceptions.ServerDisconnectedError, aiohttp.client_exceptions.ClientOSError) as e:
-        # Events are helpful but auxiliary, they should not fail the handling cycle.
-        # Yet we want to notice that something went wrong (in logs).
+    # Events are helpful but auxiliary, they should not fail the handling cycle.
+    # Yet we want to notice that something went wrong (in logs).
+    except aiohttp.ClientResponseError as e:
         logger.warning(f"Failed to post an event. Ignoring and continuing. "
                        f"Status: {e.status}. Message: {e.message}. "
+                       f"Event: type={type!r}, reason={reason!r}, message={message!r}.")
+    except aiohttp.ServerDisconnectedError as e:
+        logger.warning(f"Failed to post an event. Ignoring and continuing. "
+                       f"Message: {e.message}. "
+                       f"Event: type={type!r}, reason={reason!r}, message={message!r}.")
+    except aiohttp.ClientOSError as e:
+        logger.warning(f"Failed to post an event. Ignoring and continuing. "
                        f"Event: type={type!r}, reason={reason!r}, message={message!r}.")

--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -81,7 +81,7 @@ async def post_event(
         )
         response.raise_for_status()
 
-    except aiohttp.ClientResponseError as e:
+    except (aiohttp.ClientResponseError, aiohttp.client_exceptions.ServerDisconnectedError, aiohttp.client_exceptions.ClientOSError) as e:
         # Events are helpful but auxiliary, they should not fail the handling cycle.
         # Yet we want to notice that something went wrong (in logs).
         logger.warning(f"Failed to post an event. Ignoring and continuing. "


### PR DESCRIPTION
Copied from here:
https://github.com/zalando-incubator/kopf/pull/386

Catches more exceptions that can happen when the server shuts down.

<!-- Please give a short brief about these changes (1-3 sentences). -->


## Description

Currently the only exception that is caught when a connection to the server fails is aiohttp.ClientResponseError. However, we've observed two others occurring:

aiohttp.client_exceptions.ServerDisconnectedError
aiohttp.client_exceptions.ClientOSError

This PR catches them, and handles them the same way as the previous error.

## Issues/PRs


> Issues: 
#204 

> Related:


## Type of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [X] The code addresses only the mentioned problem, and this problem only
- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

