### PR TITLE
Exclude work-in-progress branches from being built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ dist: xenial
 language: python
 python: "3.8"
 
+# Only test the final merges and releases. The work-in-progress branches are tested by PR builds.
+branches:
+  only:
+  - master
+  - /^release\/.*$/
+  - /^\d+\.\d+(\.\d+)?(\.?(rc|dev|pre|post)\d+)?(-\S*)?(\+\S*)?$/
+
 # Linting is super-fast and lightweight, gives the near-instant feedback if code is wrong.
 # It does not depend on the environment (services, dependencies, even the framework itself).
 # Currently, most linters are optional and performed manually from time to time. This will change.


### PR DESCRIPTION
## Description

Only build the merges (the `master` branch & `release/*` branches), the version-looking tags (1.2, 1.2rc9, 1.2.3, 1.2.3rc9, etc). The work-in-progress branches are tested by the PR builds.

Otherwise, it didn't build the master branch, and probably wouldn't build the release tags.


## Issues/PRs

> Issues: 

> Related: #536 


## Type of changes

- Mostly CI/CD automation, contribution experience


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
