### PR TITLE
Substitute K8s API errors with our own classes

### DIFF
--- a/kopf/clients/discovery.py
+++ b/kopf/clients/discovery.py
@@ -1,7 +1,5 @@
 from typing import Dict, Optional, cast
 
-import aiohttp
-
 from kopf.clients import auth, errors
 from kopf.structs import resources
 
@@ -33,11 +31,8 @@ async def discover(
                         for info in respdata['resources']
                     })
 
-                except aiohttp.ClientResponseError as e:
-                    if e.status in [403, 404]:
-                        pass
-                    else:
-                        raise
+                except (errors.APINotFoundError, errors.APIForbiddenError):
+                    pass
 
     name = resource.plural if subresource is None else f'{resource.plural}/{subresource}'
     return context._discovered_resources[resource.api_version].get(name, None)

--- a/kopf/clients/discovery.py
+++ b/kopf/clients/discovery.py
@@ -20,15 +20,12 @@ async def discover(
                 context._discovered_resources[resource.api_version] = {}
 
                 try:
-                    response = await context.session.get(
-                        url=resource.get_version_url(server=context.server),
-                    )
-                    await errors.check_response(response)
-                    respdata = await response.json()
+                    url = resource.get_version_url(server=context.server)
+                    rsp = await errors.parse_response(await context.session.get(url))
 
                     context._discovered_resources[resource.api_version].update({
                         info['name']: info
-                        for info in respdata['resources']
+                        for info in rsp['resources']
                     })
 
                 except (errors.APINotFoundError, errors.APIForbiddenError):

--- a/kopf/clients/errors.py
+++ b/kopf/clients/errors.py
@@ -1,13 +1,104 @@
+"""
+K8s API errors.
+
+The underlying client library (now, ``aiohttp``) can be replaced in the future.
+We cannot rely on embedding its exceptions all over the code in the framework.
+Hence, we have our own hierarchy of exceptions for K8s API errors.
+
+Low-level errors, such as the network connectivity issues, SSL/HTTPS issues,
+etc, are escalated from the client library as is, since they are related not
+to the domain of K8s API, but rather to the networking and encryption.
+
+The original errors of the client library are chained as the causes of our own
+specialised errors -- for better explainability of errors in the stack traces.
+
+Some selected reasons of K8s API errors are made into their own classes,
+so that they could be intercepted and handled in other places of the framework.
+All other reasons are raised as the base error class and are indistinguishable
+from each other (except via the exception's fields).
+
+Unlike the underlying client library's errors, the K8s API errors contain more
+information about the reasons -- as provided by K8s API in its response bodies,
+not guessed only by HTTP statuses alone.
+
+These errors are not exposed to the users, and the users cannot catch them
+with ``except:`` clauses. The users can only see these errors in the logs
+as the reasons of failures. However, the errors are exposed to other packages.
+"""
 import collections.abc
 import json
+from typing import Collection, Optional
 
 import aiohttp
+from typing_extensions import Literal, TypedDict
 
 
-class APIClientResponseError(aiohttp.ClientResponseError):
-    """
-    Same as :class:`aiohttp.ClientResponseError`, but with information from K8s.
-    """
+class RawStatusCause(TypedDict):
+    field: str
+    reason: str
+    message: str
+
+
+class RawStatusDetails(TypedDict):
+    name: str
+    uid: str
+    retryAfterSeconds: int
+    kind: str
+    group: str
+    causes: Collection[RawStatusCause]
+
+
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#status-v1-meta
+class RawStatus(TypedDict):
+    apiVersion: str
+    kind: Literal["Status"]
+    code: int
+    status: Literal["Success", "Failure"]
+    reason: str
+    message: str
+    details: RawStatusDetails
+
+
+class APIError(Exception):
+
+    def __init__(
+            self,
+            payload: Optional[RawStatus],
+            *,
+            status: int,
+    ) -> None:
+        message = payload.get('message') if payload else None
+        super().__init__(message, payload)
+        self._status = status
+        self._payload = payload
+
+    @property
+    def status(self) -> int:
+        return self._status
+
+    @property
+    def code(self) -> Optional[int]:
+        return self._payload.get('code') if self._payload else None
+
+    @property
+    def message(self) -> Optional[str]:
+        return self._payload.get('message') if self._payload else None
+
+    @property
+    def details(self) -> Optional[RawStatusDetails]:
+        return self._payload.get('details') if self._payload else None
+
+
+class APIUnauthorizedError(APIError):
+    pass
+
+
+class APIForbiddenError(APIError):
+    pass
+
+
+class APINotFoundError(APIError):
+    pass
 
 
 async def check_response(
@@ -15,17 +106,11 @@ async def check_response(
 ) -> None:
     """
     Check for specialised K8s errors, and raise with extended information.
-
-    Built-in aiohttp's errors only provide the rudimentary titles of the status
-    codes, but not the explanation why that error happened. K8s API provides
-    this information in the bodies of non-2xx responses. That information can
-    replace aiohttp's error messages to be more helpful.
-
-    However, the same error classes are used for now, to meet the expectations
-    if some routines in their ``except:`` clauses analysing for specific HTTP
-    statuses: e.g. 401 for re-login activities, 404 for patching/deletion, etc.
     """
     if response.status >= 400:
+
+        # Read the response's body before it is closed by raise_for_status().
+        payload: Optional[RawStatus]
         try:
             payload = await response.json()
         except (json.JSONDecodeError, aiohttp.ContentTypeError, aiohttp.ClientConnectionError):
@@ -35,15 +120,16 @@ async def check_response(
         if not isinstance(payload, collections.abc.Mapping) or payload.get('kind') != 'Status':
             payload = None
 
-        # If no information can be retrieved, fall back to the original error.
-        if payload is None:
+        cls = (
+            APIUnauthorizedError if response.status == 401 else
+            APIForbiddenError if response.status == 403 else
+            APINotFoundError if response.status == 404 else
+            APIError
+        )
+
+        # Raise the framework-specific error while keeping the original error in scope.
+        # This call also closes the response's body, so it cannot be read afterwards.
+        try:
             response.raise_for_status()
-        else:
-            details = payload.get('details')
-            message = payload.get('message') or f"{details}"
-            raise APIClientResponseError(
-                response.request_info,
-                response.history,
-                status=response.status,
-                headers=response.headers,
-                message=message)
+        except aiohttp.ClientResponseError as e:
+            raise cls(payload, status=response.status) from e

--- a/kopf/clients/errors.py
+++ b/kopf/clients/errors.py
@@ -27,7 +27,7 @@ as the reasons of failures. However, the errors are exposed to other packages.
 """
 import collections.abc
 import json
-from typing import Collection, Optional
+from typing import Any, Collection, Optional
 
 import aiohttp
 from typing_extensions import Literal, TypedDict
@@ -133,3 +133,14 @@ async def check_response(
             response.raise_for_status()
         except aiohttp.ClientResponseError as e:
             raise cls(payload, status=response.status) from e
+
+
+async def parse_response(
+        response: aiohttp.ClientResponse,
+) -> Any:
+    """
+    Check the response for errors, and either raise or returned the parsed data.
+    """
+    await check_response(response)
+    payload = await response.json()
+    return payload

--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -82,6 +82,10 @@ async def post_event(
 
     # Events are helpful but auxiliary, they should not fail the handling cycle.
     # Yet we want to notice that something went wrong (in logs).
+    except errors.APIError as e:
+        logger.warning(f"Failed to post an event. Ignoring and continuing. "
+                       f"Code: {e.code}. Message: {e.message}. Details: {e.details}"
+                       f"Event: type={type!r}, reason={reason!r}, message={message!r}.")
     except aiohttp.ClientResponseError as e:
         logger.warning(f"Failed to post an event. Ignoring and continuing. "
                        f"Status: {e.status}. Message: {e.message}. "
@@ -90,6 +94,6 @@ async def post_event(
         logger.warning(f"Failed to post an event. Ignoring and continuing. "
                        f"Message: {e.message}. "
                        f"Event: type={type!r}, reason={reason!r}, message={message!r}.")
-    except aiohttp.ClientOSError as e:
+    except aiohttp.ClientOSError:
         logger.warning(f"Failed to post an event. Ignoring and continuing. "
                        f"Event: type={type!r}, reason={reason!r}, message={message!r}.")

--- a/kopf/clients/fetching.py
+++ b/kopf/clients/fetching.py
@@ -29,12 +29,9 @@ async def read_obj(
     namespace = namespace if is_namespaced else None
 
     try:
-        response = await context.session.get(
-            url=resource.get_url(server=context.server, namespace=namespace, name=name),
-        )
-        await errors.check_response(response)
-        respdata = await response.json()
-        return cast(bodies.RawBody, respdata)
+        url = resource.get_url(server=context.server, namespace=namespace, name=name)
+        rsp = await errors.parse_response(await context.session.get(url))
+        return cast(bodies.RawBody, rsp)
 
     except (errors.APINotFoundError, errors.APIForbiddenError):
         if not isinstance(default, _UNSET):
@@ -67,11 +64,8 @@ async def list_objs_rv(
     is_namespaced = await discovery.is_namespaced(resource=resource, context=context)
     namespace = namespace if is_namespaced else None
 
-    response = await context.session.get(
-        url=resource.get_url(server=context.server, namespace=namespace),
-    )
-    await errors.check_response(response)
-    rsp = await response.json()
+    url = resource.get_url(server=context.server, namespace=namespace)
+    rsp = await errors.parse_response(await context.session.get(url))
 
     items: List[bodies.RawBody] = []
     resource_version = rsp.get('metadata', {}).get('resourceVersion', None)

--- a/kopf/clients/fetching.py
+++ b/kopf/clients/fetching.py
@@ -1,8 +1,6 @@
 import enum
 from typing import Collection, List, Optional, Tuple, TypeVar, Union, cast
 
-import aiohttp
-
 from kopf.clients import auth, discovery, errors
 from kopf.structs import bodies, resources
 
@@ -38,8 +36,8 @@ async def read_obj(
         respdata = await response.json()
         return cast(bodies.RawBody, respdata)
 
-    except aiohttp.ClientResponseError as e:
-        if e.status in [403, 404] and not isinstance(default, _UNSET):
+    except (errors.APINotFoundError, errors.APIForbiddenError):
+        if not isinstance(default, _UNSET):
             return default
         raise
 

--- a/kopf/clients/patching.py
+++ b/kopf/clients/patching.py
@@ -1,7 +1,5 @@
 from typing import Optional, cast
 
-import aiohttp
-
 from kopf.clients import auth, discovery, errors
 from kopf.structs import bodies, patches, resources
 
@@ -85,8 +83,5 @@ async def patch_obj(
 
         return patched_body
 
-    except aiohttp.ClientResponseError as e:
-        if e.status == 404:
-            return None
-        else:
-            raise
+    except errors.APINotFoundError:
+        return None

--- a/kopf/clients/patching.py
+++ b/kopf/clients/patching.py
@@ -68,8 +68,7 @@ async def patch_obj(
                 headers={'Content-Type': 'application/merge-patch+json'},
                 json=body_patch,
             )
-            await errors.check_response(response)
-            patched_body = await response.json()
+            patched_body = await errors.parse_response(response)
 
         if status_patch:
             response = await context.session.patch(
@@ -78,8 +77,7 @@ async def patch_obj(
                 headers={'Content-Type': 'application/merge-patch+json'},
                 json={'status': status_patch},
             )
-            await errors.check_response(response)
-            patched_body['status'] = await response.json()
+            patched_body['status'] = await errors.parse_response(response)
 
         return patched_body
 

--- a/tests/k8s/test_discovery.py
+++ b/tests/k8s/test_discovery.py
@@ -36,7 +36,7 @@ async def test_discovery_of_unexisting_resource(
 async def test_discovery_of_unexisting_group_or_version(
         resp_mocker, aresponses, hostname, status):
 
-    list_mock = resp_mocker(return_value=aresponses.Response(status=status, reason="boo!"))
+    list_mock = resp_mocker(return_value=aresponses.Response(status=status))
     aresponses.add(hostname, '/apis/some-group.org/someversion', 'get', list_mock)
 
     resource = Resource('some-group.org', 'someversion', 'someresources')

--- a/tests/k8s/test_events.py
+++ b/tests/k8s/test_events.py
@@ -60,7 +60,7 @@ async def test_type_is_v1_not_v1beta1(
 async def test_api_errors_logged_but_suppressed(
         resp_mocker, aresponses, hostname, assert_logs):
 
-    post_mock = resp_mocker(return_value=aresponses.Response(status=555, reason='boo!'))
+    post_mock = resp_mocker(return_value=aresponses.Response(status=555))
     aresponses.add(hostname, EVENTS_CORE_V1_CRD.get_url(namespace='ns'), 'post', post_mock)
 
     obj = {'apiVersion': 'group/version',
@@ -72,9 +72,7 @@ async def test_api_errors_logged_but_suppressed(
     await post_event(ref=ref, type='type', reason='reason', message='message')
 
     assert post_mock.called
-    assert_logs([
-        "Failed to post an event.*boo!",
-    ])
+    assert_logs(["Failed to post an event."])
 
 
 async def test_regular_errors_escalate(
@@ -122,7 +120,7 @@ async def test_message_is_cut_to_max_length(
 async def test_headers_are_not_leaked(
         resp_mocker, aresponses, hostname, assert_logs, status):
 
-    post_mock = resp_mocker(return_value=aresponses.Response(status=status, reason='boo!'))
+    post_mock = resp_mocker(return_value=aresponses.Response(status=status))
     aresponses.add(hostname, EVENTS_CORE_V1_CRD.get_url(namespace='ns'), 'post', post_mock)
 
     obj = {'apiVersion': 'group/version',
@@ -134,7 +132,7 @@ async def test_headers_are_not_leaked(
     await post_event(ref=ref, type='type', reason='reason', message='message')
 
     assert_logs([
-        f"Failed to post an event. .* Status: {status}. Message: boo!",
+        "Failed to post an event.",
     ], prohibited=[
         "ClientResponseError",
         "RequestInfo",

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -1,6 +1,7 @@
 import aiohttp.web
 import pytest
 
+from kopf.clients.errors import APIError
 from kopf.clients.fetching import list_objs_rv
 
 
@@ -37,10 +38,10 @@ async def test_when_successful_namespaced(
 async def test_raises_api_error(
         resp_mocker, aresponses, hostname, resource, namespace, status):
 
-    list_mock = resp_mocker(return_value=aresponses.Response(status=status, reason="boo!"))
+    list_mock = resp_mocker(return_value=aresponses.Response(status=status))
     aresponses.add(hostname, resource.get_url(namespace=None), 'get', list_mock)
     aresponses.add(hostname, resource.get_url(namespace='ns1'), 'get', list_mock)
 
-    with pytest.raises(aiohttp.ClientResponseError) as e:
+    with pytest.raises(APIError) as e:
         await list_objs_rv(resource=resource, namespace=namespace)
     assert e.value.status == status

--- a/tests/k8s/test_read_obj.py
+++ b/tests/k8s/test_read_obj.py
@@ -1,6 +1,7 @@
 import aiohttp.web
 import pytest
 
+from kopf.clients.errors import APIError
 from kopf.clients.fetching import read_obj
 
 
@@ -36,11 +37,11 @@ async def test_when_present_namespaced(
 async def test_when_absent_with_no_default(
         resp_mocker, aresponses, hostname, resource, namespace, status):
 
-    get_mock = resp_mocker(return_value=aresponses.Response(status=status, reason="boo!"))
+    get_mock = resp_mocker(return_value=aresponses.Response(status=status))
     aresponses.add(hostname, resource.get_url(namespace=None, name='name1'), 'get', get_mock)
     aresponses.add(hostname, resource.get_url(namespace='ns1', name='name1'), 'get', get_mock)
 
-    with pytest.raises(aiohttp.ClientResponseError) as e:
+    with pytest.raises(APIError) as e:
         await read_obj(resource=resource, namespace=namespace, name='name1')
     assert e.value.status == status
 
@@ -51,7 +52,7 @@ async def test_when_absent_with_no_default(
 async def test_when_absent_with_default(
         resp_mocker, aresponses, hostname, resource, namespace, default, status):
 
-    get_mock = resp_mocker(return_value=aresponses.Response(status=status, reason="boo!"))
+    get_mock = resp_mocker(return_value=aresponses.Response(status=status))
     aresponses.add(hostname, resource.get_url(namespace=None, name='name1'), 'get', get_mock)
     aresponses.add(hostname, resource.get_url(namespace='ns1', name='name1'), 'get', get_mock)
 
@@ -64,10 +65,10 @@ async def test_when_absent_with_default(
 async def test_raises_api_error_despite_default(
         resp_mocker, aresponses, hostname, resource, namespace, status):
 
-    get_mock = resp_mocker(return_value=aresponses.Response(status=status, reason="boo!"))
+    get_mock = resp_mocker(return_value=aresponses.Response(status=status))
     aresponses.add(hostname, resource.get_url(namespace=None, name='name1'), 'get', get_mock)
     aresponses.add(hostname, resource.get_url(namespace='ns1', name='name1'), 'get', get_mock)
 
-    with pytest.raises(aiohttp.ClientResponseError) as e:
+    with pytest.raises(APIError) as e:
         await read_obj(resource=resource, namespace=namespace, name='name1', default=object())
     assert e.value.status == status


### PR DESCRIPTION
`aiohttp` is currently the underlying client library, and it raises its response errors. To enrich them with K8s's own explanations, the errors were extended by inheriting from the client library in #558. But anyway, this violates the principle that the API/HTTP client library is isolated to `kopf.clients`, and no single piece of it leaks outside to other packages (for replaceability). 

Instead, introduce our own hierarchy of exceptions for K8s API errors, which are completely independent of the underlying library. The only connection to the original exceptions will be error chaining (`raise ... from ...`).

This allows us to analyse the API errors in other packages without coupling to the underlying library, while keeps the goal of readable stack traces and error explanations in the logs.