### PR TITLE
Select the field-handlers based on the actual diff of that field

### DIFF
--- a/kopf/structs/dicts.py
+++ b/kopf/structs/dicts.py
@@ -47,12 +47,17 @@ def resolve(
         default: Union[_T, _UNSET] = _UNSET.token,
         *,
         assume_empty: bool = False,
+        ignore_wrong: bool = False,
 ) -> Union[Any, _T]:
     """
     Retrieve a nested sub-field from a dict.
 
     If ``assume_empty`` is set, then the non-existent path keys are assumed
     to be empty dictionaries, and then the ``default`` is returned.
+
+    if ``ignore_wrong`` is set, then the non-dictionaries are assumed to
+    not exist, since we cannot dive deep into non-dictionary values.
+    This is used in the diff reduction.
 
     Otherwise (by default), any attempt to get a key from ``None``
     leads to a ``TypeError`` -- same as in Python: ``None['key']``.
@@ -65,6 +70,8 @@ def resolve(
                 return default
             elif isinstance(result, collections.abc.Mapping):
                 result = result[key]
+            elif ignore_wrong:
+                result = None
             else:
                 raise TypeError(f"The structure is not a dict with field {key!r}: {result!r}")
         return result

--- a/kopf/structs/diffs.py
+++ b/kopf/structs/diffs.py
@@ -102,8 +102,8 @@ def reduce_iter(
         # Generate a new diff, with new ops, for the resolved sub-field.
         elif tuple(field) == tuple(path[:len(field)]):
             tail = path[len(field):]
-            old_tail = dicts.resolve(old, tail, default=None, assume_empty=True)
-            new_tail = dicts.resolve(new, tail, default=None, assume_empty=True)
+            old_tail = dicts.resolve(old, tail, default=None, assume_empty=True, ignore_wrong=True)
+            new_tail = dicts.resolve(new, tail, default=None, assume_empty=True, ignore_wrong=True)
             yield from diff_iter(old_tail, new_tail)
 
 

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -169,15 +169,13 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
         warnings.warn("SimpleRegistry.iter_cause_handlers() is deprecated; use "
                       "ResourceChangingRegistry.iter_handlers().", DeprecationWarning)
 
-        changed_fields = frozenset(field for _, field, _, _ in cause.diff or [])
         for handler in self._handlers:
             if not isinstance(handler, handlers.ResourceChangingHandler):
                 pass
             elif handler.reason is None or handler.reason == cause.reason:
                 if handler.initial and not cause.initial:
                     pass  # ignore initial handlers in non-initial causes.
-                elif registries.match(handler=handler, cause=cause,
-                                      changed_fields=changed_fields):
+                elif registries.match(handler=handler, cause=cause):
                     yield handler
 
 

--- a/tests/diffs/test_reduction.py
+++ b/tests/diffs/test_reduction.py
@@ -51,8 +51,19 @@ def test_existent_path_selects_relevant_ops():
     )
 
 
-def test_nonexistent_path_selects_nothing():
-    result = reduce(DIFF, ['nonexistent-key'])
+@pytest.mark.parametrize('path', [
+    ['nonexistent-key'],
+    ['key1', 'nonexistent-key'],
+    ['key2', 'nonexistent-key'],
+    ['key3', 'nonexistent-key'],
+    ['key4', 'nonexistent-key'],
+    ['key4', 'suba', 'nonexistent-key'],
+    ['key4', 'subb', 'nonexistent-key'],
+    ['key4', 'subc', 'nonexistent-key'],
+    ['key4', 'nonexistent-dict', 'nonexistent-key'],
+])
+def test_nonexistent_path_selects_nothing(path):
+    result = reduce(DIFF, path)
     assert result == ()
 
 


### PR DESCRIPTION
## What do these changes do?

Stop invoking the field handlers for _non-existent_ fields on the creation of the objects and on big changes with structures that are supposed to contain those fields, but they don't.


## Description

**Historic context:** Filtering only by diff's fields without actual diff values checked was used since the initial import and release of the framework, and was only modified in #340 by extending the filtering logic to react to sub-fields of a bigger structure changed (for example, for a field "spec.struct.field" when "spec.struct" is added at once).

**Problem:** Yet such an approach is prone to improper detection of actually changed fields: when a bigger struct is added while we expect a non-existent sub-field of it, it is believed to exist there, as the sub-field matches the bigger struct; in particular, when an object is created, it is a root-level diff from `None` to the actual content, and all the non-existent fields trigger their field handlers.

A sample way to reproduce with the existing `examples/obj.yaml` (xxx-handler should not be called at all):

```python
import kopf

@kopf.on.field('zalando.org', 'v1', 'kopfexamples', field='spec.xxx')
def updateField_changed(old, new, **_):
    print(f"XXX! {old!r} -> {new!r}")

@kopf.on.field('zalando.org', 'v1', 'kopfexamples', field='spec.field')
def updateField_changed(old, new, **_):
    print(f"FIELD! {old!r} -> {new!r}")
```

**Solution:** By checking if the actual diff of a specific field is not empty, we can properly detect if that specific field was added, removed, or changed, be that as a part of a bigger (containing) structure change, or as a change in any of its (contained) sub-fields.

**Trade-offs:** This comes at a cost of performance loss: the diff reduction is less performant than a flat iteration over the diff fields: from 20% to 150% (2.5x) slower. However, the scale of the slowdown is measured in 5-10s per 1'000'000 checks on MacBook Air 2013, so we can consider it negligible for real operators.

**Important!** To be released as 0.27.1 hotfix, and later merged into the master branch (#???).


## Issues/PRs

> Issues: #375 

> Related: #340, closes #518 (replace: no release/0.27 base branch).


## Type of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
