### PR TITLE
Add CLI options for JSON, full- & plain-text logging

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -33,6 +33,90 @@ only for fine-tuning when and if necessary.
 For more settings, see `kopf.OperatorSettings` and :kwarg:`settings` kwarg.
 
 
+Logging formats and levels
+==========================
+
+The following log formats are supported on CLI:
+
+* Full logs (the default) -- with timestamps, log levels, and logger names:
+
+    .. code-block:: bash
+
+        kopf run -v --log-format=full
+
+    .. code-block:: console
+
+        [2019-11-04 17:49:25,365] kopf.reactor.activit [INFO    ] Initial authentication has been initiated.
+        [2019-11-04 17:49:25,650] kopf.objects         [DEBUG   ] [default/kopf-example-1] Resuming event: ...
+
+* Plain logs, with only the message:
+
+    .. code-block:: bash
+
+        kopf run -v --log-format=plain
+
+    .. code-block:: console
+
+        Initial authentication has been initiated.
+        [default/kopf-example-1] Resuming event: ...
+
+  For non-JSON logs, the object prefix can be disabled to make the logs
+  completely flat (as in JSON logs):
+
+    .. code-block:: bash
+
+        kopf run -v --log-format=plain --no-log-prefix
+
+    .. code-block:: console
+
+        Initial authentication has been initiated.
+        Resuming event: ...
+
+* JSON logs, with only the message:
+
+    .. code-block:: bash
+
+        kopf run -v --log-format=json
+
+    .. code-block:: console
+
+        {"message": "Initial authentication has been initiated.", "severity": "info", "timestamp": "2020-12-31T23:59:59.123456"}
+        {"message": "Resuming event: ...", "object": {"apiVersion": "zalando.org/v1", "kind": "KopfExample", "name": "kopf-example-1", "uid": "...", "namespace": "default"}, "severity": "debug", "timestamp": "2020-12-31T23:59:59.123456"}
+
+  For JSON logs, the object reference key can be configured to match
+  the log parsers (if used) -- instead of the default ``"object"``:
+
+    .. code-block:: bash
+
+        kopf run -v --log-format=json --log-refkey=k8s-obj
+
+    .. code-block:: console
+
+        {"message": "Initial authentication has been initiated.", "severity": "info", "timestamp": "2020-12-31T23:59:59.123456"}
+        {"message": "Resuming event: ...", "k8s-obj": {...}, "severity": "debug", "timestamp": "2020-12-31T23:59:59.123456"}
+
+    Note that the object prefixing is disabled for JSON logs by default, as the
+    identifying information is available in the ref-keys. The prefixing can be
+    explicitly re-enabled if needed:
+
+    .. code-block:: bash
+
+        kopf run -v --log-format=json --log-prefix
+
+    .. code-block:: console
+
+        {"message": "Initial authentication has been initiated.", "severity": "info", "timestamp": "2020-12-31T23:59:59.123456"}
+        {"message": "[default/kopf-example-1] Resuming event: ...", "object": {...}, "severity": "debug", "timestamp": "2020-12-31T23:59:59.123456"}
+
+.. note::
+
+    Logging verbosity and formatting are only configured via CLI options,
+    not via ``settings.logging`` as all other aspects of configuration.
+    When the startup handlers happen for ``settings``, it is too late:
+    some initial messages could be already logged in the existing formats,
+    or not logged when they should be due to verbosity/quietness levels.
+
+
 Logging events
 ==============
 

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -20,6 +20,7 @@ from kopf.config import (
 )
 from kopf.engines.loggers import (
     configure,
+    LogFormat,
     ObjectLogger,
     LocalObjectLogger,
 )
@@ -163,7 +164,7 @@ HandlerRetryError = TemporaryError  # a backward-compatibility alias
 
 __all__ = [
     'on', 'lifecycles', 'register', 'execute', 'daemon', 'timer',
-    'configure',
+    'configure', 'LogFormat',
     'login', 'LoginError', 'ConnectionInfo',
     'login_via_pykube', 'login_via_client',
     'event', 'info', 'warn', 'exception',

--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -21,14 +21,32 @@ class CLIControls:
     settings: Optional[configuration.OperatorSettings] = None
 
 
+class LogFormatParamType(click.Choice):
+
+    def __init__(self) -> None:
+        super().__init__(choices=[v.name.lower() for v in loggers.LogFormat])
+
+    def convert(self, value: Any, param: Any, ctx: Any) -> loggers.LogFormat:
+        name: str = super().convert(value, param, ctx)
+        return loggers.LogFormat[name.upper()]
+
+
 def logging_options(fn: Callable[..., Any]) -> Callable[..., Any]:
-    """ A decorator to configure logging in all command in the same way."""
+    """ A decorator to configure logging in all commands the same way."""
     @click.option('-v', '--verbose', is_flag=True)
     @click.option('-d', '--debug', is_flag=True)
     @click.option('-q', '--quiet', is_flag=True)
+    @click.option('--log-format', type=LogFormatParamType(), default='full')
+    @click.option('--log-refkey', type=str)
+    @click.option('--log-prefix/--no-log-prefix', default=None)
     @functools.wraps(fn)  # to preserve other opts/args
-    def wrapper(verbose: bool, quiet: bool, debug: bool, *args: Any, **kwargs: Any) -> Any:
-        loggers.configure(debug=debug, verbose=verbose, quiet=quiet)
+    def wrapper(verbose: bool, quiet: bool, debug: bool,
+                log_format: loggers.LogFormat = loggers.LogFormat.FULL,
+                log_prefix: Optional[bool] = False,
+                log_refkey: Optional[str] = None,
+                *args: Any, **kwargs: Any) -> Any:
+        loggers.configure(debug=debug, verbose=verbose, quiet=quiet,
+                          log_format=log_format, log_refkey=log_refkey, log_prefix=log_prefix)
         return fn(*args, **kwargs)
 
     return wrapper

--- a/kopf/engines/loggers.py
+++ b/kopf/engines/loggers.py
@@ -23,7 +23,9 @@ class ObjectPrefixingFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         if hasattr(record, 'k8s_ref'):
             ref = getattr(record, 'k8s_ref')
-            prefix = f"[{ref.get('namespace', '')}/{ref.get('name', '')}]"
+            namespace = ref.get('namespace', '')
+            name = ref.get('name', '')
+            prefix = f"[{namespace}/{name}]" if namespace else f"[{name}]"
             record = copy.copy(record)  # shallow
             record.msg = f"{prefix} {record.msg}"
         return super().format(record)

--- a/kopf/engines/loggers.py
+++ b/kopf/engines/loggers.py
@@ -149,27 +149,9 @@ def configure(
     logger.addHandler(handler)
     logger.setLevel(log_level)
 
-    # Configure the Kubernetes client defaults according to our settings.
-    try:
-        import kubernetes
-    except ImportError:
-        pass
-    else:
-        config = kubernetes.client.configuration.Configuration()
-        config.logger_format = format
-        config.logger_file = None  # once again after the constructor to re-apply the formatter
-        config.debug = debug
-        kubernetes.client.configuration.Configuration.set_default(config)
-
-    # Kubernetes client is as buggy as hell: it adds its own stream handlers even in non-debug mode,
-    # does not respect the formatting, and dumps too much of the low-level info.
-    if not debug:
-        logger = logging.getLogger("urllib3")
-        del logger.handlers[1:]  # everything except the default NullHandler
-
-    # Prevent the low-level logging unless in the debug verbosity mode. Keep only the operator's messages.
+    # Prevent the low-level logging unless in the debug mode. Keep only the operator's messages.
     # For no-propagation loggers, add a dummy null handler to prevent printing the messages.
-    for name in ['urllib3', 'asyncio', 'kubernetes']:
+    for name in ['asyncio']:
         logger = logging.getLogger(name)
         logger.propagate = bool(debug)
         if not debug:

--- a/kopf/structs/configuration.py
+++ b/kopf/structs/configuration.py
@@ -59,11 +59,6 @@ class ProcessSettings:
 
 
 @dataclasses.dataclass
-class LoggingSettings:
-    pass
-
-
-@dataclasses.dataclass
 class PostingSettings:
 
     enabled: bool = True
@@ -289,7 +284,6 @@ class BackgroundSettings:
 @dataclasses.dataclass
 class OperatorSettings:
     process: ProcessSettings = dataclasses.field(default_factory=ProcessSettings)
-    logging: LoggingSettings = dataclasses.field(default_factory=LoggingSettings)
     posting: PostingSettings = dataclasses.field(default_factory=PostingSettings)
     watching: WatchingSettings = dataclasses.field(default_factory=WatchingSettings)
     batching: BatchingSettings = dataclasses.field(default_factory=BatchingSettings)

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     ],
     install_requires=[
         'typing_extensions',
+        'python-json-logger',
         'click',
         'iso8601',
         'aiohttp<4.0.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ import pytest_mock
 
 import kopf
 from kopf.clients.auth import APIContext
-from kopf.engines.loggers import ObjectPrefixingFormatter, configure
+from kopf.engines.loggers import ObjectPrefixingTextFormatter, configure
 from kopf.engines.posting import settings_var
 from kopf.structs.configuration import OperatorSettings
 from kopf.structs.credentials import ConnectionInfo, Vault, VaultKey
@@ -521,7 +521,7 @@ def logstream(caplog):
     # Inject our stream-intercepting handler.
     stream = io.StringIO()
     handler = logging.StreamHandler(stream)
-    formatter = ObjectPrefixingFormatter('prefix %(message)s')
+    formatter = ObjectPrefixingTextFormatter('prefix %(message)s')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 

--- a/tests/logging/conftest.py
+++ b/tests/logging/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _caplog_all_levels(caplog):
+    caplog.set_level(0)

--- a/tests/logging/test_configuration.py
+++ b/tests/logging/test_configuration.py
@@ -1,0 +1,96 @@
+import logging.handlers
+from typing import Collection
+
+import pytest
+
+from kopf.engines.loggers import LogFormat, ObjectFormatter, ObjectJsonFormatter, \
+                                 ObjectPrefixingJsonFormatter, ObjectPrefixingTextFormatter, \
+                                 ObjectTextFormatter, configure
+
+
+@pytest.fixture(autouse=True)
+def _clear_own_handlers():
+    logger = logging.getLogger()
+    logger.handlers[:] = [
+        handler for handler in logger.handlers
+        if not isinstance(handler, logging.StreamHandler) or
+           not isinstance(handler.formatter, ObjectFormatter)
+    ]
+
+
+def _get_own_handlers(logger: logging.Logger) -> Collection[logging.Handler]:
+    return [
+        handler for handler in logger.handlers
+        if isinstance(handler, logging.StreamHandler) and
+           isinstance(handler.formatter, ObjectFormatter)
+    ]
+
+
+def test_own_formatter_is_used():
+    configure()
+    logger = logging.getLogger()
+    own_handlers = _get_own_handlers(logger)
+    assert len(own_handlers) == 1
+
+
+@pytest.mark.parametrize('log_format', [LogFormat.FULL, LogFormat.PLAIN, '%(message)s'])
+def test_formatter_nonprefixed_text(log_format):
+    configure(log_format=log_format, log_prefix=False)
+    logger = logging.getLogger()
+    own_handlers = _get_own_handlers(logger)
+    assert len(own_handlers) == 1
+    assert type(own_handlers[0].formatter) is ObjectTextFormatter
+
+
+@pytest.mark.parametrize('log_format', [LogFormat.FULL, LogFormat.PLAIN, '%(message)s'])
+def test_formatter_prefixed_text(log_format):
+    configure(log_format=log_format, log_prefix=True)
+    logger = logging.getLogger()
+    own_handlers = _get_own_handlers(logger)
+    assert len(own_handlers) == 1
+    assert type(own_handlers[0].formatter) is ObjectPrefixingTextFormatter
+
+
+@pytest.mark.parametrize('log_format', [LogFormat.JSON])
+def test_formatter_nonprefixed_json(log_format):
+    configure(log_format=log_format, log_prefix=False)
+    logger = logging.getLogger()
+    own_handlers = _get_own_handlers(logger)
+    assert len(own_handlers) == 1
+    assert type(own_handlers[0].formatter) is ObjectJsonFormatter
+
+
+@pytest.mark.parametrize('log_format', [LogFormat.JSON])
+def test_formatter_prefixed_json(log_format):
+    configure(log_format=log_format, log_prefix=True)
+    logger = logging.getLogger()
+    own_handlers = _get_own_handlers(logger)
+    assert len(own_handlers) == 1
+    assert type(own_handlers[0].formatter) is ObjectPrefixingJsonFormatter
+
+
+@pytest.mark.parametrize('log_format', [LogFormat.JSON])
+def test_json_has_no_prefix_by_default(log_format):
+    configure(log_format=log_format, log_prefix=None)
+    logger = logging.getLogger()
+    own_handlers = _get_own_handlers(logger)
+    assert len(own_handlers) == 1
+    assert type(own_handlers[0].formatter) is ObjectJsonFormatter
+
+
+def test_error_on_unknown_formatter():
+    with pytest.raises(ValueError):
+        configure(log_format=object())
+
+
+@pytest.mark.parametrize('verbose, debug, quiet, expected_level', [
+    (None, None, None, logging.INFO),
+    (True, None, None, logging.DEBUG),
+    (None, True, None, logging.DEBUG),
+    (True, True, True, logging.DEBUG),
+    (None, None, True, logging.WARNING),
+])
+def test_levels(verbose, debug, quiet, expected_level):
+    configure(verbose=verbose, debug=debug, quiet=quiet)
+    logger = logging.getLogger()
+    assert logger.level == expected_level

--- a/tests/logging/test_formatters.py
+++ b/tests/logging/test_formatters.py
@@ -1,0 +1,144 @@
+import json
+import logging.handlers
+
+import pytest
+
+from kopf.engines.loggers import LocalObjectLogger, ObjectJsonFormatter, \
+                                 ObjectPrefixingJsonFormatter, ObjectPrefixingTextFormatter, \
+                                 ObjectTextFormatter
+from kopf.structs.bodies import Body
+
+
+@pytest.fixture()
+def ns_body():
+    return Body({
+        'kind': 'kind1',
+        'apiVersion': 'api1/v1',
+        'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'namespace1'},
+    })
+
+
+@pytest.fixture()
+def cluster_body():
+    return Body({
+        'kind': 'kind1',
+        'apiVersion': 'api1/v1',
+        'metadata': {'uid': 'uid1', 'name': 'name1'},
+    })
+
+
+@pytest.fixture()
+def ns_record(settings, ns_body):
+    handler = logging.handlers.BufferingHandler(capacity=100)
+    logger = LocalObjectLogger(body=ns_body, settings=settings)  # to avoid k8s-posting
+    logger.logger.addHandler(handler)
+    logger.info("hello")
+    return handler.buffer[0]
+
+
+@pytest.fixture()
+def cluster_record(settings, cluster_body):
+    handler = logging.handlers.BufferingHandler(capacity=100)
+    logger = LocalObjectLogger(body=cluster_body, settings=settings)  # to avoid k8s-posting
+    logger.logger.addHandler(handler)
+    logger.info("hello")
+    return handler.buffer[0]
+
+
+def test_prefixing_text_formatter_adds_prefixes_when_namespaced(ns_record):
+    formatter = ObjectPrefixingTextFormatter()
+    formatted = formatter.format(ns_record)
+    assert formatted == '[namespace1/name1] hello'
+
+
+def test_prefixing_text_formatter_adds_prefixes_when_cluster(cluster_record):
+    formatter = ObjectPrefixingTextFormatter()
+    formatted = formatter.format(cluster_record)
+    assert formatted == '[name1] hello'
+
+
+def test_prefixing_json_formatter_adds_prefixes_when_namespaced(ns_record):
+    formatter = ObjectPrefixingJsonFormatter()
+    formatted = formatter.format(ns_record)
+    decoded = json.loads(formatted)
+    assert decoded['message'] == '[namespace1/name1] hello'
+
+
+def test_prefixing_json_formatter_adds_prefixes_when_clustered(cluster_record):
+    formatter = ObjectPrefixingJsonFormatter()
+    formatted = formatter.format(cluster_record)
+    decoded = json.loads(formatted)
+    assert decoded['message'] == '[name1] hello'
+
+
+def test_regular_text_formatter_omits_prefixes(ns_record):
+    formatter = ObjectTextFormatter()
+    formatted = formatter.format(ns_record)
+    assert formatted == 'hello'
+
+
+def test_regular_json_formatter_omits_prefixes(ns_record):
+    formatter = ObjectJsonFormatter()
+    formatted = formatter.format(ns_record)
+    decoded = json.loads(formatted)
+    assert decoded['message'] == 'hello'
+
+
+@pytest.mark.parametrize('cls', [ObjectJsonFormatter, ObjectPrefixingJsonFormatter])
+@pytest.mark.parametrize('levelno, expected_severity', [
+    (0,  'debug'),
+    (logging.DEBUG - 1, 'debug'),
+    (logging.DEBUG, 'debug'),
+    (logging.DEBUG + 1, 'info'),
+    (logging.INFO - 1, 'info'),
+    (logging.INFO, 'info'),
+    (logging.INFO + 1, 'warn'),
+    (logging.WARNING - 1, 'warn'),
+    (logging.WARNING, 'warn'),
+    (logging.WARNING + 1, 'error'),
+    (logging.ERROR - 1, 'error'),
+    (logging.ERROR, 'error'),
+    (logging.ERROR + 1, 'fatal'),
+    (logging.FATAL - 1, 'fatal'),
+    (logging.FATAL, 'fatal'),
+    (logging.FATAL + 1, 'fatal'),
+    (999, 'fatal'),
+])
+def test_json_formatters_add_severity(ns_record, cls, levelno, expected_severity):
+    ns_record.levelno = levelno
+    ns_record.levelname = 'must-be-irrelevant'
+    formatter = cls()
+    formatted = formatter.format(ns_record)
+    decoded = json.loads(formatted)
+    assert 'severity' in decoded
+    assert decoded['severity'] == expected_severity
+
+
+@pytest.mark.parametrize('cls', [ObjectJsonFormatter, ObjectPrefixingJsonFormatter])
+def test_json_formatters_add_refkey_with_default_key(ns_record, cls):
+    formatter = cls()
+    formatted = formatter.format(ns_record)
+    decoded = json.loads(formatted)
+    assert 'object' in decoded
+    assert decoded['object'] == {
+        'uid': 'uid1',
+        'name': 'name1',
+        'namespace': 'namespace1',
+        'apiVersion': 'api1/v1',
+        'kind': 'kind1',
+    }
+
+
+@pytest.mark.parametrize('cls', [ObjectJsonFormatter, ObjectPrefixingJsonFormatter])
+def test_json_formatters_add_refkey_with_custom_key(ns_record, cls):
+    formatter = cls(refkey='k8s-obj')
+    formatted = formatter.format(ns_record)
+    decoded = json.loads(formatted)
+    assert 'k8s-obj' in decoded
+    assert decoded['k8s-obj'] == {
+        'uid': 'uid1',
+        'name': 'name1',
+        'namespace': 'namespace1',
+        'apiVersion': 'api1/v1',
+        'kind': 'kind1',
+    }

--- a/tests/logging/test_loggers.py
+++ b/tests/logging/test_loggers.py
@@ -1,0 +1,62 @@
+import pytest
+
+from kopf.engines.loggers import LocalObjectLogger, ObjectLogger
+from kopf.structs.bodies import Body
+
+
+@pytest.mark.parametrize('cls', [ObjectLogger, LocalObjectLogger])
+def test_mandatory_body(cls, settings, caplog):
+    with pytest.raises(TypeError):
+        cls(settings=settings)
+
+
+@pytest.mark.parametrize('cls', [ObjectLogger, LocalObjectLogger])
+def test_mandatory_settings(cls, settings, caplog):
+    with pytest.raises(TypeError):
+        cls(body=Body({}))
+
+
+@pytest.mark.parametrize('cls', [ObjectLogger, LocalObjectLogger])
+def test_extras_from_metadata(cls, settings, caplog):
+    body = Body({
+        'kind': 'kind1',
+        'apiVersion': 'api1/v1',
+        'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'namespace1'},
+    })
+
+    logger = cls(body=body, settings=settings)
+    logger.info("hello")
+
+    assert len(caplog.records) == 1
+    assert hasattr(caplog.records[0], 'k8s_ref')
+    assert caplog.records[0].k8s_ref == {
+        'uid': 'uid1',
+        'name': 'name1',
+        'namespace': 'namespace1',
+        'apiVersion': 'api1/v1',
+        'kind': 'kind1',
+    }
+
+
+@pytest.mark.parametrize('cls', [ObjectLogger])
+def test_k8s_posting_enabled_in_a_regular_logger(cls, settings, caplog):
+    body = Body({})
+
+    logger = cls(body=body, settings=settings)
+    logger.info("hello")
+
+    assert len(caplog.records) == 1
+    assert hasattr(caplog.records[0], 'k8s_skip')
+    assert caplog.records[0].k8s_skip is False
+
+
+@pytest.mark.parametrize('cls', [LocalObjectLogger])
+def test_k8s_posting_disabled_in_a_local_logger(cls, settings, caplog):
+    body = Body({})
+
+    logger = cls(body=body, settings=settings)
+    logger.info("hello")
+
+    assert len(caplog.records) == 1
+    assert hasattr(caplog.records[0], 'k8s_skip')
+    assert caplog.records[0].k8s_skip is True


### PR DESCRIPTION
## What do these changes do?

Add JSON logging configurable via CLI options. Also, add a plain-text log format (no timestamps, logger names, logging level) — for readability. The defaults remain the same.


## Description

JSON logging can be useful to upload structured log messages to the log processing systems such as Scalyr. With proper fields in the JSON structure, the log lines can be highlighted by their severity (error/warning/info/debug).

Also, the exception stack traces are sent as one message, not as multiple lines intermixed with other log lines — improves their readability in the logging analysis systems.

```shell
kopf run -v --log-format=json
```

```
{"message": "Initial authentication has been initiated.", "severity": "info"}
{"message": "Resuming event: ...", "object": {"apiVersion": "zalando.org/v1", "kind": "KopfExample", "name": "kopf-example-1", "uid": "...", "namespace": "default"}, "severity": "debug"}
```

The plain-text log messages can also be used for readability during development.

```shell
kopf run -v --log-format=plain
```

```
Initial authentication has been initiated.
[default/kopf-example-1] Resuming event: ...
```

The defaults remain the same: full-text log messages with timestamps, log levels, logger names, etc.

```shell
kopf run -v --log-format=full
```

```
[2019-11-04 17:49:25,365] kopf.reactor.activit [INFO    ] Initial authentication has been initiated.
[2019-11-04 17:49:25,650] kopf.objects         [DEBUG   ] [default/kopf-example-1] Resuming event: ...
```

## Issues/PRs

> Issues:  fixes #44 

**Note:** This PR goes without injecting the operator's peering identifier, as it is not known anywhere outside the peering engine. This feature needs some code refactoring, and brings little value — pod ids can be useful instead.

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
