### PR TITLE
Test peering

### DIFF
--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -66,8 +66,8 @@ class Peer:
             *,
             name: str,
             priority: int = 0,
-            lastseen: Optional[str] = None,
-            lifetime: int = 60,
+            lastseen: Optional[Union[str, datetime.datetime]] = None,
+            lifetime: Union[int, datetime.timedelta] = 60,
             namespace: Optional[str] = None,
             legacy: bool = False,
             **_: Any,  # for the forward-compatibility with the new fields

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -241,15 +241,15 @@ async def process_peering_event(
         if freeze_mode.is_off():
             logger.info(f"Freezing operations in favour of {prio_peers}.")
             await freeze_mode.turn_on()
-    
     elif same_peers:
         logger.warning(f"Possibly conflicting operators with the same priority: {same_peers}.")
-        logger.warning(f"Freezing all operators, including self: {peers}")
-        await freeze_mode.turn_on()
-
-    elif freeze_mode.is_on():
-        logger.info(f"Resuming operations after the freeze. Conflicting operators with the same priority are gone.")
-        await freeze_mode.turn_off()
+        if freeze_mode.is_off():
+            logger.warning(f"Freezing all operators, including self: {peers}")
+            await freeze_mode.turn_on()
+    else:
+        if freeze_mode.is_on():
+            logger.info(f"Resuming operations after the freeze. Conflicting operators with the same priority are gone.")
+            await freeze_mode.turn_off()
 
 
 async def peers_keepalive(

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -173,4 +173,4 @@ async def test_delays_are_simulated(settings, activity, mocker):
     assert sleep_or_wait.call_count >= 3  # 3 retries, 1 sleep each
     assert sleep_or_wait.call_count <= 4  # 3 retries, 1 final success (delay=None), not more
     if sleep_or_wait.call_count > 3:
-        sleep_or_wait.call_args_list[-1].args[0] is None
+        sleep_or_wait.call_args_list[-1][0][0] is None

--- a/tests/peering/conftest.py
+++ b/tests/peering/conftest.py
@@ -1,0 +1,45 @@
+import pytest
+
+from kopf.engines.peering import CLUSTER_PEERING_RESOURCE, NAMESPACED_PEERING_RESOURCE
+
+
+@pytest.fixture(autouse=True)
+def _autouse_fake_vault(fake_vault):
+    pass
+
+
+@pytest.fixture()
+def with_cluster_crd(hostname, aresponses):
+    result = {'resources': [{
+        'name': CLUSTER_PEERING_RESOURCE.plural,
+        'namespaced': False,
+    }]}
+    url = CLUSTER_PEERING_RESOURCE.get_version_url()
+    aresponses.add(hostname, url, 'get', result)
+
+
+@pytest.fixture()
+def with_namespaced_crd(hostname, aresponses):
+    result = {'resources': [{
+        'name': NAMESPACED_PEERING_RESOURCE.plural,
+        'namespaced': True,
+    }]}
+    url = NAMESPACED_PEERING_RESOURCE.get_version_url()
+    aresponses.add(hostname, url, 'get', result)
+
+
+@pytest.fixture()
+def with_both_crds(hostname, aresponses):
+    result = {'resources': [{
+        'name': CLUSTER_PEERING_RESOURCE.plural,
+        'namespaced': False,
+    }, {
+        'name': NAMESPACED_PEERING_RESOURCE.plural,
+        'namespaced': True,
+    }]}
+    urls = {
+        CLUSTER_PEERING_RESOURCE.get_version_url(),
+        NAMESPACED_PEERING_RESOURCE.get_version_url(),
+    }
+    for url in urls:
+        aresponses.add(hostname, url, 'get', result)

--- a/tests/peering/test_apply_peers.py
+++ b/tests/peering/test_apply_peers.py
@@ -1,0 +1,108 @@
+import aiohttp.web
+import freezegun
+import pytest
+
+from kopf.engines.peering import NAMESPACED_PEERING_RESOURCE, CLUSTER_PEERING_RESOURCE
+from kopf.engines.peering import Peer, apply_peers
+
+
+@pytest.mark.usefixtures('with_both_crds')
+@pytest.mark.parametrize('namespace, peering_resource', [
+    pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
+    pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
+])
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+async def test_applying_a_dead_peer_purges_it(
+        hostname, aresponses, resp_mocker, namespace, peering_resource):
+
+    patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    url = peering_resource.get_url(name='name0', namespace=namespace)
+    aresponses.add(hostname, url, 'patch', patch_mock)
+
+    peer = Peer(id='id1', name='...', namespace='ns1', lastseen='2020-01-01T00:00:00')
+    await apply_peers(peers=[peer], name='name0', namespace=namespace)
+
+    assert patch_mock.called
+    patch = await patch_mock.call_args_list[0][0][0].json()
+    assert set(patch['status']) == {'id1'}
+    assert patch['status']['id1'] is None
+
+
+@pytest.mark.usefixtures('with_both_crds')
+@pytest.mark.parametrize('namespace, peering_resource', [
+    pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
+    pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
+])
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+async def test_applying_an_alive_peer_stores_it(
+        hostname, aresponses, resp_mocker, namespace, peering_resource):
+
+    patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    url = peering_resource.get_url(name='name0', namespace=namespace)
+    aresponses.add(hostname, url, 'patch', patch_mock)
+
+    peer = Peer(id='id1', name='...', namespace='ns1', lastseen='2020-12-31T23:59:59')
+    await apply_peers(peers=[peer], name='name0', namespace=namespace)
+
+    assert patch_mock.called
+    patch = await patch_mock.call_args_list[0][0][0].json()
+    assert set(patch['status']) == {'id1'}
+    assert patch['status']['id1']['namespace'] == 'ns1'
+    assert patch['status']['id1']['priority'] == 0
+    assert patch['status']['id1']['lastseen'] == '2020-12-31T23:59:59'
+    assert patch['status']['id1']['lifetime'] == 60
+
+
+@pytest.mark.usefixtures('with_both_crds')
+@pytest.mark.parametrize('namespace, peering_resource', [
+    pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
+    pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
+])
+@pytest.mark.parametrize('lastseen', [
+    pytest.param('2020-01-01T00:00:00', id='when-dead'),
+    pytest.param('2020-12-31T23:59:59', id='when-alive'),
+])
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+async def test_keepalive(
+        hostname, aresponses, resp_mocker, namespace, peering_resource, lastseen):
+
+    patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    url = peering_resource.get_url(name='name0', namespace=namespace)
+    aresponses.add(hostname, url, 'patch', patch_mock)
+
+    peer = Peer(id='id1', name='name0', namespace=namespace, lastseen=lastseen)
+    await peer.keepalive()
+
+    assert patch_mock.called
+    patch = await patch_mock.call_args_list[0][0][0].json()
+    assert set(patch['status']) == {'id1'}
+    assert patch['status']['id1']['namespace'] == namespace
+    assert patch['status']['id1']['priority'] == 0
+    assert patch['status']['id1']['lastseen'] == '2020-12-31T23:59:59.123456'
+    assert patch['status']['id1']['lifetime'] == 60
+
+
+@pytest.mark.usefixtures('with_both_crds')
+@pytest.mark.parametrize('namespace, peering_resource', [
+    pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
+    pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
+])
+@pytest.mark.parametrize('lastseen', [
+    pytest.param('2020-01-01T00:00:00', id='when-dead'),
+    pytest.param('2020-12-31T23:59:59', id='when-alive'),
+])
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+async def test_disappear(
+        hostname, aresponses, resp_mocker, namespace, peering_resource, lastseen):
+
+    patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    url = peering_resource.get_url(name='name0', namespace=namespace)
+    aresponses.add(hostname, url, 'patch', patch_mock)
+
+    peer = Peer(id='id1', name='name0', namespace=namespace, lastseen=lastseen)
+    await peer.disappear()
+
+    assert patch_mock.called
+    patch = await patch_mock.call_args_list[0][0][0].json()
+    assert set(patch['status']) == {'id1'}
+    assert patch['status']['id1'] is None

--- a/tests/peering/test_freeze_mode.py
+++ b/tests/peering/test_freeze_mode.py
@@ -1,0 +1,263 @@
+import asyncio
+
+import freezegun
+import pytest
+
+from kopf.engines.peering import Peer, process_peering_event
+from kopf.structs import primitives, bodies
+
+
+@pytest.mark.parametrize('our_name, our_namespace, their_name, their_namespace', [
+    ['our-name', 'our-namespace', 'their-name', 'their-namespace'],
+    ['our-name', 'our-namespace', 'their-name', 'our-namespace'],
+    ['our-name', 'our-namespace', 'their-name', None],
+    ['our-name', 'our-namespace', 'our-name', 'their-namespace'],
+    ['our-name', 'our-namespace', 'our-name', None],
+    ['our-name', None, 'their-name', 'their-namespace'],
+    ['our-name', None, 'their-name', 'our-namespace'],
+    ['our-name', None, 'their-name', None],
+    ['our-name', None, 'our-name', 'their-namespace'],
+    ['our-name', None, 'their-name', 'our-namespace'],
+])
+async def test_other_peering_objects_are_ignored(
+        mocker, our_name, our_namespace, their_name, their_namespace):
+
+    ourselves = Peer(id='id', name=our_name, namespace=our_namespace)
+    status = mocker.Mock()
+    status.items.side_effect = Exception("This should not be called.")
+    event = bodies.RawEvent(
+        type='ADDED',  # irrelevant
+        object={
+            'metadata': {'name': their_name, 'namespace': their_namespace},
+            'status': status,
+        })
+    await process_peering_event(
+        raw_event=event,
+        ourselves=ourselves,
+        freeze_mode=primitives.Toggle(),
+        replenished=asyncio.Event(),
+        autoclean=False,
+    )
+    assert not status.items.called
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+async def test_toggled_on_for_higher_priority_peer_when_initially_off(caplog, assert_logs):
+    event = bodies.RawEvent(
+        type='ADDED',  # irrelevant
+        object={
+            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'status': {
+                'higher-prio': {
+                    'priority': 101,
+                    'lifetime': 10,
+                    'lastseen': '2020-12-31T23:59:59'
+                },
+            },
+        })
+
+    replenished = asyncio.Event()
+    freeze_mode = primitives.Toggle(False)
+    ourselves = Peer(id='id', name='name', namespace='namespace', priority=100)
+
+    caplog.set_level(0)
+    assert freeze_mode.is_off()
+    await process_peering_event(
+        raw_event=event,
+        freeze_mode=freeze_mode,
+        ourselves=ourselves,
+        replenished=replenished,
+        autoclean=False,
+    )
+    assert freeze_mode.is_on()
+    assert_logs(["Freezing operations in favour of"], prohibited=[
+        "Possibly conflicting operators",
+        "Freezing all operators, including self",
+        "Resuming operations after the freeze",
+    ])
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+async def test_ignored_for_higher_priority_peer_when_already_on(caplog, assert_logs):
+    event = bodies.RawEvent(
+        type='ADDED',  # irrelevant
+        object={
+            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'status': {
+                'higher-prio': {
+                    'priority': 101,
+                    'lifetime': 10,
+                    'lastseen': '2020-12-31T23:59:59'
+                },
+            },
+        })
+
+    replenished = asyncio.Event()
+    freeze_mode = primitives.Toggle(True)
+    ourselves = Peer(id='id', name='name', namespace='namespace', priority=100)
+
+    caplog.set_level(0)
+    assert freeze_mode.is_on()
+    await process_peering_event(
+        raw_event=event,
+        freeze_mode=freeze_mode,
+        ourselves=ourselves,
+        replenished=replenished,
+        autoclean=False,
+    )
+    assert freeze_mode.is_on()
+    assert_logs([], prohibited=[
+        "Possibly conflicting operators",
+        "Freezing all operators, including self",
+        "Freezing operations in favour of",
+        "Resuming operations after the freeze",
+    ])
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+async def test_toggled_off_for_lower_priority_peer_when_initially_on(caplog, assert_logs):
+    event = bodies.RawEvent(
+        type='ADDED',  # irrelevant
+        object={
+            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'status': {
+                'higher-prio': {
+                    'priority': 99,
+                    'lifetime': 10,
+                    'lastseen': '2020-12-31T23:59:59'
+                },
+            },
+        })
+
+    replenished = asyncio.Event()
+    freeze_mode = primitives.Toggle(True)
+    ourselves = Peer(id='id', name='name', namespace='namespace', priority=100)
+
+    caplog.set_level(0)
+    assert freeze_mode.is_on()
+    await process_peering_event(
+        raw_event=event,
+        freeze_mode=freeze_mode,
+        ourselves=ourselves,
+        replenished=replenished,
+        autoclean=False,
+    )
+    assert freeze_mode.is_off()
+    assert_logs(["Resuming operations after the freeze"], prohibited=[
+        "Possibly conflicting operators",
+        "Freezing all operators, including self",
+        "Freezing operations in favour of",
+    ])
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+async def test_ignored_for_lower_priority_peer_when_already_off(caplog, assert_logs):
+    event = bodies.RawEvent(
+        type='ADDED',  # irrelevant
+        object={
+            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'status': {
+                'higher-prio': {
+                    'priority': 99,
+                    'lifetime': 10,
+                    'lastseen': '2020-12-31T23:59:59'
+                },
+            },
+        })
+
+    replenished = asyncio.Event()
+    freeze_mode = primitives.Toggle(False)
+    ourselves = Peer(id='id', name='name', namespace='namespace', priority=100)
+
+    caplog.set_level(0)
+    assert freeze_mode.is_off()
+    await process_peering_event(
+        raw_event=event,
+        freeze_mode=freeze_mode,
+        ourselves=ourselves,
+        replenished=replenished,
+        autoclean=False,
+    )
+    assert freeze_mode.is_off()
+    assert_logs([], prohibited=[
+        "Possibly conflicting operators",
+        "Freezing all operators, including self",
+        "Freezing operations in favour of",
+        "Resuming operations after the freeze",
+    ])
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+async def test_toggled_on_for_same_priority_peer_when_initially_off(caplog, assert_logs):
+    event = bodies.RawEvent(
+        type='ADDED',  # irrelevant
+        object={
+            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'status': {
+                'higher-prio': {
+                    'priority': 100,
+                    'lifetime': 10,
+                    'lastseen': '2020-12-31T23:59:59'
+                },
+            },
+        })
+
+    replenished = asyncio.Event()
+    freeze_mode = primitives.Toggle(False)
+    ourselves = Peer(id='id', name='name', namespace='namespace', priority=100)
+
+    caplog.set_level(0)
+    assert freeze_mode.is_off()
+    await process_peering_event(
+        raw_event=event,
+        freeze_mode=freeze_mode,
+        ourselves=ourselves,
+        replenished=replenished,
+        autoclean=False,
+    )
+    assert freeze_mode.is_on()
+    assert_logs([
+        "Possibly conflicting operators",
+        "Freezing all operators, including self",
+    ], prohibited=[
+        "Freezing operations in favour of",
+        "Resuming operations after the freeze",
+    ])
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+async def test_ignored_for_same_priority_peer_when_already_on(caplog, assert_logs):
+    event = bodies.RawEvent(
+        type='ADDED',  # irrelevant
+        object={
+            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'status': {
+                'higher-prio': {
+                    'priority': 100,
+                    'lifetime': 10,
+                    'lastseen': '2020-12-31T23:59:59'
+                },
+            },
+        })
+
+    replenished = asyncio.Event()
+    freeze_mode = primitives.Toggle(True)
+    ourselves = Peer(id='id', name='name', namespace='namespace', priority=100)
+
+    caplog.set_level(0)
+    assert freeze_mode.is_on()
+    await process_peering_event(
+        raw_event=event,
+        freeze_mode=freeze_mode,
+        ourselves=ourselves,
+        replenished=replenished,
+        autoclean=False,
+    )
+    assert freeze_mode.is_on()
+    assert_logs([
+        "Possibly conflicting operators",
+    ], prohibited=[
+        "Freezing all operators, including self",
+        "Freezing operations in favour of",
+        "Resuming operations after the freeze",
+    ])

--- a/tests/peering/test_id_generation.py
+++ b/tests/peering/test_id_generation.py
@@ -1,0 +1,25 @@
+import os
+
+import freezegun
+import pytest
+
+from kopf.engines.peering import detect_own_id
+
+
+@pytest.fixture(autouse=True)
+def _intercept_os_calls(mocker):
+    mocker.patch('getpass.getuser', return_value='some-user')
+    mocker.patch('socket.getfqdn', return_value='some-host')
+    mocker.patch('random.choices', return_value='random-str')
+
+
+def test_from_a_pod_id(mocker):
+    mocker.patch.dict(os.environ, POD_ID='some-pod-1')
+    own_id = detect_own_id()
+    assert own_id == 'some-pod-1'
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_with_defaults():
+    own_id = detect_own_id()
+    assert own_id == 'some-user@some-host/2020-12-31T23:59:59.123456/random-str'

--- a/tests/peering/test_keepalive.py
+++ b/tests/peering/test_keepalive.py
@@ -1,0 +1,27 @@
+import pytest
+
+from kopf.engines.peering import Peer, peers_keepalive
+
+
+class StopInfiniteCycleException(Exception):
+    pass
+
+
+async def test_background_task_runs(mocker):
+    ourselves = Peer(id='id', name='name', namespace='namespace', lifetime=33)
+    keepalive_mock = mocker.patch.object(ourselves, 'keepalive')
+    disappear_mock = mocker.patch.object(ourselves, 'disappear')
+
+    sleep_mock = mocker.patch('asyncio.sleep')
+    sleep_mock.side_effect = [None, None, StopInfiniteCycleException]
+
+    with pytest.raises(StopInfiniteCycleException):
+        await peers_keepalive(ourselves=ourselves)
+
+    assert sleep_mock.call_count == 3
+    assert sleep_mock.call_args_list[0][0][0] == 33 - 10
+    assert sleep_mock.call_args_list[1][0][0] == 33 - 10
+    assert sleep_mock.call_args_list[2][0][0] == 33 - 10
+
+    assert keepalive_mock.call_count == 3
+    assert disappear_mock.call_count == 1

--- a/tests/peering/test_peer_detection.py
+++ b/tests/peering/test_peer_detection.py
@@ -1,0 +1,207 @@
+import re
+
+import pytest
+
+from kopf.engines.peering import (
+    Peer, PEERING_DEFAULT_NAME,
+    CLUSTER_PEERING_RESOURCE, NAMESPACED_PEERING_RESOURCE,
+)
+
+
+# Note: the legacy peering is intentionally not tested: it was long time before
+# these tests were written, so it does not make sense to keep it stable.
+# The legacy peering is going to be removed in version 1.0 when it happens.
+
+
+@pytest.fixture()
+def with_cluster_default(hostname, aresponses):
+    url = CLUSTER_PEERING_RESOURCE.get_url(name=PEERING_DEFAULT_NAME)
+    aresponses.add(hostname, url, 'get', {'spec': {}})
+
+
+@pytest.fixture()
+def with_cluster_specific(hostname, aresponses):
+    url = CLUSTER_PEERING_RESOURCE.get_url(name='peering-name')
+    aresponses.add(hostname, url, 'get', {'spec': {}})
+
+
+@pytest.fixture()
+def with_namespaced_default(hostname, aresponses):
+    url = NAMESPACED_PEERING_RESOURCE.get_url(namespace='namespace', name=PEERING_DEFAULT_NAME)
+    aresponses.add(hostname, url, 'get', {'spec': {}})
+
+
+@pytest.fixture()
+def with_namespaced_specific(hostname, aresponses):
+    url = NAMESPACED_PEERING_RESOURCE.get_url(namespace='namespace', name='peering-name')
+    aresponses.add(hostname, url, 'get', {'spec': {}})
+
+
+#
+# Parametrization via fixtures (it does not work from tests).
+#
+@pytest.fixture(params=[
+    pytest.param(None, id='no-crds'),
+    pytest.param('with_both_crds', id='both-crds'),
+    pytest.param('with_cluster_crd', id='only-cluster-crd'),
+    pytest.param('with_namespaced_crd', id='only-namespaced-crd'),
+])
+def all_crd_modes(request):
+    return request.getfixturevalue(request.param) if request.param else None
+
+
+@pytest.fixture(params=[
+    pytest.param('with_both_crds', id='both-crds'),
+    pytest.param('with_cluster_crd', id='only-cluster-crd'),
+])
+def all_crd_modes_with_cluster_scoped_crd(request):
+    return request.getfixturevalue(request.param) if request.param else None
+
+
+@pytest.fixture(params=[
+    pytest.param('with_both_crds', id='both-crds'),
+    pytest.param('with_namespaced_crd', id='only-namespaced-crd'),
+])
+def all_crd_modes_with_namespace_scoped_crd(request):
+    return request.getfixturevalue(request.param) if request.param else None
+
+
+@pytest.fixture(params=[
+    pytest.param(True, id='with-cluster-default'),
+    pytest.param(False, id='without-cluster-default')
+])
+def both_cluster_default_modes(request):
+    return request.getfixturevalue('with_cluster_default') if request.param else None
+
+
+@pytest.fixture(params=[
+    pytest.param(True, id='with-cluster-specific'),
+    pytest.param(False, id='without-cluster-specific')
+])
+def both_cluster_specific_modes(request):
+    return request.getfixturevalue('with_cluster_specific') if request.param else None
+
+
+@pytest.fixture(params=[
+    pytest.param(True, id='with-namespaced-default'),
+    pytest.param(False, id='without-namespaced-default')
+])
+def both_namespaced_default_modes(request):
+    return request.getfixturevalue('with_namespaced_default') if request.param else None
+
+
+@pytest.fixture(params=[
+    pytest.param(True, id='with-namespaced-specific'),
+    pytest.param(False, id='without-namespaced-specific')
+])
+def both_namespaced_specific_modes(request):
+    return request.getfixturevalue('with_namespaced_specific') if request.param else None
+
+
+#
+# Actual tests: only the action & assertions.
+#
+@pytest.mark.usefixtures('both_namespaced_specific_modes')
+@pytest.mark.usefixtures('both_namespaced_default_modes')
+@pytest.mark.usefixtures('both_cluster_specific_modes')
+@pytest.mark.usefixtures('both_cluster_default_modes')
+@pytest.mark.usefixtures('all_crd_modes')
+@pytest.mark.parametrize('name', [None, 'name'])
+@pytest.mark.parametrize('namespace', [None, 'namespaced'])
+async def test_standalone(namespace, name):
+    peer = await Peer.detect(standalone=True, namespace=namespace, name=name)
+    assert peer is None
+
+
+@pytest.mark.usefixtures('both_namespaced_specific_modes')
+@pytest.mark.usefixtures('both_namespaced_default_modes')
+@pytest.mark.usefixtures('both_cluster_specific_modes')
+@pytest.mark.usefixtures('with_cluster_default')
+@pytest.mark.usefixtures('all_crd_modes_with_cluster_scoped_crd')
+async def test_cluster_scoped_with_default_name():
+    peer = await Peer.detect(id='id', standalone=False, namespace=None, name=None)
+    assert peer.name == PEERING_DEFAULT_NAME
+    assert peer.namespace is None
+
+
+@pytest.mark.usefixtures('both_namespaced_specific_modes')
+@pytest.mark.usefixtures('with_namespaced_default')
+@pytest.mark.usefixtures('both_cluster_specific_modes')
+@pytest.mark.usefixtures('both_cluster_default_modes')
+@pytest.mark.usefixtures('all_crd_modes_with_namespace_scoped_crd')
+async def test_namespace_scoped_with_default_name():
+    peer = await Peer.detect(id='id', standalone=False, namespace='namespace', name=None)
+    assert peer.name == PEERING_DEFAULT_NAME
+    assert peer.namespace == 'namespace'
+
+
+@pytest.mark.usefixtures('both_namespaced_specific_modes')
+@pytest.mark.usefixtures('both_namespaced_default_modes')
+@pytest.mark.usefixtures('with_cluster_specific')
+@pytest.mark.usefixtures('both_cluster_default_modes')
+@pytest.mark.usefixtures('all_crd_modes_with_cluster_scoped_crd')
+async def test_cluster_scoped_with_specific_name():
+    peer = await Peer.detect(id='id', standalone=False, namespace=None, name='peering-name')
+    assert peer.name == 'peering-name'
+    assert peer.namespace is None
+
+
+@pytest.mark.usefixtures('with_namespaced_specific')
+@pytest.mark.usefixtures('both_namespaced_default_modes')
+@pytest.mark.usefixtures('both_cluster_specific_modes')
+@pytest.mark.usefixtures('both_cluster_default_modes')
+@pytest.mark.usefixtures('all_crd_modes_with_namespace_scoped_crd')
+async def test_namespace_scoped_with_specific_name():
+    peer = await Peer.detect(id='id', standalone=False, namespace='namespace', name='peering-name')
+    assert peer.name == 'peering-name'
+    assert peer.namespace == 'namespace'
+
+
+@pytest.mark.usefixtures('both_namespaced_specific_modes')
+@pytest.mark.usefixtures('both_namespaced_default_modes')
+@pytest.mark.usefixtures('both_cluster_specific_modes')
+@pytest.mark.usefixtures('both_cluster_default_modes')
+@pytest.mark.usefixtures('all_crd_modes_with_cluster_scoped_crd')
+async def test_cluster_scoped_with_absent_name(hostname, aresponses):
+    aresponses.add(hostname, re.compile(r'.*'), 'get', aresponses.Response(status=404), repeat=999)
+    with pytest.raises(Exception, match=r"The peering 'absent-name' was not found") as e:
+        await Peer.detect(id='id', standalone=False, namespace=None, name='absent-name')
+
+
+@pytest.mark.usefixtures('both_namespaced_specific_modes')
+@pytest.mark.usefixtures('both_namespaced_default_modes')
+@pytest.mark.usefixtures('both_cluster_specific_modes')
+@pytest.mark.usefixtures('both_cluster_default_modes')
+@pytest.mark.usefixtures('all_crd_modes_with_namespace_scoped_crd')
+async def test_namespace_scoped_with_absent_name(hostname, aresponses):
+    aresponses.add(hostname, re.compile(r'.*'), 'get', aresponses.Response(status=404), repeat=999)
+    with pytest.raises(Exception, match=r"The peering 'absent-name' was not found") as e:
+        await Peer.detect(id='id', standalone=False, namespace='namespace', name='absent-name')
+
+
+# NB: without cluster-default peering.
+@pytest.mark.usefixtures('both_namespaced_specific_modes')
+@pytest.mark.usefixtures('both_namespaced_default_modes')
+@pytest.mark.usefixtures('both_cluster_specific_modes')
+@pytest.mark.usefixtures('all_crd_modes_with_cluster_scoped_crd')
+async def test_cluster_scoped_with_warning(hostname, aresponses, assert_logs, caplog):
+    aresponses.add(hostname, re.compile(r'.*'), 'get', aresponses.Response(status=404), repeat=999)
+    peer = await Peer.detect(id='id', standalone=False, namespace=None, name=None)
+    assert peer is None
+    assert_logs([
+        "Default peering object not found, falling back to the standalone mode."
+    ])
+
+
+# NB: without namespaced-default peering.
+@pytest.mark.usefixtures('both_namespaced_specific_modes')
+@pytest.mark.usefixtures('both_cluster_specific_modes')
+@pytest.mark.usefixtures('both_cluster_default_modes')
+@pytest.mark.usefixtures('all_crd_modes_with_namespace_scoped_crd')
+async def test_namespace_scoped_with_warning(hostname, aresponses, assert_logs, caplog):
+    aresponses.add(hostname, re.compile(r'.*'), 'get', aresponses.Response(status=404), repeat=999)
+    peer = await Peer.detect(id='id', standalone=False, namespace='namespace', name=None)
+    assert peer is None
+    assert_logs([
+        "Default peering object not found, falling back to the standalone mode."
+    ])

--- a/tests/peering/test_peers.py
+++ b/tests/peering/test_peers.py
@@ -1,0 +1,166 @@
+import datetime
+
+import freezegun
+import pytest
+
+from kopf.engines.peering import (
+    Peer,
+    CLUSTER_PEERING_RESOURCE, NAMESPACED_PEERING_RESOURCE, LEGACY_PEERING_RESOURCE,
+)
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_defaults():
+    peer = Peer(id='id', name='name')
+    assert peer.id == 'id'
+    assert peer.name == 'name'
+    assert peer.namespace is None
+    assert peer.legacy is False
+    assert peer.lifetime == datetime.timedelta(seconds=60)
+    assert peer.lastseen == datetime.datetime(2020, 12, 31, 23, 59, 59, 123456)
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_repr():
+    peer = Peer(id='some-id', name='some-name', namespace='some-namespace')
+    text = repr(peer)
+    assert text.startswith('Peer(')
+    assert text.endswith(')')
+    assert '(some-id, ' in text
+    assert 'priority=0' in text
+    assert 'lastseen=' in text
+    assert 'lifetime=' in text
+
+    # The peering object's name is of no interest, the peer's id is.
+    assert 'name=' not in text
+
+    # The namespace of the operator can affect the conflict detection.
+    # It is not always the same as the peering object's namespace.
+    assert 'namespace=some-namespace' in text
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_priority_specified():
+    peer = Peer(id='id', name='name', priority=123)
+    assert peer.priority == 123
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_priority_unspecified():
+    peer = Peer(id='id', name='name')
+    assert peer.priority == 0
+
+
+@pytest.mark.parametrize('namespace', [None, 'namespaced'])
+def test_resource_for_legacy_peering(namespace):
+    peer = Peer(id='id', name='name', legacy=True, namespace=namespace)
+    assert peer.legacy is True
+    assert peer.resource == LEGACY_PEERING_RESOURCE
+
+
+def test_resource_for_cluster_peering():
+    peer = Peer(id='id', name='name', legacy=False, namespace=None)
+    assert peer.legacy is False
+    assert peer.resource == CLUSTER_PEERING_RESOURCE
+    assert peer.namespace is None
+
+
+def test_resource_for_namespaced_peering():
+    peer = Peer(id='id', name='name', legacy=False, namespace='namespaced')
+    assert peer.legacy is False
+    assert peer.resource == NAMESPACED_PEERING_RESOURCE
+    assert peer.namespace == 'namespaced'
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_creation_with_lifetime_as_timedelta():
+    peer = Peer(id='id', name='name', lifetime=datetime.timedelta(seconds=123))
+    assert peer.lifetime == datetime.timedelta(seconds=123)
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_creation_with_lifetime_as_number():
+    peer = Peer(id='id', name='name', lifetime=123)
+    assert peer.lifetime == datetime.timedelta(seconds=123)
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_creation_with_lifetime_unspecified():
+    peer = Peer(id='id', name='name')
+    assert peer.lifetime == datetime.timedelta(seconds=60)
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_creation_with_lastseen_as_datetime():
+    peer = Peer(id='id', name='name', lastseen=datetime.datetime(2020, 1, 1, 12, 34, 56, 789123))
+    assert peer.lastseen == datetime.datetime(2020, 1, 1, 12, 34, 56, 789123)
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_creation_with_lastseen_as_string():
+    peer = Peer(id='id', name='name', lastseen='2020-01-01T12:34:56.789123')
+    assert peer.lastseen == datetime.datetime(2020, 1, 1, 12, 34, 56, 789123)
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_creation_with_lastseen_unspecified():
+    peer = Peer(id='id', name='name')
+    assert peer.lastseen == datetime.datetime(2020, 12, 31, 23, 59, 59, 123456)
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_creation_as_alive():
+    peer = Peer(
+        id='id',
+        name='name',
+        lifetime=10,
+        lastseen='2020-12-31T23:59:50.123456',  # less than 10 seconds before "now"
+    )
+    assert peer.lifetime == datetime.timedelta(seconds=10)
+    assert peer.lastseen == datetime.datetime(2020, 12, 31, 23, 59, 50, 123456)
+    assert peer.deadline == datetime.datetime(2021, 1, 1, 0, 0, 0, 123456)
+    assert peer.is_dead is False
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_creation_as_dead():
+    peer = Peer(
+        id='id',
+        name='name',
+        lifetime=10,
+        lastseen='2020-12-31T23:59:49.123456',  # 10 seconds before "now" sharp
+    )
+    assert peer.lifetime == datetime.timedelta(seconds=10)
+    assert peer.lastseen == datetime.datetime(2020, 12, 31, 23, 59, 49, 123456)
+    assert peer.deadline == datetime.datetime(2020, 12, 31, 23, 59, 59, 123456)
+    assert peer.is_dead is True
+
+
+def test_touching_when_alive():
+    with freezegun.freeze_time('2020-01-01T10:20:30'):
+        peer = Peer(id='id1', name='name1', lifetime=123)
+
+    assert not peer.is_dead
+
+    with freezegun.freeze_time('2020-02-02T11:22:33'):
+        peer.touch()
+
+    assert peer.lifetime == datetime.timedelta(seconds=123)
+    assert peer.lastseen == datetime.datetime(2020, 2, 2, 11, 22, 33)
+    assert peer.deadline == datetime.datetime(2020, 2, 2, 11, 24, 36)
+    assert not peer.is_dead
+
+
+def test_touching_when_dead():
+    with freezegun.freeze_time('2020-01-01T10:20:30'):
+        peer = Peer(id='id1', name='name1', lifetime=123, lastseen='2019-01-01T00:00:00')
+
+    assert peer.is_dead
+
+    with freezegun.freeze_time('2020-02-02T11:22:33'):
+        peer.touch()
+
+    assert peer.lifetime == datetime.timedelta(seconds=123)
+    assert peer.lastseen == datetime.datetime(2020, 2, 2, 11, 22, 33)
+    assert peer.deadline == datetime.datetime(2020, 2, 2, 11, 24, 36)
+    assert not peer.is_dead


### PR DESCRIPTION
## What do these changes do?

Add unit- and functional tests for peering (cross-operator basic synchronization tool to avoid double-processing).


## Description

This is the last of the testing topics needed to close #13. 

Now, the peering behavior is also tested — same as all other aspects of the framework, and more or less the same way.

In addition, the logging of peering freezes is slightly improved to avoid flooding the freeze-on messages when the state is actually not changed. But keep logging the messages that explain "why" the state is kept "on", even if the reasons change over time.


## Issues/PRs

> Issues:  #13 


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- Refactoring (non-breaking change which does not alter the behaviour)
- Mostly CI/CD automation, contribution experience


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
