### PR TITLE
Give names to asyncio tasks in Python 3.8+

### DIFF
--- a/kopf/clients/watching.py
+++ b/kopf/clients/watching.py
@@ -28,6 +28,7 @@ import aiohttp
 
 from kopf.clients import auth, discovery, fetching
 from kopf.structs import bodies, configuration, primitives, resources
+from kopf.utilities import backports
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +95,9 @@ async def streaming_watch(
     # to the future's callbacks, and a background task triggers it when the mode is turned on.
     freeze_waiter: asyncio_Future
     if freeze_mode is not None:
-        freeze_waiter = asyncio.create_task(freeze_mode.wait_for_on())
+        freeze_waiter = backports.create_task(
+            freeze_mode.wait_for_on(),
+            name=f'freeze-waiter for {resource.name} @ {namespace or "cluster-wide"}')
     else:
         freeze_waiter = asyncio.Future()  # a dummy just ot have it
 

--- a/kopf/reactor/daemons.py
+++ b/kopf/reactor/daemons.py
@@ -29,6 +29,7 @@ from kopf.engines import loggers
 from kopf.reactor import causation, effects, handling, lifecycles
 from kopf.storage import states
 from kopf.structs import configuration, containers, handlers as handlers_, patches, primitives
+from kopf.utilities import backports
 
 
 async def spawn_resource_daemons(
@@ -63,13 +64,13 @@ async def spawn_resource_daemons(
                 stopper=stopper,  # for stopping (outside of causes)
                 handler=handler,
                 logger=loggers.LocalObjectLogger(body=cause.body, settings=settings),
-                task=asyncio.create_task(_runner(
+                task=backports.create_task(_runner(
                     settings=settings,
                     daemons=daemons,  # for self-garbage-collection
                     handler=handler,
                     cause=daemon_cause,
                     memory=memory,
-                )),
+                ), name=f'runner of {handler.id}'),  # sometimes, daemons; sometimes, timers.
             )
             daemons[handler.id] = daemon
     return []

--- a/kopf/utilities/backports.py
+++ b/kopf/utilities/backports.py
@@ -1,0 +1,21 @@
+import asyncio
+import sys
+from typing import TYPE_CHECKING, Any, Awaitable, Generator, Optional, TypeVar, Union
+
+_T = TypeVar('_T')
+
+if TYPE_CHECKING:
+    asyncio_Task = asyncio.Task[Any]
+else:
+    asyncio_Task = asyncio.Task
+
+# Accept `name=` always, but simulate it for Python 3.7 to do nothing.
+if sys.version_info >= (3, 8):
+    create_task = asyncio.create_task
+else:
+    def create_task(
+            coro: Union[Generator[Any, None, _T], Awaitable[_T]],
+            *,
+            name: Optional[str] = None,  # noqa
+    ) -> asyncio_Task:
+        return asyncio.create_task(coro)

--- a/tests/utilities/test_backports.py
+++ b/tests/utilities/test_backports.py
@@ -1,0 +1,24 @@
+import asyncio
+
+import pytest
+
+from kopf.utilities.backports import create_task
+
+
+async def sample() -> None:
+    pass
+
+
+@pytest.mark.skipif('sys.version_info < (3, 8)')
+def test_py38_create_task_is_the_native_one():
+    assert create_task is asyncio.create_task
+
+
+@pytest.mark.skipif('sys.version_info >= (3, 8)')
+async def test_py37_create_task_accepts_name(mocker):
+    real_create_task = mocker.patch('asyncio.create_task')
+    coro = sample()
+    task = create_task(coro, name='unused')
+    assert real_create_task.called
+    assert task is real_create_task.return_value
+    await coro  # to prevent "never awaited" errors


### PR DESCRIPTION
## What do these changes do?

Expose the name/purpose of the asyncio tasks in tests and at runtime in case of failures. Previously, they were anonymous "Task-25" and alike.

## Description

For Python 3.7, keep the tasks unnamed (it does not support named tasks):

* https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.set_name
* https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task


## Issues

#338 

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
