### PR TITLE
Warn on inconsistencies of a patch and a patched object

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ and [Historic GitHub Contributors](https://github.com/zalando-incubator/kopf/gra
 - [Daniel Middlecote](https://github.com/dlmiddlecote)
 - [Henning Jacobs](https://github.com/hjacobs)
 - [Ismail Kaboubi](https://github.com/smileisak)
+- [Michael Narodovitch](https://github.com/michaelnarodovitch)
 - [Sergey Vasilyev](https://github.com/nolar)
 - [Soroosh Sarabadani](https://github.com/psycho-ir)
 - [Trond Hindenes](https://github.com/trondhindenes)

--- a/kopf/clients/patching.py
+++ b/kopf/clients/patching.py
@@ -15,7 +15,7 @@ async def patch_obj(
         name: Optional[str] = None,
         body: Optional[bodies.Body] = None,
         context: Optional[auth.APIContext] = None,  # injected by the decorator
-) -> None:
+) -> bodies.RawBody:
     """
     Patch a resource of specific kind.
 
@@ -25,6 +25,12 @@ async def patch_obj(
     Unlike the object listing, the namespaced call is always
     used for the namespaced resources, even if the operator serves
     the whole cluster (i.e. is not namespace-restricted).
+
+    Returns the patched body. The patched body can be partial (status-only,
+    no-status, or empty) -- depending on whether there were fields in the body
+    or in the status to patch; if neither had fields for patching, the result
+    is an empty body. The result should only be used to check against the patch:
+    if there was nothing to patch, it does not matter if the fields are absent.
     """
     if context is None:
         raise RuntimeError("API instance is not injected by the decorator.")
@@ -47,24 +53,34 @@ async def patch_obj(
     body_patch = dict(patch)  # shallow: for mutation of the top-level keys below.
     status_patch = body_patch.pop('status', None) if as_subresource else None
 
+    # Patch & reconstruct the actual body as reported by the server. The reconstructed body can be
+    # partial or empty -- if the body/status patches are empty. This is fine: it is only used
+    # to verify that the patched fields are matching the patch. No patch? No mismatch!
+    patched_body = bodies.RawBody()
     try:
         if body_patch:
-            await context.session.patch(
+            response = await context.session.patch(
                 url=resource.get_url(server=context.server, namespace=namespace, name=name),
                 headers={'Content-Type': 'application/merge-patch+json'},
                 json=body_patch,
                 raise_for_status=True,
             )
+            patched_body = await response.json()
+
         if status_patch:
-            await context.session.patch(
+            response = await context.session.patch(
                 url=resource.get_url(server=context.server, namespace=namespace, name=name,
                                      subresource='status' if as_subresource else None),
                 headers={'Content-Type': 'application/merge-patch+json'},
                 json={'status': status_patch},
                 raise_for_status=True,
             )
+            patched_body['status'] = await response.json()
+
     except aiohttp.ClientResponseError as e:
         if e.status == 404:
             pass
         else:
             raise
+
+    return patched_body

--- a/tests/diffs/test_calculation.py
+++ b/tests/diffs/test_calculation.py
@@ -1,101 +1,133 @@
-from kopf.structs.diffs import diff
+import pytest
+
+from kopf.structs.diffs import DiffScope, diff
 
 
-def test_none_for_old():
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_none_for_old(scope):
     a = None
     b = object()
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == (('add', (), None, b),)
 
 
-def test_none_for_new():
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_none_for_new(scope):
     a = object()
     b = None
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == (('remove', (), a, None),)
 
 
-def test_nones_for_both():
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_nones_for_both(scope):
     a = None
     b = None
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == ()
 
 
-def test_scalars_equal():
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_scalars_equal(scope):
     a = 100
     b = 100
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == ()
 
 
-def test_scalars_unequal():
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_scalars_unequal(scope):
     a = 100
     b = 200
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == (('change', (), 100, 200),)
 
 
-def test_strings_equal():
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_strings_equal(scope):
     a = 'hello'
     b = 'hello'
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == ()
 
 
-def test_strings_unequal():
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_strings_unequal(scope):
     a = 'hello'
     b = 'world'
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == (('change', (), 'hello', 'world'),)
 
 
-def test_lists_equal():
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_lists_equal(scope):
     a = [100, 200, 300]
     b = [100, 200, 300]
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == ()
 
 
-def test_lists_unequal():
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_lists_unequal(scope):
     a = [100, 200, 300]
     b = [100, 666, 300]
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == (('change', (), [100, 200, 300], [100, 666, 300]),)
 
 
-def test_dicts_equal():
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_dicts_equal(scope):
     a = {'hello': 'world', 'key': 'val'}
     b = {'key': 'val', 'hello': 'world'}
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == ()
 
 
-def test_dicts_with_keys_added():
+@pytest.mark.parametrize('scope', [DiffScope.FULL, DiffScope.RIGHT])
+def test_dicts_with_keys_added_and_noticed(scope):
     a = {'hello': 'world'}
     b = {'hello': 'world', 'key': 'val'}
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == (('add', ('key',), None, 'val'),)
 
 
-def test_dicts_with_keys_removed():
+@pytest.mark.parametrize('scope', [DiffScope.LEFT])
+def test_dicts_with_keys_added_but_ignored(scope):
+    a = {'hello': 'world'}
+    b = {'hello': 'world', 'key': 'val'}
+    d = diff(a, b, scope=scope)
+    assert d == ()
+
+
+@pytest.mark.parametrize('scope', [DiffScope.FULL, DiffScope.LEFT])
+def test_dicts_with_keys_removed_and_noticed(scope):
     a = {'hello': 'world', 'key': 'val'}
     b = {'hello': 'world'}
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == (('remove', ('key',), 'val', None),)
 
 
-def test_dicts_with_keys_changed():
+@pytest.mark.parametrize('scope', [DiffScope.RIGHT])
+def test_dicts_with_keys_removed_but_ignored(scope):
+    a = {'hello': 'world', 'key': 'val'}
+    b = {'hello': 'world'}
+    d = diff(a, b, scope=scope)
+    assert d == ()
+
+
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_dicts_with_keys_changed(scope):
     a = {'hello': 'world', 'key': 'old'}
     b = {'hello': 'world', 'key': 'new'}
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == (('change', ('key',), 'old', 'new'),)
 
 
-def test_dicts_with_subkeys_changed():
+@pytest.mark.parametrize('scope', list(DiffScope))
+def test_dicts_with_subkeys_changed(scope):
     a = {'main': {'hello': 'world', 'key': 'old'}}
     b = {'main': {'hello': 'world', 'key': 'new'}}
-    d = diff(a, b)
+    d = diff(a, b, scope=scope)
     assert d == (('change', ('main', 'key'), 'old', 'new'),)
 
 

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -54,7 +54,7 @@ class K8sMocks:
 def k8s_mocked(mocker, resp_mocker):
     # We mock on the level of our own K8s API wrappers, not the K8s client.
     return K8sMocks(
-        patch_obj=mocker.patch('kopf.clients.patching.patch_obj'),
+        patch_obj=mocker.patch('kopf.clients.patching.patch_obj', return_value={}),
         post_event=mocker.patch('kopf.clients.events.post_event'),
         sleep_or_wait=mocker.patch('kopf.reactor.effects.sleep_or_wait', return_value=None),
     )

--- a/tests/reactor/test_patching_inconsistencies.py
+++ b/tests/reactor/test_patching_inconsistencies.py
@@ -34,6 +34,12 @@ from kopf.structs.patches import Patch
     pytest.param({'spec': {'x': None}, 'status': {'s': None}},
                  {'spec': {}, 'status': {}},
                  id='response-clean'),
+
+    # False-positive inconsistencies for K8s-managed fields.
+    pytest.param({'metadata': {'annotations': {}}}, {'metadata': {}}, id='false-annotations'),
+    pytest.param({'metadata': {'finalizers': []}}, {'metadata': {}}, id='false-finalizers'),
+    pytest.param({'metadata': {'labels': {}}}, {'metadata': {}}, id='false-labels'),
+
 ])
 async def test_patching_without_inconsistencies(
         resource, settings, caplog, assert_logs, version_api,
@@ -90,6 +96,12 @@ async def test_patching_without_inconsistencies(
     pytest.param({'spec': {'x': None}, 'status': {'s': None}},
                  {'spec': {}, 'status': {'s': 't'}},
                  id='response-status-undeleted'),
+
+    # True-positive inconsistencies for K8s-managed fields with possible false-positives.
+    pytest.param({'metadata': {'annotations': {'x': 'y'}}}, {'metadata': {}}, id='true-annotations'),
+    pytest.param({'metadata': {'finalizers': ['x', 'y']}}, {'metadata': {}}, id='true-finalizers'),
+    pytest.param({'metadata': {'labels': {'x': 'y'}}}, {'metadata': {}}, id='true-labels'),
+
 ])
 async def test_patching_with_inconsistencies(
         resource, settings, caplog, assert_logs, version_api,

--- a/tests/reactor/test_patching_inconsistencies.py
+++ b/tests/reactor/test_patching_inconsistencies.py
@@ -1,0 +1,116 @@
+import logging
+
+import aiohttp.web
+import pytest
+
+from kopf.engines.loggers import LocalObjectLogger
+from kopf.reactor.effects import patch_and_check
+from kopf.structs.bodies import Body
+from kopf.structs.patches import Patch
+
+# Assume that the underlying patch_obj() is already tested with/without status as a sub-resource.
+# Assume that the underlying diff() is already tested with left/right/full scopes and all values.
+# Test ONLY the logging/warning on patch-vs-response inconsistencies here.
+
+
+@pytest.mark.parametrize('patch, response', [
+
+    pytest.param({'spec': {'x': 'y'}, 'status': {'s': 't'}},
+                 {'spec': {'x': 'y'}, 'status': {'s': 't'}},
+                 id='response-exact'),
+
+    pytest.param({'spec': {'x': 'y'}, 'status': {'s': 't'}},
+                 {'spec': {'x': 'y'}, 'status': {'s': 't'}, 'metadata': '...'},
+                 id='response-root-extra'),
+
+    pytest.param({'spec': {'x': 'y'}, 'status': {'s': 't'}},
+                 {'spec': {'x': 'y', 'extra': '...'}, 'status': {'s': 't'}},
+                 id='response-spec-extra'),
+
+    pytest.param({'spec': {'x': 'y'}, 'status': {'s': 't'}},
+                 {'spec': {'x': 'y'}, 'status': {'s': 't', 'extra': '...'}},
+                 id='response-status-extra'),
+
+    pytest.param({'spec': {'x': None}, 'status': {'s': None}},
+                 {'spec': {}, 'status': {}},
+                 id='response-clean'),
+])
+async def test_patching_without_inconsistencies(
+        resource, settings, caplog, assert_logs, version_api,
+        aresponses, hostname, resp_mocker,
+        patch, response):
+    caplog.set_level(logging.DEBUG)
+
+    url = resource.get_url(namespace='ns1', name='name1')
+    patch_mock = resp_mocker(return_value=aiohttp.web.json_response(response))
+    aresponses.add(hostname, url, 'patch', patch_mock)
+
+    body = Body({'metadata': {'namespace': 'ns1', 'name': 'name1'}})
+    logger = LocalObjectLogger(body=body, settings=settings)
+    await patch_and_check(
+        resource=resource,
+        body=body,
+        patch=Patch(patch),
+        logger=logger,
+    )
+
+    assert_logs([
+        "Patching with:",
+    ], prohibited=[
+        "Patching failed with inconsistencies:",
+    ])
+
+
+@pytest.mark.parametrize('patch, response', [
+
+    pytest.param({'spec': {'x': 'y'}, 'status': {'s': 't'}},
+                 {},
+                 id='response-empty'),
+
+    pytest.param({'spec': {'x': 'y'}, 'status': {'s': 't'}},
+                 {'spec': {'x': 'y'}},
+                 id='response-status-lost'),
+
+    pytest.param({'spec': {'x': 'y'}, 'status': {'s': 't'}},
+                 {'status': {'s': 't'}},
+                 id='response-spec-lost'),
+
+    pytest.param({'spec': {'x': 'y'}, 'status': {'s': 't'}},
+                 {'spec': {'x': 'not-y'}, 'status': {'s': 't'}},
+                 id='response-spec-altered'),
+
+    pytest.param({'spec': {'x': 'y'}, 'status': {'s': 't'}},
+                 {'spec': {'x': 'y'}, 'status': {'s': 'not-t'}},
+                 id='response-status-altered'),
+
+    pytest.param({'spec': {'x': None}, 'status': {'s': None}},
+                 {'spec': {'x': 'y'}, 'status': {}},
+                 id='response-spec-undeleted'),
+
+    pytest.param({'spec': {'x': None}, 'status': {'s': None}},
+                 {'spec': {}, 'status': {'s': 't'}},
+                 id='response-status-undeleted'),
+])
+async def test_patching_with_inconsistencies(
+        resource, settings, caplog, assert_logs, version_api,
+        aresponses, hostname, resp_mocker,
+        patch, response):
+    caplog.set_level(logging.DEBUG)
+
+    url = resource.get_url(namespace='ns1', name='name1')
+    patch_mock = resp_mocker(return_value=aiohttp.web.json_response(response))
+    aresponses.add(hostname, url, 'patch', patch_mock)
+
+    body = Body({'metadata': {'namespace': 'ns1', 'name': 'name1'}})
+    logger = LocalObjectLogger(body=body, settings=settings)
+    await patch_and_check(
+        resource=resource,
+        body=body,
+        patch=Patch(patch),
+        logger=logger,
+    )
+
+    assert_logs([
+        "Patching with:",
+        "Patching failed with inconsistencies:",
+    ])


### PR DESCRIPTION
## What do these changes do?

Warn (in logs) if the patched object does not match the patch as a result of the PATCH operation. This should make such cases easier to debug, as they will be at least visible (previously, completely hidden).

## Description

In some cases, when Kopf wanted to PATCH an object, the PATCH API request was performed, but the object didn't actually change. K8s API returns status 2xx for that, so the request is believed to be successful. This issue happened on multiple occasions:

* The most often one was caused by the introduction of "structural schemas" in K8s 1.16+, when CRDs didn't have `x-kubernetes-preserve-unknown-fields: true` set on `.status`. As a result, state persistence was lost after the first handler, and the next handling cycle was not invoked.
* With "status as a sub-resource" kind of CRDs, while Kopf didn't know about sub-resources yet. The results were the same: the status was not persisted, the next cycle was not called.
* It can also happen in the future if another logic is added to K8s, so that in a PATCH request the data is not stored (speculatively: e.g. because of the field ownership by different operators).

Now, Kopf reconstructs the patched object from the responses of the PATCH requests (1 or 2 of per call) and compares that reconstructed object with the patch. If some patched fields mismatch, a warning is logged.

Note that the reconstructed object is not exactly the full object: it can be only the status stanza, or the main object without status, or an empty object — depending on which PATCH requests were actually needed and performed.

All object fields that are not in the patch, are ignored: this is normal that something changes remotely without this specific operator knowing: e.g. metadata's resourceVersion/generation fields are updated by K8s itself, other operators and controllers can store additional status fields or labels or annotations. As long as they are not in the scope of the current operator's intentions to modify the object, they are irrelevant.


## Issues/PRs

<!-- Cross-referencing is highly useful in hindsight. Put the main issue, and all the related/affected/causing/preceding issues and PRs related to this change. --> 

> Issues: #308 #321 #358 (and maybe more)

> Related: replaces #339 


## Type of changes

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (non-breaking change which does not alter the behaviour)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
