### PR TITLE
Sort imports with isort's mode 11

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 line_length = 100
-multi_line_output = 0
+multi_line_output = 11
 balanced_wrapping = true
 combine_as_imports = true
 case_sensitive = true

--- a/examples/.isort.cfg
+++ b/examples/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 line_length = 100
-multi_line_output = 0
+multi_line_output = 11
 balanced_wrapping = true
 combine_as_imports = true
 case_sensitive = true

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -25,8 +25,8 @@ import warnings
 from typing import Any, Optional, TypeVar, Union
 
 from kopf.storage import finalizers
-from kopf.structs import (bodies, configuration, containers, diffs,
-                          handlers, patches, primitives, resources)
+from kopf.structs import bodies, configuration, containers, diffs, \
+                         handlers, patches, primitives, resources
 
 
 @dataclasses.dataclass

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -20,8 +20,8 @@ from typing import Collection, Optional
 from kopf.engines import loggers, posting
 from kopf.reactor import causation, daemons, effects, handling, lifecycles, registries
 from kopf.storage import finalizers, states
-from kopf.structs import (bodies, configuration, containers, diffs,
-                          handlers as handlers_, patches, resources)
+from kopf.structs import bodies, configuration, containers, diffs, \
+                         handlers as handlers_, patches, resources
 
 
 async def process_resource_event(

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -16,8 +16,8 @@ import collections
 import functools
 import warnings
 from types import FunctionType, MethodType
-from typing import (Any, Callable, Container, FrozenSet, Generic, Iterable, Iterator, List,
-                    Mapping, MutableMapping, Optional, Sequence, Set, TypeVar, Union, cast)
+from typing import Any, Callable, Container, FrozenSet, Generic, Iterable, Iterator, List, \
+                   Mapping, MutableMapping, Optional, Sequence, Set, TypeVar, Union, cast
 
 from kopf.reactor import causation, invocation
 from kopf.structs import callbacks, dicts, diffs, filters, handlers, resources as resources_

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -4,8 +4,8 @@ import logging
 import signal
 import threading
 import warnings
-from typing import (TYPE_CHECKING, Any, Collection, Coroutine,
-                    MutableSequence, Optional, Sequence, Set, Tuple, cast)
+from typing import TYPE_CHECKING, Any, Collection, Coroutine, \
+                   MutableSequence, Optional, Sequence, Set, Tuple, cast
 
 from kopf.clients import auth
 from kopf.engines import peering, posting, probing

--- a/kopf/structs/credentials.py
+++ b/kopf/structs/credentials.py
@@ -27,8 +27,8 @@ import asyncio
 import collections
 import dataclasses
 import random
-from typing import (AsyncIterable, AsyncIterator, Callable, Dict, List,
-                    Mapping, NewType, Optional, Tuple, TypeVar, cast)
+from typing import AsyncIterable, AsyncIterator, Callable, Dict, List, \
+                   Mapping, NewType, Optional, Tuple, TypeVar, cast
 
 from kopf.structs import primitives
 

--- a/kopf/structs/dicts.py
+++ b/kopf/structs/dicts.py
@@ -3,8 +3,8 @@ Some basic dicts and field-in-a-dict manipulation helpers.
 """
 import collections.abc
 import enum
-from typing import (Any, Callable, Generic, Iterable, Iterator, List,
-                    Mapping, MutableMapping, Optional, Tuple, TypeVar, Union)
+from typing import Any, Callable, Generic, Iterable, Iterator, List, \
+                   Mapping, MutableMapping, Optional, Tuple, TypeVar, Union
 
 FieldPath = Tuple[str, ...]
 FieldSpec = Union[None, str, FieldPath, List[str]]

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -10,8 +10,8 @@ import warnings
 from typing import Any, Container, Iterator, Optional, Sequence, Union
 
 from kopf.reactor import causation, registries
-from kopf.structs import (bodies, callbacks, dicts, filters,
-                          handlers, patches, resources as resources_)
+from kopf.structs import bodies, callbacks, dicts, filters, \
+                         handlers, patches, resources as resources_
 
 AnyCause = Union[causation.ResourceWatchingCause, causation.ResourceChangingCause]
 AnyHandler = Union[handlers.ResourceWatchingHandler, handlers.ResourceChangingHandler]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ freezegun
 codecov
 coveralls
 mypy==0.770
+isort>=5.5.0

--- a/tests/peering/test_apply_peers.py
+++ b/tests/peering/test_apply_peers.py
@@ -2,8 +2,8 @@ import aiohttp.web
 import freezegun
 import pytest
 
-from kopf.engines.peering import (CLUSTER_PEERING_RESOURCE,
-                                  NAMESPACED_PEERING_RESOURCE, Peer, apply_peers)
+from kopf.engines.peering import CLUSTER_PEERING_RESOURCE, \
+                                 NAMESPACED_PEERING_RESOURCE, Peer, apply_peers
 
 
 @pytest.mark.usefixtures('with_both_crds')

--- a/tests/peering/test_peer_detection.py
+++ b/tests/peering/test_peer_detection.py
@@ -2,8 +2,8 @@ import re
 
 import pytest
 
-from kopf.engines.peering import (CLUSTER_PEERING_RESOURCE, NAMESPACED_PEERING_RESOURCE,
-                                  PEERING_DEFAULT_NAME, Peer)
+from kopf.engines.peering import CLUSTER_PEERING_RESOURCE, NAMESPACED_PEERING_RESOURCE, \
+                                 PEERING_DEFAULT_NAME, Peer
 
 # Note: the legacy peering is intentionally not tested: it was long time before
 # these tests were written, so it does not make sense to keep it stable.

--- a/tests/peering/test_peers.py
+++ b/tests/peering/test_peers.py
@@ -3,8 +3,8 @@ import datetime
 import freezegun
 import pytest
 
-from kopf.engines.peering import (CLUSTER_PEERING_RESOURCE, LEGACY_PEERING_RESOURCE,
-                                  NAMESPACED_PEERING_RESOURCE, Peer)
+from kopf.engines.peering import CLUSTER_PEERING_RESOURCE, LEGACY_PEERING_RESOURCE, \
+                                 NAMESPACED_PEERING_RESOURCE, Peer
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')

--- a/tests/persistence/test_essences.py
+++ b/tests/persistence/test_essences.py
@@ -2,8 +2,8 @@ from typing import Type
 
 import pytest
 
-from kopf.storage.diffbase import (LAST_SEEN_ANNOTATION, AnnotationsDiffBaseStorage,
-                                   DiffBaseStorage, StatusDiffBaseStorage)
+from kopf.storage.diffbase import LAST_SEEN_ANNOTATION, AnnotationsDiffBaseStorage, \
+                                  DiffBaseStorage, StatusDiffBaseStorage
 from kopf.structs.bodies import Body
 
 ALL_STORAGES = [AnnotationsDiffBaseStorage, StatusDiffBaseStorage]

--- a/tests/persistence/test_storing_of_diffbase.py
+++ b/tests/persistence/test_storing_of_diffbase.py
@@ -3,8 +3,8 @@ from typing import Type
 
 import pytest
 
-from kopf.storage.diffbase import (AnnotationsDiffBaseStorage, DiffBaseStorage,
-                                   MultiDiffBaseStorage, StatusDiffBaseStorage)
+from kopf.storage.diffbase import AnnotationsDiffBaseStorage, DiffBaseStorage, \
+                                  MultiDiffBaseStorage, StatusDiffBaseStorage
 from kopf.structs.bodies import Body, BodyEssence
 from kopf.structs.dicts import FieldSpec
 from kopf.structs.patches import Patch

--- a/tests/persistence/test_storing_of_progress.py
+++ b/tests/persistence/test_storing_of_progress.py
@@ -3,8 +3,8 @@ from typing import Type
 
 import pytest
 
-from kopf.storage.progress import (AnnotationsProgressStorage, ProgressRecord, ProgressStorage,
-                                   SmartProgressStorage, StatusProgressStorage)
+from kopf.storage.progress import AnnotationsProgressStorage, ProgressRecord, ProgressStorage, \
+                                  SmartProgressStorage, StatusProgressStorage
 from kopf.structs.bodies import Body
 from kopf.structs.handlers import HandlerId
 from kopf.structs.patches import Patch

--- a/tests/posting/test_poster.py
+++ b/tests/posting/test_poster.py
@@ -5,8 +5,8 @@ import pytest
 from asynctest import call
 
 from kopf import event, exception, info, warn
-from kopf.engines.posting import (K8sEvent, event_queue_loop_var,
-                                  event_queue_var, poster, settings_var)
+from kopf.engines.posting import K8sEvent, event_queue_loop_var, \
+                                 event_queue_var, poster, settings_var
 
 OBJ1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
         'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1'}}

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -3,10 +3,10 @@ import logging
 import pytest
 
 from kopf import GlobalRegistry, SimpleRegistry  # deprecated, but tested
-from kopf.reactor.causation import (ActivityCause, ResourceCause,
-                                    ResourceChangingCause, ResourceWatchingCause)
-from kopf.reactor.registries import (ActivityRegistry, OperatorRegistry, ResourceChangingRegistry,
-                                     ResourceRegistry, ResourceWatchingRegistry)
+from kopf.reactor.causation import ActivityCause, ResourceCause, \
+                                   ResourceChangingCause, ResourceWatchingCause
+from kopf.reactor.registries import ActivityRegistry, OperatorRegistry, ResourceChangingRegistry, \
+                                    ResourceRegistry, ResourceWatchingRegistry
 from kopf.structs.bodies import Body
 from kopf.structs.containers import Memo
 from kopf.structs.diffs import Diff, DiffItem

--- a/tests/test_finalizers.py
+++ b/tests/test_finalizers.py
@@ -1,7 +1,7 @@
 import pytest
 
-from kopf.storage.finalizers import (LEGACY_FINALIZER, allow_deletion, block_deletion,
-                                     is_deletion_blocked, is_deletion_ongoing)
+from kopf.storage.finalizers import LEGACY_FINALIZER, allow_deletion, block_deletion, \
+                                    is_deletion_blocked, is_deletion_ongoing
 
 
 def test_finalizer_is_fqdn(settings):


### PR DESCRIPTION
## What do these changes do?

Apply isort's new mode 11 — a grid, but without parentheses. For the beauty of it.

## Description

Just for the beauty of it.

The mode was added recently: https://github.com/PyCQA/isort/issues/1434

Before (mode 0):

![image](https://user-images.githubusercontent.com/544296/92147500-86201a80-ee1b-11ea-8a8a-0caf3640fa85.png)

After (mode 11):

![image](https://user-images.githubusercontent.com/544296/92147453-77396800-ee1b-11ea-94f9-9624117806db.png)

Also, ensure that isort is present in CI (was forgotten before).

## Issues/PRs

<!-- Cross-referencing is highly useful in hindsight. Put the main issue, and all the related/affected/causing/preceding issues and PRs related to this change. --> 

> Issues: a follow-up for #525.

> Related:


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- Refactoring (non-breaking change which does not alter the behaviour)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
