### PR TITLE
Require a finalizer for timers — same as for daemons

### DIFF
--- a/kopf/on.py
+++ b/kopf/on.py
@@ -347,7 +347,7 @@ def daemon(  # lgtm[py/similar-function]
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             labels=labels, annotations=annotations, when=when,
-            initial_delay=initial_delay, requires_finalizer=True,  #TODO: requires_finalizer? "optional"?
+            initial_delay=initial_delay, requires_finalizer=True,
             cancellation_backoff=cancellation_backoff,
             cancellation_timeout=cancellation_timeout,
             cancellation_polling=cancellation_polling,
@@ -386,7 +386,7 @@ def timer(  # lgtm[py/similar-function]
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             labels=labels, annotations=annotations, when=when,
-            initial_delay=initial_delay, requires_finalizer=None,
+            initial_delay=initial_delay, requires_finalizer=True,
             sharp=sharp, idle=idle, interval=interval,
         )
         real_registry.resource_spawning_handlers[real_resource].append(handler)


### PR DESCRIPTION
## What do these changes do?

Fix a bug when the timer never stops after the resource is deleted.

## Description

Thorough unit-testing only covered the daemons and daemon exiting routine/ The assumption was, since timers are built-in daemons with a short handler, they will behave the same. The assumption is still valid, but the timers were defined not exactly as daemons: they didn't require a finalizer, while the daemons did.

The finalizer is supposed to slow down the deletion until the framework confirms that all the cleanups are done by removing the finalizer. 

The absence of the finalizer caused an issue, where the deletion of an object was instantly fast and went unnoticed for the timer, so the timer was not stopped and continued to run.

The proper procedure is: the `metadata.deletionTimestamp` is set, the framework notices it, initiates the daemons/timers stopping, removes the finalizer, and the object actually disappears, and the "DELETED" event is sent. The actual procedure was: the object just disappeared, and the "DELETED" event was sent — but it was too late to react.

Predictably, in the presence of other daemons (not timers), or the deletion handlers, the timers were stopping properly — as the finalizer was put on the object as expected.

## Issues/PRs

> Issues: fixes #390 

> Related: introduced in #330, #342 

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
