### PR TITLE
Remember the actually invoked sub-handlers and purge their state

### DIFF
--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -62,6 +62,7 @@ class ProgressRecord(TypedDict, total=True):
     success: Optional[bool]
     failure: Optional[bool]
     message: Optional[str]
+    subrefs: Optional[Collection[handlers.HandlerId]]
 
 
 class ProgressStorage(metaclass=abc.ABCMeta):

--- a/tests/persistence/test_outcomes.py
+++ b/tests/persistence/test_outcomes.py
@@ -8,6 +8,7 @@ def test_creation_for_ignored_handlers():
     assert outcome.delay is None
     assert outcome.result is None
     assert outcome.exception is None
+    assert not outcome.subrefs
 
 
 def test_creation_for_results():
@@ -17,6 +18,7 @@ def test_creation_for_results():
     assert outcome.delay is None
     assert outcome.result is result
     assert outcome.exception is None
+    assert not outcome.subrefs
 
 
 def test_creation_for_permanent_errors():
@@ -26,6 +28,7 @@ def test_creation_for_permanent_errors():
     assert outcome.delay is None
     assert outcome.result is None
     assert outcome.exception is error
+    assert not outcome.subrefs
 
 
 def test_creation_for_temporary_errors():
@@ -35,3 +38,9 @@ def test_creation_for_temporary_errors():
     assert outcome.delay == 123
     assert outcome.result is None
     assert outcome.exception is error
+    assert not outcome.subrefs
+
+
+def test_creation_with_subrefs():
+    outcome = HandlerOutcome(final=True, subrefs=['sub1', 'sub2'])
+    assert outcome.subrefs == ['sub1', 'sub2']

--- a/tests/persistence/test_storing_of_progress.py
+++ b/tests/persistence/test_storing_of_progress.py
@@ -23,6 +23,7 @@ CONTENT_DATA_1 = ProgressRecord(
     success=False,
     failure=False,
     message=None,
+    subrefs=None,
 )
 
 CONTENT_DATA_2 = ProgressRecord(
@@ -33,6 +34,7 @@ CONTENT_DATA_2 = ProgressRecord(
     success=False,
     failure=False,
     message="Some error.",
+    subrefs=['sub1', 'sub2'],
 )
 
 CONTENT_JSON_1 = json.dumps(CONTENT_DATA_1)  # the same serialisation for all environments
@@ -197,6 +199,7 @@ def test_storing_to_annotations_storage_cleans_content(cls):
         success=None,
         failure=None,
         message=None,
+        subrefs=None,
     )
     storage.store(body=body, patch=patch, key=HandlerId('id1'), record=content)
 


### PR DESCRIPTION
## What do these changes do?

Fix a bug when sub-handlers are not invoked after the first invocation because their state is never purged from annotations or status.


## Description

Before this fix, the sub-handlers' state was not purged, as the purge operation works on specific keys only (since #331), and the sub-handlers' keys are not known at the moment when the purge happens (for example, because that main handler was not invoked during this handling cycle, as it has finished in the previous one).

A few straightforward solutions have their disadvantages:

**Scanning annotations** for all the keys that start with the main handler's key is: (a) feels wrong, since it is supposed to be a write operation for one item, we should not read/scan there; (b) would not work for long sub-handler ids due to hashing of the suffixes to fit the annotation name into 63 chars (incl. the prefix).

**Purging the sub-handlers' states in `kopf.execute()`** also causes misbehavior in some cases: if the main handler has 2+ calls of `kopf.execute()`, or fails after the call, the main handler will be retried, while the sub-handlers information is purged, and so the sub-handlers will be re-executed — this violates the "succeed only once" promise for handlers (regular and sub).

For example, here, with this approach implemented, `update/s1` handler will be invoked multiple times when `update/s3` should be invoked:

```python
import kopf

async def subhandler1(**_):
    pass

async def subhandler2(**_):
    pass

@kopf.on.update("zalando.org", "v1", "kopfexamples")
async def update(retry, **_):
    await kopf.execute(fns={"s1": subhandler1, "s2": subhandler2})
    await kopf.execute(fns={"s3": subhandler1, "s4": subhandler2})
    if retry < 10:
        raise kopf.TemporaryError("boo", delay=1)
```

---
Therefore, the only way to properly purge the sub-handlers' state is to remember the actual sub-handlers' ids in the parent handlers, mainly in each root handler (intermediate parents remember the ids just for information), and explicitly purge those sub-handlers' states when the root handler's state is purged.

Note that a set of sub-handlers is not guaranteed to be fixed on multiple calls of the main handler: the sub-handlers can depend on the object state, a number of retries, external environment circumstances, etc — until the root handler fully succeeds or permanently fails. This is one additional reason to keep the state of the sub-handlers stored (i.e. not purged) until the end of the handling cycle and purge it only when the root handler is purged (together with all other root handlers).

---
This fix also works with sub-sub-handlers and any level of nesting them:

```python
import kopf

async def subhandler1(**_):
    pass

async def subhandler2(**_):
    pass

async def subhandler3(**_):
    await kopf.execute(fns={"z1": subhandler1, "z2": subhandler2})

@kopf.on.update("zalando.org", "v1", "kopfexamples")
async def update(retry, **_):
    await kopf.execute(fns={"s1": subhandler1, "s2": subhandler3})
    await kopf.execute(fns={"s3": subhandler1, "s4": subhandler3})
```

The persisted state before a purge looks like this (formatted with #516 applied):

```
apiVersion: zalando.org/v1
kind: KopfExample
metadata:
  annotations:
    kopf.zalando.org/update: '{"started":"2020-08-22T22:40:20.521245","delayed":"2020-08-22T22:40:20.962733","retries":4,"success":false,"failure":false,"message":"None","subrefs":["update/s1","update/s2","update/s2/z1","update/s2/z2","update/s3","update/s4","update/s4/z1","update/s4/z2"]}'
    kopf.zalando.org/update.s1: '{"started":"2020-08-22T22:40:20.522447","stopped":"2020-08-22T22:40:20.524740","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update.s2: '{"started":"2020-08-22T22:40:20.522556","stopped":"2020-08-22T22:40:20.811047","retries":2,"success":true,"failure":false,"subrefs":["update/s2/z1","update/s2/z2"]}'
    kopf.zalando.org/update.s2.z1: '{"started":"2020-08-22T22:40:20.669113","stopped":"2020-08-22T22:40:20.670369","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update.s2.z2: '{"started":"2020-08-22T22:40:20.669192","stopped":"2020-08-22T22:40:20.810160","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update.s3: '{"started":"2020-08-22T22:40:20.812031","stopped":"2020-08-22T22:40:20.813800","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update.s4: '{"started":"2020-08-22T22:40:20.812214","delayed":"2020-08-22T22:40:20.962299","retries":1,"success":false,"failure":false,"message":"None","subrefs":["update/s4/z1","update/s4/z2"]}'
    kopf.zalando.org/update.s4.z1: '{"started":"2020-08-22T22:40:20.960287","stopped":"2020-08-22T22:40:20.961801","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update.s4.z2: '{"started":"2020-08-22T22:40:20.960521","retries":0,"success":false,"failure":false}'
```


## Issues/PRs

> Issues: fixes #384 

> Related: closes #385, closes #508 


## Type of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
