### PR TITLE
split logging to stdout and stderr

### DIFF
--- a/kopf/engines/loggers.py
+++ b/kopf/engines/loggers.py
@@ -12,6 +12,7 @@ import asyncio
 import copy
 import enum
 import logging
+import sys
 from typing import Any, MutableMapping, Optional, Tuple
 
 import pythonjsonlogger.jsonlogger
@@ -207,10 +208,16 @@ def configure(
 ) -> None:
     log_level = 'DEBUG' if debug or verbose else 'WARNING' if quiet else 'INFO'
     formatter = make_formatter(log_format=log_format, log_prefix=log_prefix, log_refkey=log_refkey)
-    handler = logging.StreamHandler()
-    handler.setFormatter(formatter)
+    handler_stdout = logging.StreamHandler(sys.stdout)
+    handler_stdout.setFormatter(formatter)
+    handler_stdout.addFilter(lambda record: record.levelno <= logging.INFO)
+    handler_stdout.setLevel(logging.DEBUG)
+    handler_stderr = logging.StreamHandler(sys.stderr)
+    handler_stderr.setFormatter(formatter)
+    handler_stderr.setLevel(logging.WARNING)
     logger = logging.getLogger()
-    logger.addHandler(handler)
+    logger.addHandler(handler_stdout)
+    logger.addHandler(handler_stderr)
     logger.setLevel(log_level)
 
     # Prevent the low-level logging unless in the debug mode. Keep only the operator's messages.

--- a/tests/logging/test_configuration.py
+++ b/tests/logging/test_configuration.py
@@ -30,7 +30,7 @@ def test_own_formatter_is_used():
     configure()
     logger = logging.getLogger()
     own_handlers = _get_own_handlers(logger)
-    assert len(own_handlers) == 1
+    assert len(own_handlers) == 2
 
 
 @pytest.mark.parametrize('log_format', [LogFormat.FULL, LogFormat.PLAIN, '%(message)s'])
@@ -38,8 +38,9 @@ def test_formatter_nonprefixed_text(log_format):
     configure(log_format=log_format, log_prefix=False)
     logger = logging.getLogger()
     own_handlers = _get_own_handlers(logger)
-    assert len(own_handlers) == 1
+    assert len(own_handlers) == 2
     assert type(own_handlers[0].formatter) is ObjectTextFormatter
+    assert type(own_handlers[1].formatter) is ObjectTextFormatter
 
 
 @pytest.mark.parametrize('log_format', [LogFormat.FULL, LogFormat.PLAIN, '%(message)s'])
@@ -47,8 +48,9 @@ def test_formatter_prefixed_text(log_format):
     configure(log_format=log_format, log_prefix=True)
     logger = logging.getLogger()
     own_handlers = _get_own_handlers(logger)
-    assert len(own_handlers) == 1
+    assert len(own_handlers) == 2
     assert type(own_handlers[0].formatter) is ObjectPrefixingTextFormatter
+    assert type(own_handlers[1].formatter) is ObjectPrefixingTextFormatter
 
 
 @pytest.mark.parametrize('log_format', [LogFormat.JSON])
@@ -56,8 +58,9 @@ def test_formatter_nonprefixed_json(log_format):
     configure(log_format=log_format, log_prefix=False)
     logger = logging.getLogger()
     own_handlers = _get_own_handlers(logger)
-    assert len(own_handlers) == 1
+    assert len(own_handlers) == 2
     assert type(own_handlers[0].formatter) is ObjectJsonFormatter
+    assert type(own_handlers[1].formatter) is ObjectJsonFormatter
 
 
 @pytest.mark.parametrize('log_format', [LogFormat.JSON])
@@ -65,8 +68,9 @@ def test_formatter_prefixed_json(log_format):
     configure(log_format=log_format, log_prefix=True)
     logger = logging.getLogger()
     own_handlers = _get_own_handlers(logger)
-    assert len(own_handlers) == 1
+    assert len(own_handlers) == 2
     assert type(own_handlers[0].formatter) is ObjectPrefixingJsonFormatter
+    assert type(own_handlers[1].formatter) is ObjectPrefixingJsonFormatter
 
 
 @pytest.mark.parametrize('log_format', [LogFormat.JSON])
@@ -74,8 +78,9 @@ def test_json_has_no_prefix_by_default(log_format):
     configure(log_format=log_format, log_prefix=None)
     logger = logging.getLogger()
     own_handlers = _get_own_handlers(logger)
-    assert len(own_handlers) == 1
+    assert len(own_handlers) == 2
     assert type(own_handlers[0].formatter) is ObjectJsonFormatter
+    assert type(own_handlers[1].formatter) is ObjectJsonFormatter
 
 
 def test_error_on_unknown_formatter():


### PR DESCRIPTION
## What do these changes do?
Split logging severity between stdout / stderr
INFO, DEBUG - stdout
WARN,CRITICAL  -  stderr 


## Description

<!-- What was the previous behaviour before the PR is merged? -->
All logs were logged to stderr

<!-- What will be the new behaviour after the PR is merged? -->
INFO, DEBUG - stdout
WARN,CRITICAL  -  stderr 

<!-- A code snippet showing the new features added (if any)? -->

<!-- Does the change affect the end users or is it internal? -->
Yes
<!-- Why have you decided to solve the problem this way? What were the trade-offs? (If appropriate.) -->
<!-- Are there any breaking or risky changes? -->

## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X ] The code addresses only the mentioned problem, and this problem only
- [X ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
