### PR TITLE
Get rid of mocks for causes in the tests of registries

### DIFF
--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -1,10 +1,16 @@
+import logging
+
 import pytest
 
-from kopf import ActivityRegistry
-from kopf import OperatorRegistry
-from kopf import ResourceWatchingRegistry, ResourceChangingRegistry
 from kopf import SimpleRegistry, GlobalRegistry  # deprecated, but tested
+from kopf.reactor.causation import ActivityCause, ResourceCause, ResourceWatchingCause, ResourceChangingCause
+from kopf.reactor.registries import ResourceRegistry, ActivityRegistry, OperatorRegistry
+from kopf.reactor.registries import ResourceWatchingRegistry, ResourceChangingRegistry
+from kopf.structs.bodies import Body
+from kopf.structs.containers import Memo
+from kopf.structs.diffs import Diff, DiffItem
 from kopf.structs.handlers import HandlerId, ResourceChangingHandler
+from kopf.structs.patches import Patch
 
 
 @pytest.fixture(params=[
@@ -54,3 +60,73 @@ def parent_handler():
         initial=None, deleted=None, requires_finalizer=None,
         reason=None, field=None,
     )
+
+
+@pytest.fixture()
+def cause_factory(resource):
+    """
+    A simplified factory of causes.
+
+    It assumes most of the parameters to be unused defaults, which is sufficient
+    for testing. Some parameters are of improper types (e.g. Nones), others are
+    converted from built-in types to proper types, the rest are passed as is.
+
+    The cause class is selected based on the passed ``cls``, which is either
+    directly the cause class to use, or the registry class. For the latter
+    case, the best matching cause class is used (hard-coded mapping). Classes
+    are used here as equivalents of enums, in order not to create actual enums.
+
+    All is done for simplicity of testing. This factory is not supposed to be
+    used outside of Kopf's own tests, is not packaged, is not delivered, and
+    is not available to the users.
+    """
+    def make_cause(
+            cls=ResourceChangingCause,
+            *,
+            resource=resource,
+            type=None,
+            raw=None,
+            body=None,
+            diff=(),
+            reason='some-reason',
+            initial=False,
+            activity=None,
+            settings=None,
+    ):
+        if cls is ActivityCause or cls is ActivityRegistry:
+            return ActivityCause(
+                logger=logging.getLogger('kopf.test.fake.logger'),
+                activity=activity,
+                settings=settings,
+            )
+        if cls is ResourceCause or cls is ResourceRegistry or cls is SimpleRegistry:
+            return ResourceCause(
+                logger=logging.getLogger('kopf.test.fake.logger'),
+                resource=resource,
+                patch=Patch(),
+                memo=Memo(),
+                body=Body(body if body is not None else {}),
+            )
+        if cls is ResourceWatchingCause or cls is ResourceWatchingRegistry:
+            return ResourceWatchingCause(
+                logger=logging.getLogger('kopf.test.fake.logger'),
+                resource=resource,
+                patch=Patch(),
+                memo=Memo(),
+                body=Body(body if body is not None else {}),
+                type=type,
+                raw=raw,
+            )
+        if cls is ResourceChangingCause or cls is ResourceChangingRegistry:
+            return ResourceChangingCause(
+                logger=logging.getLogger('kopf.test.fake.logger'),
+                resource=resource,
+                patch=Patch(),
+                memo=Memo(),
+                body=Body(body if body is not None else {}),
+                diff=Diff(DiffItem(*d) for d in diff),
+                initial=initial,
+                reason=reason,
+            )
+        raise TypeError(f"Cause/registry type {cls} is not supported by this fixture.")
+    return make_cause

--- a/tests/registries/legacy-1/test_legacy1_decorators.py
+++ b/tests/registries/legacy-1/test_legacy1_decorators.py
@@ -9,10 +9,10 @@ from kopf.structs.handlers import Reason
 from kopf.structs.resources import Resource
 
 
-def test_on_create_minimal(mocker):
+def test_on_create_minimal(cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
+    cause = cause_factory(resource=resource, reason=Reason.CREATE)
 
     @kopf.on.create('group', 'version', 'plural')
     def fn(**_):
@@ -31,10 +31,10 @@ def test_on_create_minimal(mocker):
     assert handlers[0].when is None
 
 
-def test_on_update_minimal(mocker):
+def test_on_update_minimal(cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE)
 
     @kopf.on.update('group', 'version', 'plural')
     def fn(**_):
@@ -53,10 +53,10 @@ def test_on_update_minimal(mocker):
     assert handlers[0].when is None
 
 
-def test_on_delete_minimal(mocker):
+def test_on_delete_minimal(cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
+    cause = cause_factory(resource=resource, reason=Reason.DELETE)
 
     @kopf.on.delete('group', 'version', 'plural')
     def fn(**_):
@@ -75,11 +75,11 @@ def test_on_delete_minimal(mocker):
     assert handlers[0].when is None
 
 
-def test_on_field_minimal(mocker):
+def test_on_field_minimal(cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
 
     @kopf.on.field('group', 'version', 'plural', 'field.subfield')
     def fn(**_):
@@ -105,10 +105,10 @@ def test_on_field_fails_without_field():
             pass
 
 
-def test_on_create_with_all_kwargs(mocker):
+def test_on_create_with_all_kwargs(mocker, cause_factory):
     registry = GlobalRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
+    cause = cause_factory(resource=resource, reason=Reason.CREATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -134,10 +134,10 @@ def test_on_create_with_all_kwargs(mocker):
     assert handlers[0].annotations == {'someanno': 'somevalue'}
     assert handlers[0].when == when
 
-def test_on_update_with_all_kwargs(mocker):
+def test_on_update_with_all_kwargs(mocker, cause_factory):
     registry = GlobalRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -168,10 +168,10 @@ def test_on_update_with_all_kwargs(mocker):
     pytest.param(True, id='optional'),
     pytest.param(False, id='mandatory'),
 ])
-def test_on_delete_with_all_kwargs(mocker, optional):
+def test_on_delete_with_all_kwargs(mocker, optional, cause_factory):
     registry = GlobalRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
+    cause = cause_factory(resource=resource, reason=Reason.DELETE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -198,11 +198,11 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     assert handlers[0].when == when
 
 
-def test_on_field_with_all_kwargs(mocker):
+def test_on_field_with_all_kwargs(mocker, cause_factory):
     registry = GlobalRegistry()
     resource = Resource('group', 'version', 'plural')
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -245,8 +245,8 @@ def test_subhandler_fails_with_no_parent_handler():
             pass
 
 
-def test_subhandler_declaratively(mocker, parent_handler):
-    cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
+def test_subhandler_declaratively(parent_handler, cause_factory):
+    cause = cause_factory(reason=Reason.UPDATE)
 
     registry = SimpleRegistry()
     subregistry_var.set(registry)
@@ -263,8 +263,8 @@ def test_subhandler_declaratively(mocker, parent_handler):
     assert handlers[0].fn is fn
 
 
-def test_subhandler_imperatively(mocker, parent_handler):
-    cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
+def test_subhandler_imperatively(parent_handler, cause_factory):
+    cause = cause_factory(reason=Reason.UPDATE)
 
     registry = SimpleRegistry()
     subregistry_var.set(registry)

--- a/tests/registries/legacy-1/test_legacy1_id_detection.py
+++ b/tests/registries/legacy-1/test_legacy1_id_detection.py
@@ -71,14 +71,15 @@ def test_id_of_lambda():
     assert fn_id.startswith(f'lambda:{__file__}:')
 
 
-def test_with_no_hints(mocker):
+def test_with_no_hints(mocker, cause_factory):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
+    cause = cause_factory()
 
     registry = SimpleRegistry()
     with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
         registry.register(some_fn)
     with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
-        handlers = registry.get_cause_handlers(mocker.MagicMock())
+        handlers = registry.get_cause_handlers(cause)
 
     assert get_fn_id.called
 
@@ -88,14 +89,15 @@ def test_with_no_hints(mocker):
 
 
 @pytest.mark.skip("Prefixes are removed from the registries, even from the legacy ones.")
-def test_with_prefix(mocker):
+def test_with_prefix(mocker, cause_factory):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
+    cause = cause_factory()
 
     registry = SimpleRegistry()
     with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
         registry.register(some_fn)
     with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
-        handlers = registry.get_cause_handlers(mocker.MagicMock())
+        handlers = registry.get_cause_handlers(cause)
 
     assert get_fn_id.called
 
@@ -104,15 +106,16 @@ def test_with_prefix(mocker):
     assert handlers[0].id == 'some-prefix/some-id'
 
 
-def test_with_suffix(mocker, field):
+def test_with_suffix(mocker, field, cause_factory):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
     diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
+    cause = cause_factory(diff=diff)
 
     registry = SimpleRegistry()
     with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
         registry.register(some_fn, field=field)
     with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
-        handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
+        handlers = registry.get_cause_handlers(cause)
 
     assert get_fn_id.called
 
@@ -122,15 +125,16 @@ def test_with_suffix(mocker, field):
 
 
 @pytest.mark.skip("Prefixes are removed from the registries, even from the legacy ones.")
-def test_with_prefix_and_suffix(mocker, field):
+def test_with_prefix_and_suffix(mocker, field, cause_factory):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
     diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
+    cause = cause_factory(diff=diff)
 
     registry = SimpleRegistry(prefix='some-prefix')
     with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
         registry.register(some_fn, field=field)
     with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
-        handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
+        handlers = registry.get_cause_handlers(cause)
 
     assert get_fn_id.called
 
@@ -140,15 +144,16 @@ def test_with_prefix_and_suffix(mocker, field):
 
 
 @pytest.mark.skip("Prefixes are removed from the registries, even from the legacy ones.")
-def test_with_explicit_id_and_prefix_and_suffix(mocker, field):
+def test_with_explicit_id_and_prefix_and_suffix(mocker, field, cause_factory):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
     diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
+    cause = cause_factory(diff=diff)
 
     registry = SimpleRegistry(prefix='some-prefix')
     with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
         registry.register(some_fn, id='explicit-id', field=field)
     with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
-        handlers = registry.get_cause_handlers(mocker.MagicMock(diff=diff))
+        handlers = registry.get_cause_handlers(cause)
 
     assert not get_fn_id.called
 

--- a/tests/registries/legacy-1/test_legacy1_registering.py
+++ b/tests/registries/legacy-1/test_legacy1_registering.py
@@ -10,9 +10,9 @@ def some_fn():
     pass
 
 
-def test_simple_registry_via_iter(mocker):
-    cause = mocker.Mock(event=None, diff=None)
+def test_simple_registry_via_iter(cause_factory):
 
+    cause = cause_factory()
     registry = SimpleRegistry()
     iterator = registry.iter_cause_handlers(cause)
 
@@ -26,9 +26,9 @@ def test_simple_registry_via_iter(mocker):
     assert not handlers
 
 
-def test_simple_registry_via_list(mocker):
-    cause = mocker.Mock(event=None, diff=None)
+def test_simple_registry_via_list(cause_factory):
 
+    cause = cause_factory()
     registry = SimpleRegistry()
     with pytest.deprecated_call(match=r"use ResourceChangingRegistry.get_handlers\(\)"):
         handlers = registry.get_cause_handlers(cause)
@@ -39,9 +39,9 @@ def test_simple_registry_via_list(mocker):
     assert not handlers
 
 
-def test_simple_registry_with_minimal_signature(mocker):
-    cause = mocker.Mock(event=None, diff=None)
+def test_simple_registry_with_minimal_signature(cause_factory):
 
+    cause = cause_factory()
     registry = SimpleRegistry()
     with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
         registry.register(some_fn)
@@ -52,9 +52,9 @@ def test_simple_registry_with_minimal_signature(mocker):
     assert handlers[0].fn is some_fn
 
 
-def test_global_registry_via_iter(mocker, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+def test_global_registry_via_iter(cause_factory):
 
+    cause = cause_factory()
     registry = GlobalRegistry()
     iterator = registry.iter_cause_handlers(cause)
 
@@ -68,9 +68,9 @@ def test_global_registry_via_iter(mocker, resource):
     assert not handlers
 
 
-def test_global_registry_via_list(mocker, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+def test_global_registry_via_list(cause_factory):
 
+    cause = cause_factory()
     registry = GlobalRegistry()
     with pytest.deprecated_call(match=r"use OperatorRegistry.get_resource_changing_handlers\(\)"):
         handlers = registry.get_cause_handlers(cause)
@@ -81,9 +81,9 @@ def test_global_registry_via_list(mocker, resource):
     assert not handlers
 
 
-def test_global_registry_with_minimal_signature(mocker, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+def test_global_registry_with_minimal_signature(cause_factory, resource):
 
+    cause = cause_factory()
     registry = GlobalRegistry()
     with pytest.deprecated_call(match=r"use OperatorRegistry.register_resource_changing_handler\(\)"):
         registry.register_cause_handler(resource.group, resource.version, resource.plural, some_fn)

--- a/tests/registries/legacy-2/test_legacy2_decorators.py
+++ b/tests/registries/legacy-2/test_legacy2_decorators.py
@@ -67,10 +67,12 @@ def test_on_probe_minimal():
 
 # Resume handlers are mixed-in into all resource-changing reactions with initial listing.
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
-def test_on_resume_minimal(mocker, reason):
+def test_on_resume_minimal(
+        reason, cause_factory):
+
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=False)
+    cause = cause_factory(resource=resource, reason=reason, initial=True)
 
     @kopf.on.resume('group', 'version', 'plural')
     def fn(**_):
@@ -92,10 +94,12 @@ def test_on_resume_minimal(mocker, reason):
     assert handlers[0].when is None
 
 
-def test_on_create_minimal(mocker):
+def test_on_create_minimal(
+        cause_factory):
+
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
+    cause = cause_factory(resource=resource, reason=Reason.CREATE)
 
     @kopf.on.create('group', 'version', 'plural')
     def fn(**_):
@@ -117,10 +121,12 @@ def test_on_create_minimal(mocker):
     assert handlers[0].when is None
 
 
-def test_on_update_minimal(mocker):
+def test_on_update_minimal(
+        cause_factory):
+
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE)
 
     @kopf.on.update('group', 'version', 'plural')
     def fn(**_):
@@ -142,10 +148,12 @@ def test_on_update_minimal(mocker):
     assert handlers[0].when is None
 
 
-def test_on_delete_minimal(mocker):
+def test_on_delete_minimal(
+        cause_factory):
+
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
+    cause = cause_factory(resource=resource, reason=Reason.DELETE)
 
     @kopf.on.delete('group', 'version', 'plural')
     def fn(**_):
@@ -167,11 +175,13 @@ def test_on_delete_minimal(mocker):
     assert handlers[0].when is None
 
 
-def test_on_field_minimal(mocker):
+def test_on_field_minimal(
+        cause_factory):
+
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
 
     @kopf.on.field('group', 'version', 'plural', 'field.subfield')
     def fn(**_):
@@ -268,10 +278,12 @@ def test_on_probe_with_all_kwargs(mocker):
 
 # Resume handlers are mixed-in into all resource-changing reactions with initial listing.
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
-def test_on_resume_with_all_kwargs(mocker, reason):
+def test_on_resume_with_all_kwargs(
+        mocker, reason, cause_factory):
+
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=False)
+    cause = cause_factory(resource=resource, reason=reason, initial=True)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -304,10 +316,12 @@ def test_on_resume_with_all_kwargs(mocker, reason):
     assert handlers[0].when == when
 
 
-def test_on_create_with_all_kwargs(mocker):
+def test_on_create_with_all_kwargs(
+        mocker, cause_factory):
+
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
+    cause = cause_factory(resource=resource, reason=Reason.CREATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -338,10 +352,12 @@ def test_on_create_with_all_kwargs(mocker):
     assert handlers[0].when == when
 
 
-def test_on_update_with_all_kwargs(mocker):
+def test_on_update_with_all_kwargs(
+        mocker, cause_factory):
+
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -376,10 +392,12 @@ def test_on_update_with_all_kwargs(mocker):
     pytest.param(True, id='optional'),
     pytest.param(False, id='mandatory'),
 ])
-def test_on_delete_with_all_kwargs(mocker, optional):
+def test_on_delete_with_all_kwargs(
+        mocker, optional, cause_factory):
+
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
+    cause = cause_factory(resource=resource, reason=Reason.DELETE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -411,11 +429,13 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     assert handlers[0].when == when
 
 
-def test_on_field_with_all_kwargs(mocker):
+def test_on_field_with_all_kwargs(
+        mocker, cause_factory):
+
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -462,9 +482,10 @@ def test_subhandler_fails_with_no_parent_handler():
             pass
 
 
-def test_subhandler_declaratively(mocker, parent_handler):
-    cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
+def test_subhandler_declaratively(
+        parent_handler, cause_factory):
 
+    cause = cause_factory(reason=Reason.UPDATE)
     registry = ResourceChangingRegistry()
     subregistry_var.set(registry)
 
@@ -478,9 +499,10 @@ def test_subhandler_declaratively(mocker, parent_handler):
     assert handlers[0].fn is fn
 
 
-def test_subhandler_imperatively(mocker, parent_handler):
-    cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
+def test_subhandler_imperatively(
+        parent_handler, cause_factory):
 
+    cause = cause_factory(reason=Reason.UPDATE)
     registry = ResourceChangingRegistry()
     subregistry_var.set(registry)
 

--- a/tests/registries/legacy-2/test_legacy2_registering.py
+++ b/tests/registries/legacy-2/test_legacy2_registering.py
@@ -2,6 +2,7 @@ import collections.abc
 
 import pytest
 
+from kopf.reactor.causation import ResourceWatchingCause, ResourceChangingCause
 from kopf.structs.handlers import Activity
 
 
@@ -10,9 +11,10 @@ def some_fn():
     pass
 
 
-def test_generic_registry_via_iter(mocker, generic_registry_cls):
-    cause = mocker.Mock(event=None, diff=None)
+def test_generic_registry_via_iter(
+        generic_registry_cls, cause_factory):
 
+    cause = cause_factory(generic_registry_cls)
     registry = generic_registry_cls()
     iterator = registry.iter_handlers(cause)
 
@@ -25,9 +27,10 @@ def test_generic_registry_via_iter(mocker, generic_registry_cls):
     assert not handlers
 
 
-def test_generic_registry_via_list(mocker, generic_registry_cls):
-    cause = mocker.Mock(event=None, diff=None)
+def test_generic_registry_via_list(
+        generic_registry_cls, cause_factory):
 
+    cause = cause_factory(generic_registry_cls)
     registry = generic_registry_cls()
     handlers = registry.get_handlers(cause)
 
@@ -37,9 +40,10 @@ def test_generic_registry_via_list(mocker, generic_registry_cls):
     assert not handlers
 
 
-def test_generic_registry_with_minimal_signature(mocker, generic_registry_cls):
-    cause = mocker.Mock(event=None, diff=None)
+def test_generic_registry_with_minimal_signature(
+        generic_registry_cls, cause_factory):
 
+    cause = cause_factory(generic_registry_cls)
     registry = generic_registry_cls()
     with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register(some_fn)
@@ -67,9 +71,9 @@ def test_operator_registry_with_activity_via_iter(
 
 
 def test_operator_registry_with_resource_watching_via_iter(
-        mocker, operator_registry_cls, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+        operator_registry_cls, cause_factory):
 
+    cause = cause_factory(ResourceWatchingCause)
     registry = operator_registry_cls()
     iterator = registry.iter_resource_watching_handlers(cause)
 
@@ -84,9 +88,9 @@ def test_operator_registry_with_resource_watching_via_iter(
 
 
 def test_operator_registry_with_resource_changing_via_iter(
-        mocker, operator_registry_cls, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+        operator_registry_cls, cause_factory):
 
+    cause = cause_factory(ResourceChangingCause)
     registry = operator_registry_cls()
     iterator = registry.iter_resource_changing_handlers(cause)
 
@@ -115,10 +119,11 @@ def test_operator_registry_with_activity_via_list(
 
 
 def test_operator_registry_with_resource_watching_via_list(
-        mocker, operator_registry_cls, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+        operator_registry_cls, cause_factory):
 
+    cause = cause_factory(ResourceWatchingCause)
     registry = operator_registry_cls()
+
     with pytest.deprecated_call(match=r"use registry.resource_watching_handlers"):
         handlers = registry.get_resource_watching_handlers(cause)
 
@@ -129,10 +134,11 @@ def test_operator_registry_with_resource_watching_via_list(
 
 
 def test_operator_registry_with_resource_changing_via_list(
-        mocker, operator_registry_cls, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+        operator_registry_cls, cause_factory):
 
+    cause = cause_factory(ResourceChangingCause)
     registry = operator_registry_cls()
+
     with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
         handlers = registry.get_resource_changing_handlers(cause)
 
@@ -157,10 +163,11 @@ def test_operator_registry_with_activity_with_minimal_signature(
 
 
 def test_operator_registry_with_resource_watching_with_minimal_signature(
-        mocker, operator_registry_cls, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+        operator_registry_cls, cause_factory, resource):
 
+    cause = cause_factory(ResourceWatchingCause)
     registry = operator_registry_cls()
+
     with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register_resource_watching_handler(resource.group, resource.version, resource.plural, some_fn)
     with pytest.deprecated_call(match=r"use registry.resource_watching_handlers"):
@@ -171,10 +178,11 @@ def test_operator_registry_with_resource_watching_with_minimal_signature(
 
 
 def test_operator_registry_with_resource_changing_with_minimal_signature(
-        mocker, operator_registry_cls, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+        operator_registry_cls, cause_factory, resource):
 
+    cause = cause_factory(ResourceChangingCause)
     registry = operator_registry_cls()
+
     with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register_resource_changing_handler(resource.group, resource.version, resource.plural, some_fn)
     with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -61,10 +61,10 @@ def test_on_probe_minimal():
 
 # Resume handlers are mixed-in into all resource-changing reactions with initial listing.
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
-def test_on_resume_minimal(mocker, reason):
+def test_on_resume_minimal(reason, cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=False)
+    cause = cause_factory(resource=resource, reason=reason, initial=True)
 
     @kopf.on.resume('group', 'version', 'plural')
     def fn(**_):
@@ -84,10 +84,10 @@ def test_on_resume_minimal(mocker, reason):
     assert handlers[0].when is None
 
 
-def test_on_create_minimal(mocker):
+def test_on_create_minimal(cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
+    cause = cause_factory(resource=resource, reason=Reason.CREATE)
 
     @kopf.on.create('group', 'version', 'plural')
     def fn(**_):
@@ -107,10 +107,10 @@ def test_on_create_minimal(mocker):
     assert handlers[0].when is None
 
 
-def test_on_update_minimal(mocker):
+def test_on_update_minimal(cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE)
 
     @kopf.on.update('group', 'version', 'plural')
     def fn(**_):
@@ -130,10 +130,10 @@ def test_on_update_minimal(mocker):
     assert handlers[0].when is None
 
 
-def test_on_delete_minimal(mocker):
+def test_on_delete_minimal(cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
+    cause = cause_factory(resource=resource, reason=Reason.DELETE)
 
     @kopf.on.delete('group', 'version', 'plural')
     def fn(**_):
@@ -153,11 +153,11 @@ def test_on_delete_minimal(mocker):
     assert handlers[0].when is None
 
 
-def test_on_field_minimal(mocker):
+def test_on_field_minimal(cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
 
     @kopf.on.field('group', 'version', 'plural', 'field.subfield')
     def fn(**_):
@@ -184,7 +184,7 @@ def test_on_field_fails_without_field():
             pass
 
 
-def test_on_startup_with_all_kwargs(mocker):
+def test_on_startup_with_all_kwargs():
     registry = OperatorRegistry()
 
     @kopf.on.startup(
@@ -246,10 +246,10 @@ def test_on_probe_with_all_kwargs(mocker):
 
 # Resume handlers are mixed-in into all resource-changing reactions with initial listing.
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
-def test_on_resume_with_all_kwargs(mocker, reason):
+def test_on_resume_with_all_kwargs(mocker, reason, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=False)
+    cause = cause_factory(resource=resource, reason=reason, initial=True)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -280,10 +280,10 @@ def test_on_resume_with_all_kwargs(mocker, reason):
     assert handlers[0].when == when
 
 
-def test_on_create_with_all_kwargs(mocker):
+def test_on_create_with_all_kwargs(mocker, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
+    cause = cause_factory(resource=resource, reason=Reason.CREATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -312,10 +312,10 @@ def test_on_create_with_all_kwargs(mocker):
     assert handlers[0].when == when
 
 
-def test_on_update_with_all_kwargs(mocker):
+def test_on_update_with_all_kwargs(mocker, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -348,10 +348,10 @@ def test_on_update_with_all_kwargs(mocker):
     pytest.param(True, id='optional'),
     pytest.param(False, id='mandatory'),
 ])
-def test_on_delete_with_all_kwargs(mocker, optional):
+def test_on_delete_with_all_kwargs(mocker, cause_factory, optional):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
+    cause = cause_factory(resource=resource, reason=Reason.DELETE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -381,11 +381,11 @@ def test_on_delete_with_all_kwargs(mocker, optional):
     assert handlers[0].when == when
 
 
-def test_on_field_with_all_kwargs(mocker):
+def test_on_field_with_all_kwargs(mocker, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False
@@ -430,8 +430,8 @@ def test_subhandler_fails_with_no_parent_handler():
             pass
 
 
-def test_subhandler_declaratively(mocker, parent_handler):
-    cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
+def test_subhandler_declaratively(parent_handler, cause_factory):
+    cause = cause_factory(reason=Reason.UPDATE)
 
     registry = ResourceChangingRegistry()
     subregistry_var.set(registry)
@@ -446,8 +446,8 @@ def test_subhandler_declaratively(mocker, parent_handler):
     assert handlers[0].fn is fn
 
 
-def test_subhandler_imperatively(mocker, parent_handler):
-    cause = mocker.MagicMock(reason=Reason.UPDATE, diff=None)
+def test_subhandler_imperatively(parent_handler, cause_factory):
+    cause = cause_factory(reason=Reason.UPDATE)
 
     registry = ResourceChangingRegistry()
     subregistry_var.set(registry)

--- a/tests/registries/test_decorators_deprecated_cooldown.py
+++ b/tests/registries/test_decorators_deprecated_cooldown.py
@@ -58,10 +58,10 @@ def test_on_probe_with_cooldown():
 
 # Resume handlers are mixed-in into all resource-changing reactions with initial listing.
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
-def test_on_resume_with_cooldown(mocker, reason):
+def test_on_resume_with_cooldown(mocker, reason, cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=False)
+    cause = cause_factory(resource=resource, reason=reason, initial=True)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     with pytest.deprecated_call(match=r"use backoff="):
@@ -78,10 +78,10 @@ def test_on_resume_with_cooldown(mocker, reason):
         assert handlers[0].cooldown == 78
 
 
-def test_on_create_with_cooldown(mocker):
+def test_on_create_with_cooldown(mocker, cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.CREATE)
+    cause = cause_factory(resource=resource, reason=Reason.CREATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     with pytest.deprecated_call(match=r"use backoff="):
@@ -98,10 +98,10 @@ def test_on_create_with_cooldown(mocker):
         assert handlers[0].cooldown == 78
 
 
-def test_on_update_with_cooldown(mocker):
+def test_on_update_with_cooldown(mocker, cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     with pytest.deprecated_call(match=r"use backoff="):
@@ -122,10 +122,10 @@ def test_on_update_with_cooldown(mocker):
     pytest.param(True, id='optional'),
     pytest.param(False, id='mandatory'),
 ])
-def test_on_delete_with_cooldown(mocker, optional):
+def test_on_delete_with_cooldown(mocker, optional, cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=Reason.DELETE)
+    cause = cause_factory(resource=resource, reason=Reason.DELETE)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     with pytest.deprecated_call(match=r"use backoff="):
@@ -142,11 +142,11 @@ def test_on_delete_with_cooldown(mocker, optional):
         assert handlers[0].cooldown == 78
 
 
-def test_on_field_with_cooldown(mocker):
+def test_on_field_with_cooldown(mocker, cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = mocker.MagicMock(resource=resource, reason=Reason.UPDATE, diff=diff)
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     with pytest.deprecated_call(match=r"use backoff="):

--- a/tests/registries/test_handler_getting.py
+++ b/tests/registries/test_handler_getting.py
@@ -2,6 +2,7 @@ import collections.abc
 
 import pytest
 
+from kopf.reactor.causation import ResourceWatchingCause, ResourceChangingCause
 from kopf.structs.handlers import Activity
 
 
@@ -10,9 +11,10 @@ def some_fn():
     pass
 
 
-def test_generic_registry_via_iter(mocker, generic_registry_cls):
-    cause = mocker.Mock(event=None, diff=None)
+def test_generic_registry_via_iter(
+        generic_registry_cls, cause_factory):
 
+    cause = cause_factory(generic_registry_cls)
     registry = generic_registry_cls()
     iterator = registry.iter_handlers(cause)
 
@@ -25,9 +27,10 @@ def test_generic_registry_via_iter(mocker, generic_registry_cls):
     assert not handlers
 
 
-def test_generic_registry_via_list(mocker, generic_registry_cls):
-    cause = mocker.Mock(event=None, diff=None)
+def test_generic_registry_via_list(
+        generic_registry_cls, cause_factory):
 
+    cause = cause_factory(generic_registry_cls)
     registry = generic_registry_cls()
     handlers = registry.get_handlers(cause)
 
@@ -54,9 +57,9 @@ def test_operator_registry_with_activity_via_iter(
 
 
 def test_operator_registry_with_resource_watching_via_iter(
-        mocker, operator_registry_cls, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+        operator_registry_cls, resource, cause_factory):
 
+    cause = cause_factory(ResourceWatchingCause)
     registry = operator_registry_cls()
     iterator = registry.resource_watching_handlers[resource].iter_handlers(cause)
 
@@ -70,9 +73,9 @@ def test_operator_registry_with_resource_watching_via_iter(
 
 
 def test_operator_registry_with_resource_changing_via_iter(
-        mocker, operator_registry_cls, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+        operator_registry_cls, resource, cause_factory):
 
+    cause = cause_factory(ResourceChangingCause)
     registry = operator_registry_cls()
     iterator = registry.resource_changing_handlers[resource].iter_handlers(cause)
 
@@ -99,9 +102,9 @@ def test_operator_registry_with_activity_via_list(
 
 
 def test_operator_registry_with_resource_watching_via_list(
-        mocker, operator_registry_cls, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+        operator_registry_cls, resource, cause_factory):
 
+    cause = cause_factory(ResourceWatchingCause)
     registry = operator_registry_cls()
     handlers = registry.resource_watching_handlers[resource].get_handlers(cause)
 
@@ -112,9 +115,9 @@ def test_operator_registry_with_resource_watching_via_list(
 
 
 def test_operator_registry_with_resource_changing_via_list(
-        mocker, operator_registry_cls, resource):
-    cause = mocker.Mock(resource=resource, event=None, diff=None)
+        operator_registry_cls, resource, cause_factory):
 
+    cause = cause_factory(ResourceChangingCause)
     registry = operator_registry_cls()
     handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
 

--- a/tests/registries/test_resumes_mixed_in.py
+++ b/tests/registries/test_resumes_mixed_in.py
@@ -7,10 +7,13 @@ from kopf.structs.resources import Resource
 
 @pytest.mark.parametrize('deleted', [True, False, None])
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
-def test_resumes_ignored_for_non_initial_causes(mocker, reason, deleted):
+def test_resumes_ignored_for_non_initial_causes(
+        reason, deleted, cause_factory):
+
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=reason, initial=False, deleted=deleted)
+    cause = cause_factory(resource=resource, reason=reason, initial=False,
+                          body={'metadata': {'deletionTimestamp': '...'} if deleted else {}})
 
     @kopf.on.resume('group', 'version', 'plural')
     def fn(**_):
@@ -21,10 +24,12 @@ def test_resumes_ignored_for_non_initial_causes(mocker, reason, deleted):
 
 
 @pytest.mark.parametrize('reason', list(set(HANDLER_REASONS) - {Reason.DELETE}))
-def test_resumes_selected_for_initial_non_deletions(mocker, reason):
+def test_resumes_selected_for_initial_non_deletions(
+        reason, cause_factory):
+
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=False)
+    cause = cause_factory(resource=resource, reason=reason, initial=True)
 
     @kopf.on.resume('group', 'version', 'plural')
     def fn(**_):
@@ -36,10 +41,13 @@ def test_resumes_selected_for_initial_non_deletions(mocker, reason):
 
 
 @pytest.mark.parametrize('reason', [Reason.DELETE])
-def test_resumes_ignored_for_initial_deletions_by_default(mocker, reason):
+def test_resumes_ignored_for_initial_deletions_by_default(
+        reason, cause_factory):
+
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=True)
+    cause = cause_factory(resource=resource, reason=reason, initial=True,
+                          body={'metadata': {'deletionTimestamp': '...'}})
 
     @kopf.on.resume('group', 'version', 'plural')
     def fn(**_):
@@ -50,10 +58,13 @@ def test_resumes_ignored_for_initial_deletions_by_default(mocker, reason):
 
 
 @pytest.mark.parametrize('reason', [Reason.DELETE])
-def test_resumes_selected_for_initial_deletions_when_explicitly_marked(mocker, reason):
+def test_resumes_selected_for_initial_deletions_when_explicitly_marked(
+        reason, cause_factory):
+
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    cause = mocker.MagicMock(resource=resource, reason=reason, initial=True, deleted=True)
+    cause = cause_factory(resource=resource, reason=reason, initial=True,
+                          body={'metadata': {'deletionTimestamp': '...'}})
 
     @kopf.on.resume('group', 'version', 'plural', deleted=True)
     def fn(**_):

--- a/tests/registries/test_subhandlers_ids.py
+++ b/tests/registries/test_subhandlers_ids.py
@@ -9,28 +9,30 @@ def child_fn(**_):
 
 
 def test_with_no_parent(
-        mocker, resource_registry_cls):
+        resource_registry_cls, cause_factory):
 
+    cause = cause_factory(resource_registry_cls)
     registry = resource_registry_cls()
 
     with context([(handler_var, None)]):
         kopf.on.this(registry=registry)(child_fn)
 
-    handlers = registry.get_handlers(mocker.MagicMock())
+    handlers = registry.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is child_fn
     assert handlers[0].id == 'child_fn'
 
 
 def test_with_parent(
-        mocker, parent_handler, resource_registry_cls):
+        parent_handler, resource_registry_cls, cause_factory):
 
+    cause = cause_factory(resource_registry_cls)
     registry = resource_registry_cls()
 
     with context([(handler_var, parent_handler)]):
         kopf.on.this(registry=registry)(child_fn)
 
-    handlers = registry.get_handlers(mocker.MagicMock())
+    handlers = registry.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is child_fn
     assert handlers[0].id == 'parent_fn/child_fn'


### PR DESCRIPTION
## What do these changes do?

Refactor tests that previously used mocks for causes — to use proper causes' classes. Mocks are bad.


## Description

Causes need to be checked with `isinstance()` in the code base, to properly pass the type checking: `isinstance()` adjusts the inferred type for operations that follow the check. An example is handler-matching functions that check for causes to be resource-changing causes, and using `.diff` only after that (`.diff` is absent in all other causes).

However, this does not work with mocks in tests: all tests do fail, because `Mock` and `MagicMock` classes do not pass the `isinstance()` criterion.

Besides that, mocks are just a terrible way of testing: first of all, they leak the abstractions of the mocked objects by knowing which fields they contain, which properties they implement and how (and can mimic them wrong); second, they prevent tests to be type-checked both by type-checkers or by IDEs.

This PR improves the test design for registries & causes so that the following PRs can also rely on proper typing of arguments (e.g. #518).


## Issues/PRs

> Issues: #338 

> Related: #518 #375 


## Type of changes

- Refactoring (non-breaking change which does not alter the behaviour)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
