### PR TITLE
Shorten peering ids, filter out IPv6/ARPA names

### DIFF
--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -122,7 +122,7 @@ def freeze(
 ) -> None:
     """ Freeze the resource handling in the cluster. """
     ourserlves = peering.Peer(
-        id=id or peering.detect_own_id(),
+        id=id or peering.detect_own_id(manual=True),
         name=peering_name,
         namespace=namespace,
         priority=priority,
@@ -151,7 +151,7 @@ def resume(
 ) -> None:
     """ Resume the resource handling in the cluster. """
     ourselves = peering.Peer(
-        id=id or peering.detect_own_id(),
+        id=id or peering.detect_own_id(manual=True),
         name=peering_name,
         namespace=namespace,
     )

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -35,13 +35,13 @@ import getpass
 import logging
 import os
 import random
-import socket
 from typing import Any, Dict, Iterable, Mapping, NoReturn, Optional, Union, cast
 
 import iso8601
 
 from kopf.clients import fetching, patching
 from kopf.structs import bodies, patches, primitives, resources
+from kopf.utilities import hostnames
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +298,7 @@ def detect_own_id() -> str:
         return pod
 
     user = getpass.getuser()
-    host = socket.getfqdn()
+    host = hostnames.get_descriptive_hostname()
     now = datetime.datetime.utcnow().isoformat()
     rnd = ''.join(random.choices('abcdefhijklmnopqrstuvwxyz0123456789', k=6))
     return f'{user}@{host}/{now}/{rnd}'

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -273,7 +273,7 @@ async def peers_keepalive(
             logger.exception(f"Couldn't remove self from the peering. Ignoring.")
 
 
-def detect_own_id() -> str:
+def detect_own_id(*, manual: bool) -> str:
     """
     Detect or generate the id for ourselves, i.e. the execute operator.
 
@@ -301,4 +301,4 @@ def detect_own_id() -> str:
     host = hostnames.get_descriptive_hostname()
     now = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
     rnd = ''.join(random.choices('abcdefhijklmnopqrstuvwxyz0123456789', k=3))
-    return f'{user}@{host}/{now}/{rnd}'
+    return f'{user}@{host}' if manual else f'{user}@{host}/{now}/{rnd}'

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -299,6 +299,6 @@ def detect_own_id() -> str:
 
     user = getpass.getuser()
     host = hostnames.get_descriptive_hostname()
-    now = datetime.datetime.utcnow().isoformat()
-    rnd = ''.join(random.choices('abcdefhijklmnopqrstuvwxyz0123456789', k=6))
+    now = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    rnd = ''.join(random.choices('abcdefhijklmnopqrstuvwxyz0123456789', k=3))
     return f'{user}@{host}/{now}/{rnd}'

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -246,7 +246,7 @@ async def spawn_tasks(
 
     # Monitor the peers, unless explicitly disabled.
     ourselves: Optional[peering.Peer] = await peering.Peer.detect(
-        id=peering.detect_own_id(), priority=priority,
+        id=peering.detect_own_id(manual=False), priority=priority,
         standalone=standalone, namespace=namespace, name=peering_name,
     )
     if ourselves:

--- a/kopf/utilities/hostnames.py
+++ b/kopf/utilities/hostnames.py
@@ -36,11 +36,20 @@ def get_descriptive_hostname() -> str:
         # Dotted hostname (fqdn) is always better, unless it is an ARPA-name or an IP-address.
         for name, ipv4, ipv6 in parsed:
             if '.' in name and not name.endswith('.arpa') and not ipv4 and not ipv6:
-                return name
+                return remove_useless_suffixes(name)
 
         # Non-dotted hostname is fine too, unless it is ARPA-name/IP-address or a localhost.
         for name, ipv4, ipv6 in parsed:
             if name != 'localhost' and not name.endswith('.arpa') and not ipv4 and not ipv6:
-                return name
+                return remove_useless_suffixes(name)
 
-    return socket.gethostname()
+    return remove_useless_suffixes(socket.gethostname())
+
+
+def remove_useless_suffixes(hostname: str) -> str:
+    suffixes = ['.local', '.localdomain']
+    while any(hostname.endswith(suffix) for suffix in suffixes):
+        for suffix in suffixes:
+            if hostname.endswith(suffix):
+                hostname = hostname[:-len(suffix)]
+    return hostname

--- a/kopf/utilities/hostnames.py
+++ b/kopf/utilities/hostnames.py
@@ -1,0 +1,46 @@
+import ipaddress
+import socket
+from typing import List, Optional, Tuple
+
+
+def get_descriptive_hostname() -> str:
+    """
+    Look for non-numeric hostnames of the machine where the operator runs.
+
+    The purpose is the host identification, not the actual host accessability.
+
+    Similar to :func:`socket.getfqdn`, but IPv6 pseudo-hostnames are excluded --
+    they are not helpful in identifying the actual host running the operator:
+    e.g. "1.0.0...0.ip6.arpa".
+    """
+    try:
+        hostname, aliases, ipaddrs = socket.gethostbyaddr(socket.gethostname())
+    except socket.error:
+        pass
+    else:
+        ipv4: Optional[ipaddress.IPv4Address]
+        ipv6: Optional[ipaddress.IPv6Address]
+        parsed: List[Tuple[str, Optional[ipaddress.IPv4Address], Optional[ipaddress.IPv6Address]]]
+        parsed = []
+        for name in [hostname] + list(aliases) + list(ipaddrs):
+            try:
+                ipv4 = ipaddress.IPv4Address(name)
+            except ipaddress.AddressValueError:
+                ipv4 = None
+            try:
+                ipv6 = ipaddress.IPv6Address(name)
+            except ipaddress.AddressValueError:
+                ipv6 = None
+            parsed.append((name, ipv4, ipv6))
+
+        # Dotted hostname (fqdn) is always better, unless it is an ARPA-name or an IP-address.
+        for name, ipv4, ipv6 in parsed:
+            if '.' in name and not name.endswith('.arpa') and not ipv4 and not ipv6:
+                return name
+
+        # Non-dotted hostname is fine too, unless it is ARPA-name/IP-address or a localhost.
+        for name, ipv4, ipv6 in parsed:
+            if name != 'localhost' and not name.endswith('.arpa') and not ipv4 and not ipv6:
+                return name
+
+    return socket.gethostname()

--- a/tests/peering/test_id_generation.py
+++ b/tests/peering/test_id_generation.py
@@ -48,12 +48,12 @@ def test_good_hostnames_over_good_aliases__symmetric(mocker, good1, good2):
     mocker.patch('socket.gethostname', return_value=good1)
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good2], []))
     own_id = detect_own_id()
-    assert own_id == f'some-user@{good1}/2020-12-31T23:59:59.123456/random-str'
+    assert own_id == f'some-user@{good1}/20201231235959/random-str'
 
     mocker.patch('socket.gethostname', return_value=good2)
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good1], []))
     own_id = detect_own_id()
-    assert own_id == f'some-user@{good2}/2020-12-31T23:59:59.123456/random-str'
+    assert own_id == f'some-user@{good2}/20201231235959/random-str'
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
@@ -62,12 +62,12 @@ def test_good_aliases_over_good_addresses__symmetric(mocker, good1, good2):
     mocker.patch('socket.gethostname', return_value='localhost')
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good1], [good2]))
     own_id = detect_own_id()
-    assert own_id == f'some-user@{good1}/2020-12-31T23:59:59.123456/random-str'
+    assert own_id == f'some-user@{good1}/20201231235959/random-str'
 
     mocker.patch('socket.gethostname', return_value='localhost')
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good2], [good1]))
     own_id = detect_own_id()
-    assert own_id == f'some-user@{good2}/2020-12-31T23:59:59.123456/random-str'
+    assert own_id == f'some-user@{good2}/20201231235959/random-str'
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
@@ -76,7 +76,7 @@ def test_good_aliases_over_bad_hostnames(mocker, good, bad):
     mocker.patch('socket.gethostname', return_value=bad)
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good], []))
     own_id = detect_own_id()
-    assert own_id == f'some-user@{good}/2020-12-31T23:59:59.123456/random-str'
+    assert own_id == f'some-user@{good}/20201231235959/random-str'
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
@@ -85,7 +85,7 @@ def test_good_addresses_over_bad_aliases(mocker, good, bad):
     mocker.patch('socket.gethostname', return_value='localhost')
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [bad], [good]))
     own_id = detect_own_id()
-    assert own_id == f'some-user@{good}/2020-12-31T23:59:59.123456/random-str'
+    assert own_id == f'some-user@{good}/20201231235959/random-str'
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
@@ -100,4 +100,4 @@ def test_useless_suffixes_removed(mocker, fqdn):
     mocker.patch('socket.gethostname', return_value=fqdn)
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [], []))
     own_id = detect_own_id()
-    assert own_id == 'some-user@my-host/2020-12-31T23:59:59.123456/random-str'
+    assert own_id == 'some-user@my-host/20201231235959/random-str'

--- a/tests/peering/test_id_generation.py
+++ b/tests/peering/test_id_generation.py
@@ -86,3 +86,18 @@ def test_good_addresses_over_bad_aliases(mocker, good, bad):
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [bad], [good]))
     own_id = detect_own_id()
     assert own_id == f'some-user@{good}/2020-12-31T23:59:59.123456/random-str'
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+@pytest.mark.parametrize('fqdn', [
+    'my-host',
+    'my-host.local',
+    'my-host.localdomain',
+    'my-host.local.localdomain',
+    'my-host.localdomain.local',
+])
+def test_useless_suffixes_removed(mocker, fqdn):
+    mocker.patch('socket.gethostname', return_value=fqdn)
+    mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [], []))
+    own_id = detect_own_id()
+    assert own_id == 'some-user@my-host/2020-12-31T23:59:59.123456/random-str'

--- a/tests/peering/test_id_generation.py
+++ b/tests/peering/test_id_generation.py
@@ -5,21 +5,84 @@ import pytest
 
 from kopf.engines.peering import detect_own_id
 
+SAME_GOOD = [
+    ('some-host.example.com', 'other-host.example.com'),
+    ('some-host', 'other-host'),
+]
+
+# Priorities: A (left) should be selected over B (right).
+GOOD_BAD = [
+    ('some-host.example.com', 'some-host'),
+    ('some-host.example.com', '1.2.3.4'),
+    ('some-host.example.com', '::1'),
+    ('some-host.example.com', '1.0...0.ip6.arpa'),
+    ('some-host.example.com', '4.3.2.1.in-addr.arpa'),
+    ('some-host.example.com', '1.2.3.4'),
+    ('some-host', '1.2.3.4'),
+    ('some-host', '::1'),
+    ('some-host', '1.0...0.ip6.arpa'),
+    ('some-host', '4.3.2.1.in-addr.arpa'),
+    ('some-host', '1.2.3.4'),
+]
+
 
 @pytest.fixture(autouse=True)
 def _intercept_os_calls(mocker):
     mocker.patch('getpass.getuser', return_value='some-user')
-    mocker.patch('socket.getfqdn', return_value='some-host')
     mocker.patch('random.choices', return_value='random-str')
+    mocker.patch('socket.gethostname')
+    mocker.patch('socket.gethostbyaddr')
 
 
 def test_from_a_pod_id(mocker):
+    mocker.patch('socket.gethostname', return_value='some-host')
+    mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [], []))
     mocker.patch.dict(os.environ, POD_ID='some-pod-1')
     own_id = detect_own_id()
     assert own_id == 'some-pod-1'
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
-def test_with_defaults():
+@pytest.mark.parametrize('good1, good2', SAME_GOOD)
+def test_good_hostnames_over_good_aliases__symmetric(mocker, good1, good2):
+    mocker.patch('socket.gethostname', return_value=good1)
+    mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good2], []))
     own_id = detect_own_id()
-    assert own_id == 'some-user@some-host/2020-12-31T23:59:59.123456/random-str'
+    assert own_id == f'some-user@{good1}/2020-12-31T23:59:59.123456/random-str'
+
+    mocker.patch('socket.gethostname', return_value=good2)
+    mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good1], []))
+    own_id = detect_own_id()
+    assert own_id == f'some-user@{good2}/2020-12-31T23:59:59.123456/random-str'
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+@pytest.mark.parametrize('good1, good2', SAME_GOOD)
+def test_good_aliases_over_good_addresses__symmetric(mocker, good1, good2):
+    mocker.patch('socket.gethostname', return_value='localhost')
+    mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good1], [good2]))
+    own_id = detect_own_id()
+    assert own_id == f'some-user@{good1}/2020-12-31T23:59:59.123456/random-str'
+
+    mocker.patch('socket.gethostname', return_value='localhost')
+    mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good2], [good1]))
+    own_id = detect_own_id()
+    assert own_id == f'some-user@{good2}/2020-12-31T23:59:59.123456/random-str'
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+@pytest.mark.parametrize('good, bad', GOOD_BAD)
+def test_good_aliases_over_bad_hostnames(mocker, good, bad):
+    mocker.patch('socket.gethostname', return_value=bad)
+    mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good], []))
+    own_id = detect_own_id()
+    assert own_id == f'some-user@{good}/2020-12-31T23:59:59.123456/random-str'
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+@pytest.mark.parametrize('good, bad', GOOD_BAD)
+def test_good_addresses_over_bad_aliases(mocker, good, bad):
+    mocker.patch('socket.gethostname', return_value='localhost')
+    mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [bad], [good]))
+    own_id = detect_own_id()
+    assert own_id == f'some-user@{good}/2020-12-31T23:59:59.123456/random-str'

--- a/tests/peering/test_id_generation.py
+++ b/tests/peering/test_id_generation.py
@@ -29,66 +29,77 @@ GOOD_BAD = [
 @pytest.fixture(autouse=True)
 def _intercept_os_calls(mocker):
     mocker.patch('getpass.getuser', return_value='some-user')
-    mocker.patch('random.choices', return_value='random-str')
     mocker.patch('socket.gethostname')
     mocker.patch('socket.gethostbyaddr')
 
 
-def test_from_a_pod_id(mocker):
+@pytest.mark.parametrize('manual', [True, False])
+def test_from_a_pod_id(mocker, manual):
     mocker.patch('socket.gethostname', return_value='some-host')
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [], []))
     mocker.patch.dict(os.environ, POD_ID='some-pod-1')
-    own_id = detect_own_id()
+    own_id = detect_own_id(manual=manual)
     assert own_id == 'some-pod-1'
 
 
-@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+def test_suffixes_appended(mocker):
+    mocker.patch('random.choices', return_value='random-str')
+    mocker.patch('socket.gethostname', return_value='some-host')
+    mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [], []))
+    with freezegun.freeze_time('2020-12-31T23:59:59.123456'):
+        own_id = detect_own_id(manual=False)
+    assert own_id == 'some-user@some-host/20201231235959/random-str'
+
+
+def test_suffixes_ignored(mocker):
+    mocker.patch('socket.gethostname', return_value='some-host')
+    mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [], []))
+    own_id = detect_own_id(manual=True)
+    assert own_id == 'some-user@some-host'
+
+
 @pytest.mark.parametrize('good1, good2', SAME_GOOD)
 def test_good_hostnames_over_good_aliases__symmetric(mocker, good1, good2):
     mocker.patch('socket.gethostname', return_value=good1)
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good2], []))
-    own_id = detect_own_id()
-    assert own_id == f'some-user@{good1}/20201231235959/random-str'
+    own_id = detect_own_id(manual=True)
+    assert own_id == f'some-user@{good1}'
 
     mocker.patch('socket.gethostname', return_value=good2)
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good1], []))
-    own_id = detect_own_id()
-    assert own_id == f'some-user@{good2}/20201231235959/random-str'
+    own_id = detect_own_id(manual=True)
+    assert own_id == f'some-user@{good2}'
 
 
-@freezegun.freeze_time('2020-12-31T23:59:59.123456')
 @pytest.mark.parametrize('good1, good2', SAME_GOOD)
 def test_good_aliases_over_good_addresses__symmetric(mocker, good1, good2):
     mocker.patch('socket.gethostname', return_value='localhost')
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good1], [good2]))
-    own_id = detect_own_id()
-    assert own_id == f'some-user@{good1}/20201231235959/random-str'
+    own_id = detect_own_id(manual=True)
+    assert own_id == f'some-user@{good1}'
 
     mocker.patch('socket.gethostname', return_value='localhost')
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good2], [good1]))
-    own_id = detect_own_id()
-    assert own_id == f'some-user@{good2}/20201231235959/random-str'
+    own_id = detect_own_id(manual=True)
+    assert own_id == f'some-user@{good2}'
 
 
-@freezegun.freeze_time('2020-12-31T23:59:59.123456')
 @pytest.mark.parametrize('good, bad', GOOD_BAD)
 def test_good_aliases_over_bad_hostnames(mocker, good, bad):
     mocker.patch('socket.gethostname', return_value=bad)
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [good], []))
-    own_id = detect_own_id()
-    assert own_id == f'some-user@{good}/20201231235959/random-str'
+    own_id = detect_own_id(manual=True)
+    assert own_id == f'some-user@{good}'
 
 
-@freezegun.freeze_time('2020-12-31T23:59:59.123456')
 @pytest.mark.parametrize('good, bad', GOOD_BAD)
 def test_good_addresses_over_bad_aliases(mocker, good, bad):
     mocker.patch('socket.gethostname', return_value='localhost')
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [bad], [good]))
-    own_id = detect_own_id()
-    assert own_id == f'some-user@{good}/20201231235959/random-str'
+    own_id = detect_own_id(manual=True)
+    assert own_id == f'some-user@{good}'
 
 
-@freezegun.freeze_time('2020-12-31T23:59:59.123456')
 @pytest.mark.parametrize('fqdn', [
     'my-host',
     'my-host.local',
@@ -99,5 +110,5 @@ def test_good_addresses_over_bad_aliases(mocker, good, bad):
 def test_useless_suffixes_removed(mocker, fqdn):
     mocker.patch('socket.gethostname', return_value=fqdn)
     mocker.patch('socket.gethostbyaddr', side_effect=lambda fqdn: (fqdn, [], []))
-    own_id = detect_own_id()
-    assert own_id == 'some-user@my-host/20201231235959/random-str'
+    own_id = detect_own_id(manual=True)
+    assert own_id == 'some-user@my-host'


### PR DESCRIPTION
Improve peering identities in IPv6 environments: ignore special ARPA hostnames of reversed IPv6 addresses, and prefer the actual hostnames of the pods/machine.

Previously, pseudo-hostnames like `1.0.0.0.....0.0.ip6.arpa` were selected, as this is how stdlib works with `socker.getfqdn()` — it is not very suited for IPv6, only IPv4.

As a side effect of having our own implementation, also drop useless suffixes like `.local` for Mac OS — also to improve the readability of the peering ids. 

And also, convert timestamps of the operator start time to just a long number.

Was: 
```nolar@1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa/2020-10-21T20:51:11.618987/vy08ew```

Now:
```nolar@SV-Pro/20201021205056/dqp```

These peering ids are visible in the messages about conflicting operators:

```
[INFO    ] Freezing operations in favour of [Peer(nolar@SV-Pro/20201021205206/c4g, namespace=default, priority=100, lastseen=2020-10-21 20:53:09.715236, lifetime=0:00:10)].
```

Generally, a peering id MUST be a unique string; SHOULD help the developers to identify where the operator runs (or who does that). No other obligations regarding the structure or hostname accessibility. Therefore, by changing the internal structure of the peering ids, the backward compatibility is not affected.