### PR TITLE
Keep the lengthy handler names in the annotations if possible

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -202,7 +202,7 @@ To store the state only in the annotations with your own prefix:
 
     @kopf.on.startup()
     def configure(settings: kopf.OperatorSettings, **_):
-        settings.persistence.storage = kopf.AnnotationsStateStorage(prefix='my-op.example.com')
+        settings.persistence.progress_storage = kopf.AnnotationsProgressStorage(prefix='my-op.example.com')
 
 To store the state only in the status or any other field:
 
@@ -212,7 +212,7 @@ To store the state only in the status or any other field:
 
     @kopf.on.startup()
     def configure(settings: kopf.OperatorSettings, **_):
-        settings.persistence.storage = kopf.StatusStateStorage(field='status.my-operator')
+        settings.persistence.progress_storage = kopf.StatusProgressStorage(field='status.my-operator')
 
 To store in multiple places (stored in sync, but the first found state will be
 used when fetching, i.e. the first storage has precedence):
@@ -223,9 +223,9 @@ used when fetching, i.e. the first storage has precedence):
 
     @kopf.on.startup()
     def configure(settings: kopf.OperatorSettings, **_):
-        settings.persistence.storage = kopf.MultiStateStorage([
-            kopf.AnnotationsStateStorage(prefix='my-op.example.com'),
-            kopf.StatusStateStorage(field='status.my-operator'),
+        settings.persistence.progress_storage = kopf.MultiProgressStorage([
+            kopf.AnnotationsProgressStorage(prefix='my-op.example.com'),
+            kopf.StatusProgressStorage(field='status.my-operator'),
         ])
 
 The default storage is at both annotations and status, with annotations having
@@ -241,17 +241,17 @@ It is an equivalent of:
 
     @kopf.on.startup()
     def configure(settings: kopf.OperatorSettings, **_):
-        settings.persistence.storage = kopf.SmartStateStorage()
+        settings.persistence.progress_storage = kopf.SmartProgressStorage()
 
 It is also possible to implement custom state storage instead of storing
 the state directly in the resource's fields -- e.g., in external databases.
-For this, inherit from `kopf.StateStorage`, and implement its abstract methods
+For this, inherit from `kopf.ProgressStorage` and implement its abstract methods
 (``fetch()``, ``store()``, ``purge()``, optionally ``flush()``).
 
 .. note::
 
     The legacy behavior is an equivalent of
-    ``kopf.StatusStateStorage(field='status.kopf.progress')``.
+    ``kopf.StatusProgressStorage(field='status.kopf.progress')``.
 
     Starting with Kubernetes 1.16, both custom and built-in resources have
     strict structural schemas with pruning of unknown fields

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -43,6 +43,7 @@ import base64
 import copy
 import hashlib
 import json
+import warnings
 from typing import Any, Collection, Dict, Mapping, Optional, Union, cast
 
 from typing_extensions import TypedDict
@@ -168,6 +169,10 @@ class AnnotationsProgressStorage(ProgressStorage):
         self.prefix = prefix
         self.verbose = verbose
         self.touch_key = touch_key
+
+        # 253 is the max length, 63 is the most lengthy name part, 1 is for the "/" separator.
+        if len(self.prefix or '') > 253 - 63 - 1:
+            warnings.warn("The annotations prefix is too long. It can cause errors when PATCHing.")
 
     def fetch(
             self,

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -229,7 +229,7 @@ class AnnotationsProgressStorage(ProgressStorage):
         essence = super().clear(essence=essence)
         annotations = essence.get('metadata', {}).get('annotations', {})
         for name in list(annotations.keys()):
-            if name.startswith(f'{self.prefix}/'):
+            if self.prefix and name.startswith(f'{self.prefix}/'):
                 del annotations[name]
         return essence
 

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -180,7 +180,7 @@ class AnnotationsProgressStorage(ProgressStorage):
             key: handlers.HandlerId,
             body: bodies.Body,
     ) -> Optional[ProgressRecord]:
-        full_key = self.make_key(key)
+        full_key = self.make_key_v1(key)
         key_field = ['metadata', 'annotations', full_key]
         encoded = dicts.resolve(body, key_field, None, assume_empty=True)
         decoded = json.loads(encoded) if encoded is not None else None
@@ -194,7 +194,7 @@ class AnnotationsProgressStorage(ProgressStorage):
             body: bodies.Body,
             patch: patches.Patch,
     ) -> None:
-        full_key = self.make_key(key)
+        full_key = self.make_key_v1(key)
         key_field = ['metadata', 'annotations', full_key]
         decoded = {key: val for key, val in record.items() if self.verbose or val is not None}
         encoded = json.dumps(decoded, separators=(',', ':'))  # NB: no spaces
@@ -208,7 +208,7 @@ class AnnotationsProgressStorage(ProgressStorage):
             patch: patches.Patch,
     ) -> None:
         absent = object()
-        full_key = self.make_key(key)
+        full_key = self.make_key_v1(key)
         key_field = ['metadata', 'annotations', full_key]
         body_value = dicts.resolve(body, key_field, absent, assume_empty=True)
         patch_value = dicts.resolve(patch, key_field, absent, assume_empty=True)
@@ -224,7 +224,7 @@ class AnnotationsProgressStorage(ProgressStorage):
             patch: patches.Patch,
             value: Optional[str],
     ) -> None:
-        full_key = self.make_key(self.touch_key)
+        full_key = self.make_key_v1(self.touch_key)
         key_field = ['metadata', 'annotations', full_key]
         body_value = dicts.resolve(body, key_field, None, assume_empty=True)
         if body_value != value:  # also covers absent-vs-None cases.
@@ -239,6 +239,11 @@ class AnnotationsProgressStorage(ProgressStorage):
         return essence
 
     def make_key(self, key: Union[str, handlers.HandlerId], max_length: int = 63) -> str:
+        warnings.warn("make_key() is deprecated; use make_key_v1(), make_key_v2(), make_keys(), "
+                      "or avoid making the keys directly at all.", DeprecationWarning)
+        return self.make_key_v1(key, max_length=max_length)
+
+    def make_key_v1(self, key: Union[str, handlers.HandlerId], max_length: int = 63) -> str:
 
         # K8s has a limitation on the allowed charsets in annotation/label keys.
         # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -164,11 +164,13 @@ class AnnotationsProgressStorage(ProgressStorage):
             prefix: Optional[str] = 'kopf.zalando.org',
             verbose: bool = False,
             touch_key: str = 'touch-dummy',  # NB: not dotted, but dashed
+            v1: bool = True,  # Will be switch to False a few releases later.
     ) -> None:
         super().__init__()
         self.prefix = prefix
         self.verbose = verbose
         self.touch_key = touch_key
+        self.v1 = v1
 
         # 253 is the max length, 63 is the most lengthy name part, 1 is for the "/" separator.
         if len(self.prefix or '') > 253 - 63 - 1:
@@ -246,7 +248,9 @@ class AnnotationsProgressStorage(ProgressStorage):
         return self.make_key_v1(key, max_length=max_length)
 
     def make_keys(self, key: Union[str, handlers.HandlerId]) -> Iterable[str]:
-        return [self.make_key_v2(key), self.make_key_v1(key)]
+        v2_keys = [self.make_key_v2(key)]
+        v1_keys = [self.make_key_v1(key)] if self.v1 else []
+        return v2_keys + list(set(v1_keys) - set(v2_keys))
 
     def make_key_v1(self, key: Union[str, handlers.HandlerId], max_length: int = 63) -> str:
 

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -256,12 +256,15 @@ class AnnotationsProgressStorage(ProgressStorage):
         if len(safe_key) <= max_length - len(prefix):
             suffix = ''
         else:
-            digest = hashlib.blake2b(safe_key.encode('utf-8'), digest_size=4).digest()
-            alnums = base64.b64encode(digest, altchars=b'-.').decode('ascii')
-            suffix = f'-{alnums}'.rstrip('=-.')
+            suffix = self.make_suffix(safe_key)
 
         full_key = f'{prefix}{safe_key[:max_length - len(prefix) - len(suffix)]}{suffix}'
         return full_key
+
+    def make_suffix(self, key: str) -> str:
+        digest = hashlib.blake2b(key.encode('utf-8'), digest_size=4).digest()
+        alnums = base64.b64encode(digest, altchars=b'-.').decode('ascii')
+        return f'-{alnums}'.rstrip('=-.')
 
 
 class StatusProgressStorage(ProgressStorage):

--- a/tests/persistence/test_annotations_hashing.py
+++ b/tests/persistence/test_annotations_hashing.py
@@ -28,7 +28,7 @@ COMMON_KEYS = [
 ]
 
 V1_KEYS = [
-    # For length cutting. Hint: the prefix length is 23, the remaining space is 63 - 23 - 1 = 39.
+    # For V1 length cutting. Hint: the prefix length is 23, the remaining space is 63 - 23 - 1 = 39.
     # The suffix itself (if appended) takes 9, so it is 30 left. The same math for no prefix.
     ['my-operator.example.com', 'x', 'my-operator.example.com/x'],
     ['my-operator.example.com', 'x' * 39, 'my-operator.example.com/' + 'x' * 39],
@@ -47,6 +47,26 @@ V1_KEYS = [
     [None, 'fn' * 323, 'fn' * 27 + 'fn-Az-r.g'],  # base64: Az-r.g==
 ]
 
+V2_KEYS = [
+    # For V2 length cutting: 63 for the name part only, not the whole annotation.
+    # The suffix itself (if appended) takes 9, so it is 63-9=54 left.
+    ['my-operator.example.com', 'x', 'my-operator.example.com/x'],
+    ['my-operator.example.com', 'x' * 63, 'my-operator.example.com/' + 'x' * 63],
+    ['my-operator.example.com', 'x' * 64, 'my-operator.example.com/' + 'x' * 54 + 'xx-SItAqA'],
+    ['my-operator.example.com', 'y' * 64, 'my-operator.example.com/' + 'y' * 54 + 'yy-0d251g'],
+    ['my-operator.example.com', 'z' * 64, 'my-operator.example.com/' + 'z' * 54 + 'zz-E7wvIA'],
+    [None, 'x', 'x'],
+    [None, 'x' * 63, 'x' * 63],
+    [None, 'x' * 64, 'x' * 54 + 'xx-SItAqA'],  # base64: SItAqA==
+    [None, 'y' * 64, 'y' * 54 + 'yy-0d251g'],  # base64: 0d251g==
+    [None, 'z' * 64, 'z' * 54 + 'zz-E7wvIA'],  # base64: E7wvIA==
+
+    # For special chars in base64 encoding ("+" and "/"), which are not compatible with K8s.
+    # The numbers are found empirically so that both "/" and "+" are found in the base64'ed digest.
+    ['my-operator.example.com', 'fn' * 323, 'my-operator.example.com/' + 'fn' * 27 + 'fn-Az-r.g'],
+    [None, 'fn' * 323, 'fn' * 27 + 'fn-Az-r.g'],  # base64: Az-r.g==
+]
+
 
 def test_unversioned_keys_are_depecated():
     storage = AnnotationsProgressStorage()
@@ -56,6 +76,28 @@ def test_unversioned_keys_are_depecated():
     assert returned_key == v1_key
 
 
+def test_keys_for_all_versions():
+    storage = AnnotationsProgressStorage(v1=True)
+    v1_key = storage.make_key_v1('.' * 64)
+    v2_key = storage.make_key_v2('.' * 64)
+    assert v1_key != v2_key  # prerequisite
+    keys = storage.make_keys('.' * 64)
+    assert len(list(keys)) == 2
+    assert v1_key in keys
+    assert v2_key in keys
+
+
+def test_keys_deduplication():
+    storage = AnnotationsProgressStorage(v1=True)
+    v1_key = storage.make_key_v1('...')
+    v2_key = storage.make_key_v2('...')
+    assert v1_key == v2_key  # prerequisite
+    keys = storage.make_keys('...')
+    assert len(list(keys)) == 1
+    assert v1_key in keys
+    assert v2_key in keys
+
+
 @pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS)
 def test_key_hashing_v1(prefix, provided_key, expected_key):
     storage = AnnotationsProgressStorage(prefix=prefix)
@@ -63,7 +105,14 @@ def test_key_hashing_v1(prefix, provided_key, expected_key):
     assert returned_key == expected_key
 
 
-@pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS)
+@pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V2_KEYS)
+def test_key_hashing_v2(prefix, provided_key, expected_key):
+    storage = AnnotationsProgressStorage(prefix=prefix)
+    returned_key = storage.make_key_v2(provided_key)
+    assert returned_key == expected_key
+
+
+@pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS + V2_KEYS)
 @pytest.mark.parametrize('cls', ANNOTATIONS_POPULATING_STORAGES)
 def test_keys_hashed_on_fetching(cls, prefix, provided_key, expected_key):
     storage = cls(prefix=prefix)
@@ -73,34 +122,34 @@ def test_keys_hashed_on_fetching(cls, prefix, provided_key, expected_key):
     assert record == CONTENT_DATA
 
 
-@pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS)
+@pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS + V2_KEYS)
 @pytest.mark.parametrize('cls', ANNOTATIONS_POPULATING_STORAGES)
 def test_keys_normalized_on_storing(cls, prefix, provided_key, expected_key):
     storage = cls(prefix=prefix)
     patch = Patch()
     body = Body({'metadata': {'annotations': {expected_key: 'null'}}})
     storage.store(body=body, patch=patch, key=HandlerId(provided_key), record=CONTENT_DATA)
-    assert set(patch.metadata.annotations) == {expected_key}
+    assert expected_key in patch.metadata.annotations
 
 
-@pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS)
+@pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS + V2_KEYS)
 @pytest.mark.parametrize('cls', ANNOTATIONS_POPULATING_STORAGES)
 def test_keys_normalized_on_purging(cls, prefix, provided_key, expected_key):
     storage = cls(prefix=prefix)
     patch = Patch()
     body = Body({'metadata': {'annotations': {expected_key: 'null'}}})
     storage.purge(body=body, patch=patch, key=HandlerId(provided_key))
-    assert set(patch.metadata.annotations) == {expected_key}
+    assert expected_key in patch.metadata.annotations
 
 
-@pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS)
+@pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS + V2_KEYS)
 @pytest.mark.parametrize('cls', ANNOTATIONS_POPULATING_STORAGES)
 def test_keys_normalized_on_touching(cls, prefix, provided_key, expected_key):
     storage = cls(prefix=prefix, touch_key=provided_key)
     patch = Patch()
     body = Body({})
     storage.touch(body=body, patch=patch, value='irrelevant')
-    assert set(patch.metadata.annotations) == {expected_key}
+    assert expected_key in patch.metadata.annotations
 
 
 @pytest.mark.parametrize('cls', ANNOTATIONS_POPULATING_STORAGES)

--- a/tests/persistence/test_annotations_hashing.py
+++ b/tests/persistence/test_annotations_hashing.py
@@ -48,10 +48,18 @@ V1_KEYS = [
 ]
 
 
+def test_unversioned_keys_are_depecated():
+    storage = AnnotationsProgressStorage()
+    v1_key = storage.make_key_v1('...')
+    with pytest.deprecated_call(match=r"make_key\(\) is deprecated"):
+        returned_key = storage.make_key('...')
+    assert returned_key == v1_key
+
+
 @pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS)
 def test_key_hashing_v1(prefix, provided_key, expected_key):
     storage = AnnotationsProgressStorage(prefix=prefix)
-    returned_key = storage.make_key(provided_key)
+    returned_key = storage.make_key_v1(provided_key)
     assert returned_key == expected_key
 
 

--- a/tests/persistence/test_annotations_hashing.py
+++ b/tests/persistence/test_annotations_hashing.py
@@ -94,3 +94,9 @@ def test_keys_normalized_on_touching(cls, prefix, provided_key, expected_key):
     body = Body({})
     storage.touch(body=body, patch=patch, value='irrelevant')
     assert set(patch.metadata.annotations) == {expected_key}
+
+
+@pytest.mark.parametrize('cls', ANNOTATIONS_POPULATING_STORAGES)
+def test_warning_on_long_prefix(cls):
+    with pytest.warns(UserWarning, match=r"The annotations prefix is too long"):
+        cls(prefix='x' * (253 - 63))


### PR DESCRIPTION
## What do these changes do?

Loosen the overly restrictive length limitations for annotations that contain the state of the handlers.

The issue only shows up with either an operator's long prefix (identity) or with lengthy handler/function names plus field names or sub-handlers. See the examples below in this PR.

## Description

Previously, since #346, a restriction on the annotations' keys length was introduced, limiting them to 63 characters max for the whole annotation, including the prefix. 

[K8s says](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set) that only the name part is max 63 chars long, while the whole key (i.e. including the prefix, if present) can be max 253 chars. The sentence was improperly read by me.

This caused an unnecessary and avoidable loss of useful information: e.g. `lengthy-operator-name-to-hit-63-chars.example.com/update-OJOYLA`  instead of `lengthy-operator-name-to-hit-63-chars.example.com/update.sub1`; the same with the lengthy handler/sub-handler/field names even with a short prefix.

Detected while working with #517 (but it is neither connected to it, nor causes it, nor is caused by it).

Those old keys are now renamed as **V1** keys, keeping the exact implementation of suffixing as before. **V2** keys implement a new hashing approach, trying to keep as much information in the annotations' names as possible. Only the really lengthy keys will be cut the same way as V1 keys.

Since this PR, both V1 & V2 keys are equally supported: stored, fetched, purged — for smoother upgrades of operators from V1 to V2 and for safer rollbacks from V2 to V1. At some point in time, the V1 keys will be read, purged, but not stored, thus cutting the rollback possibilities to Kopf versions with V1 keys. At a later point, V1 keys will be completely removed (presumable during the next purge, i.e. in the 1.0 release).

In most cases, the operator developers would not notice the difference:

1. The V1-vs-V2 difference only shows up with lengthy annotation keys, which does not happen often. Without lengthy keys, both V1 & V2 will be the same one key, and the behaviour will be equivalent to the old one.

2. Since the annotations are purged after a successful handling cycle, this multi-versioned behaviour will most likely be unnoticed by the users, except when investigating the issues with persistence.


## Issues/PRs

> Issues: 
> Related: introduced in #346, detected during #517, partially fixes #388 (for the docs).


## Type of changes

- Refactoring (non-breaking change which does not alter the behaviour)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->


---

An example state taken from #517 sample code:


```python
import kopf

async def subhandler1(**_):
    pass

async def subhandler2(**_):
    pass

@kopf.on.update("zalando.org", "v1", "kopfexamples")
async def update_xxxxx(retry, **_):
    await kopf.execute(fns={"s1": subhandler1, "s2": subhandler2})
    await kopf.execute(fns={"s3": subhandler1, "s4": subhandler2})
```

```
    lengthy-operator-name-to-hit-63-chars.example.com/update-1SIn8Q: '{"started":"2020-09-02T18:22:48.830548","stopped":"2020-09-02T18:22:48.832226","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update-8cdFkA: '{"started":"2020-09-02T18:22:48.686102","stopped":"2020-09-02T18:22:48.829764","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update-OJOYLA: '{"started":"2020-09-02T18:22:48.830691","retries":0,"success":false,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update-Pvz.jQ: '{"started":"2020-09-02T18:22:48.685962","stopped":"2020-09-02T18:22:48.687928","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx: '{"started":"2020-09-02T18:22:48.684611","delayed":"2020-09-02T18:22:48.833316","retries":2,"success":false,"failure":false,"message":"None","subrefs":["update_xxxxx/s1","update_xxxxx/s2","update_xxxxx/s3","update_xxxxx/s4"]}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s1: '{"started":"2020-09-02T18:22:48.685962","stopped":"2020-09-02T18:22:48.687928","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s2: '{"started":"2020-09-02T18:22:48.686102","stopped":"2020-09-02T18:22:48.829764","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s3: '{"started":"2020-09-02T18:22:48.830548","stopped":"2020-09-02T18:22:48.832226","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s4: '{"started":"2020-09-02T18:22:48.830691","retries":0,"success":false,"failure":false}'
```

---

An example with even more lengthy sub-handler ids.

```python
import kopf

async def subhandler1(**_):
    pass

async def subhandler2(**_):
    pass

async def subhandler3(**_):
    await kopf.execute(fns={"z1": subhandler1, "z2": subhandler2})

@kopf.on.update("zalando.org", "v1", "kopfexamples")
async def update_xxxxx(retry, **_):
    await kopf.execute(fns={"s1": subhandler1, "s2": subhandler3})
    await kopf.execute(fns={"s3": subhandler1, "s4": subhandler3})
```

```
    lengthy-operator-name-to-hit-63-chars.example.com/update-1SIn8Q: '{"started":"2020-09-02T18:27:43.911729","stopped":"2020-09-02T18:27:43.915123","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update-2.UpGw: '{"started":"2020-09-02T18:27:44.042233","retries":0,"success":false,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update-8cdFkA: '{"started":"2020-09-02T18:27:43.637259","stopped":"2020-09-02T18:27:43.911037","retries":2,"success":true,"failure":false,"subrefs":["update_xxxxx/s2/z1","update_xxxxx/s2/z2"]}'
    lengthy-operator-name-to-hit-63-chars.example.com/update-OJOYLA: '{"started":"2020-09-02T18:27:43.911875","delayed":"2020-09-02T18:27:44.044739","retries":1,"success":false,"failure":false,"message":"None","subrefs":["update_xxxxx/s4/z1","update_xxxxx/s4/z2"]}'
    lengthy-operator-name-to-hit-63-chars.example.com/update-Pvz.jQ: '{"started":"2020-09-02T18:27:43.637152","stopped":"2020-09-02T18:27:43.638719","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update-jBCOXA: '{"started":"2020-09-02T18:27:44.042121","stopped":"2020-09-02T18:27:44.043775","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update-kCxXGg: '{"started":"2020-09-02T18:27:43.768841","stopped":"2020-09-02T18:27:43.909615","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update-pgzDhg: '{"started":"2020-09-02T18:27:43.768710","stopped":"2020-09-02T18:27:43.770555","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx: '{"started":"2020-09-02T18:27:43.636045","delayed":"2020-09-02T18:27:44.045377","retries":4,"success":false,"failure":false,"message":"None","subrefs":["update_xxxxx/s1","update_xxxxx/s2","update_xxxxx/s2/z1","update_xxxxx/s2/z2","update_xxxxx/s3","update_xxxxx/s4","update_xxxxx/s4/z1","update_xxxxx/s4/z2"]}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s1: '{"started":"2020-09-02T18:27:43.637152","stopped":"2020-09-02T18:27:43.638719","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s2: '{"started":"2020-09-02T18:27:43.637259","stopped":"2020-09-02T18:27:43.911037","retries":2,"success":true,"failure":false,"subrefs":["update_xxxxx/s2/z1","update_xxxxx/s2/z2"]}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s2.z1: '{"started":"2020-09-02T18:27:43.768710","stopped":"2020-09-02T18:27:43.770555","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s2.z2: '{"started":"2020-09-02T18:27:43.768841","stopped":"2020-09-02T18:27:43.909615","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s3: '{"started":"2020-09-02T18:27:43.911729","stopped":"2020-09-02T18:27:43.915123","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s4: '{"started":"2020-09-02T18:27:43.911875","delayed":"2020-09-02T18:27:44.044739","retries":1,"success":false,"failure":false,"message":"None","subrefs":["update_xxxxx/s4/z1","update_xxxxx/s4/z2"]}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s4.z1: '{"started":"2020-09-02T18:27:44.042121","stopped":"2020-09-02T18:27:44.043775","retries":1,"success":true,"failure":false}'
    lengthy-operator-name-to-hit-63-chars.example.com/update_xxxxx.s4.z2: '{"started":"2020-09-02T18:27:44.042233","retries":0,"success":false,"failure":false}'
```

---

An example with a lengthy handler id with the default operator identity:

```python
import kopf

@kopf.on.field("zalando.org", "v1", "kopfexamples",
               field='status.children-app-name.latest')
async def start_pipeline_step2_when_pipeline_step1_is_done(**_):
    pass

@kopf.on.update("zalando.org", "v1", "kopfexamples")
async def update_fn(**_):
    pass
```

```bash
kubectl patch -f examples/obj.yaml --type=merge -p '{"status":{"children-app-name":{"latest": 200}}}'
```

```
    kopf.zalando.org/start_pipeline_step2_when_pipeline_step-IJln3A: '{"started":"2020-09-02T18:33:27.246260","stopped":"2020-09-02T18:33:27.247912","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/start_pipeline_step2_when_pipeline_step1_is_done.status.--s5R-g: '{"started":"2020-09-02T18:33:27.246260","stopped":"2020-09-02T18:33:27.247912","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update_fn: '{"started":"2020-09-02T18:33:27.246356","retries":0,"success":false,"failure":false}'
```

The same operator when the function is called "start_step2".

```
    kopf.zalando.org/start_step2.status.children-app-name.latest: '{"started":"2020-09-02T18:37:09.857007","stopped":"2020-09-02T18:37:09.859570","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/update_fn: '{"started":"2020-09-02T18:37:09.857163","retries":0,"success":false,"failure":false}'
```