### PR TITLE
Field filters for all resource handlers

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -2,78 +2,76 @@
 Filtering
 =========
 
-.. highlight:: python
+Handlers can be restricted to only the resources that match certain criteria.
 
-It is possible to only execute handlers when the object that triggers a handler
-matches certain criteria.
+Multiple criteria are joined with AND, i.e. they all must be satisfied.
 
-The following filters are available for all resource-related handlers
-(event-watching and change-detecting):
+Unless stated otherwise, the described filters are available for all handlers:
+resuming, creation, deletion, updating, event-watching, timers, daemons,
+or even to sub-handlers (thus eliminating some checks in its parent's code).
 
+There are only a few kinds of checks:
 
-By labels
-=========
+* Specific values -- expressed with Python literals such as ``"a string"``.
+* Presence of values -- with special markers ``kopf.PRESENT/kopf.ABSENT``.
+* Per-value callbacks -- with anything callable and evaluatable to true/false.
+* Whole-body callbacks -- with anything callable and evaluatable to true/false.
 
-* Match an object's label and value::
-
-    @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
-                    labels={'some-label': 'somevalue'})
-    def my_handler(spec, **_):
-        pass
-
-* Match on the existence of an object's label::
-
-    @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
-                    labels={'some-label': kopf.PRESENT})
-    def my_handler(spec, **_):
-        pass
-
-* Match on the absence of an object's label::
-
-    @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
-                    labels={'some-label': kopf.ABSENT})
-    def my_handler(spec, **_):
-        pass
+But there are multiple places where these checks can be applied,
+each has its own specifics.
 
 
-By annotations
-==============
+Metadata filters
+================
 
-* Match on object's annotation and value::
+Metadata is the most commonly filtered aspect of the resources.
+
+Match only when the resource's label or annotation has a specific value:
+
+.. code-block:: python
 
     @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
+                    labels={'some-label': 'somevalue'},
                     annotations={'some-annotation': 'somevalue'})
     def my_handler(spec, **_):
         pass
 
-* Match on the existence of an object's annotation::
+Match only when the resource has a label or an annotation with any value:
+
+.. code-block:: python
 
     @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
+                    labels={'some-label': kopf.PRESENT},
                     annotations={'some-annotation': kopf.PRESENT})
     def my_handler(spec, **_):
         pass
 
-* Match on the absence of an object's annotation::
+Match only when the resource has no label or annotation with that name:
+
+.. code-block:: python
 
     @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
+                    labels={'some-label': kopf.ABSENT},
                     annotations={'some-annotation': kopf.ABSENT})
     def my_handler(spec, **_):
         pass
 
+Note that empty strings in labels and annotations are treated as regular values,
+i.e. they are considered as present on the resource.
 
-By arbitrary callbacks
-======================
 
-* Check on any field on the body with a when callback.
-  The filter callback takes the same args as a handler (see :doc:`kwargs`)::
+Value callbacks
+===============
 
-    @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
-                    when=lambda spec, **_: spec.get('my-field') == 'somevalue')
-    def my_handler(spec, **_):
-        pass
+Instead of specific values or special markers, all the value-based filters can
+use arbitrary per-value callbacks (as an advanced use-case for advanced logic).
 
-* Check on labels/annotations with an arbitrary callback for individual values
-  (the value comes as the first positional argument, plus usual :doc:`kwargs`)::
+The value callbacks must receive the same :doc:`keyword arguments <kwargs>`
+as the respective handlers (with ``**kwargs/**_`` for forward compatibility),
+plus one *positional* (not keyword!) argument with the value being checked.
+The passed value will be ``None`` if the value is absent in the resource.
+
+.. code-block:: python
 
     def check_value(value, spec, **_):
         return value == 'some-value' and spec.get('field') is not None
@@ -84,8 +82,41 @@ By arbitrary callbacks
     def my_handler(spec, **_):
         pass
 
-Kopf provides few helpers to combine multiple callbacks into one
-(the semantics is the same as for Python's built-in functions)::
+
+Callback filters
+================
+
+The resource callbacks must receive the same :doc:`keyword arguments <kwargs>`
+as the respective handlers (with ``**kwargs/**_`` for forward compatibility).
+
+.. code-block:: python
+
+    def is_good_enough(spec, **_):
+        return spec.get('field') in spec.get('items', [])
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
+                    when=is_good_enough)
+    def my_handler(spec, **_):
+        pass
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples',
+                    when=lambda spec, **_: spec.get('field') in spec.get('items', []))
+    def my_handler(spec, **_):
+        pass
+
+There is no need for the callback filters to only check the resource's content.
+They can filter by any kwarg data, e.g. by a :kwarg:`reason` of this invocation,
+remembered :kwarg:`memo` values, etc. However, it is highly recommended that
+the filters do not modify the state of the operator -- keep it for handlers.
+
+
+Callback helpers
+================
+
+Kopf provides several helpers to combine multiple callbacks into one
+(the semantics is the same as for Python's built-in functions):
+
+.. code-block:: python
 
     import kopf
 

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -60,6 +60,155 @@ Note that empty strings in labels and annotations are treated as regular values,
 i.e. they are considered as present on the resource.
 
 
+Field filters
+=============
+
+Specific fields can be checked for specific values or for presence/absence,
+similar to the metadata filters:
+
+.. code-block:: python
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', field='spec.field',
+                    value='world')
+    def created_with_world_in_field(**_):
+        pass
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', field='spec.field',
+                    value=kopf.PRESENT)
+    def created_with_field(**_):
+        pass
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', field='spec.no-field',
+                    value=kopf.ABSENT)
+    def created_without_field(**_):
+        pass
+
+When the ``value=`` filter is not specified, but the ``field=`` filter is,
+it is equivalent to ``value=kopf.PRESENT``, i.e. the field must be present
+with any value (for update handlers: present before or after the change).
+
+.. code-block:: python
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', field='spec.field')
+    def created_with_field(**_):
+        pass
+
+    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', field='spec.field')
+    def field_is_affected(old, new, **_):
+        pass
+
+Due to a special nature of the update handlers (``@on.update``, ``@on.field``),
+described in a note below, this filtering semantics is extended for them:
+
+The ``field=`` filter restricts the update-handlers to cases when the specified
+field is in any way affected: changed, added or removed to/from the resource.
+When the specified field is not affected, but something else is changed,
+such update-handlers are not invoked even if they do match the field criteria.
+
+The ``value=`` filter applies to either the old or the new value:
+i.e. if any of them satisfies the value criterion. This covers both sides
+of the state transition: when the value criterion has just been satisfied
+(though was not satisfied before), or when the value criterion was satisfied
+before (but stopped being satisfied). For the latter case, it means that
+the transitioning resource still satisfies the filter in its "old" state.
+
+.. note::
+
+    **Technically,** the update handlers are called after the change has already
+    happened on the low level -- i.e. when the field already has the new value.
+
+    **Semantically,** the update handlers are only initiated by this change,
+    but are executed before the current (new) state is processed and persisted,
+    thus marking the end of the change processing cycle -- i.e. they are called
+    in-between the old and new states, and therefore belong to both of them.
+
+    **In general,** the resource-changing handlers are an abstraction on top
+    of the low level K8s machinery for eventual processing of such state
+    transitions, so their semantics can differ from K8s's low-level semantics.
+    In most cases, this is not visible or important to the operator developers,
+    except for such cases, where it might affect the semantics of e.g. filters.
+
+For reacting to *unrelated* changes of other fields while this field
+satisfies the criterion, use ``when=`` instead of ``field=/value=``.
+
+For reacting to only the cases when the desired state is reached
+but not when the desired state is lost, use ``new=`` with the same criterion;
+similarly, for the cases when the desired state is only lost, use ``old=``.
+
+For all other handlers with no concept of "updating" and being in-between of
+two equally valid and applicable states, the ``field=/value=`` filters
+check the resource in its current --and the only-- state.
+The handlers are being invoked and the daemons are running
+as long as the field and the value match the criterion.
+
+
+Change filters
+==============
+
+The update handlers (specifically, ``@kopf.on.update`` and ``@kopf.on.field``)
+check the ``value=`` filter against both old & new values,
+which might be not what is intended.
+For more precision on filtering, the old/new values
+can be checked separately with the ``old=/new=`` filters
+with the same filtering methods/markers as all other filters.
+
+.. code-block:: python
+
+    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', field='spec.field',
+                    old='x', new='y')
+    def field_is_edited(**_):
+        pass
+
+    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', field='spec.field',
+                    old=kopf.ABSENT, new=kopf.PRESENT)
+    def field_is_added(**_):
+        pass
+
+    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', field='spec.field',
+                    old=kopf.PRESENT, new=kopf.ABSENT)
+    def field_is_removed(**_):
+        pass
+
+If one of ``old=`` or ``new=`` is not specified (or set to ``None``),
+that part is not checked, but the other (specified) part is still checked:
+
+*Match when the field reaches a specific value either by being edited/patched
+to it or by adding it to the resource (i.e. regardless of the old value):*
+
+.. code-block:: python
+
+    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', field='spec.field',
+                    new='world')
+    def hello_world(**_):
+        pass
+
+*Match when the field loses a specific value either by being edited/patched
+to something else, or by removing the field from the resource:*
+
+.. code-block:: python
+
+    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', field='spec.field',
+                    old='world')
+    def goodbye_world(**_):
+        pass
+
+Generally, the update handlers with ``old=/new=`` filters are invoked only when
+the field's value is changed, and are not invoked when it remains the same.
+
+For clarity, "a change" means not only an actual change of the value,
+but also a change in the field's presence or absence in the resource.
+
+If none of the ``old=/new=/value=`` filters is specified, the handler is invoked
+if the field is affected in any way, i.e. if it was modified, added, or removed.
+This is the same behaviour as with the unspecified ``value=`` filter.
+
+.. note::
+
+    ``value=`` is currently made to be mutually exclusive with ``old=/new=``:
+    only one filtering method can be used; if both methods are used together,
+    it would be ambiguous. This can be reconsidered in the future.
+
+
 Value callbacks
 ===============
 

--- a/examples/11-filtering-handlers/example.py
+++ b/examples/11-filtering-handlers/example.py
@@ -57,3 +57,36 @@ def create_with_filter_satisfied(logger, **kwargs):
 @kopf.on.create('zalando.org', 'v1', 'kopfexamples', when=lambda body, **_: False)
 def create_with_filter_not_satisfied(logger, **kwargs):
     logger.info("Filter not satisfied.")
+
+
+@kopf.on.create('zalando.org', 'v1', 'kopfexamples', field='spec.field', value='value')
+def create_with_field_value_satisfied(logger, **kwargs):
+    logger.info("Field value is satisfied.")
+
+
+@kopf.on.create('zalando.org', 'v1', 'kopfexamples', field='spec.field', value='something-else')
+def create_with_field_value_not_satisfied(logger, **kwargs):
+    logger.info("Field value is not satisfied.")
+
+
+@kopf.on.create('zalando.org', 'v1', 'kopfexamples', field='spec.field', value=kopf.PRESENT)
+def create_with_field_presence_satisfied(logger, **kwargs):
+    logger.info("Field presence is satisfied.")
+
+
+@kopf.on.create('zalando.org', 'v1', 'kopfexamples', field='spec.inexistent', value=kopf.PRESENT)
+def create_with_field_presence_not_satisfied(logger, **kwargs):
+    logger.info("Field presence is not satisfied.")
+
+
+@kopf.on.update('zalando.org', 'v1', 'kopfexamples',
+                field='spec.field', old='value', new='changed')
+def update_with_field_change_satisfied(logger, **kwargs):
+    logger.info("Field change is satisfied.")
+
+
+@kopf.daemon('zalando.org', 'v1', 'kopfexamples', field='spec.field', value='value')
+def daemon_with_field(stopped, logger, **kwargs):
+    while not stopped:
+        logger.info("Field daemon is satisfied.")
+        stopped.wait(1)

--- a/examples/11-filtering-handlers/test_example_11.py
+++ b/examples/11-filtering-handlers/test_example_11.py
@@ -46,6 +46,9 @@ def test_handler_filtering():
         subprocess.run(f"kubectl create -f {obj_yaml}",
                        shell=True, check=True, timeout=10, capture_output=True)
         time.sleep(5)  # give it some time to react
+        subprocess.run(f"kubectl patch -f {obj_yaml} --type merge -p '" '{"spec":{"field":"changed"}}' "'",
+                       shell=True, check=True, timeout=10, capture_output=True)
+        time.sleep(2)  # give it some time to react
         subprocess.run(f"kubectl delete -f {obj_yaml}",
                        shell=True, check=True, timeout=10, capture_output=True)
         time.sleep(1)  # give it some time to react
@@ -65,3 +68,9 @@ def test_handler_filtering():
     assert '[default/kopf-example-1] Annotation callback mismatch.' not in runner.stdout
     assert '[default/kopf-example-1] Filter satisfied.' in runner.stdout
     assert '[default/kopf-example-1] Filter not satisfied.' not in runner.stdout
+    assert '[default/kopf-example-1] Field value is satisfied.' in runner.stdout
+    assert '[default/kopf-example-1] Field value is not satisfied.' not in runner.stdout
+    assert '[default/kopf-example-1] Field presence is satisfied.' in runner.stdout
+    assert '[default/kopf-example-1] Field presence is not satisfied.' not in runner.stdout
+    assert '[default/kopf-example-1] Field change is satisfied.' in runner.stdout
+    assert '[default/kopf-example-1] Field daemon is satisfied.' in runner.stdout

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -351,6 +351,8 @@ def event(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
+        field: Optional[dicts.FieldSpec] = None,
+        value: Optional[filters.ValueFilter] = None,
 ) -> ResourceWatchingDecorator:
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
     def decorator(  # lgtm[py/similar-function]
@@ -358,13 +360,15 @@ def event(  # lgtm[py/similar-function]
     ) -> callbacks.ResourceWatchingFn:
         _warn_deprecated_signatures(fn)
         _warn_deprecated_filters(labels, annotations)
+        _warn_conflicting_values(field, value)
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
+        real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ResourceWatchingHandler(
             fn=fn, id=real_id,
             errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
-            labels=labels, annotations=annotations, when=when,
+            labels=labels, annotations=annotations, when=when, field=real_field, value=value,
         )
         real_registry.resource_watching_handlers[real_resource].append(handler)
         return fn
@@ -384,6 +388,8 @@ def daemon(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
+        field: Optional[dicts.FieldSpec] = None,
+        value: Optional[filters.ValueFilter] = None,
         initial_delay: Optional[float] = None,
         cancellation_backoff: Optional[float] = None,
         cancellation_timeout: Optional[float] = None,
@@ -395,13 +401,15 @@ def daemon(  # lgtm[py/similar-function]
     ) -> callbacks.ResourceDaemonFn:
         _warn_deprecated_signatures(fn)
         _warn_deprecated_filters(labels, annotations)
+        _warn_conflicting_values(field, value)
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
+        real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ResourceDaemonHandler(
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            labels=labels, annotations=annotations, when=when,
+            labels=labels, annotations=annotations, when=when, field=real_field, value=value,
             initial_delay=initial_delay, requires_finalizer=True,
             cancellation_backoff=cancellation_backoff,
             cancellation_timeout=cancellation_timeout,
@@ -425,6 +433,8 @@ def timer(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
+        field: Optional[dicts.FieldSpec] = None,
+        value: Optional[filters.ValueFilter] = None,
         initial_delay: Optional[float] = None,
         sharp: Optional[bool] = None,
         idle: Optional[float] = None,
@@ -436,13 +446,15 @@ def timer(  # lgtm[py/similar-function]
     ) -> callbacks.ResourceTimerFn:
         _warn_deprecated_signatures(fn)
         _warn_deprecated_filters(labels, annotations)
+        _warn_conflicting_values(field, value)
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_resource = resources.Resource(group, version, plural)
+        real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ResourceTimerHandler(
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            labels=labels, annotations=annotations, when=when,
+            labels=labels, annotations=annotations, when=when, field=real_field, value=value,
             initial_delay=initial_delay, requires_finalizer=True,
             sharp=sharp, idle=idle, interval=interval,
         )

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -104,7 +104,8 @@ async def execute(
                 errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
                 labels=None, annotations=None, when=None,
                 initial=None, deleted=None, requires_finalizer=None,
-                reason=None, field=None,
+                reason=None, field=None, value=None, old=None, new=None,
+                field_needs_change=None,
             )
             subregistry.append(handler)
 
@@ -117,7 +118,8 @@ async def execute(
                 errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
                 labels=None, annotations=None, when=None,
                 initial=None, deleted=None, requires_finalizer=None,
-                reason=None, field=None,
+                reason=None, field=None, value=None, old=None, new=None,
+                field_needs_change=None,
             )
             subregistry.append(handler)
 

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -118,7 +118,10 @@ async def process_resource_causes(
 ) -> Tuple[Collection[float], bool]:
 
     finalizer = settings.persistence.finalizer
-    extra_fields = registry.resource_changing_handlers[resource].get_extra_fields()
+    extra_fields = (
+        registry.resource_watching_handlers[resource].get_extra_fields() |
+        registry.resource_changing_handlers[resource].get_extra_fields() |
+        registry.resource_spawning_handlers[resource].get_extra_fields())
     old = settings.persistence.diffbase_storage.fetch(body=body)
     new = settings.persistence.diffbase_storage.build(body=body, extra_fields=extra_fields)
     old = settings.persistence.progress_storage.clear(essence=old) if old is not None else None

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -155,7 +155,7 @@ class WhenFilterFn(Protocol):
 class MetaFilterFn(Protocol):
     def __call__(  # lgtm[py/similar-function]
             self,
-            value: Optional[str],  # because it is either labels or annotations, nothing else.
+            value: Any,
             *args: Any,
             body: bodies.Body,
             meta: bodies.Meta,

--- a/kopf/structs/filters.py
+++ b/kopf/structs/filters.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Mapping, Union
+from typing import Any, Mapping, Union
 
 from kopf.structs import callbacks
 
@@ -16,3 +16,7 @@ PRESENT = MetaFilterToken.PRESENT
 
 # Filters for handler specifications (not the same as the object's values).
 MetaFilter = Mapping[str, Union[None, str, MetaFilterToken, callbacks.MetaFilterFn]]
+
+# Filters for old/new values of a field.
+# NB: `Any` covers all other values, but we want to highlight that they are specially treated.
+ValueFilter = Union[None, Any, MetaFilterToken, callbacks.MetaFilterFn]

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -123,10 +123,14 @@ class ResourceWatchingHandler(ResourceHandler):
 class ResourceChangingHandler(ResourceHandler):
     fn: callbacks.ResourceChangingFn  # type clarification
     reason: Optional[Reason]
-    field: Optional[dicts.FieldPath]
     initial: Optional[bool]
     deleted: Optional[bool]  # used for mixed-in (initial==True) @on.resume handlers only.
     requires_finalizer: Optional[bool]
+    field_needs_change: Optional[bool]  # to identify on-field/on-update with support for old=/new=.
+    field: Optional[dicts.FieldPath]
+    value: Optional[filters.ValueFilter]
+    old: Optional[filters.ValueFilter]
+    new: Optional[filters.ValueFilter]
 
     @property
     def event(self) -> Optional[Reason]:

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -112,6 +112,8 @@ class ResourceHandler(BaseHandler):
     labels: Optional[filters.MetaFilter]
     annotations: Optional[filters.MetaFilter]
     when: Optional[callbacks.WhenFilterFn]
+    field: Optional[dicts.FieldPath]
+    value: Optional[filters.ValueFilter]
 
 
 @dataclasses.dataclass
@@ -127,8 +129,6 @@ class ResourceChangingHandler(ResourceHandler):
     deleted: Optional[bool]  # used for mixed-in (initial==True) @on.resume handlers only.
     requires_finalizer: Optional[bool]
     field_needs_change: Optional[bool]  # to identify on-field/on-update with support for old=/new=.
-    field: Optional[dicts.FieldPath]
-    value: Optional[filters.ValueFilter]
     old: Optional[filters.ValueFilter]
     new: Optional[filters.ValueFilter]
 

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -106,10 +106,11 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
         handler = LegacyAllPurposeResourcerHandler(
             id=real_id, fn=fn,  # type: ignore
-            reason=reason, field=real_field,
+            reason=reason,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             initial=initial, deleted=deleted, requires_finalizer=requires_finalizer,
             labels=labels, annotations=annotations, when=when,
+            field=real_field, value=None, old=None, new=None, field_needs_change=None,
         )
         self.append(handler)
         return fn

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -153,7 +153,7 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
         for handler in self._handlers:
             if not isinstance(handler, handlers.ResourceWatchingHandler):
                 pass
-            elif registries.match(handler=handler, cause=cause, ignore_fields=True):
+            elif registries.match(handler=handler, cause=cause):
                 yield handler
 
     def iter_cause_handlers(

--- a/tests/basic-structs/test_handlers.py
+++ b/tests/basic-structs/test_handlers.py
@@ -40,7 +40,6 @@ def test_resource_handler_with_all_args(mocker):
     fn = mocker.Mock()
     id = mocker.Mock()
     reason = mocker.Mock()
-    field = mocker.Mock()
     errors = mocker.Mock()
     timeout = mocker.Mock()
     retries = mocker.Mock()
@@ -50,12 +49,16 @@ def test_resource_handler_with_all_args(mocker):
     labels = mocker.Mock()
     annotations = mocker.Mock()
     when = mocker.Mock()
+    field = mocker.Mock()
+    value = mocker.Mock()
+    old = mocker.Mock()
+    new = mocker.Mock()
+    field_needs_change = mocker.Mock()
     requires_finalizer = mocker.Mock()
     handler = ResourceChangingHandler(
         fn=fn,
         id=id,
         reason=reason,
-        field=field,
         errors=errors,
         timeout=timeout,
         retries=retries,
@@ -66,12 +69,16 @@ def test_resource_handler_with_all_args(mocker):
         labels=labels,
         annotations=annotations,
         when=when,
+        field=field,
+        value=value,
+        old=old,
+        new=new,
+        field_needs_change=field_needs_change,
         requires_finalizer=requires_finalizer,
     )
     assert handler.fn is fn
     assert handler.id is id
     assert handler.reason is reason
-    assert handler.field is field
     assert handler.errors is errors
     assert handler.timeout is timeout
     assert handler.retries is retries
@@ -81,6 +88,11 @@ def test_resource_handler_with_all_args(mocker):
     assert handler.labels is labels
     assert handler.annotations is annotations
     assert handler.when is when
+    assert handler.field is field
+    assert handler.value is value
+    assert handler.old is old
+    assert handler.new is new
+    assert handler.field_needs_change is field_needs_change
     assert handler.requires_finalizer is requires_finalizer
 
     with pytest.deprecated_call(match=r"use handler.reason"):

--- a/tests/basic-structs/test_handlers_deprecated_cooldown.py
+++ b/tests/basic-structs/test_handlers_deprecated_cooldown.py
@@ -41,7 +41,6 @@ def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
     fn = mocker.Mock()
     id = mocker.Mock()
     reason = mocker.Mock()
-    field = mocker.Mock()
     errors = mocker.Mock()
     timeout = mocker.Mock()
     retries = mocker.Mock()
@@ -51,6 +50,11 @@ def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
     labels = mocker.Mock()
     annotations = mocker.Mock()
     when = mocker.Mock()
+    field = mocker.Mock()
+    value = mocker.Mock()
+    old = mocker.Mock()
+    new = mocker.Mock()
+    field_needs_change = mocker.Mock()
     requires_finalizer = mocker.Mock()
 
     with pytest.deprecated_call(match=r"use backoff="):
@@ -58,7 +62,6 @@ def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
             fn=fn,
             id=id,
             reason=reason,
-            field=field,
             errors=errors,
             timeout=timeout,
             retries=retries,
@@ -69,13 +72,17 @@ def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
             labels=labels,
             annotations=annotations,
             when=when,
+            field=field,
+            value=value,
+            old=old,
+            new=new,
+            field_needs_change=field_needs_change,
             requires_finalizer=requires_finalizer,
         )
 
     assert handler.fn is fn
     assert handler.id is id
     assert handler.reason is reason
-    assert handler.field is field
     assert handler.errors is errors
     assert handler.timeout is timeout
     assert handler.retries is retries
@@ -85,4 +92,9 @@ def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
     assert handler.labels is labels
     assert handler.annotations is annotations
     assert handler.when is when
+    assert handler.field is field
+    assert handler.value is value
+    assert handler.old is old
+    assert handler.new is new
+    assert handler.field_needs_change is field_needs_change
     assert handler.requires_finalizer is requires_finalizer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,11 @@ def clear_default_registry():
         kopf.set_default_registry(old_registry)
 
 
+@pytest.fixture()
+def registry(clear_default_registry):
+    return clear_default_registry
+
+
 #
 # Mocks for Kubernetes API clients (any of them). Reasons:
 # 1. We do not test the clients, we test the layers on top of them,

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -60,11 +60,6 @@ def k8s_mocked(mocker, resp_mocker):
     )
 
 
-@pytest.fixture()
-def registry(clear_default_registry):
-    return clear_default_registry
-
-
 @dataclasses.dataclass(frozen=True, eq=False, order=False)
 class HandlersContainer:
     event_mock: Mock

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -26,7 +26,8 @@ async def test_skipped_with_no_handlers(
         reason='a-non-existent-cause-type',
         fn=lambda **_: None, id='id',
         errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
-        annotations=None, labels=None, when=None, field=None,
+        annotations=None, labels=None, when=None,
+        field=None, value=None, old=None, new=None, field_needs_change=None,
         deleted=None, initial=None, requires_finalizer=None,
     ))
 
@@ -80,7 +81,8 @@ async def test_stealth_mode_with_mismatching_handlers(
         reason=None,
         fn=lambda **_: None, id='id',
         errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
-        annotations=annotations, labels=labels, when=when, field=None,
+        annotations=annotations, labels=labels, when=when,
+        field=None, value=None, old=None, new=None, field_needs_change=None,
         deleted=deleted, initial=initial, requires_finalizer=None,
     ))
 

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -3,10 +3,11 @@ import logging
 import pytest
 
 from kopf import GlobalRegistry, SimpleRegistry  # deprecated, but tested
-from kopf.reactor.causation import ActivityCause, ResourceCause, \
-                                   ResourceChangingCause, ResourceWatchingCause
+from kopf.reactor.causation import ActivityCause, ResourceCause, ResourceChangingCause, \
+                                   ResourceSpawningCause, ResourceWatchingCause
 from kopf.reactor.registries import ActivityRegistry, OperatorRegistry, ResourceChangingRegistry, \
-                                    ResourceRegistry, ResourceWatchingRegistry
+                                    ResourceRegistry, ResourceSpawningRegistry, \
+                                    ResourceWatchingRegistry
 from kopf.structs.bodies import Body
 from kopf.structs.containers import Memo
 from kopf.structs.diffs import Diff, DiffItem
@@ -133,6 +134,15 @@ def cause_factory(resource):
                 new=new,
                 initial=initial,
                 reason=reason,
+            )
+        if cls is ResourceSpawningCause or cls is ResourceSpawningRegistry:
+            return ResourceSpawningCause(
+                logger=logging.getLogger('kopf.test.fake.logger'),
+                resource=resource,
+                patch=Patch(),
+                memo=Memo(),
+                body=Body(body if body is not None else {}),
+                reset=False,
             )
         raise TypeError(f"Cause/registry type {cls} is not supported by this fixture.")
     return make_cause

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -58,8 +58,9 @@ def parent_handler():
         fn=parent_fn, id=HandlerId('parent_fn'),
         errors=None, retries=None, timeout=None, backoff=None, cooldown=None,
         labels=None, annotations=None, when=None,
+        field=None, value=None, old=None, new=None, field_needs_change=None,
         initial=None, deleted=None, requires_finalizer=None,
-        reason=None, field=None,
+        reason=None,
     )
 
 
@@ -89,6 +90,8 @@ def cause_factory(resource):
             raw=None,
             body=None,
             diff=(),
+            old=None,
+            new=None,
             reason='some-reason',
             initial=False,
             activity=None,
@@ -126,6 +129,8 @@ def cause_factory(resource):
                 memo=Memo(),
                 body=Body(body if body is not None else {}),
                 diff=Diff(DiffItem(*d) for d in diff),
+                old=old,
+                new=new,
                 initial=initial,
                 reason=reason,
             )

--- a/tests/registries/legacy-1/test_legacy1_decorators.py
+++ b/tests/registries/legacy-1/test_legacy1_decorators.py
@@ -80,7 +80,7 @@ def test_on_field_minimal(cause_factory):
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
     cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
 
-    @kopf.on.field('group', 'version', 'plural', 'field.subfield')
+    @kopf.on.field('group', 'version', 'plural', field='field.subfield')
     def fn(**_):
         pass
 
@@ -206,7 +206,7 @@ def test_on_field_with_all_kwargs(mocker, cause_factory):
 
     when = lambda **_: False
 
-    @kopf.on.field('group', 'version', 'plural', 'field.subfield',
+    @kopf.on.field('group', 'version', 'plural', field='field.subfield',
                    id='id', timeout=123, registry=registry,
                    labels={'somelabel': 'somevalue'},
                    annotations={'someanno': 'somevalue'},

--- a/tests/registries/legacy-1/test_legacy1_decorators.py
+++ b/tests/registries/legacy-1/test_legacy1_decorators.py
@@ -77,8 +77,9 @@ def test_on_delete_minimal(cause_factory):
 def test_on_field_minimal(cause_factory):
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
+    old = {'field': {'subfield': 'old'}}
+    new = {'field': {'subfield': 'new'}}
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE, old=old, new=new, body=new)
 
     @kopf.on.field('group', 'version', 'plural', field='field.subfield')
     def fn(**_):
@@ -200,8 +201,9 @@ def test_on_delete_with_all_kwargs(mocker, optional, cause_factory):
 def test_on_field_with_all_kwargs(mocker, cause_factory):
     registry = GlobalRegistry()
     resource = Resource('group', 'version', 'plural')
-    diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
+    old = {'field': {'subfield': 'old'}}
+    new = {'field': {'subfield': 'new'}}
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE, old=old, new=new, body=new)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     when = lambda **_: False

--- a/tests/registries/legacy-1/test_legacy1_handler_matching.py
+++ b/tests/registries/legacy-1/test_legacy1_handler_matching.py
@@ -32,28 +32,42 @@ def register_fn(registry, resource):
 
 
 @pytest.fixture(params=[
-    pytest.param([], id='with-empty-diff'),
+    # The original no-diff was equivalent to no-field until body/old/new were added to the check.
+    pytest.param(dict(old={}, new={}, body={}, diff=[]), id='with-empty-diff'),
 ])
 def cause_no_diff(request, cause_factory):
-    body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
-    return cause_factory(diff=request.param, body=body)
+    request.param['body'].update(
+        {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(**request.param)
+    return cause
 
 
 @pytest.fixture(params=[
-    pytest.param([('op', ('some-field',), 'old', 'new')], id='with-field-diff'),
+    pytest.param(dict(old={'some-field': 'old'},
+                      new={'some-field': 'new'},
+                      body={'some-field': 'new'},
+                      diff=[('op', ('some-field',), 'old', 'new')]), id='with-field-diff'),
 ])
 def cause_with_diff(request, cause_factory):
-    body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
-    return cause_factory(diff=request.param, body=body)
+    request.param['body'].update(
+        {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(**request.param)
+    return cause
 
 
 @pytest.fixture(params=[
-    pytest.param([], id='with-empty-diff'),
-    pytest.param([('op', ('some-field',), 'old', 'new')], id='with-field-diff'),
+    # The original no-diff was equivalent to no-field until body/old/new were added to the check.
+    pytest.param(dict(old={}, new={}, body={}, diff=[]), id='with-empty-diff'),
+    pytest.param(dict(old={'some-field': 'old'},
+                      new={'some-field': 'new'},
+                      body={'some-field': 'new'},
+                      diff=[('op', ('some-field',), 'old', 'new')]), id='with-field-diff'),
 ])
 def cause_any_diff(request, cause_factory):
-    body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
-    return cause_factory(diff=request.param, body=body)
+    request.param['body'].update(
+        {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(**request.param)
+    return cause
 
 
 #

--- a/tests/registries/legacy-1/test_legacy1_id_detection.py
+++ b/tests/registries/legacy-1/test_legacy1_id_detection.py
@@ -108,8 +108,9 @@ def test_with_prefix(mocker, cause_factory):
 
 def test_with_suffix(mocker, field, cause_factory):
     get_fn_id = mocker.patch('kopf.reactor.registries.get_callable_id', return_value='some-id')
-    diff = [('add', ('some-field', 'sub-field'), 'old', 'new')]
-    cause = cause_factory(diff=diff)
+    old = {'some-field': {'sub-field': 'old'}}
+    new = {'some-field': {'sub-field': 'new'}}
+    cause = cause_factory(old=old, new=new, body=new)
 
     registry = SimpleRegistry()
     with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):

--- a/tests/registries/legacy-2/test_legacy2_decorators.py
+++ b/tests/registries/legacy-2/test_legacy2_decorators.py
@@ -180,8 +180,9 @@ def test_on_field_minimal(
 
     registry = kopf.get_default_registry()
     resource = Resource('group', 'version', 'plural')
-    diff = [('op', ('field', 'subfield'), 'old', 'new')]
-    cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
+    old = {'field': {'subfield': 'old'}}
+    new = {'field': {'subfield': 'new'}}
+    cause = cause_factory(resource=resource, reason=Reason.UPDATE, old=old, new=new, body=new)
 
     @kopf.on.field('group', 'version', 'plural', field='field.subfield')
     def fn(**_):

--- a/tests/registries/legacy-2/test_legacy2_decorators.py
+++ b/tests/registries/legacy-2/test_legacy2_decorators.py
@@ -183,7 +183,7 @@ def test_on_field_minimal(
     diff = [('op', ('field', 'subfield'), 'old', 'new')]
     cause = cause_factory(resource=resource, reason=Reason.UPDATE, diff=diff)
 
-    @kopf.on.field('group', 'version', 'plural', 'field.subfield')
+    @kopf.on.field('group', 'version', 'plural', field='field.subfield')
     def fn(**_):
         pass
 
@@ -440,7 +440,7 @@ def test_on_field_with_all_kwargs(
 
     when = lambda **_: False
 
-    @kopf.on.field('group', 'version', 'plural', 'field.subfield',
+    @kopf.on.field('group', 'version', 'plural', field='field.subfield',
                    id='id', registry=registry,
                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                    labels={'somelabel': 'somevalue'},

--- a/tests/registries/legacy-2/test_legacy2_handler_matching.py
+++ b/tests/registries/legacy-2/test_legacy2_handler_matching.py
@@ -30,28 +30,42 @@ def register_fn(registry, resource):
 
 
 @pytest.fixture(params=[
-    pytest.param([], id='with-empty-diff'),
+    # The original no-diff was equivalent to no-field until body/old/new were added to the check.
+    pytest.param(dict(old={}, new={}, body={}, diff=[]), id='with-empty-diff'),
 ])
 def cause_no_diff(request, cause_factory):
-    body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
-    return cause_factory(diff=request.param, body=body)
+    request.param['body'].update(
+        {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(**request.param)
+    return cause
 
 
 @pytest.fixture(params=[
-    pytest.param([('op', ('some-field',), 'old', 'new')], id='with-field-diff'),
+    pytest.param(dict(old={'some-field': 'old'},
+                      new={'some-field': 'new'},
+                      body={'some-field': 'new'},
+                      diff=[('op', ('some-field',), 'old', 'new')]), id='with-field-diff'),
 ])
 def cause_with_diff(request, cause_factory):
-    body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
-    return cause_factory(diff=request.param, body=body)
+    request.param['body'].update(
+        {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(**request.param)
+    return cause
 
 
 @pytest.fixture(params=[
-    pytest.param([], id='with-empty-diff'),
-    pytest.param([('op', ('some-field',), 'old', 'new')], id='with-field-diff'),
+    # The original no-diff was equivalent to no-field until body/old/new were added to the check.
+    pytest.param(dict(old={}, new={}, body={}, diff=[]), id='with-empty-diff'),
+    pytest.param(dict(old={'some-field': 'old'},
+                      new={'some-field': 'new'},
+                      body={'some-field': 'new'},
+                      diff=[('op', ('some-field',), 'old', 'new')]), id='with-field-diff'),
 ])
 def cause_any_diff(request, cause_factory):
-    body = {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}}
-    return cause_factory(diff=request.param, body=body)
+    request.param['body'].update(
+        {'metadata': {'labels': {'somelabel': 'somevalue'}, 'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(**request.param)
+    return cause
 
 
 #

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -82,6 +82,9 @@ def test_on_resume_minimal(reason, cause_factory):
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
     assert handlers[0].when is None
+    assert handlers[0].field is None
+    assert handlers[0].old is None
+    assert handlers[0].new is None
 
 
 def test_on_create_minimal(cause_factory):
@@ -105,6 +108,9 @@ def test_on_create_minimal(cause_factory):
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
     assert handlers[0].when is None
+    assert handlers[0].field is None
+    assert handlers[0].old is None
+    assert handlers[0].new is None
 
 
 def test_on_update_minimal(cause_factory):
@@ -128,6 +134,9 @@ def test_on_update_minimal(cause_factory):
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
     assert handlers[0].when is None
+    assert handlers[0].field is None
+    assert handlers[0].old is None
+    assert handlers[0].new is None
 
 
 def test_on_delete_minimal(cause_factory):
@@ -151,6 +160,9 @@ def test_on_delete_minimal(cause_factory):
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
     assert handlers[0].when is None
+    assert handlers[0].field is None
+    assert handlers[0].old is None
+    assert handlers[0].new is None
 
 
 def test_on_field_minimal(cause_factory):
@@ -267,7 +279,7 @@ def test_on_probe_with_all_kwargs(mocker):
 
 # Resume handlers are mixed-in into all resource-changing reactions with initial listing.
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
-def test_on_resume_with_all_kwargs(mocker, reason, cause_factory):
+def test_on_resume_with_most_kwargs(mocker, reason, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
     cause = cause_factory(resource=resource, reason=reason, initial=True)
@@ -289,7 +301,6 @@ def test_on_resume_with_all_kwargs(mocker, reason, cause_factory):
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason is None
-    assert handlers[0].field is None
     assert handlers[0].id == 'id'
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
@@ -299,9 +310,13 @@ def test_on_resume_with_all_kwargs(mocker, reason, cause_factory):
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
     assert handlers[0].when == when
+    assert handlers[0].field is None
+    assert handlers[0].value is None
+    assert handlers[0].old is None
+    assert handlers[0].new is None
 
 
-def test_on_create_with_all_kwargs(mocker, cause_factory):
+def test_on_create_with_most_kwargs(mocker, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
     cause = cause_factory(resource=resource, reason=Reason.CREATE)
@@ -322,7 +337,6 @@ def test_on_create_with_all_kwargs(mocker, cause_factory):
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.CREATE
-    assert handlers[0].field is None
     assert handlers[0].id == 'id'
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
@@ -331,9 +345,13 @@ def test_on_create_with_all_kwargs(mocker, cause_factory):
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
     assert handlers[0].when == when
+    assert handlers[0].field is None
+    assert handlers[0].value is None
+    assert handlers[0].old is None
+    assert handlers[0].new is None
 
 
-def test_on_update_with_all_kwargs(mocker, cause_factory):
+def test_on_update_with_most_kwargs(mocker, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
     cause = cause_factory(resource=resource, reason=Reason.UPDATE)
@@ -354,7 +372,6 @@ def test_on_update_with_all_kwargs(mocker, cause_factory):
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.UPDATE
-    assert handlers[0].field is None
     assert handlers[0].id == 'id'
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
@@ -363,13 +380,17 @@ def test_on_update_with_all_kwargs(mocker, cause_factory):
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
     assert handlers[0].when == when
+    assert handlers[0].field is None
+    assert handlers[0].value is None
+    assert handlers[0].old is None
+    assert handlers[0].new is None
 
 
 @pytest.mark.parametrize('optional', [
     pytest.param(True, id='optional'),
     pytest.param(False, id='mandatory'),
 ])
-def test_on_delete_with_all_kwargs(mocker, cause_factory, optional):
+def test_on_delete_with_most_kwargs(mocker, cause_factory, optional):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
     cause = cause_factory(resource=resource, reason=Reason.DELETE)
@@ -391,7 +412,6 @@ def test_on_delete_with_all_kwargs(mocker, cause_factory, optional):
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.DELETE
-    assert handlers[0].field is None
     assert handlers[0].id == 'id'
     assert handlers[0].errors == ErrorsMode.PERMANENT
     assert handlers[0].timeout == 123
@@ -400,9 +420,13 @@ def test_on_delete_with_all_kwargs(mocker, cause_factory, optional):
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
     assert handlers[0].when == when
+    assert handlers[0].field is None
+    assert handlers[0].value is None
+    assert handlers[0].old is None
+    assert handlers[0].new is None
 
 
-def test_on_field_with_all_kwargs(mocker, cause_factory):
+def test_on_field_with_most_kwargs(mocker, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
     old = {'field': {'subfield': 'old'}}
@@ -417,8 +441,7 @@ def test_on_field_with_all_kwargs(mocker, cause_factory):
                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                    labels={'somelabel': 'somevalue'},
                    annotations={'someanno': 'somevalue'},
-                   when=when,
-                   value='value')
+                   when=when)
     def fn(**_):
         pass
 
@@ -435,7 +458,7 @@ def test_on_field_with_all_kwargs(mocker, cause_factory):
     assert handlers[0].annotations == {'someanno': 'somevalue'}
     assert handlers[0].when == when
     assert handlers[0].field == ('field', 'subfield')
-    assert handlers[0].value == 'value'
+    assert handlers[0].value is None
     assert handlers[0].old is None
     assert handlers[0].new is None
 
@@ -521,3 +544,108 @@ def test_annotations_filter_with_nones(resource, decorator, kwargs):
                    annotations={'x': None})
         def fn(**_):
             pass
+
+
+@pytest.mark.parametrize('decorator, causeargs, handlers_prop', [
+    pytest.param(kopf.on.event, dict(), 'resource_watching_handlers', id='on-event'),
+    pytest.param(kopf.on.resume, dict(reason=None, initial=True), 'resource_changing_handlers', id='on-resume'),
+    pytest.param(kopf.on.create, dict(reason=Reason.CREATE), 'resource_changing_handlers', id='on-create'),
+    pytest.param(kopf.on.update, dict(reason=Reason.UPDATE), 'resource_changing_handlers', id='on-update'),
+    pytest.param(kopf.on.delete, dict(reason=Reason.DELETE), 'resource_changing_handlers', id='on-delete'),
+    pytest.param(kopf.on.field, dict(reason=Reason.UPDATE), 'resource_changing_handlers', id='on-field'),
+    pytest.param(kopf.daemon, dict(), 'resource_spawning_handlers', id='on-daemon'),
+    pytest.param(kopf.timer, dict(), 'resource_spawning_handlers', id='on-timer'),
+])
+def test_field_with_value(mocker, cause_factory, decorator, causeargs, handlers_prop):
+    registry = OperatorRegistry()
+    resource = Resource('group', 'version', 'plural')
+    old = {'field': {'subfield': 'old'}}
+    new = {'field': {'subfield': 'new'}}
+    cause = cause_factory(resource=resource, old=old, new=new, body=new, **causeargs)
+    mocker.patch('kopf.reactor.registries.match', return_value=True)
+
+    @decorator('group', 'version', 'plural', registry=registry,
+               field='spec.field', value='value')
+    def fn(**_):
+        pass
+
+    handlers_registry = getattr(registry, handlers_prop)
+    handlers = handlers_registry[resource].get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].field == ('spec', 'field')
+    assert handlers[0].value == 'value'
+
+
+@pytest.mark.parametrize('decorator, causeargs, handlers_prop', [
+    pytest.param(kopf.on.update, dict(reason=Reason.UPDATE), 'resource_changing_handlers', id='on-update'),
+    pytest.param(kopf.on.field, dict(reason=Reason.UPDATE), 'resource_changing_handlers', id='on-field'),
+])
+def test_field_with_oldnew(mocker, cause_factory, decorator, causeargs, handlers_prop):
+    registry = OperatorRegistry()
+    resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, **causeargs)
+    mocker.patch('kopf.reactor.registries.match', return_value=True)
+
+    @decorator('group', 'version', 'plural', registry=registry,
+               field='spec.field', old='old', new='new')
+    def fn(**_):
+        pass
+
+    handlers_registry = getattr(registry, handlers_prop)
+    handlers = handlers_registry[resource].get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].field == ('spec', 'field')
+    assert handlers[0].value is None
+    assert handlers[0].old == 'old'
+    assert handlers[0].new == 'new'
+
+
+@pytest.mark.parametrize('decorator', [
+    pytest.param(kopf.on.event, id='on-event'),
+    pytest.param(kopf.on.resume, id='on-resume'),
+    pytest.param(kopf.on.create, id='on-create'),
+    pytest.param(kopf.on.update, id='on-update'),
+    pytest.param(kopf.on.delete, id='on-delete'),
+    pytest.param(kopf.daemon, id='on-daemon'),
+    pytest.param(kopf.timer, id='on-timer'),
+])
+def test_missing_field_with_specified_value(resource, decorator):
+    with pytest.raises(TypeError, match="without a mandatory field"):
+        @decorator(resource.group, resource.version, resource.plural, value='v')
+        def fn(**_):
+            pass
+
+
+@pytest.mark.parametrize('kwargs', [
+    pytest.param(dict(field='f', value='v', old='x'), id='value-vs-old'),
+    pytest.param(dict(field='f', value='v', new='x'), id='value-vs-new'),
+])
+@pytest.mark.parametrize('decorator', [
+    pytest.param(kopf.on.update, id='on-update'),
+    pytest.param(kopf.on.field, id='on-field'),
+])
+def test_conflicts_of_values_vs_oldnew(resource, decorator, kwargs):
+    with pytest.raises(TypeError, match="Either value= or old=/new="):
+        @decorator(resource.group, resource.version, resource.plural, **kwargs)
+        def fn(**_):
+            pass
+
+
+@pytest.mark.parametrize('decorator', [
+    pytest.param(kopf.on.resume, id='on-resume'),
+    pytest.param(kopf.on.create, id='on-create'),
+    pytest.param(kopf.on.delete, id='on-delete'),
+])
+def test_invalid_oldnew_for_inappropriate_subhandlers(resource, decorator, registry):
+
+    @decorator(resource.group, resource.version, resource.plural)
+    def fn(**_):
+        @kopf.on.this(field='f', old='x')
+        def fn2(**_):
+            pass
+
+    subregistry = ResourceChangingRegistry()
+    handler = registry.resource_changing_handlers[resource].get_all_handlers()[0]
+    with context([(handler_var, handler), (subregistry_var, subregistry)]):
+        with pytest.raises(TypeError, match="can only be used in update handlers"):
+            handler.fn()

--- a/tests/registries/test_decorators_deprecated_cooldown.py
+++ b/tests/registries/test_decorators_deprecated_cooldown.py
@@ -150,7 +150,7 @@ def test_on_field_with_cooldown(mocker, cause_factory):
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
     with pytest.deprecated_call(match=r"use backoff="):
-        @kopf.on.field('group', 'version', 'plural', 'field.subfield', cooldown=78)
+        @kopf.on.field('group', 'version', 'plural', field='field.subfield', cooldown=78)
         def fn(**_):
             pass
 

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -46,11 +46,6 @@ mismatching_reason_and_decorator = pytest.mark.parametrize('reason, decorator', 
 
 
 @pytest.fixture()
-def registry():
-    return OperatorRegistry()
-
-
-@pytest.fixture()
 def handler_factory(registry, resource):
     def factory(**kwargs):
         handler = ResourceChangingHandler(**dict(dict(

--- a/tests/registries/test_matching_for_spawning.py
+++ b/tests/registries/test_matching_for_spawning.py
@@ -1,0 +1,506 @@
+import copy
+
+import pytest
+
+import kopf
+from kopf.reactor.causation import ResourceSpawningCause
+from kopf.structs.dicts import parse_field
+from kopf.structs.filters import MetaFilterToken
+from kopf.structs.handlers import ResourceDaemonHandler, \
+                                  ResourceSpawningHandler, ResourceTimerHandler
+
+
+# Used in the tests. Must be global-scoped, or its qualname will be affected.
+def some_fn(x=None):
+    pass
+
+
+def _never(*_, **__):
+    return False
+
+
+def _always(*_, **__):
+    return True
+
+
+spawning_decorators = pytest.mark.parametrize('decorator', [
+    (kopf.timer),
+    (kopf.daemon),
+])
+
+
+@pytest.fixture()
+def handler_factory(registry, resource):
+    def factory(**kwargs):
+        handler = ResourceSpawningHandler(**dict(dict(
+            fn=some_fn, id='a',
+            errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
+            annotations=None, labels=None, when=None,
+            field=None, value=None,
+            requires_finalizer=None, initial_delay=None,
+        ), **kwargs))
+        registry.resource_spawning_handlers[resource].append(handler)
+        return handler
+    return factory
+
+
+@pytest.fixture(params=[
+    pytest.param(dict(body={}), id='no-field'),
+])
+def cause_no_field(request, cause_factory):
+    kwargs = copy.deepcopy(request.param)
+    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
+                                        'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(cls=ResourceSpawningCause, **kwargs)
+    return cause
+
+
+@pytest.fixture(params=[
+    pytest.param(dict(body={'some-field': 'new'}), id='with-field'),
+])
+def cause_with_field(request, cause_factory):
+    kwargs = copy.deepcopy(request.param)
+    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
+                                        'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(cls=ResourceSpawningCause, **kwargs)
+    return cause
+
+
+@pytest.fixture(params=[
+    # The original no-diff was equivalent to no-field until body/old/new were added to the check.
+    pytest.param(dict(body={}, diff=[]), id='no-field'),
+    pytest.param(dict(body={'some-field': 'new'}), id='with-field'),
+])
+def cause_any_field(request, cause_factory):
+    kwargs = copy.deepcopy(request.param)
+    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
+                                        'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(cls=ResourceSpawningCause, **kwargs)
+    return cause
+
+
+#
+# "Catch-all" handlers are those with event == None.
+#
+
+def test_catchall_handlers_without_field_found(
+        cause_any_field, registry, handler_factory):
+    cause = cause_any_field
+    handler_factory(field=None)
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+def test_catchall_handlers_with_field_found(
+        cause_with_field, registry, handler_factory):
+    cause = cause_with_field
+    handler_factory(field=parse_field('some-field'))
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+def test_catchall_handlers_with_field_ignored(
+        cause_no_field, registry, handler_factory):
+    cause = cause_no_field
+    handler_factory(field=parse_field('some-field'))
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+])
+def test_catchall_handlers_with_exact_labels_satisfied(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': 'somevalue'})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+])
+def test_catchall_handlers_with_exact_labels_not_satisfied(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': 'somevalue'})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_desired_labels_present(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': MetaFilterToken.PRESENT})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+])
+def test_catchall_handlers_with_desired_labels_absent(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': MetaFilterToken.PRESENT})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_undesired_labels_present(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': MetaFilterToken.ABSENT})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+])
+def test_catchall_handlers_with_undesired_labels_absent(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': MetaFilterToken.ABSENT})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_labels_callback_says_true(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': _always})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_labels_callback_says_false(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': _never})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+])
+def test_catchall_handlers_without_labels(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels=None)
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
+])
+def test_catchall_handlers_with_exact_annotations_satisfied(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': 'somevalue'})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+])
+def test_catchall_handlers_with_exact_annotations_not_satisfied(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': 'somevalue'})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_desired_annotations_present(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': MetaFilterToken.PRESENT})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+])
+def test_catchall_handlers_with_desired_annotations_absent(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': MetaFilterToken.PRESENT})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_undesired_annotations_present(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': MetaFilterToken.ABSENT})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+])
+def test_catchall_handlers_with_undesired_annotations_absent(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': MetaFilterToken.ABSENT})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_annotations_callback_says_true(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': _always})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_annotations_callback_says_false(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': _never})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+    pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
+])
+def test_catchall_handlers_without_annotations(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory()
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels, annotations', [
+    pytest.param({'somelabel': 'somevalue'}, {'someannotation': 'somevalue'}, id='with-label-annotation'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue'}, id='with-extra-label-annotation'),
+    pytest.param({'somelabel': 'somevalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-label-extra-annotation'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-label-extra-annotation'),
+])
+def test_catchall_handlers_with_labels_and_annotations_satisfied(
+        cause_factory, registry, handler_factory, resource, labels, annotations):
+    cause = cause_factory(body={'metadata': {'labels': labels, 'annotations': annotations}})
+    handler_factory(labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+])
+def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('when', [
+    pytest.param(None, id='without-when'),
+    pytest.param(lambda body=None, **_: body['spec']['name'] == 'test', id='with-when'),
+    pytest.param(lambda **_: True, id='with-other-when'),
+])
+def test_catchall_handlers_with_when_callback_matching(
+        cause_factory, registry, handler_factory, resource, when):
+    cause = cause_factory(body={'spec': {'name': 'test'}})
+    handler_factory(when=when)
+    handlers = registry.resource_spawning_handlers[resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('when', [
+    pytest.param(lambda body=None, **_: body['spec']['name'] != "test", id='with-when'),
+    pytest.param(lambda **_: False, id='with-other-when'),
+])
+def test_catchall_handlers_with_when_callback_mismatching(
+        cause_factory, registry, handler_factory, resource, when):
+    cause = cause_factory(body={'spec': {'name': 'test'}})
+    handler_factory(when=when)
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@spawning_decorators
+def test_decorator_without_field_found(
+        cause_any_field, registry, resource, decorator):
+
+    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+               field=None)
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@spawning_decorators
+def test_decorator_with_field_found(
+        cause_with_field, registry, resource, decorator):
+
+    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+               field='some-field')
+    def some_fn(**_): ...
+
+    cause = cause_with_field
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@spawning_decorators
+def test_decorator_with_field_ignored(
+        cause_no_field, registry, resource, decorator):
+
+    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+               field='some-field')
+    def some_fn(**_): ...
+
+    cause = cause_no_field
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@spawning_decorators
+def test_decorator_with_labels_satisfied(
+        cause_any_field, registry, resource, decorator):
+
+    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+               labels={'somelabel': MetaFilterToken.PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@spawning_decorators
+def test_decorator_with_labels_not_satisfied(
+        cause_any_field, registry, resource, decorator):
+
+    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+               labels={'otherlabel': MetaFilterToken.PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@spawning_decorators
+def test_decorator_with_annotations_satisfied(
+        cause_any_field, registry, resource, decorator):
+
+    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+               annotations={'someannotation': MetaFilterToken.PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@spawning_decorators
+def test_decorator_with_annotations_not_satisfied(
+        cause_any_field, registry, resource, decorator):
+
+    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+               annotations={'otherannotation': MetaFilterToken.PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@spawning_decorators
+def test_decorator_with_filter_satisfied(
+        cause_any_field, registry, resource, decorator):
+
+    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+               when=_always)
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@spawning_decorators
+def test_decorator_with_filter_not_satisfied(
+        cause_any_field, registry, resource, decorator):
+
+    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+               when=_never)
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_spawning_handlers[cause.resource].get_handlers(cause)
+    assert not handlers

--- a/tests/registries/test_matching_for_watching.py
+++ b/tests/registries/test_matching_for_watching.py
@@ -1,0 +1,489 @@
+import copy
+
+import pytest
+
+import kopf
+from kopf.reactor.causation import ResourceWatchingCause
+from kopf.structs.dicts import parse_field
+from kopf.structs.filters import MetaFilterToken
+from kopf.structs.handlers import ResourceWatchingHandler
+
+
+# Used in the tests. Must be global-scoped, or its qualname will be affected.
+def some_fn(x=None):
+    pass
+
+
+def _never(*_, **__):
+    return False
+
+
+def _always(*_, **__):
+    return True
+
+
+@pytest.fixture()
+def handler_factory(registry, resource):
+    def factory(**kwargs):
+        handler = ResourceWatchingHandler(**dict(dict(
+            fn=some_fn, id='a',
+            errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
+            annotations=None, labels=None, when=None,
+            field=None, value=None,
+        ), **kwargs))
+        registry.resource_watching_handlers[resource].append(handler)
+        return handler
+    return factory
+
+
+@pytest.fixture(params=[
+    pytest.param(dict(body={}), id='no-field'),
+])
+def cause_no_field(request, cause_factory):
+    kwargs = copy.deepcopy(request.param)
+    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
+                                        'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
+    return cause
+
+
+@pytest.fixture(params=[
+    pytest.param(dict(body={'some-field': 'new'}), id='with-field'),
+])
+def cause_with_field(request, cause_factory):
+    kwargs = copy.deepcopy(request.param)
+    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
+                                        'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
+    return cause
+
+
+@pytest.fixture(params=[
+    # The original no-diff was equivalent to no-field until body/old/new were added to the check.
+    pytest.param(dict(body={}, diff=[]), id='no-field'),
+    pytest.param(dict(body={'some-field': 'new'}), id='with-field'),
+])
+def cause_any_field(request, cause_factory):
+    kwargs = copy.deepcopy(request.param)
+    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
+                                        'annotations': {'someannotation': 'somevalue'}}})
+    cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
+    return cause
+
+
+#
+# "Catch-all" handlers are those with event == None.
+#
+
+def test_catchall_handlers_without_field_found(
+        cause_any_field, registry, handler_factory):
+    cause = cause_any_field
+    handler_factory(field=None)
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+def test_catchall_handlers_with_field_found(
+        cause_with_field, registry, handler_factory):
+    cause = cause_with_field
+    handler_factory(field=parse_field('some-field'))
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+def test_catchall_handlers_with_field_ignored(
+        cause_no_field, registry, handler_factory):
+    cause = cause_no_field
+    handler_factory(field=parse_field('some-field'))
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+])
+def test_catchall_handlers_with_exact_labels_satisfied(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': 'somevalue'})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+])
+def test_catchall_handlers_with_exact_labels_not_satisfied(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': 'somevalue'})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_desired_labels_present(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': MetaFilterToken.PRESENT})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+])
+def test_catchall_handlers_with_desired_labels_absent(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': MetaFilterToken.PRESENT})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_undesired_labels_present(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': MetaFilterToken.ABSENT})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+])
+def test_catchall_handlers_with_undesired_labels_absent(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': MetaFilterToken.ABSENT})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_labels_callback_says_true(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': _always})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_labels_callback_says_false(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': _never})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+])
+def test_catchall_handlers_without_labels(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels=None)
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
+])
+def test_catchall_handlers_with_exact_annotations_satisfied(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': 'somevalue'})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+])
+def test_catchall_handlers_with_exact_annotations_not_satisfied(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': 'somevalue'})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_desired_annotations_present(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': MetaFilterToken.PRESENT})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+])
+def test_catchall_handlers_with_desired_annotations_absent(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': MetaFilterToken.PRESENT})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_undesired_annotations_present(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': MetaFilterToken.ABSENT})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+])
+def test_catchall_handlers_with_undesired_annotations_absent(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': MetaFilterToken.ABSENT})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_annotations_callback_says_true(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': _always})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_annotations_callback_says_false(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'someannotation': _never})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
+    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+    pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
+])
+def test_catchall_handlers_without_annotations(
+        cause_factory, registry, handler_factory, resource, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory()
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels, annotations', [
+    pytest.param({'somelabel': 'somevalue'}, {'someannotation': 'somevalue'}, id='with-label-annotation'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue'}, id='with-extra-label-annotation'),
+    pytest.param({'somelabel': 'somevalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-label-extra-annotation'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-label-extra-annotation'),
+])
+def test_catchall_handlers_with_labels_and_annotations_satisfied(
+        cause_factory, registry, handler_factory, resource, labels, annotations):
+    cause = cause_factory(body={'metadata': {'labels': labels, 'annotations': annotations}})
+    handler_factory(labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
+    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+])
+def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
+        cause_factory, registry, handler_factory, resource, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('when', [
+    pytest.param(None, id='without-when'),
+    pytest.param(lambda body=None, **_: body['spec']['name'] == 'test', id='with-when'),
+    pytest.param(lambda **_: True, id='with-other-when'),
+])
+def test_catchall_handlers_with_when_callback_matching(
+        cause_factory, registry, handler_factory, resource, when):
+    cause = cause_factory(body={'spec': {'name': 'test'}})
+    handler_factory(when=when)
+    handlers = registry.resource_watching_handlers[resource].get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('when', [
+    pytest.param(lambda body=None, **_: body['spec']['name'] != "test", id='with-when'),
+    pytest.param(lambda **_: False, id='with-other-when'),
+])
+def test_catchall_handlers_with_when_callback_mismatching(
+        cause_factory, registry, handler_factory, resource, when):
+    cause = cause_factory(body={'spec': {'name': 'test'}})
+    handler_factory(when=when)
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+def test_decorator_without_field_found(
+        cause_any_field, registry, resource):
+
+    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+                   field=None)
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+def test_decorator_with_field_found(
+        cause_with_field, registry, resource):
+
+    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+                   field='some-field')
+    def some_fn(**_): ...
+
+    cause = cause_with_field
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+def test_decorator_with_field_ignored(
+        cause_no_field, registry, resource):
+
+    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+                   field='some-field')
+    def some_fn(**_): ...
+
+    cause = cause_no_field
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+def test_decorator_with_labels_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+                   labels={'somelabel': MetaFilterToken.PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+def test_decorator_with_labels_not_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+                   labels={'otherlabel': MetaFilterToken.PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+def test_decorator_with_annotations_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+                   annotations={'someannotation': MetaFilterToken.PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+def test_decorator_with_annotations_not_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+                   annotations={'otherannotation': MetaFilterToken.PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers
+
+
+def test_decorator_with_filter_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+                   when=_always)
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert handlers
+
+
+def test_decorator_with_filter_not_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+                   when=_never)
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    assert not handlers

--- a/tests/registries/test_subhandlers_ids.py
+++ b/tests/registries/test_subhandlers_ids.py
@@ -8,21 +8,6 @@ def child_fn(**_):
     pass
 
 
-def test_with_no_parent(
-        resource_registry_cls, cause_factory):
-
-    cause = cause_factory(resource_registry_cls)
-    registry = resource_registry_cls()
-
-    with context([(handler_var, None)]):
-        kopf.on.this(registry=registry)(child_fn)
-
-    handlers = registry.get_handlers(cause)
-    assert len(handlers) == 1
-    assert handlers[0].fn is child_fn
-    assert handlers[0].id == 'child_fn'
-
-
 def test_with_parent(
         parent_handler, resource_registry_cls, cause_factory):
 


### PR DESCRIPTION
Implement field & value filters for all resource-changing handlers: `@kopf.on.resume/create/update/delete`.

_It was a long-needed feature to replace field handlers (`@kopf.on.field`) with more clear, explicit, and less ambiguous syntax. It was drafted in Jan'2020, but didn't get into the main codebase due to some semantical complications. Over the past year, the complications were resolved, so it seems easy to implement this feature now._

If `field=` is set on any handler, the handler is triggered only if the field is present in the object, and `old`/`new`/`diff` kwargs are reduced to that field instead of the whole body; the usually `body` & co kwargs still point to the full body, as expected.

```python
@kopf.on.create(..., field='spec.field')
def fn(new, **_):
  print(f"{new!r}")
```

As with other filters (labels, annotations), either specific values are accepted and checked for equality, or `kopf.ABSENT`/`kopf.PRESENT` markers are accepted, or callbacks that accept a positional value and all typical kwargs, and return a boolean for whether it matches or not.

```python
@kopf.on.create(..., field='spec.field', value='value')
@kopf.on.create(..., field='spec.field', value=kopf.PRESENT)
@kopf.on.create(..., field='spec.field', value=kopf.ABSENT)
@kopf.on.create(..., field='spec.field', value=lambda val, **_: 'a' in val)
@kopf.on.create(..., field='spec.field', value=kopf.any_([fn1, fn2]))
@kopf.on.create(..., field='spec.field', value=kopf.all_([fn1, fn2]))
@kopf.on.create(..., field='spec.field', value=kopf.none_([fn1, fn2]))
def fn(**_): pass
```

The default behaviour depends on what kind of a filter/handler it is:

For single-value filters (creation/resuming/deletion handlers), by default (i.e. `value=None`), the field must be present, and it is equivalent to `value=kopf.PRESENT`:

```python
@kopf.on.create(..., field='spec.field')
def fn(**_): pass
```

For the update & on-field handlers, additional criteria can be used: `old` & `new`. By default, it is only triggered if the value is changed (including the case when it is changed from anything to `None` — i.e. the field is removed):

```python
@kopf.on.update(..., field='spec.field')  # if changed (incl. if removed)
@kopf.on.update(..., field='spec.field', old='x', new='y')  # only this specific change
@kopf.on.update(..., field='spec.field', old=kopf.ABSENT, new=kopf.PRESENT)  # the field was set
@kopf.on.update(..., field='spec.field', old=kopf.PRESENT, new=kopf.ABSENT)  # the field was unset
def fn(**_): pass
```

Using both `value=` & `old=/new=` is prohibited, as it is confusing. It is either-either. Essentially, `new` is the same as `value`.

---

Some unusual tricks are now possible — as side-effects, not as the main goal of this change:

Trigger a handler only if the required field is NOT defined — the opposite of the default behaviour. The value of `new` will be `None`:

```python
@kopf.on.create(..., field='spec.nofield', value=kopf.ABSENT)
def fn(**_): pass
```

---

`@kopf.on.field` handler are now discouraged — but not yet deprecated. They will most likely remain for some long time for backward compatibility. A field handler like this:

```python
@kopf.on.field(..., field='spec.field')
def fn(old, new, **_):
    pass
```

Is equivalent to this:

```python
@kopf.on.create(..., field='spec.field')
@kopf.on.update(..., field='spec.field')
def fn(old, new, **_):
    pass
```

Note: but not for deletion & resuming, as nothing changes in those occasions, and on-field is only triggered when something is changed. 

---

The field-value (but not old/new) filtering logic can also be applied to all other resource handlers:

```python
import kopf

@kopf.on.event(..., field='spec.field', value='value')
def event_fn(**_):
    pass

@kopf.timer(..., field='spec.field', value='value', interval=1)
def timer_fn(**_):
    pass

@kopf.daemon(..., field='spec.field', value='value')
def event_fn(stopped, **_):
    stopped.wait(1000)
```

Their semantics is the same as the labels/annotations/callback filtering: the handler is invoked and the daemon is running as long as the criterion is satisfied. Once the resource changes so that it does not satisfy the criterion, the handlers are not invoked, and the daemon is stopped.

---

Remaining TODOs:

* [x] **Test things manually and verify that the behaviour is consistent and intuitive.**
* [x] Raise field&value (but not old&new) filters to all resource handlers: on.event, daemon, timer.
* [x] Performance optimisations for dict lookups.
* [x] Unit-tests.
* [x] An example (or extend the example 05-handlers?).
* [x] Documentation (preview: https://kopf.readthedocs.io/en/field-filters/filters/)

Related: #571 #566 