### PR TITLE
Use Configuration.get_default_copy

### DIFF
--- a/kopf/utilities/piggybacking.py
+++ b/kopf/utilities/piggybacking.py
@@ -46,7 +46,11 @@ def login_via_client(
             raise credentials.LoginError(f"Cannot authenticate client neither in-cluster, nor via kubeconfig.")
 
     # We do not even try to understand how it works and why. Just load it, and extract the results.
-    config = kubernetes.client.Configuration.get_default_copy()
+    # For kubernetes client >= 12.0.0 use the new 'get_default_copy' method
+    if callable(getattr(kubernetes.client.Configuration, 'get_default_copy', None)):
+        config = kubernetes.client.Configuration.get_default_copy()
+    else:
+        config = kubernetes.client.Configuration()
 
     # For auth-providers, this method is monkey-patched with the auth-provider's one.
     # We need the actual auth-provider's token, so we call it instead of accessing api_key.

--- a/kopf/utilities/piggybacking.py
+++ b/kopf/utilities/piggybacking.py
@@ -46,7 +46,7 @@ def login_via_client(
             raise credentials.LoginError(f"Cannot authenticate client neither in-cluster, nor via kubeconfig.")
 
     # We do not even try to understand how it works and why. Just load it, and extract the results.
-    config = kubernetes.client.Configuration()
+    config = kubernetes.client.Configuration.get_default_copy()
 
     # For auth-providers, this method is monkey-patched with the auth-provider's one.
     # We need the actual auth-provider's token, so we call it instead of accessing api_key.


### PR DESCRIPTION
## What do these changes do?

When loading the config from the load_incluster_config or load_kube_config methods
the result is stored in Configuration._default. We must then use the get_default_copy
method in order to retrieve a copy of the configuration containing the actually
config values previously loaded. Testest with kubernetes==12.0.0


## Description

When creating a new Configuration instance using the constructor, the host always defaulted to http://localhost which resulted in the client not being able to connect if this is not what is actually configured in the kubeconfig.

With this change the loaded config is retrieved via the get_default_copy which then contains the configured values.

Only tested with kubernetes==12.0.0.

## Type of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x ] The code addresses only the mentioned problem, and this problem only
- [x ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
