### PR TITLE
Switch to Python 3.9 release (instead of "3.9-dev")

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os: linux
 arch: amd64
 dist: focal
 language: python
-python: "3.9-dev"
+python: "3.9"
 
 # Only test the final merges and releases. The work-in-progress branches are tested by PR builds.
 branches:
@@ -94,7 +94,7 @@ jobs:
   - { <<: *linting, name: Linting and static analysis }
   - { <<: *unittests, python: "3.7" }
   - { <<: *unittests, python: "3.8" }
-  - { <<: *unittests, python: "3.9-dev" }
+  - { <<: *unittests, python: "3.9" }
 
   fast_finish: true
   allow_failures:


### PR DESCRIPTION
Python 3.9 release should be used for the functional tests, not the dev-version (it is 1 month after the release already).

Python 3.10-dev is not yet ready to be tested, as it failed on installing the dependencies (pyyaml, etc): https://travis-ci.com/github/nolar/kopf/jobs/434072728 — it would just waste build-minutes with no benefit.

