### PR TITLE
Unify the logic of annotations for storages: alphabets, lengths, hashes, v1/v2 keys

### DIFF
--- a/kopf/storage/conventions.py
+++ b/kopf/storage/conventions.py
@@ -1,0 +1,139 @@
+"""
+Some reusable implementation details regarding naming in K8s.
+
+This module implements conventions for annotations & labels with restrictions.
+They are used to identify operator's own keys consistently during the run,
+keep backward- & forward-compatibility of naming schemas across the versions.
+
+For some fields, such as annotations and labels, K8s puts extra restrictions
+on the alphabet used and on lengths of the names, name parts, and values.
+All such restrictions are implemented here in combination with the conventions.
+
+Terminology (to be on the same page; `aligned with K8s's documentation`__):
+
+__ https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+
+* **prefix** is a fqdn-like optional part (e.g. `kopf.zalando.org/`);
+* **name** is the main part of an annotation/label (e.g. `kopf-managed`);
+* **key** (a dictionary key, a full key) is the **prefix** plus the **name**,
+  possibly suffixed, infixed (named-prefixed), fully or partially hashed
+  (e.g. `example.com/kopf-managed` or `kopf.zalando.org/handler1.subhandlerA`),
+  but used as a dictionary key for the annotations (hence the name).
+
+Note: there are also progress storages' **record keys**, which are not related
+to the annotations/labels keys of this convention: they correspond to the names:
+in most cases, they will be used as the annotation names with special symbols
+replaced; in some cases, they will be cut and hash-suffixed.
+"""
+import base64
+import hashlib
+import warnings
+from typing import Any, Iterable, Optional
+
+
+class StorageKeyFormingConvention:
+    """
+    A helper mixin to manage annotations/labels naming as per K8s restrictions.
+
+    Used both in the diff-base storages and the progress storages where
+    applicable. It provides a few optional methods to manage annotation
+    prefixes, keys, and names (in this context, a name is a prefix + a key).
+    Specifically, the annotations keys are split to V1 & V2 (would be V3, etc).
+
+    **V1** keys were implemented overly restrictive: the length of 63 chars
+    was applied to the whole annotation key, including the prefix.
+
+    This caused unnecessary and avoidable loss of useful information: e.g.
+    ``lengthy-operator-name-to-hit-63-chars.example.com/update-OJOYLA``
+    instead of
+    ``lengthy-operator-name-to-hit-63-chars.example.com/update.sub1``.
+
+    `K8s says`__ that only the name is max 63 chars long, while the whole key
+    (i.e. including the prefix, if present) can be max 253 chars.
+
+    __ https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+
+    **V2** keys implement this new hashing approach, trying to keep as much
+    information in the keys as possible. Only the really lengthy keys
+    will be cut the same way as V1 keys.
+
+    If the prefix is longer than 189 chars (253-63-1), the full key could
+    be longer than the limit of 253 chars -- e.g. with lengthy handler ids,
+    more often for field-handlers or sub-handlers. In that case,
+    the annotation keys are not shortened, and the patching would fail.
+
+    It is the developer's responsibility to choose the prefix short enough
+    to fit into K8s's restrictions. However, a warning is issued on storage
+    creation, so that the strict-mode operators could convert the warning
+    into an exception, thus failing the operator startup.
+
+    For smoother upgrades of operators from V1 to V2, and for safer rollbacks
+    from V2 to V1, both versions of keys are stored in annotations.
+    At some point in time, the V1 keys will be read, purged, but not stored,
+    thus cutting the rollback possibilities to Kopf versions with V1 keys.
+
+    Since the annotations are purged in case of a successful handling cycle,
+    this multi-versioned behaviour will most likely be unnoticed by the users,
+    except when investigating the issues with persistence.
+
+    This mode can be controlled via the storage's constructor parameter
+    ``v1=True/False`` (the default is ``True`` for the time of transition).
+    """
+
+    def __init__(
+            self,
+            *args: Any,
+            prefix: Optional[str],
+            v1: bool,
+            **kwargs: Any,
+    ) -> None:
+        # TODO: Remove type-ignore when this is fixed: https://github.com/python/mypy/issues/5887
+        #       Too many arguments for "__init__" of "object" -- but this is typical for mixins!
+        super().__init__(*args, **kwargs)  # type: ignore
+        self.prefix = prefix
+        self.v1 = v1
+
+        # 253 is the max length, 63 is the most lengthy name part, 1 is for the "/" separator.
+        if len(self.prefix or '') > 253 - 63 - 1:
+            warnings.warn("The annotations prefix is too long. It can cause errors when PATCHing.")
+
+    def make_key(self, key: str, max_length: int = 63) -> str:
+        warnings.warn("make_key() is deprecated; use make_v1_key(), make_v2_key(), make_keys(), "
+                      "or avoid making the keys directly at all.", DeprecationWarning)
+        return self.make_v1_key(key, max_length=max_length)
+
+    def make_keys(self, key: str) -> Iterable[str]:
+        v2_keys = [self.make_v2_key(key)]
+        v1_keys = [self.make_v1_key(key)] if self.v1 else []
+        return v2_keys + list(set(v1_keys) - set(v2_keys))
+
+    def make_v1_key(self, key: str, max_length: int = 63) -> str:
+
+        # K8s has a limitation on the allowed charsets in annotation/label keys.
+        # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+        safe_key = key.replace('/', '.')
+
+        # K8s has a limitation of 63 chars per annotation/label key.
+        # Force it to 63 chars by replacing the tail with a consistent hash (with full alphabet).
+        # Force it to end with alnums instead of altchars or trailing chars (K8s requirement).
+        prefix = f'{self.prefix}/' if self.prefix else ''
+        if len(safe_key) <= max_length - len(prefix):
+            suffix = ''
+        else:
+            suffix = self.make_suffix(safe_key)
+
+        full_key = f'{prefix}{safe_key[:max_length - len(prefix) - len(suffix)]}{suffix}'
+        return full_key
+
+    def make_v2_key(self, key: str, max_length: int = 63) -> str:
+        prefix = f'{self.prefix}/' if self.prefix else ''
+        suffix = self.make_suffix(key) if len(key) > max_length else ''
+        key_limit = max(0, max_length - len(suffix))
+        clean_key = key.replace('/', '.')
+        final_key = f'{prefix}{clean_key[:key_limit]}{suffix}'
+        return final_key
+
+    def make_suffix(self, key: str) -> str:
+        digest = hashlib.blake2b(key.encode('utf-8'), digest_size=4).digest()
+        alnums = base64.b64encode(digest, altchars=b'-.').decode('ascii')
+        return f'-{alnums}'.rstrip('=-.')

--- a/kopf/storage/diffbase.py
+++ b/kopf/storage/diffbase.py
@@ -1,6 +1,7 @@
 import abc
 import copy
 import json
+import warnings
 from typing import Any, Collection, Dict, Iterable, Optional, cast
 
 from kopf.structs import bodies, dicts, patches
@@ -115,10 +116,26 @@ class AnnotationsDiffBaseStorage(DiffBaseStorage):
     def __init__(
             self,
             *,
-            name: str = 'kopf.zalando.org/last-handled-configuration',
+            prefix: Optional[str] = 'kopf.zalando.org',
+            key: str = 'last-handled-configuration',
+            name: Optional[str] = None,  # deprecated, but parsed into prefix+name
     ) -> None:
+        if name is not None:
+            warnings.warn("name= is deprecated for AnnotationsDiffBaseStorage(); "
+                          "use prefix= & key=", DeprecationWarning)
+            if '/' in name:
+                prefix, key = name.split('/', 1)
+            else:
+                prefix, key = None, name
+
         super().__init__()
-        self.name = name
+        self.prefix = prefix
+        self.key = key
+
+    @property
+    def name(self) -> str:
+        prefix = f'{self.prefix}/' if self.prefix else ''
+        return f'{prefix}{self.key}'
 
     def build(
             self,

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -284,16 +284,16 @@ class AnnotationsProgressStorage(ProgressStorage):
         return essence
 
     def make_key(self, key: str, max_length: int = 63) -> str:
-        warnings.warn("make_key() is deprecated; use make_key_v1(), make_key_v2(), make_keys(), "
+        warnings.warn("make_key() is deprecated; use make_v1_key(), make_v2_key(), make_keys(), "
                       "or avoid making the keys directly at all.", DeprecationWarning)
-        return self.make_key_v1(key, max_length=max_length)
+        return self.make_v1_key(key, max_length=max_length)
 
     def make_keys(self, key: str) -> Iterable[str]:
-        v2_keys = [self.make_key_v2(key)]
-        v1_keys = [self.make_key_v1(key)] if self.v1 else []
+        v2_keys = [self.make_v2_key(key)]
+        v1_keys = [self.make_v1_key(key)] if self.v1 else []
         return v2_keys + list(set(v1_keys) - set(v2_keys))
 
-    def make_key_v1(self, key: str, max_length: int = 63) -> str:
+    def make_v1_key(self, key: str, max_length: int = 63) -> str:
 
         # K8s has a limitation on the allowed charsets in annotation/label keys.
         # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
@@ -311,7 +311,7 @@ class AnnotationsProgressStorage(ProgressStorage):
         full_key = f'{prefix}{safe_key[:max_length - len(prefix) - len(suffix)]}{suffix}'
         return full_key
 
-    def make_key_v2(self, key: str, max_length: int = 63) -> str:
+    def make_v2_key(self, key: str, max_length: int = 63) -> str:
         prefix = f'{self.prefix}/' if self.prefix else ''
         suffix = self.make_suffix(key) if len(key) > max_length else ''
         key_limit = max(0, max_length - len(suffix))

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -193,10 +193,10 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention, Progre
             body: bodies.Body,
             patch: patches.Patch,
     ) -> None:
+        decoded = {key: val for key, val in record.items() if self.verbose or val is not None}
+        encoded = json.dumps(decoded, separators=(',', ':'))  # NB: no spaces
         for full_key in self.make_keys(key):
             key_field = ['metadata', 'annotations', full_key]
-            decoded = {key: val for key, val in record.items() if self.verbose or val is not None}
-            encoded = json.dumps(decoded, separators=(',', ':'))  # NB: no spaces
             dicts.ensure(patch, key_field, encoded)
 
     def purge(

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -39,15 +39,13 @@ with the following keys:
 All timestamps are strings in ISO8601 format in UTC (no explicit ``Z`` suffix).
 """
 import abc
-import base64
 import copy
-import hashlib
 import json
-import warnings
-from typing import Any, Collection, Dict, Iterable, Mapping, Optional, cast
+from typing import Any, Collection, Dict, Mapping, Optional, cast
 
 from typing_extensions import TypedDict
 
+from kopf.storage import conventions
 from kopf.structs import bodies, dicts, handlers, patches
 
 
@@ -129,7 +127,7 @@ class ProgressStorage(metaclass=abc.ABCMeta):
         pass
 
 
-class AnnotationsProgressStorage(ProgressStorage):
+class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention, ProgressStorage):
     """
     State storage in ``.metadata.annotations`` with JSON-serialised content.
 
@@ -157,46 +155,8 @@ class AnnotationsProgressStorage(ProgressStorage):
         spec: ...
         status: ...
 
-    A note on the annotation names/keys:
-
-    **V1** keys were implemented overly restrictive: the length of 63 chars
-    was applied to the whole annotation key, including the prefix.
-
-    This caused unnecessary and avoidable loss of useful information: e.g.
-    ``lengthy-operator-name-to-hit-63-chars.example.com/update-OJOYLA``
-    instead of
-    ``lengthy-operator-name-to-hit-63-chars.example.com/update.sub1``.
-
-    `K8s says`__ that only the name is max 63 chars long, while the whole key
-    (i.e. including the prefix, if present) can be max 253 chars.
-
-    __ https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
-
-    **V2** keys implement this new hashing approach, trying to keep as much
-    information in the keys as possible. Only the really lengthy keys
-    will be cut the same way as V1 keys.
-
-    If the prefix is longer than 189 chars (253-63-1), the full key could
-    be longer than the limit of 253 chars -- e.g. with lengthy handler ids,
-    more often for field-handlers or sub-handlers. In that case,
-    the annotation keys are not shortened, and the patching would fail.
-
-    It is the developer's responsibility to choose the prefix short enough
-    to fit into K8s's restrictions. However, a warning is issued on storage
-    creation, so that the strict-mode operators could convert the warning
-    into an exception, thus failing the operator startup.
-
-    For smoother upgrades of operators from V1 to V2, and for safer rollbacks
-    from V2 to V1, both versions of keys are stored in annotations.
-    At some point in time, the V1 keys will be read, purged, but not stored,
-    thus cutting the rollback possibilities to Kopf versions with V1 keys.
-
-    Since the annotations are purged in case of a successful handling cycle,
-    this multi-versioned behaviour will most likely be unnoticed by the users,
-    except when investigating the issues with persistence.
-
-    This mode can be controlled via the storage's constructor parameter
-    ``v1=True/False`` (the default is ``True`` for the time of transition).
+    For the annotations' naming conventions, hashing, and V1 & V2 differences,
+    see :class:`AnnotationsNamingMixin`.
     """
 
     def __init__(
@@ -205,17 +165,11 @@ class AnnotationsProgressStorage(ProgressStorage):
             prefix: Optional[str] = 'kopf.zalando.org',
             verbose: bool = False,
             touch_key: str = 'touch-dummy',  # NB: not dotted, but dashed
-            v1: bool = True,  # Will be switch to False a few releases later.
+            v1: bool = True,  # will be switched to False a few releases later
     ) -> None:
-        super().__init__()
-        self.prefix = prefix
+        super().__init__(prefix=prefix, v1=v1)
         self.verbose = verbose
         self.touch_key = touch_key
-        self.v1 = v1
-
-        # 253 is the max length, 63 is the most lengthy name part, 1 is for the "/" separator.
-        if len(self.prefix or '') > 253 - 63 - 1:
-            warnings.warn("The annotations prefix is too long. It can cause errors when PATCHing.")
 
     def fetch(
             self,
@@ -282,47 +236,6 @@ class AnnotationsProgressStorage(ProgressStorage):
             if self.prefix and name.startswith(f'{self.prefix}/'):
                 del annotations[name]
         return essence
-
-    def make_key(self, key: str, max_length: int = 63) -> str:
-        warnings.warn("make_key() is deprecated; use make_v1_key(), make_v2_key(), make_keys(), "
-                      "or avoid making the keys directly at all.", DeprecationWarning)
-        return self.make_v1_key(key, max_length=max_length)
-
-    def make_keys(self, key: str) -> Iterable[str]:
-        v2_keys = [self.make_v2_key(key)]
-        v1_keys = [self.make_v1_key(key)] if self.v1 else []
-        return v2_keys + list(set(v1_keys) - set(v2_keys))
-
-    def make_v1_key(self, key: str, max_length: int = 63) -> str:
-
-        # K8s has a limitation on the allowed charsets in annotation/label keys.
-        # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
-        safe_key = key.replace('/', '.')
-
-        # K8s has a limitation of 63 chars per annotation/label key.
-        # Force it to 63 chars by replacing the tail with a consistent hash (with full alphabet).
-        # Force it to end with alnums instead of altchars or trailing chars (K8s requirement).
-        prefix = f'{self.prefix}/' if self.prefix else ''
-        if len(safe_key) <= max_length - len(prefix):
-            suffix = ''
-        else:
-            suffix = self.make_suffix(safe_key)
-
-        full_key = f'{prefix}{safe_key[:max_length - len(prefix) - len(suffix)]}{suffix}'
-        return full_key
-
-    def make_v2_key(self, key: str, max_length: int = 63) -> str:
-        prefix = f'{self.prefix}/' if self.prefix else ''
-        suffix = self.make_suffix(key) if len(key) > max_length else ''
-        key_limit = max(0, max_length - len(suffix))
-        clean_key = key.replace('/', '.')
-        final_key = f'{prefix}{clean_key[:key_limit]}{suffix}'
-        return final_key
-
-    def make_suffix(self, key: str) -> str:
-        digest = hashlib.blake2b(key.encode('utf-8'), digest_size=4).digest()
-        alnums = base64.b64encode(digest, altchars=b'-.').decode('ascii')
-        return f'-{alnums}'.rstrip('=-.')
 
 
 class StatusProgressStorage(ProgressStorage):

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -44,7 +44,7 @@ import copy
 import hashlib
 import json
 import warnings
-from typing import Any, Collection, Dict, Iterable, Mapping, Optional, Union, cast
+from typing import Any, Collection, Dict, Iterable, Mapping, Optional, cast
 
 from typing_extensions import TypedDict
 
@@ -283,17 +283,17 @@ class AnnotationsProgressStorage(ProgressStorage):
                 del annotations[name]
         return essence
 
-    def make_key(self, key: Union[str, handlers.HandlerId], max_length: int = 63) -> str:
+    def make_key(self, key: str, max_length: int = 63) -> str:
         warnings.warn("make_key() is deprecated; use make_key_v1(), make_key_v2(), make_keys(), "
                       "or avoid making the keys directly at all.", DeprecationWarning)
         return self.make_key_v1(key, max_length=max_length)
 
-    def make_keys(self, key: Union[str, handlers.HandlerId]) -> Iterable[str]:
+    def make_keys(self, key: str) -> Iterable[str]:
         v2_keys = [self.make_key_v2(key)]
         v1_keys = [self.make_key_v1(key)] if self.v1 else []
         return v2_keys + list(set(v1_keys) - set(v2_keys))
 
-    def make_key_v1(self, key: Union[str, handlers.HandlerId], max_length: int = 63) -> str:
+    def make_key_v1(self, key: str, max_length: int = 63) -> str:
 
         # K8s has a limitation on the allowed charsets in annotation/label keys.
         # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
@@ -311,7 +311,7 @@ class AnnotationsProgressStorage(ProgressStorage):
         full_key = f'{prefix}{safe_key[:max_length - len(prefix) - len(suffix)]}{suffix}'
         return full_key
 
-    def make_key_v2(self, key: Union[str, handlers.HandlerId], max_length: int = 63) -> str:
+    def make_key_v2(self, key: str, max_length: int = 63) -> str:
         prefix = f'{self.prefix}/' if self.prefix else ''
         suffix = self.make_suffix(key) if len(key) > max_length else ''
         key_limit = max(0, max_length - len(suffix))

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -433,9 +433,10 @@ class SmartProgressStorage(MultiProgressStorage):
             touch_key: str = 'touch-dummy',  # NB: not dotted, but dashed
             touch_field: dicts.FieldSpec = 'status.{name}.dummy',
             prefix: str = 'kopf.zalando.org',
+            v1: bool = True,  # will be switched to False a few releases later
             verbose: bool = False,
     ) -> None:
         super().__init__([
-            AnnotationsProgressStorage(prefix=prefix, verbose=verbose, touch_key=touch_key),
+            AnnotationsProgressStorage(v1=v1, prefix=prefix, verbose=verbose, touch_key=touch_key),
             StatusProgressStorage(name=name, field=field, touch_field=touch_field),
         ])

--- a/tests/persistence/test_annotations_hashing.py
+++ b/tests/persistence/test_annotations_hashing.py
@@ -70,7 +70,7 @@ V2_KEYS = [
 
 def test_unversioned_keys_are_depecated():
     storage = AnnotationsProgressStorage()
-    v1_key = storage.make_key_v1('...')
+    v1_key = storage.make_v1_key('...')
     with pytest.deprecated_call(match=r"make_key\(\) is deprecated"):
         returned_key = storage.make_key('...')
     assert returned_key == v1_key
@@ -78,8 +78,8 @@ def test_unversioned_keys_are_depecated():
 
 def test_keys_for_all_versions():
     storage = AnnotationsProgressStorage(v1=True)
-    v1_key = storage.make_key_v1('.' * 64)
-    v2_key = storage.make_key_v2('.' * 64)
+    v1_key = storage.make_v1_key('.' * 64)
+    v2_key = storage.make_v2_key('.' * 64)
     assert v1_key != v2_key  # prerequisite
     keys = storage.make_keys('.' * 64)
     assert len(list(keys)) == 2
@@ -89,8 +89,8 @@ def test_keys_for_all_versions():
 
 def test_keys_deduplication():
     storage = AnnotationsProgressStorage(v1=True)
-    v1_key = storage.make_key_v1('...')
-    v2_key = storage.make_key_v2('...')
+    v1_key = storage.make_v1_key('...')
+    v2_key = storage.make_v2_key('...')
     assert v1_key == v2_key  # prerequisite
     keys = storage.make_keys('...')
     assert len(list(keys)) == 1
@@ -101,14 +101,14 @@ def test_keys_deduplication():
 @pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS)
 def test_key_hashing_v1(prefix, provided_key, expected_key):
     storage = AnnotationsProgressStorage(prefix=prefix)
-    returned_key = storage.make_key_v1(provided_key)
+    returned_key = storage.make_v1_key(provided_key)
     assert returned_key == expected_key
 
 
 @pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V2_KEYS)
 def test_key_hashing_v2(prefix, provided_key, expected_key):
     storage = AnnotationsProgressStorage(prefix=prefix)
-    returned_key = storage.make_key_v2(provided_key)
+    returned_key = storage.make_v2_key(provided_key)
     assert returned_key == expected_key
 
 


### PR DESCRIPTION
## What do these changes do?

Extract the logic of annotations (v1/v2, etc) into a mixin, and use the same logic of suffixing for the diff-base storage too.

_This is a preparational PR for #539_

## Description

Annotations logic and ensuring that it works with K8s API seems to be sophisticated enough to make it reusable, not only available for the progress annotations (handlers' state) but for all annotation storages.


## Issues/PRs


> Issues: #372 

> Related: #529 #346 


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
