### PR TITLE
Fix generics & MROs for Python 3.9 and Kopf 0.28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # The primary environment for testing. Some jobs selectively override these settings.
 os: linux
 arch: amd64
-dist: xenial
+dist: focal
 language: python
 python: "3.8"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os: linux
 arch: amd64
 dist: focal
 language: python
-python: "3.8"
+python: "3.9-dev"
 
 # Only test the final merges and releases. The work-in-progress branches are tested by PR builds.
 branches:
@@ -94,10 +94,11 @@ jobs:
   - { <<: *linting, name: Linting and static analysis }
   - { <<: *unittests, python: "3.7" }
   - { <<: *unittests, python: "3.8" }
+  - { <<: *unittests, python: "3.9-dev" }
 
   fast_finish: true
   allow_failures:
-    - python: "3.9-dev"
+    - python: "3.10-dev"
 
 deploy:
   provider: pypi

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -108,8 +108,8 @@ class ActivityRegistry(GenericRegistry[
 
 
 class ResourceRegistry(
-        Generic[CauseT, HandlerFnT, ResourceHandlerT],
-        GenericRegistry[HandlerFnT, ResourceHandlerT]):
+        GenericRegistry[HandlerFnT, ResourceHandlerT],
+        Generic[CauseT, HandlerFnT, ResourceHandlerT]):
 
     def get_handlers(
             self,

--- a/kopf/structs/dicts.py
+++ b/kopf/structs/dicts.py
@@ -201,7 +201,7 @@ def walk(
         yield objs  # NB: not a mapping, no nested sub-fields.
 
 
-class MappingView(Generic[_K, _V], Mapping[_K, _V]):
+class MappingView(Mapping[_K, _V], Generic[_K, _V]):
     """
     A lazy resolver for the "on-demand" dict keys.
 
@@ -238,7 +238,7 @@ class MappingView(Generic[_K, _V], Mapping[_K, _V]):
         return resolve(self._src, self._path + (item,))
 
 
-class MutableMappingView(Generic[_K, _V], MappingView[_K, _V], MutableMapping[_K, _V]):
+class MutableMappingView(MappingView[_K, _V], MutableMapping[_K, _V], Generic[_K, _V]):
     """
     A mapping view with values stored and sub-dicts auto-created.
 
@@ -264,7 +264,7 @@ class MutableMappingView(Generic[_K, _V], MappingView[_K, _V], MutableMapping[_K
         ensure(self._src, self._path + (item,), value)
 
 
-class ReplaceableMappingView(Generic[_K, _V], MappingView[_K, _V]):
+class ReplaceableMappingView(MappingView[_K, _V], Generic[_K, _V]):
     """
     A mapping view where the whole source can be replaced atomically.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ asynctest
 freezegun
 codecov
 coveralls
-mypy==0.770
+mypy==0.782
 isort>=5.5.0


### PR DESCRIPTION
## What do these changes do?

Enable Kopf for Python 3.9 by fixing an issue when some of the classes were reporting `TypeError: Cannot create a consistent method resolution order (MRO) for bases Generic, ...` on their declaration (not at runtime).

Since nothing changes essentially in the codebase, I assume the change is safe enough. That was surprisingly easy (easier than I thought it will be).

Related: https://github.com/k8spin/k8spin-operator/pull/24

The proper Python tag (3.9 instead of 3.9-dev) will be released later — it needs Travis & pyenv to support 3.9 first, but 3.9 was released only 2 days ago. See: https://travis-ci.community/t/python-3-9-0-build/10091