### PR TITLE
Stealth mode for filtered out resources

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -112,3 +112,30 @@ The following wrappers are available:
 * `kopf.any_([...])` -- at least one of the functions must return ``True``.
 * `kopf.all_([...])` -- all of the functions must return ``True``.
 * `kopf.none_([...])` -- all of the functions must return ``False``.
+
+
+Stealth mode
+============
+
+.. note::
+
+    Please note that if an object does not match any filters of any handlers
+    for its resource kind, there will be no messages logged and no annotations
+    stored on the object. Such objects are processed in the stealth mode
+    even if the operator technically sees them in the watch-stream.
+
+    As the result, when the object is updated to match the filters some time
+    later (e.g. by putting labels/annotations on it, or changing its spec),
+    this will not be considered as an update, but as a creation.
+
+    From the operator's point of view, the object has suddenly appeared
+    in sight with no diff-base, which means that it is a newly created object;
+    so, the on-creation handlers will be called instead of the on-update ones.
+
+    This behaviour is correct and reasonable from the filtering logic side.
+    If this is a problem, then create a dummy handler without filters
+    (e.g. a field-handler for a non-existent field) --
+    this will make all the objects always being in the scope of the operator,
+    even if the operator did not react to their creation/update/deletion,
+    and so the diff-base annotations ("last-handled-configuration", etc)
+    will be always added on the actual object creation, not on scope changes.

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -270,6 +270,15 @@ class ResourceChangingRegistry(ResourceRegistry[
                     elif match(handler=handler, cause=cause):
                         yield handler
 
+    def prematch(
+            self,
+            cause: causation.ResourceChangingCause,
+    ) -> bool:
+        for handler in self._handlers:
+            if match(handler=handler, cause=cause, ignore_fields=True):
+                return True
+        return False
+
 
 class OperatorRegistry:
     """


### PR DESCRIPTION
## What do these changes do?

If there are handlers for the resource kind in general, but no single matching handlers for a specific resource object (e.g. due to annotations/labels/when filters), then go **stealth mode**: store no last-handled-configuration, log nothing about the handling cycle.

## Description

Previously, Kopf put the last-handled-configuration annotation for all the objects that had high-level handlers (on-creation/update/deletion/resuming), and logged about the end of the handling cycle for all objects regardless of the handlers. This polluted the logs with the messages about the object of no interest.

As an example, the resources can be filtered out by namespace with `when=` in a cluster-scoped operator. Or by labels/annotations designated for this specific operator/controller to react to.

Another common example is watching for all the pods in the cluster, but only creating to those belonging to one specific application. Without the stealth mode, all the pods of all apps, even the K8s's own system pods, are logged and annotated (even if there are no handlers for them).

Now, if the individual object has no matching handlers, even if there are handlers for this resource kind in general, such an object will be ignored completely: no logs, no annotations.

---

This leads to some **unusual, but correct** behaviour. Consider this operator:

```python
import kopf

@kopf.on.update('zalando.org', 'v1', 'kopfexamples', labels={'xxx': '123'})
def update_fn(**kwargs):
    pass
```

Once the object is created, it will be ignored, as described. However, once a label xxx=123 is put on it later (minutes/hours/days), it will not be considered as an object update, but as an object creation: because there was no "last-handled-configuration".

From Kopf's point of view, the object has suddenly appeared in scope, so it is a newly created object — and so, the `@kopf.on.create` handlers will be called, not the `@kopf.on.update` handlers.

It is left to the operator developers to describe handlers properly for such scenarios with filtering (e.g. with one function annotated with both creation & update decorators, or with a no-op creation handler without filters, or even a fake field-handler for a nonexistent field and no other filters — that would work too).

---
Another example: when an object is in scope on the creation or later, the "last-handled-configuration" is put on it, and the logs are made. If later it falls out of scope — e.g. again by annotations/labels/when filters — this happens completely silently, with no logs.

From Kopf's point of view, the object suddenly ceased to exist anymore. There is no way to detect the case when the object is leaving the operator's scope, and to clean any associated system/external resources, except as to have unfiltered on-deletion handlers. This seems reasonable: if the deletion reaction is narrowed to specific preconditions, then without these preconditions, the reaction does not happen.

Previously, there were some phantom log lines about the finished handling cycle & "really deleted" messages, that at least hinted about the object's existence.

---
For regular cases without filtering at least for one (any!) handler, the objects are handled as before.


## Issues/PRs

> Issues: fixes #374 #158 


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
