### PR TITLE
Purge the handlers' states even if the handlers are filtered out

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -52,10 +52,10 @@ from kopf.reactor.lifecycles import (
     set_default_lifecycle,
 )
 from kopf.reactor.registries import (
-    ActivityRegistry,
-    ResourceRegistry,
-    ResourceWatchingRegistry,
-    ResourceChangingRegistry,
+    ActivityRegistry,  # deprecated
+    ResourceRegistry,  # deprecated
+    ResourceWatchingRegistry,  # deprecated
+    ResourceChangingRegistry,  # deprecated
     OperatorRegistry,
     get_default_registry,
     set_default_registry,
@@ -185,10 +185,10 @@ __all__ = [
     'BaseRegistry',  # deprecated
     'SimpleRegistry',  # deprecated
     'GlobalRegistry',  # deprecated
-    'ActivityRegistry',
-    'ResourceRegistry',
-    'ResourceWatchingRegistry',
-    'ResourceChangingRegistry',
+    'ActivityRegistry',  # deprecated
+    'ResourceRegistry',  # deprecated
+    'ResourceWatchingRegistry',  # deprecated
+    'ResourceChangingRegistry',  # deprecated
     'OperatorRegistry',
     'get_default_registry',
     'set_default_registry',

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -101,7 +101,7 @@ async def run_activity(
     # For the activity handlers, we have neither bodies, nor patches, just the state.
     cause = causation.ActivityCause(logger=logger, activity=activity, settings=settings)
     handlers = registry.activity_handlers.get_handlers(activity=activity)
-    state = states.State.from_scratch(handlers=handlers)
+    state = states.State.from_scratch().with_handlers(handlers)
     outcomes: MutableMapping[handlers_.HandlerId, states.HandlerOutcome] = {}
     while not state.done:
         current_outcomes = await handling.execute_handlers_once(

--- a/kopf/reactor/daemons.py
+++ b/kopf/reactor/daemons.py
@@ -373,7 +373,7 @@ async def _resource_daemon(
         await effects.sleep_or_wait(handler.initial_delay, cause.stopper)
 
     # Similar to activities (in-memory execution), but applies patches on every attempt.
-    state = states.State.from_scratch(handlers=[handler])
+    state = states.State.from_scratch().with_handlers([handler])
     while not stopper.is_set() and not state.done:
 
         outcomes = await handling.execute_handlers_once(
@@ -436,13 +436,13 @@ async def _resource_timer(
         await effects.sleep_or_wait(handler.initial_delay, stopper)
 
     # Similar to activities (in-memory execution), but applies patches on every attempt.
-    state = states.State.from_scratch(handlers=[handler])
+    state = states.State.from_scratch().with_handlers([handler])
     while not stopper.is_set():  # NB: ignore state.done! it is checked below explicitly.
 
         # Reset success/failure retry counters & timers if it has succeeded. Keep it if failed.
         # Every next invocation of a successful handler starts the retries from scratch (from zero).
         if state.done:
-            state = states.State.from_scratch(handlers=[handler])
+            state = states.State.from_scratch().with_handlers([handler])
 
         # Both `now` and `last_seen_time` are moving targets: the last seen time is updated
         # on every watch-event received, and prolongs the sleep. The sleep is never shortened.

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -149,13 +149,15 @@ async def execute(
 
     # Execute the real handlers (all or few or one of them, as per the lifecycle).
     settings: configuration.OperatorSettings = subsettings_var.get()
-    subhandlers = subregistry.get_handlers(cause=cause)
+    owned_handlers = subregistry.get_all_handlers()
+    cause_handlers = subregistry.get_handlers(cause=cause)
     storage = settings.persistence.progress_storage
-    state = states.State.from_storage(body=cause.body, storage=storage, handlers=subhandlers)
+    state = states.State.from_storage(body=cause.body, storage=storage, handlers=owned_handlers)
+    state = state.with_handlers(cause_handlers)
     outcomes = await execute_handlers_once(
         lifecycle=lifecycle,
         settings=settings,
-        handlers=subhandlers,
+        handlers=cause_handlers,
         cause=cause,
         state=state,
     )

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -16,8 +16,8 @@ import collections
 import functools
 import warnings
 from types import FunctionType, MethodType
-from typing import Any, Callable, Container, FrozenSet, Generic, Iterable, Iterator, List, \
-                   Mapping, MutableMapping, Optional, Sequence, Set, TypeVar, Union, cast
+from typing import Any, Callable, Collection, Container, FrozenSet, Generic, Iterable, Iterator, \
+                   List, Mapping, MutableMapping, Optional, Sequence, Set, TypeVar, Union, cast
 
 from kopf.reactor import causation, invocation
 from kopf.structs import callbacks, dicts, diffs, filters, handlers, resources as resources_
@@ -48,6 +48,9 @@ class GenericRegistry(Generic[HandlerFnT, HandlerT]):
 
     def append(self, handler: HandlerT) -> None:
         self._handlers.append(handler)
+
+    def get_all_handlers(self) -> Collection[HandlerT]:
+        return list(self._handlers)
 
 
 class ActivityRegistry(GenericRegistry[

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -79,8 +79,6 @@ async def test_2nd_step_finishes_the_handlers(caplog,
     event_body = {
         'metadata': {'finalizers': [settings.persistence.finalizer]},
         'status': {'kopf': {'progress': {
-            'resume_fn':  {'started': '1979-01-01T00:00:00', 'success': True},
-            'resume_fn2':  {'started': '1979-01-01T00:00:00', 'success': True},
             name1: {'started': '1979-01-01T00:00:00', 'success': True},
             name2: {'started': '1979-01-01T00:00:00'},
         }}}

--- a/tests/lifecycles/test_handler_selection.py
+++ b/tests/lifecycles/test_handler_selection.py
@@ -12,7 +12,7 @@ from kopf.storage.states import HandlerOutcome, State
     kopf.lifecycles.asap,
 ])
 def test_with_empty_input(lifecycle):
-    state = State.from_scratch(handlers=[])
+    state = State.from_scratch()
     handlers = []
     selected = lifecycle(handlers, state=state)
     assert isinstance(selected, (tuple, list))
@@ -83,7 +83,7 @@ def test_asap_takes_the_first_one_when_no_retries(mocker):
     handler2 = mocker.Mock(id='id2', spec_set=['id'])
     handler3 = mocker.Mock(id='id3', spec_set=['id'])
 
-    state = State.from_scratch(handlers=[handler1, handler2, handler3])
+    state = State.from_scratch().with_handlers([handler1, handler2, handler3])
     handlers = [handler1, handler2, handler3]
     selected = kopf.lifecycles.asap(handlers, state=state)
     assert isinstance(selected, (tuple, list))
@@ -97,7 +97,7 @@ def test_asap_takes_the_least_retried(mocker):
     handler3 = mocker.Mock(id='id3', spec_set=['id'])
 
     # Set the pre-existing state, and verify that it was set properly.
-    state = State.from_scratch(handlers=[handler1, handler2, handler3])
+    state = State.from_scratch().with_handlers([handler1, handler2, handler3])
     state = state.with_outcomes({handler1.id: HandlerOutcome(final=False)})
     state = state.with_outcomes({handler1.id: HandlerOutcome(final=False)})
     state = state.with_outcomes({handler3.id: HandlerOutcome(final=False)})

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -25,7 +25,7 @@ async def test_protocol_invocation(lifecycle, resource):
     Especially when the new kwargs are added or an invocation protocol changed.
     """
     # The values are irrelevant, they can be anything.
-    state = State.from_scratch(handlers=[])
+    state = State.from_scratch()
     cause = ResourceChangingCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
         resource=resource,

--- a/tests/persistence/test_states.py
+++ b/tests/persistence/test_states.py
@@ -34,11 +34,9 @@ def handler():
 
 
 @freezegun.freeze_time(TS0)
-def test_always_started_when_created_from_scratch(storage, handler):
-    patch = Patch()
-    state = State.from_scratch(handlers=[handler])
-    state.store(body=Body({}), patch=patch, storage=storage)
-    assert patch['status']['kopf']['progress']['some-id']['started'] == TS0_ISO
+def test_created_empty_from_scratch(storage, handler):
+    state = State.from_scratch()
+    assert len(state) == 0
 
 
 @pytest.mark.parametrize('expected, body', [
@@ -46,6 +44,23 @@ def test_always_started_when_created_from_scratch(storage, handler):
     (TS0_ISO, {'status': {}}),
     (TS0_ISO, {'status': {'kopf': {}}}),
     (TS0_ISO, {'status': {'kopf': {'progress': {}}}}),
+])
+@freezegun.freeze_time(TS0)
+def test_created_empty_from_empty_storage(storage, handler, body, expected):
+    state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    assert len(state) == 0
+
+
+@freezegun.freeze_time(TS0)
+def test_started_from_scratch(storage, handler):
+    patch = Patch()
+    state = State.from_scratch()
+    state = state.with_handlers([handler])
+    state.store(body=Body({}), patch=patch, storage=storage)
+    assert patch['status']['kopf']['progress']['some-id']['started'] == TS0_ISO
+
+
+@pytest.mark.parametrize('expected, body', [
     (TS0_ISO, {'status': {'kopf': {'progress': {'some-id': {}}}}}),
     (TS0_ISO, {'status': {'kopf': {'progress': {'some-id': {'started': None}}}}}),
     (TS0_ISO, {'status': {'kopf': {'progress': {'some-id': {'started': TS0_ISO}}}}}),
@@ -53,9 +68,26 @@ def test_always_started_when_created_from_scratch(storage, handler):
     (TSA_ISO, {'status': {'kopf': {'progress': {'some-id': {'started': TSA_ISO}}}}}),
 ])
 @freezegun.freeze_time(TS0)
-def test_always_started_when_created_from_body(storage, handler, body, expected):
+def test_started_from_storage(storage, handler, body, expected):
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state.store(body=Body({}), patch=patch, storage=storage)
+    assert patch['status']['kopf']['progress']['some-id']['started'] == expected
+
+
+@pytest.mark.parametrize('expected, body', [
+    (TS0_ISO, {'status': {'kopf': {'progress': {'some-id': {}}}}}),
+    (TS0_ISO, {'status': {'kopf': {'progress': {'some-id': {'started': None}}}}}),
+    (TS0_ISO, {'status': {'kopf': {'progress': {'some-id': {'started': TS0_ISO}}}}}),
+    (TSB_ISO, {'status': {'kopf': {'progress': {'some-id': {'started': TSB_ISO}}}}}),
+    (TSA_ISO, {'status': {'kopf': {'progress': {'some-id': {'started': TSA_ISO}}}}}),
+])
+def test_started_from_storage_is_preferred_over_from_scratch(storage, handler, body, expected):
+    with freezegun.freeze_time(TS0):
+        state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    with freezegun.freeze_time(TS1):
+        state = state.with_handlers([handler])
+    patch = Patch()
     state.store(body=Body({}), patch=patch, storage=storage)
     assert patch['status']['kopf']['progress']['some-id']['started'] == expected
 
@@ -74,6 +106,7 @@ def test_always_started_when_created_from_body(storage, handler, body, expected)
 @freezegun.freeze_time(TS0)
 def test_runtime(storage, handler, expected, body):
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     result = state[handler.id].runtime
     assert result == expected
 
@@ -93,6 +126,7 @@ def test_runtime(storage, handler, expected, body):
 ])
 def test_finished_flag(storage, handler, expected, body):
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     result = state[handler.id].finished
     assert result == expected
 
@@ -127,6 +161,7 @@ def test_finished_flag(storage, handler, expected, body):
 @freezegun.freeze_time(TS0)
 def test_sleeping_flag(storage, handler, expected, body):
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     result = state[handler.id].sleeping
     assert result == expected
 
@@ -161,6 +196,7 @@ def test_sleeping_flag(storage, handler, expected, body):
 @freezegun.freeze_time(TS0)
 def test_awakened_flag(storage, handler, expected, body):
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     result = state[handler.id].awakened
     assert result == expected
 
@@ -176,6 +212,7 @@ def test_awakened_flag(storage, handler, expected, body):
 ])
 def test_awakening_time(storage, handler, expected, body):
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     result = state[handler.id].delayed
     assert result == expected
 
@@ -190,6 +227,7 @@ def test_awakening_time(storage, handler, expected, body):
 ])
 def test_get_retry_count(storage, handler, expected, body):
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     result = state[handler.id].retries
     assert result == expected
 
@@ -203,6 +241,7 @@ def test_get_retry_count(storage, handler, expected, body):
 def test_set_awake_time(storage, handler, expected, body, delay):
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=False, delay=delay)})
     state.store(patch=patch, body=Body(body), storage=storage)
     assert patch['status']['kopf']['progress']['some-id'].get('delayed') == expected
@@ -225,6 +264,7 @@ def test_set_awake_time(storage, handler, expected, body, delay):
 def test_set_retry_time(storage, handler, expected_retries, expected_delayed, body, delay):
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=False, delay=delay)})
     state.store(patch=patch, body=Body(body), storage=storage)
     assert patch['status']['kopf']['progress']['some-id']['retries'] == expected_retries
@@ -238,6 +278,7 @@ def test_subrefs_added_to_empty_state(storage, handler):
     expected_subrefs = ['sub1', 'sub2', 'sub2/a', 'sub2/b', 'sub3']
     outcome = HandlerOutcome(final=True, subrefs=outcome_subrefs)
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     state = state.with_outcomes(outcomes={handler.id: outcome})
     state.store(patch=patch, body=Body(body), storage=storage)
     assert patch['status']['kopf']['progress']['some-id']['subrefs'] == expected_subrefs
@@ -250,6 +291,7 @@ def test_subrefs_added_to_preexisting_subrefs(storage, handler):
     expected_subrefs = ['sub1', 'sub2', 'sub2/a', 'sub2/b', 'sub3', 'sub9/1', 'sub9/2']
     outcome = HandlerOutcome(final=True, subrefs=outcome_subrefs)
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     state = state.with_outcomes(outcomes={handler.id: outcome})
     state.store(patch=patch, body=Body(body), storage=storage)
     assert patch['status']['kopf']['progress']['some-id']['subrefs'] == expected_subrefs
@@ -260,6 +302,7 @@ def test_subrefs_ignored_when_not_specified(storage, handler):
     patch = Patch()
     outcome = HandlerOutcome(final=True, subrefs=[])
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     state = state.with_outcomes(outcomes={handler.id: outcome})
     state.store(patch=patch, body=Body(body), storage=storage)
     assert patch['status']['kopf']['progress']['some-id']['subrefs'] is None
@@ -274,6 +317,7 @@ def test_store_failure(storage, handler, expected_retries, expected_stopped, bod
     error = Exception('some-error')
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=True, exception=error)})
     state.store(patch=patch, body=Body(body), storage=storage)
     assert patch['status']['kopf']['progress']['some-id']['success'] is False
@@ -291,6 +335,7 @@ def test_store_failure(storage, handler, expected_retries, expected_stopped, bod
 def test_store_success(storage, handler, expected_retries, expected_stopped, body):
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state = state.with_handlers([handler])
     state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=True)})
     state.store(patch=patch, body=Body(body), storage=storage)
     assert patch['status']['kopf']['progress']['some-id']['success'] is True
@@ -316,7 +361,7 @@ def test_purge_progress_when_exists_in_body(storage, handler):
     body = {'status': {'kopf': {'progress': {'some-id': {'retries': 5}}}}}
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
-    state.purge(patch=patch, body=Body(body), storage=storage)
+    state.purge(patch=patch, body=Body(body), storage=storage, handlers=[handler])
     assert patch == {'status': {'kopf': {'progress': {'some-id': None}}}}
 
 
@@ -324,16 +369,32 @@ def test_purge_progress_when_already_empty_in_body_and_patch(storage, handler):
     body = {}
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
-    state.purge(patch=patch, body=Body(body), storage=storage)
+    state.purge(patch=patch, body=Body(body), storage=storage, handlers=[handler])
     assert not patch
 
 
-def test_purge_progress_when_already_empty_in_body_but_not_in__patch(storage, handler):
+def test_purge_progress_when_already_empty_in_body_but_not_in_patch(storage, handler):
     body = {}
     patch = Patch({'status': {'kopf': {'progress': {'some-id': {'retries': 5}}}}})
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
-    state.purge(patch=patch, body=Body(body), storage=storage)
+    state.purge(patch=patch, body=Body(body), storage=storage, handlers=[handler])
     assert not patch
+
+
+def test_purge_progress_when_known_at_restoration_only(storage, handler):
+    body = {'status': {'kopf': {'progress': {'some-id': {'retries': 5}}}}}
+    patch = Patch()
+    state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
+    state.purge(patch=patch, body=Body(body), storage=storage, handlers=[])
+    assert patch == {'status': {'kopf': {'progress': {'some-id': None}}}}
+
+
+def test_purge_progress_when_known_at_purge_only(storage, handler):
+    body = {'status': {'kopf': {'progress': {'some-id': {'retries': 5}}}}}
+    patch = Patch()
+    state = State.from_storage(body=Body(body), handlers=[], storage=storage)
+    state.purge(patch=patch, body=Body(body), storage=storage, handlers=[handler])
+    assert patch == {'status': {'kopf': {'progress': {'some-id': None}}}}
 
 
 def test_purge_progress_cascades_to_subrefs(storage, handler):
@@ -346,7 +407,7 @@ def test_purge_progress_cascades_to_subrefs(storage, handler):
     }}}}
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
-    state.purge(patch=patch, body=Body(body), storage=storage)
+    state.purge(patch=patch, body=Body(body), storage=storage, handlers=[handler])
     assert patch == {'status': {'kopf': {'progress': {
         'some-id': None,
         'sub1': None,


### PR DESCRIPTION
Purge the persisted state of the handlers that become excluded (e.g. filtered out) by the time when the state is purged.

Compared to the historic baseline behaviour, it is still as before, when the whole `.status.kopf.progress` section was purged, regardless of the content. Now, when the purge is explicit for each handler id (which is needed for annotation storages), these ids must not be lost/forgotten on the go.

Fixes #556.

**Rejected solutions:**

Unlike #517, where the ids of sub-handlers are remembered in their parent handler's state so that they could be explicitly purged too, the root handlers' ids are not remembered here. That would require an additional annotation or a status field, which would complicate the storages. This is an overkill: unlike the dynamically formed sub-handlers (based on `if` & `for` & variables at runtime), the root handlers are known in advance even if filtered out sometimes. Instead, a convention is used: all handlers that are defined for the resource kind, are assumed to be persisted despite the filters, and therefore must be purged. A little optional optimization is used to avoid unnecessary purging of what is not even stored.