### PR TITLE
Terminate ultimately via SIGKILL after a timeout (10m by default)

### DIFF
--- a/kopf/structs/configuration.py
+++ b/kopf/structs/configuration.py
@@ -34,6 +34,31 @@ from kopf.storage import diffbase, progress
 
 
 @dataclasses.dataclass
+class ProcessSettings:
+    """
+    Settings for Kopf's OS processes: e.g. when started via CLI as `kopf run`.
+    """
+
+    ultimate_exiting_timeout: Optional[float] = 10 * 60
+    """
+    How long to wait for the graceful exit before SIGKILL'ing the operator.
+
+    This is the last resort to make the operator exit instead of getting stuck
+    at exiting due to the framework's bugs, operator's bugs, threads left,
+    daemons not exiting, etc.
+    
+    The countdown goes from when a graceful signal arrives (SIGTERM/SIGINT),
+    regardless of what is happening in the graceful exiting routine.
+
+    Measured in seconds. Set to `None` to disable (on your own risk).
+    
+    The default is 10 minutes -- high enough for all common sense cases,
+    and higher than K8s pods' ``terminationGracePeriodSeconds`` -- 
+    to let K8s kill the operator's pod instead, if it can.
+    """
+
+
+@dataclasses.dataclass
 class LoggingSettings:
     pass
 
@@ -263,6 +288,7 @@ class BackgroundSettings:
 
 @dataclasses.dataclass
 class OperatorSettings:
+    process: ProcessSettings = dataclasses.field(default_factory=ProcessSettings)
     logging: LoggingSettings = dataclasses.field(default_factory=LoggingSettings)
     posting: PostingSettings = dataclasses.field(default_factory=PostingSettings)
     watching: WatchingSettings = dataclasses.field(default_factory=WatchingSettings)

--- a/kopf/structs/primitives.py
+++ b/kopf/structs/primitives.py
@@ -64,6 +64,26 @@ async def raise_flag(
         raise TypeError(f"Unsupported type of a flag: {flag!r}")
 
 
+def check_flag(
+        flag: Optional[Flag],
+) -> Optional[bool]:
+    """
+    Check if a flag is raised.
+    """
+    if flag is None:
+        return None
+    elif isinstance(flag, asyncio.Future):
+        return flag.done()
+    elif isinstance(flag, asyncio.Event):
+        return flag.is_set()
+    elif isinstance(flag, concurrent.futures.Future):
+        return flag.done()
+    elif isinstance(flag, threading.Event):
+        return flag.is_set()
+    else:
+        raise TypeError(f"Unsupported type of a flag: {flag!r}")
+
+
 class Toggle:
     """
     An synchronisation primitive that can be awaited both until set or cleared.

--- a/tests/primitives/test_flags.py
+++ b/tests/primitives/test_flags.py
@@ -4,7 +4,7 @@ import threading
 
 import pytest
 
-from kopf.structs.primitives import raise_flag, wait_flag
+from kopf.structs.primitives import check_flag, raise_flag, wait_flag
 
 
 @pytest.fixture(params=[
@@ -26,6 +26,70 @@ async def flag(request):
             flag.cancel()
         if hasattr(flag, 'set'):
             flag.set()
+
+
+async def test_checking_of_unsupported_raises_an_error():
+    with pytest.raises(TypeError):
+        check_flag(object())
+
+
+async def test_checking_of_none_is_none():
+    result = check_flag(None)
+    assert result is None
+
+
+async def test_checking_of_asyncio_event_when_raised():
+    event = asyncio.Event()
+    event.set()
+    result = check_flag(event)
+    assert result is True
+
+
+async def test_checking_of_asyncio_event_when_unset():
+    event = asyncio.Event()
+    event.clear()
+    result = check_flag(event)
+    assert result is False
+
+
+async def test_checking_of_asyncio_future_when_set():
+    future = asyncio.Future()
+    future.set_result(None)
+    result = check_flag(future)
+    assert result is True
+
+
+async def test_checking_of_asyncio_future_when_empty():
+    future = asyncio.Future()
+    result = check_flag(future)
+    assert result is False
+
+
+async def test_checking_of_threading_event_when_set():
+    event = threading.Event()
+    event.set()
+    result = check_flag(event)
+    assert result is True
+
+
+async def test_checking_of_threading_event_when_unset():
+    event = threading.Event()
+    event.clear()
+    result = check_flag(event)
+    assert result is False
+
+
+async def test_checking_of_concurrent_future_when_set():
+    future = concurrent.futures.Future()
+    future.set_result(None)
+    result = check_flag(future)
+    assert result is True
+
+
+async def test_checking_of_concurrent_future_when_unset():
+    future = concurrent.futures.Future()
+    result = check_flag(future)
+    assert result is False
 
 
 async def test_raising_of_unsupported_raises_an_error():


### PR DESCRIPTION
## What do these changes do?

Force-terminate the operator after 10 minutes of its inability to gracefully terminate. This is needed to prevent operators from being stuck forever or even overnight — now, they can restart at least somewhen soon.

## Description

If the operator is able to gracefully terminate within the timeout, the behaviour remains as before.

A case where this is reproduced artificially (run, then Ctrl-C or SIGINT or SIGTERM it; in PyCharm, Cmd+F2 — it will never exit without this PR).

```python
import time
import kopf

@kopf.daemon('zalando.org', 'v1', 'kopfexamples')
def daemon_fn(**_):
    i = 0
    while True:
        print(i)
        time.sleep(1)
        i += 1
```

This feature does not cover the case when the operator decides to exit from inside: e.g. when the stop_flag is set by an operator-controlling app, or an error happens.

The code is not unit-tested: we do not have unit-test for the running routines and tasks. This is indirectly tested by example operators not crashing, and manually with the timeout of 10 seconds and a sync daemon that never exits and ignores `stopped` flag.


## Issues/PRs

<!-- Cross-referencing is highly useful in hindsight. Put the main issue, and all the related/affected/causing/preceding issues and PRs related to this change. --> 

> Issues: fixes #370

> Related: #509 (reduces the probability of this bug happening, but does not remove it completely, as seen in the code snippet).


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
