### PR TITLE
Stabilise time-based tests: polling with sleeps → async primitives

### DIFF
--- a/tests/reactor/conftest.py
+++ b/tests/reactor/conftest.py
@@ -21,19 +21,15 @@ def processor():
     return CoroutineMock()
 
 
-# Code overhead is not used, but is needed to order the fixtures: first,
-# the measurement, which requires the real worker; then, the worker mocking.
 @pytest.fixture()
-def worker_spy(mocker, overhead):
+def worker_spy(mocker):
     """ Spy on the watcher: actually call it, but provide the mock-fields. """
     spy = CoroutineMock(spec=original_worker, wraps=original_worker)
     return mocker.patch('kopf.reactor.queueing.worker', spy)
 
 
-# Code overhead is not used, but is needed to order the fixtures: first,
-# the measurement, which requires the real worker; then, the worker mocking.
 @pytest.fixture()
-def worker_mock(mocker, overhead):
+def worker_mock(mocker):
     """ Prevent the queue consumption, so that the queues could be checked. """
     return mocker.patch('kopf.reactor.queueing.worker')
 
@@ -73,106 +69,3 @@ def watcher_in_background(settings, resource, event_loop, worker_spy, stream):
             event_loop.run_until_complete(task)
         except asyncio.CancelledError:
             pass
-
-
-@dataclasses.dataclass(frozen=True)
-class Overhead:
-    min: float
-    avg: float
-    max: float
-
-
-@pytest.fixture(scope='session')
-def _overhead_cache():
-    return []
-
-
-@pytest.fixture()
-async def overhead(
-        resource, stream, aresponses, watcher_limited, timer,
-        _overhead_cache,
-) -> Overhead:
-    """
-    Estimate the overhead of synchronous code in the watching routines.
-
-    The code overhead is caused by Kopf's and tests' own low-level activities:
-    the code of ``watcher()``/``worker()`` itself, including a job scheduler,
-    the local ``aresponses`` server, the API communication with that server
-    in ``aiohttp``, serialization/deserialization in ``kopf.clients``, etc.
-
-    The actual aspect being tested are the ``watcher()``/``worker()`` routines:
-    their input/output and their timing regarding the blocking queue operations
-    or explicit sleeps, not the timing of underlying low-level activities.
-    So, the expected values for the durations of the call are adjusted for
-    the estimated code overhead before asserting them.
-
-    .. note::
-
-        The tests are designed with small timeouts to run fast, so that
-        the whole test-suite with thousands of tests is not delayed much.
-        Once there is a way to simulate asyncio time like with ``freezegun``,
-        or ``freezegun`` supports asyncio time, the problem can be solved by
-        using the lengthy timeouts and ignoring the code overhead._
-
-    The estimation of the overhead is measured by running a single-event cycle,
-    which means one worker only, but with batching of events disabled. This
-    ensures that only the fastest way is executed: no explicit or implicit
-    sleeps are used (e.g. as in getting from an empty queue with timeouts).
-
-    Extra 10-30% are added to the measured overhead to ensure that the future
-    code executions would fit into the estimation despite the variations.
-
-    Empirically, the overhead usually remains within the range of 50-150 ms.
-    It does not depend on the number of events or unique uids in the stream.
-    It does depend on the hardware used, or containers in the CI systems.
-
-    Several dummy runs are used to average the values, to avoid fluctuation.
-    The estimation happens only once per session, and is reused for all tests.
-    """
-    if not _overhead_cache:
-
-        # Collect a few data samples to make the estimation realistic.
-        overheads: List[float] = []
-        for _ in range(10):
-
-            # We feed the stream and consume the stream before we go into the tests,
-            # which can feed the stream with their own events.
-            stream.feed([
-                {'type': 'ADDED', 'object': {'metadata': {'uid': 'uid'}}},
-            ])
-            stream.close()
-
-            # We use our own fixtures -- to not collide with the tests' fixtures.
-            processor = CoroutineMock()
-            settings = OperatorSettings()
-            settings.batching.batch_window = 0
-            settings.batching.idle_timeout = 1
-            settings.batching.exit_timeout = 1
-
-            with timer:
-                await watcher(
-                    namespace=None,
-                    resource=resource,
-                    settings=settings,
-                    processor=processor,
-                )
-
-            # Ensure that everything worked as expected, i.e. the worker is not mocked,
-            # and the whole code is actually executed down to the processor callback.
-            assert processor.awaited, "The processor is not called for code overhead measurement."
-            overheads.append(timer.seconds)
-
-        # Reserve extra 10-30% from both sides for occasional variations.
-        _overhead_cache.append(Overhead(
-            min=min(overheads) * 0.9,
-            avg=sum(overheads) / len(overheads),
-            max=max(overheads) * 1.1,
-        ))
-
-        # Cleanup our own endpoints, if something is left.
-        aresponses._responses[:] = []
-
-    # Uncomment for debugging of the actual timing: visible only with -s pytest option.
-    # print(f"The estimated code overhead is {overhead}.")
-
-    return _overhead_cache[0]


### PR DESCRIPTION
## What do these changes do?

Refactor some of the time-based tests that were influenced by extra time wasted on unnecessary sleeps while polling the job scheduler. Now, they use sync primitives, so the sleeps of 0.2-0.5s are not needed anymore.

## Description

More and more often, the CI pipelines fail due to tests with timed blocks missing their allowed thresholds. While there is no clear and obvious way how to refactor these tests with any form of artificial asyncio time (see #212), some remedy can be applied now.

* Numerous branch/PR builds are failed: https://travis-ci.org/github/nolar/kopf/jobs/722895190 — though, they are usually restarted a few times until success, so the links are lost.
* Sometimes, master branch failed after a successful PR run: https://travis-ci.org/github/nolar/kopf/jobs/723969381
* Even the sped-up K3d/K3s branch fails with these errors: https://travis-ci.org/github/nolar/kopf/builds/724528729

For these specific tests of watcher-workers queueing & batching of the events from the API's watch-stream, one of the biggest contributors to time discrepancies is the exit timeout. It is performed as one hundred polls of the scheduler's readiness at regular intervals, which are `exit_timeout / 100` seconds. 

This is fine for the regular operators' flow, but is a problem for the tests: when the timeout is artificially increased to e.g. 100 seconds, the sleeps become 1-second long; even if shortened to 1/1000th of the timeout, it will be 0.1 second, while the test is expected to finish in 0.2-0.3 seconds of the batch timeout — and becomes the most often cause of failures.

There were a few attempts to solve this problem: e.g. by measuring the code overhead in the runtime environment — #522 #528 — neither did help.

With this PR, the watcher's finalization, scheduler's closure, workers' exits, and the queues' depletion are synchronised via asynchronous primitives (`asyncio.Condition` in this case): whenever a worker exits, it wakes up the depletion routine. As a result, there is no need for polling and thus sleeps. And so, the watcher's exit is not delayed by the queue depletion routine anymore, even of 0.1-1s. And so, the time measurements of the watcher are more reliable and can be kept small (to keep the tests fast).

_**PS:** On a side-note: this is also a reason why this 1/100th fraction or an interval were not moved to the settings (unlike exit_timeout, batch_window, etc): it was originally known as an internal hack that should be refactored to something normal. Now, the time has come._

_**PPS:** This was also a reason why exit_timeout was set to 0.5 seconds in the tests, while it should never be used: because 1/100th of it should be low enough too. Now, the timeout can be 100 seconds, with no influence on the tests' outcomes._


## Issues/PRs

> Issues: #212 #338 


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- Mostly CI/CD automation, contribution experience


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
