### PR TITLE
Fix generics & MROs for Python 3.9 and Kopf 0.27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - KUBERNETES_VERSION=v1.15.0 CLIENT=no CRDAPI=v1beta1
     - KUBERNETES_VERSION=v1.14.0 CLIENT=no CRDAPI=v1beta1
     - KUBERNETES_VERSION=v1.13.0 CLIENT=no CRDAPI=v1beta1
-    - KUBERNETES_VERSION=v1.12.0 CLIENT=no CRDAPI=v1beta1
+#    - KUBERNETES_VERSION=v1.12.0 CLIENT=no CRDAPI=v1beta1
 #    - KUBERNETES_VERSION=v1.11.10  # Minikube fails on CRI preflight checks
 #    - KUBERNETES_VERSION=v1.10.13  # CRDs require spec.version, which fails on 1.14
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ matrix:
     - python: "3.7"
       env: KUBERNETES_VERSION=latest CLIENT=no
     - python: "3.9-dev"
-  allow_failures:
-    - python: "3.9-dev"
 
 before_install:
   - sudo apt-get update -y

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -111,8 +111,8 @@ class ActivityRegistry(GenericRegistry[
 
 
 class ResourceRegistry(
-        Generic[CauseT, HandlerFnT, ResourceHandlerT],
-        GenericRegistry[HandlerFnT, ResourceHandlerT]):
+        GenericRegistry[HandlerFnT, ResourceHandlerT],
+        Generic[CauseT, HandlerFnT, ResourceHandlerT]):
 
     def get_handlers(
             self,

--- a/kopf/structs/dicts.py
+++ b/kopf/structs/dicts.py
@@ -194,7 +194,7 @@ def walk(
         yield objs  # NB: not a mapping, no nested sub-fields.
 
 
-class MappingView(Generic[_K, _V], Mapping[_K, _V]):
+class MappingView(Mapping[_K, _V], Generic[_K, _V]):
     """
     A lazy resolver for the "on-demand" dict keys.
 
@@ -231,7 +231,7 @@ class MappingView(Generic[_K, _V], Mapping[_K, _V]):
         return resolve(self._src, self._path + (item,))
 
 
-class MutableMappingView(Generic[_K, _V], MappingView[_K, _V], MutableMapping[_K, _V]):
+class MutableMappingView(MappingView[_K, _V], MutableMapping[_K, _V], Generic[_K, _V]):
     """
     A mapping view with values stored and sub-dicts auto-created.
 
@@ -257,7 +257,7 @@ class MutableMappingView(Generic[_K, _V], MappingView[_K, _V], MutableMapping[_K
         ensure(self._src, self._path + (item,), value)
 
 
-class ReplaceableMappingView(Generic[_K, _V], MappingView[_K, _V]):
+class ReplaceableMappingView(MappingView[_K, _V], Generic[_K, _V]):
     """
     A mapping view where the whole source can be replaced atomically.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ asynctest
 freezegun
 codecov
 coveralls
-mypy==0.770
+mypy==0.782


### PR DESCRIPTION
## What do these changes do?

Enable Kopf 0.27.x for Python 3.9 by fixing an issue when some of the classes were reporting `TypeError: Cannot create a consistent method resolution order (MRO) for bases Generic, ...` on their declaration (not at runtime).

Since nothing changes essentially in the codebase, I assume the change is safe enough. That was surprisingly easy (easier than I thought it will be).

This PR is the same as the primary one — https://github.com/nolar/kopf/pull/561 — but for 0.27 (to be released as 0.27.1).

Related: https://github.com/k8spin/k8spin-operator/pull/24
