### PR TITLE
Refactor the safe resolution of fields in dicts by default

### DIFF
--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -344,8 +344,8 @@ async def invoke_handler(
             isinstance(cause, causation.ResourceChangingCause) and
             isinstance(handler, handlers_.ResourceHandler) and
             handler.field is not None):
-        old = dicts.resolve(cause.old, handler.field, None, assume_empty=True)
-        new = dicts.resolve(cause.new, handler.field, None, assume_empty=True)
+        old = dicts.resolve(cause.old, handler.field, None)
+        new = dicts.resolve(cause.new, handler.field, None)
         diff = diffs.reduce(cause.diff, handler.field)
         cause = causation.enrich_cause(cause=cause, old=old, new=new, diff=diff)
 

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -181,7 +181,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
     ) -> Optional[ProgressRecord]:
         for full_key in self.make_keys(key):
             key_field = ['metadata', 'annotations', full_key]
-            encoded = dicts.resolve(body, key_field, None, assume_empty=True)
+            encoded = dicts.resolve(body, key_field, None)
             decoded = json.loads(encoded) if encoded is not None else None
             if decoded is not None:
                 return cast(ProgressRecord, decoded)
@@ -212,8 +212,8 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
         absent = object()
         for full_key in self.make_keys(key):
             key_field = ['metadata', 'annotations', full_key]
-            body_value = dicts.resolve(body, key_field, absent, assume_empty=True)
-            patch_value = dicts.resolve(patch, key_field, absent, assume_empty=True)
+            body_value = dicts.resolve(body, key_field, absent)
+            patch_value = dicts.resolve(patch, key_field, absent)
             if body_value is not absent:
                 dicts.ensure(patch, key_field, None)
             elif patch_value is not absent:
@@ -228,7 +228,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
     ) -> None:
         for full_key in self.make_keys(self.touch_key):
             key_field = ['metadata', 'annotations', full_key]
-            body_value = dicts.resolve(body, key_field, None, assume_empty=True)
+            body_value = dicts.resolve(body, key_field, None)
             if body_value != value:  # also covers absent-vs-None cases.
                 dicts.ensure(patch, key_field, value)
                 self._store_marker(prefix=self.prefix, patch=patch, body=body)
@@ -340,8 +340,8 @@ class StatusProgressStorage(ProgressStorage):
     ) -> None:
         absent = object()
         key_field = self.field + (key,)
-        body_value = dicts.resolve(body, key_field, absent, assume_empty=True)
-        patch_value = dicts.resolve(patch, key_field, absent, assume_empty=True)
+        body_value = dicts.resolve(body, key_field, absent)
+        patch_value = dicts.resolve(patch, key_field, absent)
         if body_value is not absent:
             dicts.ensure(patch, key_field, None)
         elif patch_value is not absent:
@@ -355,7 +355,7 @@ class StatusProgressStorage(ProgressStorage):
             value: Optional[str],
     ) -> None:
         key_field = self.touch_field
-        body_value = dicts.resolve(body, key_field, None, assume_empty=True)
+        body_value = dicts.resolve(body, key_field, None)
         if body_value != value:  # also covers absent-vs-None cases.
             dicts.ensure(patch, key_field, value)
 

--- a/kopf/structs/diffs.py
+++ b/kopf/structs/diffs.py
@@ -122,8 +122,8 @@ def reduce_iter(
         # Generate a new diff, with new ops, for the resolved sub-field.
         elif tuple(field) == tuple(path[:len(field)]):
             tail = path[len(field):]
-            old_tail = dicts.resolve(old, tail, default=None, assume_empty=True, ignore_wrong=True)
-            new_tail = dicts.resolve(new, tail, default=None, assume_empty=True, ignore_wrong=True)
+            old_tail = dicts.resolve(old, tail, default=None)
+            new_tail = dicts.resolve(new, tail, default=None)
             yield from diff_iter(old_tail, new_tail)
 
 

--- a/tests/dicts/test_resolving.py
+++ b/tests/dicts/test_resolving.py
@@ -1,37 +1,77 @@
+"""
+The test design notes:
+
+* The field "abc.def.hij" is existent.
+* The field "rst.uvw.xyz" is inexistent.
+* Its mixtures ("a.b.z", "a.y.z") are used to simulate partial inexistence.
+
+* For the existent keys, kwargs should not matter.
+* For the non-existent keys, the default is returned,
+  or a ``KeyError`` raised -- as with regular mappings.
+
+* For special cases with "wrong" values (``"value"["z"]``, ``None["z"]``, etc),
+  either a ``TypeError`` should be raised normally. If "wrong" values are said
+  to be ignored, then they are treated the same as inexistent values,
+  and the default value is returned or a ``KeyError`` is raised.
+
+"""
 import pytest
 
 from kopf.structs.dicts import resolve
 
+default = object()
 
-def test_existing_key():
+
+def test_existent_key_with_no_default():
     d = {'abc': {'def': {'hij': 'val'}}}
     r = resolve(d, ['abc', 'def', 'hij'])
     assert r == 'val'
 
 
-def test_unexisting_key_with_no_default():
+def test_existent_key_with_default():
+    d = {'abc': {'def': {'hij': 'val'}}}
+    r = resolve(d, ['abc', 'def', 'hij'], default)
+    assert r == 'val'
+
+
+@pytest.mark.parametrize('key', [
+    pytest.param(['rst', 'uvw', 'xyz'], id='1stlvl'),
+    pytest.param(['abc', 'uvw', 'xyz'], id='2ndlvl'),
+    pytest.param(['abc', 'def', 'xyz'], id='3rdlvl'),
+])
+def test_inexistent_key_with_no_default(key):
     d = {'abc': {'def': {'hij': 'val'}}}
     with pytest.raises(KeyError):
-        resolve(d, ['abc', 'def', 'xyz'])
+        resolve(d, key)
 
 
-def test_unexisting_key_with_default_none():
+@pytest.mark.parametrize('key', [
+    pytest.param(['rst', 'uvw', 'xyz'], id='1stlvl'),
+    pytest.param(['abc', 'uvw', 'xyz'], id='2ndlvl'),
+    pytest.param(['abc', 'def', 'xyz'], id='3rdlvl'),
+])
+def test_inexistent_key_with_default(key):
     d = {'abc': {'def': {'hij': 'val'}}}
-    r = resolve(d, ['abc', 'def', 'xyz'], None)
-    assert r is None
-
-
-def test_unexisting_key_with_default_value():
-    default = object()
-    d = {'abc': {'def': {'hij': 'val'}}}
-    r = resolve(d, ['abc', 'def', 'xyz'], default)
+    r = resolve(d, key, default)
     assert r is default
 
 
-def test_nonmapping_key():
+def test_nonmapping_with_no_default():
     d = {'key': 'val'}
     with pytest.raises(TypeError):
         resolve(d, ['key', 'sub'])
+
+
+def test_nonmapping_with_default():
+    d = {'key': 'val'}
+    r = resolve(d, ['key', 'sub'], default)
+    assert r is default
+
+
+def test_none_is_treated_as_a_regular_default_value():
+    d = {'abc': {'def': {'hij': 'val'}}}
+    r = resolve(d, ['abc', 'def', 'xyz'], None)
+    assert r is None
 
 
 def test_empty_path():


### PR DESCRIPTION
`assume_empty=True` was enabled for almost all cases where `dicts.resolve()` was used. And in those where it was not enabled, it should be, and the absence of it looked like a mistake.

By this change, simplify the codebase, and use the safe mode always when a default value is specified. This dict resolution is not a generic routine but is specific to our usage in this framework only; and for K8s, it makes sense to expect the data corruption from outside — instead of failing the process the resource forever after corrupted.
