### PR TITLE
Double the timing expectations for the queue batching tests

### DIFF
--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -135,8 +135,8 @@ async def test_watchevent_batching(settings, resource, processor, timer, overhea
         )
 
     # Significantly less than the queue getting timeout, but sufficient to run.
-    # 2x: 1 pull for the event chain + 1 pull for EOS. TODO: 1x must be enough.
-    assert overhead.min < timer.seconds < settings.batching.batch_window + overhead.max
+    # 2x = 1x batch window on queue pulling of the event chain + 1x for the EOS token.
+    assert overhead.min < timer.seconds < 2 * settings.batching.batch_window + overhead.max
 
     # Was the processor called at all? Awaited as needed for async fns?
     assert processor.awaited


### PR DESCRIPTION
## What do these changes do?

Double the timing expectations for the queue-batching tests. 


## Description

Previously, before #522, the timing allowances were very broad, so the tests passed even if the number of "batching" attempts (and, therefore, timing) were different from expected.

Now, the timing allowances are dynamically & statistically calculated in the environment where it runs, with different overhead for the non-timed code. As a result, the timing allowances for the tests were narrowed to the strictly expected timing of each "batching" cycle plus overhead. As a result, the number of times this "baching" is performed started to matter.

In the queue batching test, there are 2 batches actually expected: one for a batch of events, another one for the EOS token when the watcher finishes. The tests were expecting only 1. 

Now, they will expected 2.

This only fixes the CI pipeline and does not affect the users.


## Issues/PRs

> Issues: #212 #338 

> Related: a follow-up for #522.


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- Bug fix (non-breaking change which fixes an issue)
- Mostly CI/CD automation, contribution experience


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
