### PR TITLE
Fix #384: Prune sub-handler state when done

### DIFF
--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -170,8 +170,10 @@ async def execute(
     state.store(body=cause.body, patch=cause.patch, storage=storage)
     states.deliver_results(outcomes=outcomes, patch=cause.patch)
 
-    # Escalate `HandlerChildrenRetry` if the execute should be continued on the next iteration.
-    if not state.done:
+    if state.done:
+        state.purge(body=cause.body, patch=cause.patch, storage=storage)
+    else:
+        # Escalate `HandlerChildrenRetry` if the execute should be continued on the next iteration.
         raise HandlerChildrenRetry(delay=state.delay)
 
 


### PR DESCRIPTION
Without this change, the completed state remains in storage, causing the
handlers to not be executed again in a new handling cycle.

## Issues/PRs

Issues: #384 

Related: #279 


## Type of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`