### PR TITLE
Ignore annotations made by other Kopf-based operators

### DIFF
--- a/kopf/storage/conventions.py
+++ b/kopf/storage/conventions.py
@@ -93,6 +93,10 @@ class StorageKeyFormingConvention:
         self.prefix = prefix
         self.v1 = v1
 
+        if not self.prefix:
+            warnings.warn("Non-prefixed storages are deprecated. "
+                          "Please, add any prefix or use the default one.", DeprecationWarning)
+
         # 253 is the max length, 63 is the most lengthy name part, 1 is for the "/" separator.
         if len(self.prefix or '') > 253 - 63 - 1:
             warnings.warn("The annotations prefix is too long. It can cause errors when PATCHing.")

--- a/kopf/storage/conventions.py
+++ b/kopf/storage/conventions.py
@@ -3,7 +3,12 @@ Some reusable implementation details regarding naming in K8s.
 
 This module implements conventions for annotations & labels with restrictions.
 They are used to identify operator's own keys consistently during the run,
-keep backward- & forward-compatibility of naming schemas across the versions.
+keep backward- & forward-compatibility of naming schemas across the versions,
+and to detect cross-operator keys to prevent ping-pong effects (if Kopf-based).
+
+This is mostly important for storages in the shared spaces, such as annotations
+or labels of a resource being handled: to distinguish operator-related and
+unrelated keys (e.g. manually added annotations/labels).
 
 For some fields, such as annotations and labels, K8s puts extra restrictions
 on the alphabet used and on lengths of the names, name parts, and values.
@@ -28,7 +33,9 @@ replaced; in some cases, they will be cut and hash-suffixed.
 import base64
 import hashlib
 import warnings
-from typing import Any, Iterable, Optional
+from typing import Any, Collection, Iterable, Optional, Set
+
+from kopf.structs import bodies, patches
 
 
 class StorageKeyFormingConvention:
@@ -141,3 +148,74 @@ class StorageKeyFormingConvention:
         digest = hashlib.blake2b(key.encode('utf-8'), digest_size=4).digest()
         alnums = base64.b64encode(digest, altchars=b'-.').decode('ascii')
         return f'-{alnums}'.rstrip('=-.')
+
+
+class StorageKeyMarkingConvention:
+    """
+    A mixin to detect annotations of other Kopf-based operators.
+
+    The detection of other Kopf-based operators' annotations should prevent
+    "ping-pong" effects of multiple operators handling the same resources:
+
+    (1) operator A persists its state into an object;
+    (2) operator B believes it is a valid essential change and reacts;
+    (3) operator B persists its updated state (diff-base), which contains
+        the state of the operator A as the essential payload;
+    (4) operator A believes the new change is a valid essential change;
+    (∞) and so it continues forever (the annotations sizes can explode fast).
+
+    To detect the annotations as belonging to Kopf-based operators, the storages
+    inject a marker into the annotation names, and later detect these markers.
+
+    As an extra safety measure, all names of the whole `domain.tld/` prefix,
+    both V1 & V2, are detected as marked if there is at least one marked V2 name
+    under that prefix -- assuming that the prefix is for a Kopf-based operator.
+    For non-prefixed storages, the V1 names are detected by their V2
+    counterparts with some additional treatment (marker & hashes removed).
+
+    The marker and the marking are not configurable to prevent turning them off,
+    except as by writing self-made storages. In that case, all ping-pong issues
+    are considered as intended and handled by the storage/operator developers.
+
+    This logic is already included into all Kopf-provided storages, both with
+    and without annotations, so there is no need to explicitly configure it.
+    The only case where this class can be of direct use, is when custom storages
+    are implemented, but other operators' annotations still have to be cleaned.
+    """
+
+    __KNOWN_MARKERS = frozenset([
+        'kopf-managed',
+    ])
+
+    __KNOWN_PREFIXES = frozenset([
+        'kopf.zalando.org',
+    ])
+
+    def _detect_marked_prefixes(self, keys: Collection[str]) -> Collection[str]:
+        """
+        Detect annotation prefixes managed by any other Kopf-based operators.
+        """
+        prefixes: Set[str] = set()
+        for prefix, name in (key.split('/', 1) for key in keys if '/' in key):
+            if name in self.__KNOWN_MARKERS:
+                prefixes.add(prefix)
+            elif prefix in self.__KNOWN_PREFIXES:
+                prefixes.add(prefix)
+            elif any(prefix.endswith(f'.{p}') for p in self.__KNOWN_PREFIXES):
+                prefixes.add(prefix)
+        return frozenset(prefixes)
+
+    def _store_marker(
+            self,
+            prefix: Optional[str],
+            patch: patches.Patch,
+            body: bodies.Body,
+    ) -> None:
+        """
+        Store a Kopf-branding marker to make this operator's prefix detectable.
+        """
+        value = 'yes'
+        if prefix and not prefix.startswith('kopf.'):
+            marker = f'{prefix}/kopf-managed'
+            if marker not in body.metadata.annotations and marker not in patch.metadata.annotations:
+                patch.metadata.annotations[marker] = value

--- a/kopf/storage/diffbase.py
+++ b/kopf/storage/diffbase.py
@@ -7,9 +7,6 @@ from typing import Any, Collection, Dict, Iterable, Optional, cast
 from kopf.storage import conventions
 from kopf.structs import bodies, dicts, patches
 
-LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
-""" The annotation name for the last stored state of the resource. """
-
 
 class DiffBaseStorage(conventions.StorageKeyMarkingConvention, metaclass=abc.ABCMeta):
     """

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -127,7 +127,9 @@ class ProgressStorage(metaclass=abc.ABCMeta):
         pass
 
 
-class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention, ProgressStorage):
+class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
+                                 conventions.StorageKeyMarkingConvention,
+                                 ProgressStorage):
     """
     State storage in ``.metadata.annotations`` with JSON-serialised content.
 
@@ -198,6 +200,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention, Progre
         for full_key in self.make_keys(key):
             key_field = ['metadata', 'annotations', full_key]
             dicts.ensure(patch, key_field, encoded)
+        self._store_marker(prefix=self.prefix, patch=patch, body=body)
 
     def purge(
             self,
@@ -228,6 +231,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention, Progre
             body_value = dicts.resolve(body, key_field, None, assume_empty=True)
             if body_value != value:  # also covers absent-vs-None cases.
                 dicts.ensure(patch, key_field, value)
+                self._store_marker(prefix=self.prefix, patch=patch, body=body)
 
     def clear(self, *, essence: bodies.BodyEssence) -> bodies.BodyEssence:
         essence = super().clear(essence=essence)

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -4,11 +4,10 @@ import json
 import pytest
 
 from kopf.reactor.causation import detect_resource_changing_cause
-from kopf.storage.diffbase import LAST_SEEN_ANNOTATION
 from kopf.structs.bodies import Body
 from kopf.structs.handlers import Reason
 
-# Same as in the settings by default.
+LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 FINALIZER = 'fin'
 
 # Encoded at runtime, so that we do not make any assumptions on json formatting.

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -5,9 +5,10 @@ import pytest
 
 import kopf
 from kopf.reactor.processing import process_resource_event
-from kopf.storage.diffbase import LAST_SEEN_ANNOTATION
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import Reason
+
+LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 
 EVENT_TYPES = [None, 'ADDED', 'MODIFIED', 'DELETED']
 EVENT_TYPES_WHEN_EXISTS = [None, 'ADDED', 'MODIFIED']

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -5,9 +5,10 @@ import pytest
 
 import kopf
 from kopf.reactor.processing import process_resource_event
-from kopf.storage.diffbase import LAST_SEEN_ANNOTATION
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import HANDLER_REASONS, ResourceChangingHandler
+
+LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 
 
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)

--- a/tests/persistence/test_annotations_hashing.py
+++ b/tests/persistence/test_annotations_hashing.py
@@ -77,6 +77,8 @@ V2_KEYS = [
     [None, 'fn' * 323, 'fn' * 27 + 'fn-Az-r.g'],  # base64: Az-r.g==
 ]
 
+pytestmark = pytest.mark.filterwarnings("ignore:Non-prefixed storages are deprecated")
+
 
 @pytest.mark.parametrize('cls', STORAGE_KEY_FORMING_CLASSES)
 def test_unversioned_keys_are_depecated(cls):

--- a/tests/persistence/test_essences.py
+++ b/tests/persistence/test_essences.py
@@ -95,6 +95,61 @@ def test_get_essence_removes_garbage_annotations_but_keeps_others(
     assert essence == {'metadata': {'annotations': {'other': 'y'}}}
 
 
+@pytest.mark.parametrize('prefix', [
+    'kopf-domain.tld',
+    'kopf.domain.tld',
+    'domain.tld.kopf',
+    'domain.tld-kopf',
+    'domain.kopf.tld',
+    'domain.kopf-tld',
+    'domain-kopf.tld',
+    'domain-kopf-tld',
+])
+@pytest.mark.parametrize('cls', ALL_STORAGES)
+def test_get_essence_keeps_annotations_mentioning_kopf_but_not_from_other_operators(
+        prefix: str,
+        cls: Type[DiffBaseStorage],
+):
+    annotation = f'{prefix}/to-be-removed'
+    body = Body({'metadata': {'annotations': {annotation: 'x'}}})
+    storage = cls()
+    essence = storage.build(body=body)
+    assert essence == {'metadata': {'annotations': {annotation: 'x'}}}
+
+
+@pytest.mark.parametrize('prefix', [
+    'kopf.zalando.org',
+    'sub.kopf.zalando.org',
+    'sub.sub.kopf.zalando.org',
+])
+@pytest.mark.parametrize('cls', ALL_STORAGES)
+def test_get_essence_removes_other_operators_annotations_by_domain(
+        prefix: str,
+        cls: Type[DiffBaseStorage],
+):
+    annotation = f'{prefix}/to-be-removed'
+    body = Body({'metadata': {'annotations': {annotation: 'x', 'other': 'y'}}})
+    storage = cls()
+    essence = storage.build(body=body)
+    assert essence == {'metadata': {'annotations': {'other': 'y'}}}
+
+
+@pytest.mark.parametrize('prefix', [
+    'domain.tld',
+])
+@pytest.mark.parametrize('cls', ALL_STORAGES)
+def test_get_essence_removes_other_operators_annotations_by_marker(
+        prefix: str,
+        cls: Type[DiffBaseStorage],
+):
+    marker = f'{prefix}/kopf-managed'
+    annotation = f'{prefix}/to-be-removed'
+    body = Body({'metadata': {'annotations': {annotation: 'x', marker: 'yes', 'other': 'y'}}})
+    storage = cls()
+    essence = storage.build(body=body)
+    assert essence == {'metadata': {'annotations': {'other': 'y'}}}
+
+
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_removes_status_and_cleans_parents(
         cls: Type[DiffBaseStorage],

--- a/tests/persistence/test_essences.py
+++ b/tests/persistence/test_essences.py
@@ -2,8 +2,7 @@ from typing import Type
 
 import pytest
 
-from kopf.storage.diffbase import LAST_SEEN_ANNOTATION, AnnotationsDiffBaseStorage, \
-                                  DiffBaseStorage, StatusDiffBaseStorage
+from kopf.storage.diffbase import AnnotationsDiffBaseStorage, DiffBaseStorage, StatusDiffBaseStorage
 from kopf.structs.bodies import Body
 
 ALL_STORAGES = [AnnotationsDiffBaseStorage, StatusDiffBaseStorage]
@@ -66,7 +65,6 @@ def test_get_essence_removes_system_fields_but_keeps_extra_fields(
 
 
 @pytest.mark.parametrize('annotation', [
-    pytest.param(LAST_SEEN_ANNOTATION, id='kopf'),
     pytest.param('kubectl.kubernetes.io/last-applied-configuration', id='kubectl'),
 ])
 @pytest.mark.parametrize('cls', ALL_STORAGES)
@@ -81,7 +79,6 @@ def test_get_essence_removes_garbage_annotations_and_cleans_parents(
 
 
 @pytest.mark.parametrize('annotation', [
-    pytest.param(LAST_SEEN_ANNOTATION, id='kopf'),
     pytest.param('kubectl.kubernetes.io/last-applied-configuration', id='kubectl'),
 ])
 @pytest.mark.parametrize('cls', ALL_STORAGES)

--- a/tests/persistence/test_storing_of_diffbase.py
+++ b/tests/persistence/test_storing_of_diffbase.py
@@ -63,6 +63,14 @@ def test_annotations_store_deprecates_name():
     assert storage.name == 'my-operator.my-company.com/diff-base'
 
 
+def test_annotations_store_deprecates_nonprefixed():
+    with pytest.deprecated_call(match=r'Non-prefixed storages are deprecated'):
+        storage = AnnotationsDiffBaseStorage(prefix=None, key='diff-base')
+    assert storage.prefix is None
+    assert storage.key == 'diff-base'
+    assert storage.name == 'diff-base'
+
+
 def test_annotations_store_with_defaults():
     storage = AnnotationsDiffBaseStorage()
     assert storage.prefix == 'kopf.zalando.org'

--- a/tests/persistence/test_storing_of_progress.py
+++ b/tests/persistence/test_storing_of_progress.py
@@ -62,6 +62,12 @@ def test_status_storage_with_field():
     assert storage.touch_field == ('status', 'my-dummy')
 
 
+def test_annotations_store_deprecates_nonprefixed():
+    with pytest.deprecated_call(match=r'Non-prefixed storages are deprecated'):
+        storage = AnnotationsProgressStorage(prefix=None)
+    assert storage.prefix is None
+
+
 def test_annotations_storage_with_defaults():
     storage = AnnotationsProgressStorage()
     assert storage.prefix == 'kopf.zalando.org'


### PR DESCRIPTION
## What do these changes do?

Inject Kopf's identity into annotations of all Kopf-based operators. Use that identity to detect and ignore annotations belonging to other Kopf-based operators regardless of their identities.

By this, reduce ping-pong effects with multiple operators handling the same resources, which can overload the K8s API and explode the resources' sizes.


## Description

**Problem:**

Kopf implements additional constructs on top of the regular watch-and-react flow of K8s. To make this work in multiple reaction cycles, Kopf persist its own state into the resource itself. Since #331, the state is persisted into the resource's annotations in addition to (or instead of) the status stanza.

If multiple Kopf-based operators handle the same resources, they can cause ping-pong behaviour:

* (1) operator A persists its state into an object;
* (2) operator B believes it is a valid essential change and reacts;
* (3) operator B persists its updated diff-base, which contains
      the state of the operator A as the essential payload;
* (4) operator A believes the new change is a valid essential change;
* (∞) and so it continues forever.

This can quickly overload K8s API with requests per second (ping-pong happens fast), and blow the size of the resources.

The problem becomes more complicated when the operators have different identities: then, operators in the cluster could be unaware that other operators are Kopf-based too, and their annotations are for their state persistence, i.e. it is not something useful.

It is impossible for operator developers to configure their operators so that they would be aware of any other Kopf-based operators, unless the developers control each and every of those operators.

---
**Solution:**

To solve the problem with other Kopf-based operators' persistence being detected as meaningful content (i.e. the "essence"), these annotations should be filtered out from the essence and become invisible to any other Kopf-based operator — same as this already happens with the whole `.status` stanza.

However, Kopf's annotations are stored in a space shared with other non-Kopf-based operators, controllers, applications, and human-made annotations — all of these should be considered as the essential content, and its changes should be detected. Currently, there is no way to distinguish the annotations by their type or origin.

To filter out the annotations of Kopf-based operators, they all should be marked or tainted, and then these marks/taints should be used to ignore them.

Such detection should be independent of the operator's identity, i.e. shared by all operators made on this framework that produces these annotations.

---
**Why so?**

Looking back into history, the annotations store the information that previously (before #331) was stored in the status stanza, which is fully ignored when extracting the body's essence and diff — unless some specific fields are _explicitly_ marked as of interest by having a field-handler for that field.

The state-persisting annotations should behave the same: they should all be ignored, no matter from which operator they come, and only be noticed when explicitly monitored. This is not the case now.

---
**Exclusion logic:**

In this PR, the following logic of annotation detection is used:

* ~Ignore all annotations that have a prefix, which contains _"kopf"_ as a separate item (dot- or dash-separated): e.g. `kopf.zalando.org/*`, `my-kopf-operator.com/*`, etc.~ **UPD:** Narrowed to the following, to allow mentioning Kopf without losing the annotations from diffs, and to keep to specific namespaces only. After all, it can be just a coincidence that the annotations contain "kopf".

1. **Reserved prefixes:** Ignore all annotations that have a prefix which is a reserved prefix, or a subdomain of that reserved prefix. Currently, only `kopf.zalando.org` is reserved, but can be extended. Examples: `kopf.zalando.org/*`, `demo.kopf.zalando.org/*`, etc. — but not `kopf.my-operator.com/*`, `my-kopf-operator.com/*` or `com.example.kopf/*`.

2. **Arbitrary prefixes:** Ignore all annotations that have a prefix, for which a standalone annotation named `*/kopf-managed` exists: e.g. `example.com/kopf-managed`. The value of the marking annotation is irrelevant for detection. This annotation is automatically created every time any other annotation with that prefix is stored by Kopf, but only if the annotation is not identifiable by the prefix itself (i.e. the annotation is not detectable by the 1st rule).

This logic only works with prefixed annotations.

For non-prefixed annotations, the implementation would be too complex. Instead, the non-prefixed storages (both diffbase & progress) are deprecated, and a warning is issued when the prefix is set to `None`. By default, the prefix is `kopf.zalando.org`, so it would work "out of the box" without any issues as before.

An example (based on a code snippet from #517):

```yaml
metadata:
  annotations:
    another.com/kopf-managed: "yes"
    another.com/last-handled-configuration: |
      {"spec":{"duration":"1m","field":"value","items":["item1","item2"],"x":400},"metadata":{"labels":{"somelabel":"somevalue"},"annotations":{"someannotation":"somevalue"}}}
    example.com/kopf-managed: "yes"
    example.com/last-handled-configuration: |
      {"spec":{"duration":"1m","field":"value","items":["item1","item2"]},"metadata":{"labels":{"somelabel":"somevalue"},"annotations":{"someannotation":"somevalue"}}}
    example.com/update_fn: '{"started":"2020-09-09T20:49:34.304534","delayed":"2020-09-09T20:49:34.753660","retries":4,"success":false,"failure":false,"message":"None","subrefs":["update_fn/s1","update_fn/s2","update_fn/s2/z1","update_fn/s2/z2","update_fn/s3","update_fn/s4","update_fn/s4/z1","update_fn/s4/z2"]}'
    example.com/update_fn.s1: '{"started":"2020-09-09T20:49:34.306154","stopped":"2020-09-09T20:49:34.308542","retries":1,"success":true,"failure":false}'
    example.com/update_fn.s2: '{"started":"2020-09-09T20:49:34.306256","stopped":"2020-09-09T20:49:34.604117","retries":2,"success":true,"failure":false,"subrefs":["update_fn/s2/z1","update_fn/s2/z2"]}'
    example.com/update_fn.s2.z1: '{"started":"2020-09-09T20:49:34.461745","stopped":"2020-09-09T20:49:34.464269","retries":1,"success":true,"failure":false}'
    example.com/update_fn.s2.z2: '{"started":"2020-09-09T20:49:34.461850","stopped":"2020-09-09T20:49:34.602632","retries":1,"success":true,"failure":false}'
    example.com/update_fn.s3: '{"started":"2020-09-09T20:49:34.604924","stopped":"2020-09-09T20:49:34.606769","retries":1,"success":true,"failure":false}'
    example.com/update_fn.s4: '{"started":"2020-09-09T20:49:34.605008","delayed":"2020-09-09T20:49:34.752832","retries":1,"success":false,"failure":false,"message":"None","subrefs":["update_fn/s4/z1","update_fn/s4/z2"]}'
    example.com/update_fn.s4.z1: '{"started":"2020-09-09T20:49:34.749341","stopped":"2020-09-09T20:49:34.751653","retries":1,"success":true,"failure":false}'
    example.com/update_fn.s4.z2: '{"started":"2020-09-09T20:49:34.749447","retries":0,"success":false,"failure":false}'
    someannotation: somevalue
```

--- 
**Reproduction:**

Start 2 operators in parallel:

```python
import kopf

@kopf.on.startup()
def cfg(settings: kopf.OperatorSettings, **_):
    settings.persistence.progress_storage = kopf.AnnotationsProgressStorage(prefix='example.com')
    settings.persistence.diffbase_storage = kopf.AnnotationsDiffBaseStorage(prefix='example.com')

@kopf.on.update("zalando.org", "v1", "kopfexamples")
async def update_fn(**_):
    pass
```

```python
import kopf

@kopf.on.startup()
def cfg(settings: kopf.OperatorSettings, **_):
    settings.persistence.progress_storage = kopf.AnnotationsProgressStorage(prefix='another.com')
    settings.persistence.diffbase_storage = kopf.AnnotationsDiffBaseStorage(prefix='another.com')

@kopf.on.update("zalando.org", "v1", "kopfexamples")
async def update_fn(**_):
    pass
```

With the unfixed code: The "ping-pong" issue is observed immediately: the object size increases to approximately 188KB in a matter of a second, and the operator becomes unable to PATCH the resource since the API fails with "Unprocessable Entity" — and the throttling begins.

With the fixed code: Go to `kopf.storage.conventions.StorageKeyMarkingConvention` and modify the "known marker" (from `kopf-managed` to `kopf-managed-2`). Observe the issue as if the code is unfixed. Once the marker is restored, all those garbage annotations disappear on the first successful handling cycle.

---
**Risks:**

If the user modifies the resource and deletes the `*/kopf-managed` annotation in case of a non-Kopf-branded prefix, this would immediately notify all Kopf-based operators about a change, and they could "notice" the addition of all annotations in that group. It is the same kind of risk, as deleting the `*/last-handled-configuration`, which would trigger the on-creation handlers. It is expected that the users do not modify the annotations they do no understand.

The existing state-persisting annotations remain the same, so both the upgrades from any previous versions are possible, and the downgrades (rollbacks) to any other previous version are possible.

---
**Discarded ideas:**

There was a draft implementation which added `kopf--` infixes to the annotation names (e.g. `example.com/kopf--handler1.subhanderA-HaSh`) and used that for detection both of the Kopf-based prefixes and even non-prefixed annotations. The solution was quite complex, but what is worse: it would require storing duplicate annotations even for the `*/last-handled-configuration` (i.e. `*/kopf--last-handled-configuration`). This would pollute the annotations for the time of upgrade/downgrade for no good reason, would break the upgrade path through versions, and would steal extra 6 characters from the 63 available for the annotation names. This schema didn't have any significant advantages over having just one Kopf-branding annotation per prefix.

Another idea was to inject the markers into the content of the annotations, such as `//kopf` in the end or `#kopf` in the beginning of the annotation's value. There are no promises on what exactly and how exactly is stored in the annotations, so there is no need for it to be a JSON. However, JSON is a common convention and we should avoid breaking it. This approach would also break backward compatibility.

Another idea was to explicitly configure the operators to be aware of other operators by listing their prefixes. This wouldn't work: the developers (1) do not want to control the operators' environment that closely, and (2) are not able to control the environment with some third-party Kopf-based operators involved. It all should work "out of the box".

## Issues/PRs

> Issues: #372 

> Related: #538 


## Type of changes

- Bug fix (non-breaking change which fixes an issue)
- Refactoring (non-breaking change which does not alter the behaviour)

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
