### PR TITLE
Sort imports with isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,11 @@
+[settings]
+line_length = 100
+multi_line_output = 0
+balanced_wrapping = true
+combine_as_imports = true
+case_sensitive = true
+
+known_first_party = kopf
+
+filter_files = true
+skip_glob = examples/*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,10 @@ script:
   - pytest --only-e2e  # NB: after the coverage uploads!
   - mypy kopf --strict --pretty
 
+  # Currently, code linting is optional and performed manually from time to time.
+  - isort . --check --diff || true
+  - isort examples --settings=examples --check --diff || true
+
 deploy:
   provider: pypi
   username: "__token__"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 # Configuration file for the Sphinx documentation builder.
 # http://www.sphinx-doc.org/en/master/config
 import os
+
 import docutils.nodes
 
 ###############################################################################

--- a/examples/.isort.cfg
+++ b/examples/.isort.cfg
@@ -1,0 +1,11 @@
+[settings]
+line_length = 100
+multi_line_output = 0
+balanced_wrapping = true
+combine_as_imports = true
+case_sensitive = true
+
+known_third_party = kopf
+
+filter_files = true
+skip_glob = kopf/**

--- a/examples/09-testing/test_example_09.py
+++ b/examples/09-testing/test_example_09.py
@@ -2,9 +2,8 @@ import os.path
 import subprocess
 import time
 
-import pytest
-
 import kopf.testing
+import pytest
 
 obj_yaml = os.path.relpath(os.path.join(os.path.dirname(__file__), '..', 'obj.yaml'))
 example_py = os.path.relpath(os.path.join(os.path.dirname(__file__), 'example.py'))

--- a/examples/10-builtins/test_example_10.py
+++ b/examples/10-builtins/test_example_10.py
@@ -1,9 +1,8 @@
 import os.path
 import time
 
-import pykube
-
 import kopf.testing
+import pykube
 
 
 def test_pods_reacted():

--- a/examples/11-filtering-handlers/test_example_11.py
+++ b/examples/11-filtering-handlers/test_example_11.py
@@ -2,9 +2,8 @@ import os.path
 import subprocess
 import time
 
-import pytest
-
 import kopf.testing
+import pytest
 
 obj_yaml = os.path.relpath(os.path.join(os.path.dirname(__file__), '..', 'obj.yaml'))
 example_py = os.path.relpath(os.path.join(os.path.dirname(__file__), 'example.py'))

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -1,6 +1,7 @@
 """
 The main Kopf module for all the exported functions & classes.
 """
+# isort: skip_file
 
 # Unlike all other places, where we import other modules and refer
 # the functions via the modules, this is the framework's top-level interface,

--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -1,17 +1,13 @@
 import asyncio
 import dataclasses
 import functools
-from typing import Any, Optional, Callable, List
+from typing import Any, Callable, List, Optional
 
 import click
 
-from kopf.engines import logging
-from kopf.engines import peering
-from kopf.reactor import registries
-from kopf.reactor import running
-from kopf.structs import configuration
-from kopf.structs import credentials
-from kopf.structs import primitives
+from kopf.engines import logging, peering
+from kopf.reactor import registries, running
+from kopf.structs import configuration, credentials, primitives
 from kopf.utilities import loaders
 
 

--- a/kopf/clients/auth.py
+++ b/kopf/clients/auth.py
@@ -6,7 +6,7 @@ import ssl
 import tempfile
 import warnings
 from contextvars import ContextVar
-from typing import Optional, Callable, Any, TypeVar, Dict, Iterator, Mapping, cast
+from typing import Any, Callable, Dict, Iterator, Mapping, Optional, TypeVar, cast
 
 import aiohttp
 

--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -6,8 +6,7 @@ from typing import Optional
 import aiohttp
 
 from kopf.clients import auth
-from kopf.structs import bodies
-from kopf.structs import resources
+from kopf.structs import bodies, resources
 
 logger = logging.getLogger(__name__)
 

--- a/kopf/clients/fetching.py
+++ b/kopf/clients/fetching.py
@@ -1,12 +1,10 @@
 import enum
-from typing import TypeVar, Optional, Union, Collection, List, Tuple, cast
+from typing import Collection, List, Optional, Tuple, TypeVar, Union, cast
 
 import aiohttp
 
-from kopf.clients import auth
-from kopf.clients import discovery
-from kopf.structs import bodies
-from kopf.structs import resources
+from kopf.clients import auth, discovery
+from kopf.structs import bodies, resources
 
 _T = TypeVar('_T')
 

--- a/kopf/clients/patching.py
+++ b/kopf/clients/patching.py
@@ -2,11 +2,8 @@ from typing import Optional, cast
 
 import aiohttp
 
-from kopf.clients import auth
-from kopf.clients import discovery
-from kopf.structs import bodies
-from kopf.structs import patches
-from kopf.structs import resources
+from kopf.clients import auth, discovery
+from kopf.structs import bodies, patches, resources
 
 
 @auth.reauthenticated_request

--- a/kopf/clients/watching.py
+++ b/kopf/clients/watching.py
@@ -22,17 +22,12 @@ import asyncio
 import contextlib
 import json
 import logging
-from typing import Optional, Dict, AsyncIterator, Any, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, Optional, cast
 
 import aiohttp
 
-from kopf.clients import auth
-from kopf.clients import discovery
-from kopf.clients import fetching
-from kopf.structs import bodies
-from kopf.structs import configuration
-from kopf.structs import primitives
-from kopf.structs import resources
+from kopf.clients import auth, discovery, fetching
+from kopf.structs import bodies, configuration, primitives, resources
 
 logger = logging.getLogger(__name__)
 

--- a/kopf/engines/logging.py
+++ b/kopf/engines/logging.py
@@ -11,11 +11,10 @@ the operators' code, and can lead to information loss or mismatch
 import asyncio
 import copy
 import logging
-from typing import Tuple, MutableMapping, Any, Optional
+from typing import Any, MutableMapping, Optional, Tuple
 
 from kopf.engines import posting
-from kopf.structs import bodies
-from kopf.structs import configuration
+from kopf.structs import bodies, configuration
 
 
 class ObjectPrefixingFormatter(logging.Formatter):

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -36,16 +36,12 @@ import logging
 import os
 import random
 import socket
-from typing import Any, Dict, Iterable, Optional, Union, NoReturn, Mapping, cast
+from typing import Any, Dict, Iterable, Mapping, NoReturn, Optional, Union, cast
 
 import iso8601
 
-from kopf.clients import fetching
-from kopf.clients import patching
-from kopf.structs import bodies
-from kopf.structs import patches
-from kopf.structs import primitives
-from kopf.structs import resources
+from kopf.clients import fetching, patching
+from kopf.structs import bodies, patches, primitives, resources
 
 logger = logging.getLogger(__name__)
 

--- a/kopf/engines/posting.py
+++ b/kopf/engines/posting.py
@@ -18,12 +18,10 @@ import asyncio
 import logging
 import sys
 from contextvars import ContextVar
-from typing import NamedTuple, NoReturn, Optional, Union, Iterator, Iterable, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable, Iterator, NamedTuple, NoReturn, Optional, Union, cast
 
 from kopf.clients import events
-from kopf.structs import bodies
-from kopf.structs import configuration
-from kopf.structs import dicts
+from kopf.structs import bodies, configuration, dicts
 
 if TYPE_CHECKING:
     K8sEventQueue = asyncio.Queue["K8sEvent"]

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -2,16 +2,12 @@ import asyncio
 import datetime
 import logging
 import urllib.parse
-from typing import Optional, Tuple, MutableMapping
+from typing import MutableMapping, Optional, Tuple
 
 import aiohttp.web
 
-from kopf.reactor import activities
-from kopf.reactor import lifecycles
-from kopf.reactor import registries
-from kopf.structs import callbacks
-from kopf.structs import configuration
-from kopf.structs import handlers
+from kopf.reactor import activities, lifecycles, registries
+from kopf.structs import callbacks, configuration, handlers
 
 logger = logging.getLogger(__name__)
 

--- a/kopf/engines/sleeping.py
+++ b/kopf/engines/sleeping.py
@@ -3,7 +3,7 @@ Advanced modes of sleeping.
 """
 import asyncio
 import collections
-from typing import Optional, Collection, Union
+from typing import Collection, Optional, Union
 
 from kopf.structs import primitives
 

--- a/kopf/events.py
+++ b/kopf/events.py
@@ -3,12 +3,7 @@
 """
 import warnings
 
-from kopf.engines.posting import (
-    event,
-    info,
-    warn,
-    exception,
-)
+from kopf.engines.posting import event, exception, info, warn
 
 __all__ = ['event', 'info', 'warn', 'exception']
 

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -13,16 +13,10 @@ This module is a part of the framework's public interface.
 # TODO: add cluster=True support (different API methods)
 import inspect
 import warnings
+from typing import Any, Callable, Optional
 
-from typing import Optional, Callable, Any
-
-from kopf.reactor import handling
-from kopf.reactor import registries
-from kopf.structs import callbacks
-from kopf.structs import dicts
-from kopf.structs import filters
-from kopf.structs import handlers
-from kopf.structs import resources
+from kopf.reactor import handling, registries
+from kopf.structs import callbacks, dicts, filters, handlers, resources
 
 ActivityDecorator = Callable[[callbacks.ActivityFn], callbacks.ActivityFn]
 ResourceWatchingDecorator = Callable[[callbacks.ResourceWatchingFn], callbacks.ResourceWatchingFn]

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -17,18 +17,12 @@ The process is intentionally split into multiple packages:
   belong to neither the reactor, nor the engines, nor the client wrappers.
 """
 import logging
-from typing import NoReturn, Mapping, MutableMapping
+from typing import Mapping, MutableMapping, NoReturn
 
 from kopf.engines import sleeping
-from kopf.reactor import causation
-from kopf.reactor import handling
-from kopf.reactor import lifecycles
-from kopf.reactor import registries
+from kopf.reactor import causation, handling, lifecycles, registries
 from kopf.storage import states
-from kopf.structs import callbacks
-from kopf.structs import configuration
-from kopf.structs import credentials
-from kopf.structs import handlers as handlers_
+from kopf.structs import callbacks, configuration, credentials, handlers as handlers_
 
 logger = logging.getLogger(__name__)
 

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -22,17 +22,11 @@ could execute on the yet-existing object (and its children, if created).
 import dataclasses
 import logging
 import warnings
-from typing import Any, Optional, Union, TypeVar
+from typing import Any, Optional, TypeVar, Union
 
 from kopf.storage import finalizers
-from kopf.structs import bodies
-from kopf.structs import configuration
-from kopf.structs import containers
-from kopf.structs import diffs
-from kopf.structs import handlers
-from kopf.structs import patches
-from kopf.structs import primitives
-from kopf.structs import resources
+from kopf.structs import (bodies, configuration, containers, diffs,
+                          handlers, patches, primitives, resources)
 
 
 @dataclasses.dataclass

--- a/kopf/reactor/daemons.py
+++ b/kopf/reactor/daemons.py
@@ -23,20 +23,13 @@ of the daemons, and they are not actually "hung".
 import asyncio
 import time
 import warnings
-from typing import MutableMapping, Mapping, Sequence, Collection, List
+from typing import Collection, List, Mapping, MutableMapping, Sequence
 
 from kopf.clients import patching
-from kopf.engines import logging as logging_engine
-from kopf.engines import sleeping
-from kopf.reactor import causation
-from kopf.reactor import handling
-from kopf.reactor import lifecycles
+from kopf.engines import logging as logging_engine, sleeping
+from kopf.reactor import causation, handling, lifecycles
 from kopf.storage import states
-from kopf.structs import configuration
-from kopf.structs import containers
-from kopf.structs import handlers as handlers_
-from kopf.structs import patches
-from kopf.structs import primitives
+from kopf.structs import configuration, containers, handlers as handlers_, patches, primitives
 
 
 async def spawn_resource_daemons(

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -11,20 +11,12 @@ import asyncio
 import collections.abc
 import logging
 from contextvars import ContextVar
-from typing import Optional, Union, Iterable, Collection, Mapping, MutableMapping, Any, Set
+from typing import Any, Collection, Iterable, Mapping, MutableMapping, Optional, Set, Union
 
 from kopf.engines import logging as logging_engine
-from kopf.reactor import causation
-from kopf.reactor import invocation
-from kopf.reactor import lifecycles
-from kopf.reactor import registries
+from kopf.reactor import causation, invocation, lifecycles, registries
 from kopf.storage import states
-from kopf.structs import callbacks
-from kopf.structs import configuration
-from kopf.structs import dicts
-from kopf.structs import diffs
-from kopf.structs import handlers as handlers_
-
+from kopf.structs import callbacks, configuration, dicts, diffs, handlers as handlers_
 
 DEFAULT_RETRY_DELAY = 1 * 60
 """ The default delay duration for the regular exception in retry-mode. """

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -9,11 +9,10 @@ import asyncio
 import contextlib
 import contextvars
 import functools
-from typing import Optional, Any, List, Iterable, Iterator, Tuple, Dict, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Optional, Tuple, cast
 
 from kopf.reactor import causation
-from kopf.structs import callbacks
-from kopf.structs import configuration
+from kopf.structs import callbacks, configuration
 
 if TYPE_CHECKING:
     asyncio_Future = asyncio.Future[Any]

--- a/kopf/reactor/lifecycles.py
+++ b/kopf/reactor/lifecycles.py
@@ -10,7 +10,7 @@ execute in the order they are registered, one by one.
 """
 import logging
 import random
-from typing import Sequence, Any, Optional
+from typing import Any, Optional, Sequence
 
 from typing_extensions import Protocol
 

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -19,23 +19,11 @@ import time
 from typing import Collection, Optional
 
 from kopf.clients import patching
-from kopf.engines import logging as logging_engine
-from kopf.engines import posting
-from kopf.engines import sleeping
-from kopf.reactor import causation
-from kopf.reactor import daemons
-from kopf.reactor import handling
-from kopf.reactor import lifecycles
-from kopf.reactor import registries
-from kopf.storage import finalizers
-from kopf.storage import states
-from kopf.structs import bodies
-from kopf.structs import configuration
-from kopf.structs import containers
-from kopf.structs import diffs
-from kopf.structs import handlers as handlers_
-from kopf.structs import patches
-from kopf.structs import resources
+from kopf.engines import logging as logging_engine, posting, sleeping
+from kopf.reactor import causation, daemons, handling, lifecycles, registries
+from kopf.storage import finalizers, states
+from kopf.structs import (bodies, configuration, containers, diffs,
+                          handlers as handlers_, patches, resources)
 
 # How often to wake up from the long sleep, to show liveness in the logs.
 WAITING_KEEPALIVE_INTERVAL = 10 * 60

--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -27,16 +27,13 @@ import asyncio
 import enum
 import logging
 import time
-from typing import Tuple, Union, MutableMapping, NewType, NamedTuple, TYPE_CHECKING, cast, Optional
+from typing import TYPE_CHECKING, MutableMapping, NamedTuple, NewType, Optional, Tuple, Union, cast
 
 import aiojobs
 from typing_extensions import Protocol
 
 from kopf.clients import watching
-from kopf.structs import bodies
-from kopf.structs import configuration
-from kopf.structs import primitives
-from kopf.structs import resources
+from kopf.structs import bodies, configuration, primitives, resources
 
 logger = logging.getLogger(__name__)
 

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -16,18 +16,11 @@ import collections
 import functools
 import warnings
 from types import FunctionType, MethodType
-from typing import (Any, MutableMapping, Optional, Sequence, Iterable, Iterator,
-                    List, Set, FrozenSet, Mapping, Callable, cast, Generic, TypeVar, Union,
-                    Container)
+from typing import (Any, Callable, Container, FrozenSet, Generic, Iterable, Iterator, List,
+                    Mapping, MutableMapping, Optional, Sequence, Set, TypeVar, Union, cast)
 
-from kopf.reactor import causation
-from kopf.reactor import invocation
-from kopf.structs import callbacks
-from kopf.structs import dicts
-from kopf.structs import diffs
-from kopf.structs import filters
-from kopf.structs import handlers
-from kopf.structs import resources as resources_
+from kopf.reactor import causation, invocation
+from kopf.structs import callbacks, dicts, diffs, filters, handlers, resources as resources_
 from kopf.utilities import piggybacking
 
 # We only type-check for known classes of handlers/callbacks, and ignore any custom subclasses.

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -4,24 +4,13 @@ import logging
 import signal
 import threading
 import warnings
-from typing import (Optional, Collection, Tuple, Set, Any, Coroutine,
-                    Sequence, MutableSequence, cast, TYPE_CHECKING)
+from typing import (TYPE_CHECKING, Any, Collection, Coroutine,
+                    MutableSequence, Optional, Sequence, Set, Tuple, cast)
 
 from kopf.clients import auth
-from kopf.engines import peering
-from kopf.engines import posting
-from kopf.engines import probing
-from kopf.reactor import activities
-from kopf.reactor import daemons
-from kopf.reactor import lifecycles
-from kopf.reactor import processing
-from kopf.reactor import queueing
-from kopf.reactor import registries
-from kopf.structs import configuration
-from kopf.structs import containers
-from kopf.structs import credentials
-from kopf.structs import handlers
-from kopf.structs import primitives
+from kopf.engines import peering, posting, probing
+from kopf.reactor import activities, daemons, lifecycles, processing, queueing, registries
+from kopf.structs import configuration, containers, credentials, handlers, primitives
 
 if TYPE_CHECKING:
     asyncio_Task = asyncio.Task[None]

--- a/kopf/storage/diffbase.py
+++ b/kopf/storage/diffbase.py
@@ -1,11 +1,9 @@
 import abc
 import copy
 import json
-from typing import Optional, Iterable, Collection, cast, Dict, Any
+from typing import Any, Collection, Dict, Iterable, Optional, cast
 
-from kopf.structs import bodies
-from kopf.structs import dicts
-from kopf.structs import patches
+from kopf.structs import bodies, dicts, patches
 
 LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 """ The annotation name for the last stored state of the resource. """

--- a/kopf/storage/finalizers.py
+++ b/kopf/storage/finalizers.py
@@ -5,8 +5,7 @@ Finalizers are used to block the actual deletion until the finalizers
 are removed, meaning that the operator has done all its duties
 to "release" the object (e.g. cleanups; delete-handlers in our case).
 """
-from kopf.structs import bodies
-from kopf.structs import patches
+from kopf.structs import bodies, patches
 
 LEGACY_FINALIZER = 'KopfFinalizerMarker'
 

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -43,14 +43,11 @@ import base64
 import copy
 import hashlib
 import json
-from typing import Optional, Collection, Mapping, Dict, Union, Any, cast
+from typing import Any, Collection, Dict, Mapping, Optional, Union, cast
 
 from typing_extensions import TypedDict
 
-from kopf.structs import bodies
-from kopf.structs import dicts
-from kopf.structs import handlers
-from kopf.structs import patches
+from kopf.structs import bodies, dicts, handlers, patches
 
 
 class ProgressRecord(TypedDict, total=True):

--- a/kopf/storage/states.py
+++ b/kopf/storage/states.py
@@ -15,13 +15,10 @@ import collections.abc
 import copy
 import dataclasses
 import datetime
-from typing import Any, Optional, Mapping, Dict, Collection, Iterator, overload
+from typing import Any, Collection, Dict, Iterator, Mapping, Optional, overload
 
 from kopf.storage import progress
-from kopf.structs import bodies
-from kopf.structs import callbacks
-from kopf.structs import handlers as handlers_
-from kopf.structs import patches
+from kopf.structs import bodies, callbacks, handlers as handlers_, patches
 
 
 @dataclasses.dataclass(frozen=True)

--- a/kopf/structs/bodies.py
+++ b/kopf/structs/bodies.py
@@ -41,9 +41,9 @@ In case the operators are also type-checked, type casting can be used
     and object-processing functions. The internal dicts will remain the same.
 """
 
-from typing import Any, Mapping, MutableMapping, Union, List, Optional, cast
+from typing import Any, List, Mapping, MutableMapping, Optional, Union, cast
 
-from typing_extensions import TypedDict, Literal
+from typing_extensions import Literal, TypedDict
 
 from kopf.structs import dicts
 

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -5,14 +5,11 @@ Since these signatures contain a lot of copy-pasted kwargs and are
 not so important for the codebase, they are moved to this separate module.
 """
 import logging
-from typing import NewType, Any, Collection, Union, Optional, Callable, Coroutine, TypeVar
+from typing import Any, Callable, Collection, Coroutine, NewType, Optional, TypeVar, Union
 
 from typing_extensions import Protocol
 
-from kopf.structs import bodies
-from kopf.structs import diffs
-from kopf.structs import patches
-from kopf.structs import primitives
+from kopf.structs import bodies, diffs, patches, primitives
 
 # A specialised type to highlight the purpose or origin of the data of type Any,
 # to not be mixed with other arbitrary Any values, where it is indeed "any".

--- a/kopf/structs/configuration.py
+++ b/kopf/structs/configuration.py
@@ -30,8 +30,7 @@ import dataclasses
 from typing import Optional
 
 from kopf import config  # for legacy defaults only
-from kopf.storage import diffbase
-from kopf.storage import progress
+from kopf.storage import diffbase, progress
 
 
 @dataclasses.dataclass

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -11,12 +11,9 @@ import asyncio
 import dataclasses
 import logging
 import time
-from typing import MutableMapping, Dict, Set, Any, Iterator, Optional, Union, NewType, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Iterator, MutableMapping, NewType, Optional, Set, Union
 
-from kopf.structs import bodies
-from kopf.structs import handlers
-from kopf.structs import primitives
-
+from kopf.structs import bodies, handlers, primitives
 
 if TYPE_CHECKING:
     asyncio_Task = asyncio.Task[None]

--- a/kopf/structs/credentials.py
+++ b/kopf/structs/credentials.py
@@ -27,8 +27,8 @@ import asyncio
 import collections
 import dataclasses
 import random
-from typing import (Optional, AsyncIterable, AsyncIterator, Tuple,
-                    NewType, Dict, List, Mapping, Callable, TypeVar, cast)
+from typing import (AsyncIterable, AsyncIterator, Callable, Dict, List,
+                    Mapping, NewType, Optional, Tuple, TypeVar, cast)
 
 from kopf.structs import primitives
 

--- a/kopf/structs/dicts.py
+++ b/kopf/structs/dicts.py
@@ -3,8 +3,8 @@ Some basic dicts and field-in-a-dict manipulation helpers.
 """
 import collections.abc
 import enum
-from typing import (TypeVar, Any, Union, MutableMapping, Mapping, Tuple, List,
-                    Iterable, Iterator, Callable, Optional, Generic)
+from typing import (Any, Callable, Generic, Iterable, Iterator, List,
+                    Mapping, MutableMapping, Optional, Tuple, TypeVar, Union)
 
 FieldPath = Tuple[str, ...]
 FieldSpec = Union[None, str, FieldPath, List[str]]

--- a/kopf/structs/diffs.py
+++ b/kopf/structs/diffs.py
@@ -3,7 +3,7 @@ All the functions to calculate the diffs of the dicts.
 """
 import collections.abc
 import enum
-from typing import Any, Iterator, Sequence, NamedTuple, Iterable, Union, overload
+from typing import Any, Iterable, Iterator, NamedTuple, Sequence, Union, overload
 
 from kopf.structs import dicts
 

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -1,11 +1,9 @@
 import dataclasses
 import enum
 import warnings
-from typing import NewType, Optional, Any
+from typing import Any, NewType, Optional
 
-from kopf.structs import callbacks
-from kopf.structs import dicts
-from kopf.structs import filters
+from kopf.structs import callbacks, dicts, filters
 
 # Strings are taken from the users, but then tainted as this type for stricter type-checking:
 # to prevent usage of some other strings (e.g. operator id) as the handlers ids.

--- a/kopf/structs/patches.py
+++ b/kopf/structs/patches.py
@@ -8,7 +8,7 @@ In the future, it can be extended to a standalone object, which exposes
 a dict-like behaviour, and remembers the changes in order of their execution,
 and then generates the JSON patch (RFC 6902).
 """
-from typing import Dict, MutableMapping, Optional, Any
+from typing import Any, Dict, MutableMapping, Optional
 
 from kopf.structs import dicts
 

--- a/kopf/structs/primitives.py
+++ b/kopf/structs/primitives.py
@@ -6,8 +6,7 @@ import concurrent.futures
 import enum
 import threading
 import time
-from typing import Optional, Union, Any, TYPE_CHECKING
-
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 if TYPE_CHECKING:
     asyncio_Future = asyncio.Future[Any]

--- a/kopf/structs/resources.py
+++ b/kopf/structs/resources.py
@@ -1,5 +1,5 @@
 import urllib.parse
-from typing import NamedTuple, Optional, Mapping, List
+from typing import List, Mapping, NamedTuple, Optional
 
 
 # An immutable reference to a custom resource definition.

--- a/kopf/toolkits/hierarchies.py
+++ b/kopf/toolkits/hierarchies.py
@@ -1,12 +1,10 @@
 """
 All the functions to properly build the object hierarchies.
 """
-from typing import Optional, Iterable, Iterator, cast, Mapping, MutableMapping, Any, Union
+from typing import Any, Iterable, Iterator, Mapping, MutableMapping, Optional, Union, cast
 
-from kopf.reactor import causation
-from kopf.reactor import handling
-from kopf.structs import bodies
-from kopf.structs import dicts
+from kopf.reactor import causation, handling
+from kopf.structs import bodies, dicts
 
 K8sObject = MutableMapping[Any, Any]
 K8sObjects = Union[K8sObject, Iterable[K8sObject]]

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -7,17 +7,11 @@ with an incompatible class hierarchy and method signatures.
 """
 import abc
 import warnings
-from typing import Any, Union, Sequence, Iterator, Container, Optional
+from typing import Any, Container, Iterator, Optional, Sequence, Union
 
-from kopf.reactor import causation
-from kopf.reactor import registries
-from kopf.structs import bodies
-from kopf.structs import callbacks
-from kopf.structs import dicts
-from kopf.structs import filters
-from kopf.structs import handlers
-from kopf.structs import patches
-from kopf.structs import resources as resources_
+from kopf.reactor import causation, registries
+from kopf.structs import (bodies, callbacks, dicts, filters,
+                          handlers, patches, resources as resources_)
 
 AnyCause = Union[causation.ResourceWatchingCause, causation.ResourceChangingCause]
 AnyHandler = Union[handlers.ResourceWatchingHandler, handlers.ResourceChangingHandler]

--- a/kopf/toolkits/runner.py
+++ b/kopf/toolkits/runner.py
@@ -3,7 +3,7 @@ import concurrent.futures
 import contextlib
 import threading
 import types
-from typing import cast, Any, Optional, Tuple, Type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Type, cast
 
 import click.testing
 from typing_extensions import Literal

--- a/kopf/utilities/piggybacking.py
+++ b/kopf/utilities/piggybacking.py
@@ -12,7 +12,7 @@ in them, and extracts the basic credentials for its own use.
 """
 import logging
 import warnings
-from typing import Any, Union, Optional, Sequence
+from typing import Any, Optional, Sequence, Union
 
 from kopf.clients import auth
 from kopf.structs import credentials

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os.path
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as f:
     LONG_DESCRIPTION = f.read()

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -2,8 +2,8 @@ import pytest
 
 from kopf.reactor.activities import authenticate
 from kopf.reactor.registries import OperatorRegistry
-from kopf.structs.credentials import Vault, ConnectionInfo, LoginError
-from kopf.structs.handlers import ActivityHandler, Activity
+from kopf.structs.credentials import ConnectionInfo, LoginError, Vault
+from kopf.structs.handlers import Activity, ActivityHandler
 
 
 async def test_empty_registry_produces_no_credentials(settings):

--- a/tests/authentication/test_connectioninfo.py
+++ b/tests/authentication/test_connectioninfo.py
@@ -1,4 +1,4 @@
-from kopf.structs.credentials import VaultKey, ConnectionInfo
+from kopf.structs.credentials import ConnectionInfo, VaultKey
 
 
 def test_key_as_string():

--- a/tests/authentication/test_credentials.py
+++ b/tests/authentication/test_credentials.py
@@ -4,8 +4,8 @@ import textwrap
 
 import pytest
 
-from kopf.clients.auth import reauthenticated_request, vault_var, APIContext
-from kopf.structs.credentials import Vault, ConnectionInfo
+from kopf.clients.auth import APIContext, reauthenticated_request, vault_var
+from kopf.structs.credentials import ConnectionInfo, Vault
 
 # These are Minikube's locally geenrated certificates (CN=minikubeCA).
 # They are not in any public use, and are regenerated regularly.

--- a/tests/authentication/test_login.py
+++ b/tests/authentication/test_login.py
@@ -2,9 +2,8 @@
 Remember: We do not test the clients, we assume they work when used properly.
 We test our own functions here, and check if the clients were called.
 """
-import pytest
-
 import pykube
+import pytest
 
 from kopf import login
 

--- a/tests/authentication/test_reauthentication.py
+++ b/tests/authentication/test_reauthentication.py
@@ -1,4 +1,4 @@
-from typing import Optional, AsyncIterator, Tuple
+from typing import AsyncIterator, Optional, Tuple
 
 import aiohttp.web
 

--- a/tests/authentication/test_vault.py
+++ b/tests/authentication/test_vault.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kopf.structs.credentials import Vault, ConnectionInfo, VaultKey, LoginError
+from kopf.structs.credentials import ConnectionInfo, LoginError, Vault, VaultKey
 
 
 async def test_evals_as_false_when_empty():

--- a/tests/basic-structs/test_causes.py
+++ b/tests/basic-structs/test_causes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kopf.reactor.causation import ActivityCause, ResourceWatchingCause, ResourceChangingCause
+from kopf.reactor.causation import ActivityCause, ResourceChangingCause, ResourceWatchingCause
 
 
 @pytest.mark.parametrize('cls', [ActivityCause, ResourceWatchingCause, ResourceChangingCause])

--- a/tests/basic-structs/test_containers.py
+++ b/tests/basic-structs/test_containers.py
@@ -3,7 +3,7 @@ import collections.abc
 import pytest
 
 from kopf.structs.bodies import Body
-from kopf.structs.containers import ResourceMemory, ResourceMemories, Memo
+from kopf.structs.containers import Memo, ResourceMemories, ResourceMemory
 
 BODY: Body = {
     'metadata': {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,10 @@ import pytest_mock
 
 import kopf
 from kopf.clients.auth import APIContext
-from kopf.engines.logging import configure, ObjectPrefixingFormatter
+from kopf.engines.logging import ObjectPrefixingFormatter, configure
 from kopf.engines.posting import settings_var
 from kopf.structs.configuration import OperatorSettings
-from kopf.structs.credentials import Vault, VaultKey, ConnectionInfo
+from kopf.structs.credentials import ConnectionInfo, Vault, VaultKey
 from kopf.structs.resources import Resource
 
 

--- a/tests/diffs/test_reduction.py
+++ b/tests/diffs/test_reduction.py
@@ -1,7 +1,6 @@
 import pytest
 
-from kopf.structs.diffs import reduce, Diff, DiffItem, DiffOperation
-
+from kopf.structs.diffs import Diff, DiffItem, DiffOperation, reduce
 
 DIFF = Diff([
     DiffItem(DiffOperation.ADD   , ('key1',), None, 'new1'),

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,7 +1,5 @@
 import glob
 import os.path
-import re
-
 import pathlib
 import subprocess
 

--- a/tests/handling/daemons/test_daemon_filtration.py
+++ b/tests/handling/daemons/test_daemon_filtration.py
@@ -4,7 +4,6 @@ import pytest
 
 import kopf
 
-
 # We assume that the handler filtering is tested in details elsewhere (for all handlers).
 # Here, we only test if it is applied or not applied.
 

--- a/tests/handling/daemons/test_timer_filtration.py
+++ b/tests/handling/daemons/test_timer_filtration.py
@@ -4,7 +4,6 @@ import pytest
 
 import kopf
 
-
 # We assume that the handler filtering is tested in details elsewhere (for all handlers).
 # Here, we only test if it is applied or not applied.
 

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -8,7 +8,7 @@ from kopf.reactor.handling import PermanentError, TemporaryError
 from kopf.reactor.lifecycles import all_at_once
 from kopf.reactor.registries import OperatorRegistry
 from kopf.storage.states import HandlerOutcome
-from kopf.structs.handlers import HandlerId, ActivityHandler, Activity
+from kopf.structs.handlers import Activity, ActivityHandler, HandlerId
 
 
 def test_activity_error_exception():

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -6,7 +6,7 @@ import pytest
 import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
-from kopf.structs.handlers import Reason, HANDLER_REASONS, ALL_REASONS
+from kopf.structs.handlers import ALL_REASONS, HANDLER_REASONS, Reason
 
 
 @pytest.mark.parametrize('cause_type', ALL_REASONS)

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -7,10 +7,10 @@ import pytest
 
 import kopf
 from kopf.reactor.handling import TemporaryError
-from kopf.reactor.processing import process_resource_event, WAITING_KEEPALIVE_INTERVAL
+from kopf.reactor.processing import WAITING_KEEPALIVE_INTERVAL, process_resource_event
 from kopf.storage.states import HandlerState
 from kopf.structs.containers import ResourceMemories
-from kopf.structs.handlers import Reason, HANDLER_REASONS
+from kopf.structs.handlers import HANDLER_REASONS, Reason
 
 
 @pytest.mark.parametrize('cause_reason', HANDLER_REASONS)

--- a/tests/handling/test_errors.py
+++ b/tests/handling/test_errors.py
@@ -7,7 +7,7 @@ import kopf
 from kopf.reactor.handling import PermanentError, TemporaryError
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
-from kopf.structs.handlers import Reason, HANDLER_REASONS
+from kopf.structs.handlers import HANDLER_REASONS, Reason
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -5,7 +5,7 @@ import pytest
 import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
-from kopf.structs.handlers import Reason, HANDLER_REASONS
+from kopf.structs.handlers import HANDLER_REASONS, Reason
 
 
 @pytest.mark.parametrize('deletion_ts', [

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -7,7 +7,7 @@ import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.storage.diffbase import LAST_SEEN_ANNOTATION
 from kopf.structs.containers import ResourceMemories
-from kopf.structs.handlers import ResourceChangingHandler, HANDLER_REASONS
+from kopf.structs.handlers import HANDLER_REASONS, ResourceChangingHandler
 
 
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -7,7 +7,7 @@ import pytest
 import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
-from kopf.structs.handlers import Reason, HANDLER_REASONS
+from kopf.structs.handlers import HANDLER_REASONS, Reason
 
 
 # The timeout is hard-coded in conftest.py:handlers().

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -6,7 +6,7 @@ import kopf
 from kopf.reactor.causation import ResourceChangingCause, ResourceWatchingCause
 from kopf.reactor.handling import cause_var
 from kopf.reactor.invocation import context
-from kopf.structs.bodies import RawBody, RawMeta, RawEvent, Body
+from kopf.structs.bodies import Body, RawBody, RawEvent, RawMeta
 from kopf.structs.containers import Memo
 from kopf.structs.handlers import Reason
 from kopf.structs.patches import Patch

--- a/tests/hierarchies/test_namespace_adjusting.py
+++ b/tests/hierarchies/test_namespace_adjusting.py
@@ -1,6 +1,5 @@
 import kopf
 
-
 #
 # If namespace is set, it should be preserved, unmodified.
 #

--- a/tests/hierarchies/test_owner_referencing.py
+++ b/tests/hierarchies/test_owner_referencing.py
@@ -1,9 +1,8 @@
 import copy
-
-from unittest.mock import call, Mock
+from unittest.mock import Mock, call
 
 import kopf
-from kopf.structs.bodies import RawBody, RawMeta, Body
+from kopf.structs.bodies import Body, RawBody, RawMeta
 
 OWNER_API_VERSION = 'owner-api-version'
 OWNER_NAMESPACE = 'owner-namespace'

--- a/tests/k8s/test_events.py
+++ b/tests/k8s/test_events.py
@@ -1,8 +1,8 @@
 import aiohttp.web
 import pytest
 
+from kopf.clients.events import EVENTS_CORE_V1_CRD, EVENTS_V1BETA1_CRD, post_event
 from kopf.structs.bodies import build_object_reference
-from kopf.clients.events import post_event, EVENTS_V1BETA1_CRD, EVENTS_CORE_V1_CRD
 
 
 async def test_posting(

--- a/tests/k8s/test_read_crd.py
+++ b/tests/k8s/test_read_crd.py
@@ -1,7 +1,7 @@
 import aiohttp.web
 import pytest
 
-from kopf.clients.fetching import read_crd, CRD_CRD
+from kopf.clients.fetching import CRD_CRD, read_crd
 
 
 async def test_when_present(

--- a/tests/k8s/test_watching.py
+++ b/tests/k8s/test_watching.py
@@ -14,7 +14,7 @@ import logging
 import aiohttp
 import pytest
 
-from kopf.clients.watching import streaming_watch, infinite_watch, WatchingError
+from kopf.clients.watching import WatchingError, infinite_watch, streaming_watch
 from kopf.structs.primitives import Toggle
 
 STREAM_WITH_NORMAL_EVENTS = [

--- a/tests/k8s/test_watching_iterjsonlines.py
+++ b/tests/k8s/test_watching_iterjsonlines.py
@@ -1,4 +1,5 @@
 import asynctest
+
 from kopf.clients.watching import _iter_jsonlines
 
 

--- a/tests/lifecycles/test_handler_selection.py
+++ b/tests/lifecycles/test_handler_selection.py
@@ -1,7 +1,7 @@
 import pytest
 
 import kopf
-from kopf.storage.states import State, HandlerOutcome
+from kopf.storage.states import HandlerOutcome, State
 
 
 @pytest.mark.parametrize('lifecycle', [

--- a/tests/peering/test_apply_peers.py
+++ b/tests/peering/test_apply_peers.py
@@ -2,8 +2,8 @@ import aiohttp.web
 import freezegun
 import pytest
 
-from kopf.engines.peering import NAMESPACED_PEERING_RESOURCE, CLUSTER_PEERING_RESOURCE
-from kopf.engines.peering import Peer, apply_peers
+from kopf.engines.peering import (CLUSTER_PEERING_RESOURCE,
+                                  NAMESPACED_PEERING_RESOURCE, Peer, apply_peers)
 
 
 @pytest.mark.usefixtures('with_both_crds')

--- a/tests/peering/test_freeze_mode.py
+++ b/tests/peering/test_freeze_mode.py
@@ -4,7 +4,7 @@ import freezegun
 import pytest
 
 from kopf.engines.peering import Peer, process_peering_event
-from kopf.structs import primitives, bodies
+from kopf.structs import bodies, primitives
 
 
 @pytest.mark.parametrize('our_name, our_namespace, their_name, their_namespace', [

--- a/tests/peering/test_peer_detection.py
+++ b/tests/peering/test_peer_detection.py
@@ -2,11 +2,8 @@ import re
 
 import pytest
 
-from kopf.engines.peering import (
-    Peer, PEERING_DEFAULT_NAME,
-    CLUSTER_PEERING_RESOURCE, NAMESPACED_PEERING_RESOURCE,
-)
-
+from kopf.engines.peering import (CLUSTER_PEERING_RESOURCE, NAMESPACED_PEERING_RESOURCE,
+                                  PEERING_DEFAULT_NAME, Peer)
 
 # Note: the legacy peering is intentionally not tested: it was long time before
 # these tests were written, so it does not make sense to keep it stable.

--- a/tests/peering/test_peers.py
+++ b/tests/peering/test_peers.py
@@ -3,10 +3,8 @@ import datetime
 import freezegun
 import pytest
 
-from kopf.engines.peering import (
-    Peer,
-    CLUSTER_PEERING_RESOURCE, NAMESPACED_PEERING_RESOURCE, LEGACY_PEERING_RESOURCE,
-)
+from kopf.engines.peering import (CLUSTER_PEERING_RESOURCE, LEGACY_PEERING_RESOURCE,
+                                  NAMESPACED_PEERING_RESOURCE, Peer)
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')

--- a/tests/persistence/test_annotations_hashing.py
+++ b/tests/persistence/test_annotations_hashing.py
@@ -2,10 +2,10 @@ import json
 
 import pytest
 
+from kopf.storage.progress import AnnotationsProgressStorage, ProgressRecord, SmartProgressStorage
 from kopf.structs.bodies import Body
 from kopf.structs.handlers import HandlerId
 from kopf.structs.patches import Patch
-from kopf.storage.progress import ProgressRecord, AnnotationsProgressStorage, SmartProgressStorage
 
 ANNOTATIONS_POPULATING_STORAGES = [AnnotationsProgressStorage, SmartProgressStorage]
 

--- a/tests/persistence/test_essences.py
+++ b/tests/persistence/test_essences.py
@@ -2,8 +2,8 @@ from typing import Type
 
 import pytest
 
-from kopf.storage.diffbase import DiffBaseStorage, AnnotationsDiffBaseStorage, StatusDiffBaseStorage
-from kopf.storage.diffbase import LAST_SEEN_ANNOTATION
+from kopf.storage.diffbase import (LAST_SEEN_ANNOTATION, AnnotationsDiffBaseStorage,
+                                   DiffBaseStorage, StatusDiffBaseStorage)
 from kopf.structs.bodies import Body
 
 ALL_STORAGES = [AnnotationsDiffBaseStorage, StatusDiffBaseStorage]

--- a/tests/persistence/test_states.py
+++ b/tests/persistence/test_states.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import freezegun
 import pytest
 
-from kopf.storage.progress import StatusProgressStorage, SmartProgressStorage
+from kopf.storage.progress import SmartProgressStorage, StatusProgressStorage
 from kopf.storage.states import HandlerOutcome, State, deliver_results
 from kopf.structs.bodies import Body
 from kopf.structs.patches import Patch

--- a/tests/persistence/test_storing_of_diffbase.py
+++ b/tests/persistence/test_storing_of_diffbase.py
@@ -3,12 +3,11 @@ from typing import Type
 
 import pytest
 
-from kopf.storage.diffbase import (
-    DiffBaseStorage, AnnotationsDiffBaseStorage, StatusDiffBaseStorage, MultiDiffBaseStorage,
-)
+from kopf.storage.diffbase import (AnnotationsDiffBaseStorage, DiffBaseStorage,
+                                   MultiDiffBaseStorage, StatusDiffBaseStorage)
 from kopf.structs.bodies import Body, BodyEssence
-from kopf.structs.patches import Patch
 from kopf.structs.dicts import FieldSpec
+from kopf.structs.patches import Patch
 
 
 class DualDiffBaseStore(MultiDiffBaseStorage):

--- a/tests/persistence/test_storing_of_progress.py
+++ b/tests/persistence/test_storing_of_progress.py
@@ -3,13 +3,11 @@ from typing import Type
 
 import pytest
 
+from kopf.storage.progress import (AnnotationsProgressStorage, ProgressRecord, ProgressStorage,
+                                   SmartProgressStorage, StatusProgressStorage)
 from kopf.structs.bodies import Body
 from kopf.structs.handlers import HandlerId
 from kopf.structs.patches import Patch
-from kopf.storage.progress import (
-    ProgressStorage, ProgressRecord,
-    AnnotationsProgressStorage, StatusProgressStorage, SmartProgressStorage,
-)
 
 ALL_STORAGES = [AnnotationsProgressStorage, StatusProgressStorage, SmartProgressStorage]
 ANNOTATIONS_POPULATING_STORAGES = [AnnotationsProgressStorage, SmartProgressStorage]

--- a/tests/posting/conftest.py
+++ b/tests/posting/conftest.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from kopf.engines.posting import event_queue_var, event_queue_loop_var
+from kopf.engines.posting import event_queue_loop_var, event_queue_var
 
 
 @pytest.fixture()

--- a/tests/posting/test_log2k8s.py
+++ b/tests/posting/test_log2k8s.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from kopf.engines.logging import ObjectLogger, LocalObjectLogger
+from kopf.engines.logging import LocalObjectLogger, ObjectLogger
 
 OBJ1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
         'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1'}}

--- a/tests/posting/test_poster.py
+++ b/tests/posting/test_poster.py
@@ -4,8 +4,9 @@ import logging
 import pytest
 from asynctest import call
 
-from kopf import event, info, warn, exception
-from kopf.engines.posting import poster, K8sEvent, event_queue_var, event_queue_loop_var, settings_var
+from kopf import event, exception, info, warn
+from kopf.engines.posting import (K8sEvent, event_queue_loop_var,
+                                  event_queue_var, poster, settings_var)
 
 OBJ1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
         'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1'}}

--- a/tests/primitives/test_flags.py
+++ b/tests/primitives/test_flags.py
@@ -4,7 +4,7 @@ import threading
 
 import pytest
 
-from kopf.structs.primitives import wait_flag, raise_flag
+from kopf.structs.primitives import raise_flag, wait_flag
 
 
 @pytest.fixture(params=[

--- a/tests/reactor/conftest.py
+++ b/tests/reactor/conftest.py
@@ -6,8 +6,7 @@ import pytest
 from asynctest import CoroutineMock
 
 from kopf.clients.watching import streaming_watch
-from kopf.reactor.queueing import watcher
-from kopf.reactor.queueing import worker as original_worker
+from kopf.reactor.queueing import watcher, worker as original_worker
 from kopf.structs.configuration import OperatorSettings
 
 

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -16,7 +16,7 @@ import weakref
 
 import pytest
 
-from kopf.reactor.queueing import watcher, EOS
+from kopf.reactor.queueing import EOS, watcher
 
 
 @pytest.mark.parametrize('uids, cnts, events', [

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -2,10 +2,11 @@ import logging
 
 import pytest
 
-from kopf import SimpleRegistry, GlobalRegistry  # deprecated, but tested
-from kopf.reactor.causation import ActivityCause, ResourceCause, ResourceWatchingCause, ResourceChangingCause
-from kopf.reactor.registries import ResourceRegistry, ActivityRegistry, OperatorRegistry
-from kopf.reactor.registries import ResourceWatchingRegistry, ResourceChangingRegistry
+from kopf import GlobalRegistry, SimpleRegistry  # deprecated, but tested
+from kopf.reactor.causation import (ActivityCause, ResourceCause,
+                                    ResourceChangingCause, ResourceWatchingCause)
+from kopf.reactor.registries import (ActivityRegistry, OperatorRegistry, ResourceChangingRegistry,
+                                     ResourceRegistry, ResourceWatchingRegistry)
 from kopf.structs.bodies import Body
 from kopf.structs.containers import Memo
 from kopf.structs.diffs import Diff, DiffItem

--- a/tests/registries/legacy-1/test_legacy1_creation.py
+++ b/tests/registries/legacy-1/test_legacy1_creation.py
@@ -1,4 +1,4 @@
-from kopf import BaseRegistry, SimpleRegistry, GlobalRegistry
+from kopf import BaseRegistry, GlobalRegistry, SimpleRegistry
 
 
 def test_creation_of_simple():

--- a/tests/registries/legacy-1/test_legacy1_decorators.py
+++ b/tests/registries/legacy-1/test_legacy1_decorators.py
@@ -1,9 +1,8 @@
 import pytest
 
 import kopf
-from kopf import SimpleRegistry, GlobalRegistry
-from kopf.reactor.handling import handler_var
-from kopf.reactor.handling import subregistry_var
+from kopf import GlobalRegistry, SimpleRegistry
+from kopf.reactor.handling import handler_var, subregistry_var
 from kopf.reactor.invocation import context
 from kopf.structs.handlers import Reason
 from kopf.structs.resources import Resource

--- a/tests/registries/legacy-1/test_legacy1_handler_matching.py
+++ b/tests/registries/legacy-1/test_legacy1_handler_matching.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from kopf import SimpleRegistry, GlobalRegistry
+from kopf import GlobalRegistry, SimpleRegistry
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.

--- a/tests/registries/legacy-1/test_legacy1_registering.py
+++ b/tests/registries/legacy-1/test_legacy1_registering.py
@@ -2,7 +2,7 @@ import collections.abc
 
 import pytest
 
-from kopf import SimpleRegistry, GlobalRegistry
+from kopf import GlobalRegistry, SimpleRegistry
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.

--- a/tests/registries/legacy-2/test_legacy2_decorators.py
+++ b/tests/registries/legacy-2/test_legacy2_decorators.py
@@ -1,10 +1,10 @@
 import pytest
 
 import kopf
-from kopf.reactor.handling import subregistry_var, handler_var
+from kopf.reactor.handling import handler_var, subregistry_var
 from kopf.reactor.invocation import context
 from kopf.reactor.registries import OperatorRegistry, ResourceChangingRegistry
-from kopf.structs.handlers import ErrorsMode, Activity, Reason, HANDLER_REASONS
+from kopf.structs.handlers import HANDLER_REASONS, Activity, ErrorsMode, Reason
 from kopf.structs.resources import Resource
 
 

--- a/tests/registries/legacy-2/test_legacy2_registering.py
+++ b/tests/registries/legacy-2/test_legacy2_registering.py
@@ -2,7 +2,7 @@ import collections.abc
 
 import pytest
 
-from kopf.reactor.causation import ResourceWatchingCause, ResourceChangingCause
+from kopf.reactor.causation import ResourceChangingCause, ResourceWatchingCause
 from kopf.structs.handlers import Activity
 
 

--- a/tests/registries/legacy-2/test_legacy2_resumes_mixed_in.py
+++ b/tests/registries/legacy-2/test_legacy2_resumes_mixed_in.py
@@ -1,7 +1,7 @@
 import pytest
 
 import kopf
-from kopf.structs.handlers import Reason, HANDLER_REASONS
+from kopf.structs.handlers import HANDLER_REASONS, Reason
 from kopf.structs.resources import Resource
 
 

--- a/tests/registries/test_creation.py
+++ b/tests/registries/test_creation.py
@@ -1,4 +1,4 @@
-from kopf import ActivityRegistry, ResourceRegistry, OperatorRegistry
+from kopf import ActivityRegistry, OperatorRegistry, ResourceRegistry
 
 
 def test_activity_registry(activity_registry_cls):

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -1,10 +1,10 @@
 import pytest
 
 import kopf
-from kopf.reactor.handling import subregistry_var, handler_var
+from kopf.reactor.handling import handler_var, subregistry_var
 from kopf.reactor.invocation import context
 from kopf.reactor.registries import OperatorRegistry, ResourceChangingRegistry
-from kopf.structs.handlers import ErrorsMode, Activity, Reason, HANDLER_REASONS
+from kopf.structs.handlers import HANDLER_REASONS, Activity, ErrorsMode, Reason
 from kopf.structs.resources import Resource
 
 

--- a/tests/registries/test_decorators_deprecated_cooldown.py
+++ b/tests/registries/test_decorators_deprecated_cooldown.py
@@ -1,7 +1,7 @@
 import pytest
 
 import kopf
-from kopf.structs.handlers import Activity, Reason, HANDLER_REASONS
+from kopf.structs.handlers import HANDLER_REASONS, Activity, Reason
 from kopf.structs.resources import Resource
 
 

--- a/tests/registries/test_handler_getting.py
+++ b/tests/registries/test_handler_getting.py
@@ -2,7 +2,7 @@ import collections.abc
 
 import pytest
 
-from kopf.reactor.causation import ResourceWatchingCause, ResourceChangingCause
+from kopf.reactor.causation import ResourceChangingCause, ResourceWatchingCause
 from kopf.structs.handlers import Activity
 
 

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -7,9 +7,9 @@ from kopf import OperatorRegistry
 from kopf.reactor.causation import ResourceChangingCause
 from kopf.structs.bodies import Body
 from kopf.structs.dicts import parse_field
-from kopf.structs.diffs import DiffOperation, DiffItem, Diff, EMPTY
+from kopf.structs.diffs import EMPTY, Diff, DiffItem, DiffOperation
 from kopf.structs.filters import MetaFilterToken
-from kopf.structs.handlers import ResourceChangingHandler, Reason, ALL_REASONS
+from kopf.structs.handlers import ALL_REASONS, Reason, ResourceChangingHandler
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.

--- a/tests/registries/test_resumes_mixed_in.py
+++ b/tests/registries/test_resumes_mixed_in.py
@@ -1,7 +1,7 @@
 import pytest
 
 import kopf
-from kopf.structs.handlers import Reason, HANDLER_REASONS
+from kopf.structs.handlers import HANDLER_REASONS, Reason
 from kopf.structs.resources import Resource
 
 

--- a/tests/test_finalizers.py
+++ b/tests/test_finalizers.py
@@ -1,8 +1,7 @@
 import pytest
 
-from kopf.storage.finalizers import LEGACY_FINALIZER
-from kopf.storage.finalizers import block_deletion, allow_deletion
-from kopf.storage.finalizers import is_deletion_ongoing, is_deletion_blocked
+from kopf.storage.finalizers import (LEGACY_FINALIZER, allow_deletion, block_deletion,
+                                     is_deletion_blocked, is_deletion_ongoing)
 
 
 def test_finalizer_is_fqdn(settings):

--- a/tests/test_liveness.py
+++ b/tests/test_liveness.py
@@ -5,7 +5,7 @@ import pytest
 
 from kopf.engines.probing import health_reporter
 from kopf.reactor.registries import OperatorRegistry
-from kopf.structs.handlers import ActivityHandler, Activity
+from kopf.structs.handlers import Activity, ActivityHandler
 
 
 @pytest.fixture()

--- a/tests/test_sleeping.py
+++ b/tests/test_sleeping.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import pytest
 
 from kopf.engines.sleeping import sleep_or_wait


### PR DESCRIPTION
# What do these changes do?

Refactoring: sort imports with `isort`, combine same-source module imports to one statement.


## Description

Same-source "from"-imports are compacted into one statement, same as PyCharm tries to auto-format them when refactoring.

This is now done only once manually, but later can become the automated code linting step.

Note that the examples consider `kopf` as a third-party library — the same as it would be with the real Kopf-based operators.



## Issues/PRs

> Issues: 

> Related:


## Type of changes

- Refactoring (non-breaking change which does not alter the behaviour)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
