### PR TITLE
Store compact JSON in annotations for better presentation in kubectl

### DIFF
--- a/kopf/storage/diffbase.py
+++ b/kopf/storage/diffbase.py
@@ -150,7 +150,9 @@ class AnnotationsDiffBaseStorage(DiffBaseStorage):
             patch: patches.Patch,
             essence: bodies.BodyEssence,
     ) -> None:
-        patch.metadata.annotations[self.name] = json.dumps(essence)
+        encoded: str = json.dumps(essence, separators=(',', ':'))  # NB: no spaces
+        encoded += '\n'  # for better kubectl presentation without wrapping (same as kubectl's one)
+        patch.metadata.annotations[self.name] = encoded
 
 
 class StatusDiffBaseStorage(DiffBaseStorage):
@@ -206,7 +208,7 @@ class StatusDiffBaseStorage(DiffBaseStorage):
             essence: bodies.BodyEssence,
     ) -> None:
         # Store as a single string instead of full dict -- to avoid merges and unexpected data.
-        encoded: str = json.dumps(essence)
+        encoded: str = json.dumps(essence, separators=(',', ':'))  # NB: no spaces
         dicts.ensure(patch, self.field, encoded)
 
 

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -194,7 +194,7 @@ class AnnotationsProgressStorage(ProgressStorage):
         full_key = self.make_key(key)
         key_field = ['metadata', 'annotations', full_key]
         decoded = {key: val for key, val in record.items() if self.verbose or val is not None}
-        encoded = json.dumps(decoded)
+        encoded = json.dumps(decoded, separators=(',', ':'))  # NB: no spaces
         dicts.ensure(patch, key_field, encoded)
 
     def purge(

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -13,9 +13,9 @@ FINALIZER = 'fin'
 
 # Encoded at runtime, so that we do not make any assumptions on json formatting.
 SPEC_DATA = {'spec': {'field': 'value'}}
-SPEC_JSON = json.dumps((SPEC_DATA))
+SPEC_JSON = json.dumps(SPEC_DATA, separators=(',', ':'))
 ALT_DATA = {'spec': {'field': 'other'}}
-ALT_JSON = json.dumps((ALT_DATA))
+ALT_JSON = json.dumps(ALT_DATA, separators=(',', ':'))
 
 #
 # The following factors contribute to the detection of the cause

--- a/tests/persistence/test_annotations_hashing.py
+++ b/tests/persistence/test_annotations_hashing.py
@@ -19,7 +19,7 @@ CONTENT_DATA = ProgressRecord(
     message=None,
 )
 
-CONTENT_JSON = json.dumps(CONTENT_DATA)  # the same serialisation for all environments
+CONTENT_JSON = json.dumps(CONTENT_DATA, separators=(',', ':'))
 
 
 keys = pytest.mark.parametrize('prefix, provided_key, expected_key', [

--- a/tests/persistence/test_storing_of_progress.py
+++ b/tests/persistence/test_storing_of_progress.py
@@ -35,8 +35,8 @@ CONTENT_DATA_2 = ProgressRecord(
     message="Some error.",
 )
 
-CONTENT_JSON_1 = json.dumps(CONTENT_DATA_1)  # the same serialisation for all environments
-CONTENT_JSON_2 = json.dumps(CONTENT_DATA_2)  # the same serialisation for all environments
+CONTENT_JSON_1 = json.dumps(CONTENT_DATA_1, separators=(',', ':'))
+CONTENT_JSON_2 = json.dumps(CONTENT_DATA_2, separators=(',', ':'))
 
 
 #


### PR DESCRIPTION
## What do these changes do?

Improve how the annotations look like in `kubectl` YAML-format: as one line, not wrapped at arbitrary spaces, making it difficult to read and debug.

## Description

It will still be wrapped at spaces in the handler's progress field, e.g. `message` (which contains error/exception messages), but this happens not so often.

Note: this is the same as `kubectl` itself stores its own annotation.

Compare the output of command during a sample operator run:

```
kubectl get -o yaml -f examples/obj.yaml
```

Before:

```
apiVersion: zalando.org/v1
kind: KopfExample
metadata:
  annotations:
    kopf.zalando.org/last-handled-configuration: '{"spec":{"duration":"1m","field":"value","items":["item1","item2"],"x":600},"metadata":{"labels":{"somelabel":"somevalue"},"annotations":{"someannotation":"somevalue"}}}'
    kopf.zalando.org/update: '{"started": "2020-08-22T19:38:36.850462", "delayed":
      "2020-08-22T19:38:37.277965", "retries": 4, "success": false, "failure": false,
      "message": "None", "subrefs": ["update/s1", "update/s2", "update/s2/z1", "update/s2/z2",
      "update/s3", "update/s4", "update/s4/z1", "update/s4/z2"]}'
    kopf.zalando.org/update.s1: '{"started": "2020-08-22T19:38:36.851463", "stopped":
      "2020-08-22T19:38:36.853665", "retries": 1, "success": true, "failure": false}'
    kopf.zalando.org/update.s2: '{"started": "2020-08-22T19:38:36.851542", "stopped":
      "2020-08-22T19:38:37.134753", "retries": 2, "success": true, "failure": false,
      "subrefs": ["update/s2/z1", "update/s2/z2"]}'
    kopf.zalando.org/update.s2.z1: '{"started": "2020-08-22T19:38:36.997186", "stopped":
      "2020-08-22T19:38:36.998416", "retries": 1, "success": true, "failure": false}'
    kopf.zalando.org/update.s2.z2: '{"started": "2020-08-22T19:38:36.997264", "stopped":
      "2020-08-22T19:38:37.133993", "retries": 1, "success": true, "failure": false}'
    kopf.zalando.org/update.s3: '{"started": "2020-08-22T19:38:37.135138", "stopped":
      "2020-08-22T19:38:37.136068", "retries": 1, "success": true, "failure": false}'
    kopf.zalando.org/update.s4: '{"started": "2020-08-22T19:38:37.135197", "delayed":
      "2020-08-22T19:38:37.277547", "retries": 1, "success": false, "failure": false,
      "message": "None", "subrefs": ["update/s4/z1", "update/s4/z2"]}'
    kopf.zalando.org/update.s4.z1: '{"started": "2020-08-22T19:38:37.275760", "stopped":
      "2020-08-22T19:38:37.276967", "retries": 1, "success": true, "failure": false}'
    kopf.zalando.org/update.s4.z2: '{"started": "2020-08-22T19:38:37.275867", "retries":
      0, "success": false, "failure": false}'
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"zalando.org/v1","kind":"KopfExample","metadata":{"annotations":{"someannotation":"somevalue"},"labels":{"somelabel":"somevalue"},"name":"kopf-example-1","namespace":"default"},"spec":{"duration":"1m","field":"value","
    someannotation: somevalue
```

After:

```
apiVersion: zalando.org/v1
kind: KopfExample
metadata:
  annotations:
    kopf.zalando.org/last-handled-configuration: |
      {"spec":{"duration":"1m","field":"value","items":["item1","item2"],"x":700},"metadata":{"labels":{"somelabel":"somevalue"},"annotations":{"someannotation":"somevalue"}}}
    kopf.zalando.org/update: '{"started":"2020-08-22T19:35:41.853274","delayed":"2020-08-22T19:35:42.291393","retries":4,"success":false,"failure":false,"message":"None","subrefs":["update/s1","update/s2","update/s2/z1","update/s2/z2","up
    kopf.zalando.org/update.s1: '{"started":"2020-08-22T19:35:41.854561","stopped":"2020-08-22T19:35:41.856038","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update.s2: '{"started":"2020-08-22T19:35:41.854639","stopped":"2020-08-22T19:35:42.146998","retries":2,"success":true,"failure":false,"subrefs":["update/s2/z1","update/s2/z2"]}'
    kopf.zalando.org/update.s2.z1: '{"started":"2020-08-22T19:35:42.013957","stopped":"2020-08-22T19:35:42.014978","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update.s2.z2: '{"started":"2020-08-22T19:35:42.014018","stopped":"2020-08-22T19:35:42.145090","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update.s3: '{"started":"2020-08-22T19:35:42.147980","stopped":"2020-08-22T19:35:42.149392","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update.s4: '{"started":"2020-08-22T19:35:42.148266","delayed":"2020-08-22T19:35:42.290835","retries":1,"success":false,"failure":false,"message":"None","subrefs":["update/s4/z1","update/s4/z2"]}'
    kopf.zalando.org/update.s4.z1: '{"started":"2020-08-22T19:35:42.288954","stopped":"2020-08-22T19:35:42.290224","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update.s4.z2: '{"started":"2020-08-22T19:35:42.289030","retries":0,"success":false,"failure":false}'
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"zalando.org/v1","kind":"KopfExample","metadata":{"annotations":{"someannotation":"somevalue"},"labels":{"somelabel":"somevalue"},"name":"kopf-example-1","namespace":"default"},"spec":{"duration":"1m","field":"value","
    someannotation: somevalue
```

The behavior of the operators during the switch is not affected: they only compare and operate on the actual values, not their string representation. Mass-recoding is not expected either: the existing fields will be compacted only on the next occasion when they are written for any other reason.


## Issues/PRs

> Related: #384 


## Type of changes

- Refactoring (non-breaking change which does not alter the behaviour)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
