### PR TITLE
Optionally remove Status handler_id prefix.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,3 +17,5 @@ and [Historic GitHub Contributors](https://github.com/zalando-incubator/kopf/gra
 - [Trond Hindenes](https://github.com/trondhindenes)
 - [Vennamaneni Sai Narasimha](https://github.com/thevennamaneni)
 - [Cliff Burdick](https://github.com/cliffburdick)
+- [Jim Ramsay](https://github.com/lack)
+- [Sam Giles](https://github.com/samgiles)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Kopf: Kubernetes Operators Framework
    results
    errors
    scopes
+   status
 
 .. toctree::
    :maxdepth: 2

--- a/docs/status.rst
+++ b/docs/status.rst
@@ -1,0 +1,59 @@
+=======
+Updating Status
+=======
+
+Kopf will take the return value of all state-changing handlers (even
+sub-handlers) and add them to the ``Status`` of the corresponding Kuberenetes
+resource.  By default, this is stored under the handler id which by default is 
+the function name.
+
+.. note::
+
+    The ``CustomResourceDefinition`` requires that the fields that will be set in
+    status have a corresponding schema.
+
+    You could also use ``x-kubernetes-preserve-unknown-fields: true``::
+
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              ...
+
+Given the following handler definition::
+
+    import kopf
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples')
+    def my_handler(spec, **_):
+        return {'field': 'value}
+
+The resulting object will have the following data::
+
+    spec:
+      ...
+    status:
+      my_handler:
+        field: value
+
+In order to remove the handler ID from the result, you may set the optional
+``status_prefix=False`` when defining the handler.
+
+So with the handler definition::
+
+    import kopf
+
+    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', status_prefix=False)
+    def my_handler(spec, **_):
+        return {'field': 'value}
+
+The resulting object will have the following data::
+
+    spec:
+      ...
+    status:
+      field: value

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -145,6 +145,7 @@ def resume(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceChangingDecorator:
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
     def decorator(  # lgtm[py/similar-function]
@@ -161,6 +162,7 @@ def resume(  # lgtm[py/similar-function]
             labels=labels, annotations=annotations, when=when,
             initial=True, deleted=deleted, requires_finalizer=None,
             reason=None,
+            status_prefix=status_prefix,
         )
         real_registry.resource_changing_handlers[real_resource].append(handler)
         return fn
@@ -180,6 +182,7 @@ def create(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceChangingDecorator:
     """ ``@kopf.on.create()`` handler for the object creation. """
     def decorator(  # lgtm[py/similar-function]
@@ -196,6 +199,7 @@ def create(  # lgtm[py/similar-function]
             labels=labels, annotations=annotations, when=when,
             initial=None, deleted=None, requires_finalizer=None,
             reason=handlers.Reason.CREATE,
+            status_prefix=status_prefix,
         )
         real_registry.resource_changing_handlers[real_resource].append(handler)
         return fn
@@ -215,6 +219,7 @@ def update(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceChangingDecorator:
     """ ``@kopf.on.update()`` handler for the object update or change. """
     def decorator(  # lgtm[py/similar-function]
@@ -231,6 +236,7 @@ def update(  # lgtm[py/similar-function]
             labels=labels, annotations=annotations, when=when,
             initial=None, deleted=None, requires_finalizer=None,
             reason=handlers.Reason.UPDATE,
+            status_prefix=status_prefix,
         )
         real_registry.resource_changing_handlers[real_resource].append(handler)
         return fn
@@ -251,6 +257,7 @@ def delete(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceChangingDecorator:
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     def decorator(  # lgtm[py/similar-function]
@@ -267,6 +274,7 @@ def delete(  # lgtm[py/similar-function]
             labels=labels, annotations=annotations, when=when,
             initial=None, deleted=None, requires_finalizer=bool(not optional),
             reason=handlers.Reason.DELETE,
+            status_prefix=status_prefix,
         )
         real_registry.resource_changing_handlers[real_resource].append(handler)
         return fn
@@ -287,6 +295,7 @@ def field(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceChangingDecorator:
     """ ``@kopf.on.field()`` handler for the individual field changes. """
     def decorator(  # lgtm[py/similar-function]
@@ -304,6 +313,7 @@ def field(  # lgtm[py/similar-function]
             labels=labels, annotations=annotations, when=when,
             initial=None, deleted=None, requires_finalizer=None,
             reason=None,
+            status_prefix=status_prefix,
         )
         real_registry.resource_changing_handlers[real_resource].append(handler)
         return fn
@@ -318,6 +328,7 @@ def event(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
+        status_prefix: bool = True,
 ) -> ResourceWatchingDecorator:
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
     def decorator(  # lgtm[py/similar-function]
@@ -396,6 +407,7 @@ def timer(  # lgtm[py/similar-function]
         sharp: Optional[bool] = None,
         idle: Optional[float] = None,
         interval: Optional[float] = None,
+        status_prefix: bool = True,
 ) -> ResourceTimerDecorator:
     """ ``@kopf.timer()`` handler for the regular events. """
     def decorator(  # lgtm[py/similar-function]
@@ -432,6 +444,7 @@ def this(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
+        status_prefix: Optional[bool] = None,
 ) -> ResourceChangingDecorator:
     """
     ``@kopf.on.this()`` decorator for the dynamically generated sub-handlers.
@@ -471,12 +484,14 @@ def this(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else handling.subregistry_var.get()
         real_id = registries.generate_id(fn=fn, id=id,
                                          prefix=parent_handler.id if parent_handler else None)
+        handler_status_prefix = status_prefix if status_prefix is not None else parent_handler.status_prefix if parent_handler else True
         handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id, field=None,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             labels=labels, annotations=annotations, when=when,
             initial=None, deleted=None, requires_finalizer=None,
             reason=None,
+            status_prefix=handler_status_prefix,
         )
         real_registry.append(handler)
         return fn

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -90,6 +90,7 @@ async def execute(
     cause = cause if cause is not None else cause_var.get()
     parent_handler: handlers_.BaseHandler = handler_var.get()
     parent_prefix = parent_handler.id if parent_handler is not None else None
+    parent_status_prefix = parent_handler.status_prefix if parent_handler else None
 
     # Validate the inputs; the function signatures cannot put these kind of restrictions, so we do.
     if len([v for v in [fns, handlers, registry] if v is not None]) > 1:
@@ -104,7 +105,7 @@ async def execute(
                 errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
                 labels=None, annotations=None, when=None,
                 initial=None, deleted=None, requires_finalizer=None,
-                reason=None, field=None,
+                reason=None, field=None, status_prefix=parent_status_prefix,
             )
             subregistry.append(handler)
 
@@ -117,7 +118,7 @@ async def execute(
                 errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
                 labels=None, annotations=None, when=None,
                 initial=None, deleted=None, requires_finalizer=None,
-                reason=None, field=None,
+                reason=None, field=None, status_prefix=parent_status_prefix,
             )
             subregistry.append(handler)
 

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -252,7 +252,7 @@ class ResourceChangingRegistry(ResourceRegistry[
             id=real_id, fn=fn, reason=reason, field=real_field,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             initial=initial, deleted=deleted, requires_finalizer=requires_finalizer,
-            labels=labels, annotations=annotations, when=when,
+            labels=labels, annotations=annotations, when=when, status_prefix=True,
         )
 
         self.append(handler)

--- a/kopf/storage/states.py
+++ b/kopf/storage/states.py
@@ -305,9 +305,16 @@ def deliver_results(
             pass
         elif isinstance(outcome.result, collections.abc.Mapping):
             # TODO: merge recursively (patch-merge), do not overwrite the keys if they are present.
-            patch.setdefault('status', {}).setdefault(handler_id, {}).update(outcome.result)
+            if hasattr(outcome.handler, 'status_prefix') and not outcome.handler.status_prefix:
+                base = patch.setdefault('status', {})
+            else:
+                base = patch.setdefault('status', {}).setdefault(handler_id, {})
+            base.update(outcome.result)
         else:
-            patch.setdefault('status', {})[handler_id] = copy.deepcopy(outcome.result)
+            if hasattr(outcome.handler, 'status_prefix') and not outcome.handler.status_prefix:
+                patch.setdefault('status', {})[copy.deepcopy(outcome.result)] = {}
+            else:
+                patch.setdefault('status', {})[handler_id] = copy.deepcopy(outcome.result)
 
 
 @overload

--- a/kopf/storage/states.py
+++ b/kopf/storage/states.py
@@ -34,6 +34,7 @@ class HandlerOutcome:
     possibly after few executions, and consisting of simple data types
     (for YAML/JSON serialisation) rather than the actual in-memory objects.
     """
+    handler: handlers_.BaseHandler
     final: bool
     delay: Optional[float] = None
     result: Optional[callbacks.Result] = None

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -127,6 +127,7 @@ class ResourceChangingHandler(ResourceHandler):
     initial: Optional[bool]
     deleted: Optional[bool]  # used for mixed-in (initial==True) @on.resume handlers only.
     requires_finalizer: Optional[bool]
+    status_prefix: Optional[bool]
 
     @property
     def event(self) -> Optional[Reason]:

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -109,7 +109,7 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
             reason=reason, field=real_field,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             initial=initial, deleted=deleted, requires_finalizer=requires_finalizer,
-            labels=labels, annotations=annotations, when=when,
+            labels=labels, annotations=annotations, when=when, status_prefix=True,
         )
         self.append(handler)
         return fn

--- a/tests/basic-structs/test_handlers.py
+++ b/tests/basic-structs/test_handlers.py
@@ -51,6 +51,7 @@ def test_resource_handler_with_all_args(mocker):
     annotations = mocker.Mock()
     when = mocker.Mock()
     requires_finalizer = mocker.Mock()
+    status_prefix = mocker.Mock()
     handler = ResourceChangingHandler(
         fn=fn,
         id=id,
@@ -67,6 +68,7 @@ def test_resource_handler_with_all_args(mocker):
         annotations=annotations,
         when=when,
         requires_finalizer=requires_finalizer,
+        status_prefix=status_prefix,
     )
     assert handler.fn is fn
     assert handler.id is id
@@ -82,6 +84,7 @@ def test_resource_handler_with_all_args(mocker):
     assert handler.annotations is annotations
     assert handler.when is when
     assert handler.requires_finalizer is requires_finalizer
+    assert handler.status_prefix is status_prefix
 
     with pytest.deprecated_call(match=r"use handler.reason"):
         assert handler.event is reason

--- a/tests/basic-structs/test_handlers_deprecated_cooldown.py
+++ b/tests/basic-structs/test_handlers_deprecated_cooldown.py
@@ -52,6 +52,7 @@ def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
     annotations = mocker.Mock()
     when = mocker.Mock()
     requires_finalizer = mocker.Mock()
+    status_prefix = mocker.Mock()
 
     with pytest.deprecated_call(match=r"use backoff="):
         handler = ResourceChangingHandler(
@@ -70,6 +71,7 @@ def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
             annotations=annotations,
             when=when,
             requires_finalizer=requires_finalizer,
+            status_prefix=status_prefix
         )
 
     assert handler.fn is fn
@@ -86,3 +88,4 @@ def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
     assert handler.annotations is annotations
     assert handler.when is when
     assert handler.requires_finalizer is requires_finalizer
+    assert handler.status_prefix is status_prefix

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -1,4 +1,5 @@
 from typing import Mapping
+from unittest.mock import Mock
 
 import freezegun
 import pytest
@@ -11,10 +12,15 @@ from kopf.storage.states import HandlerOutcome
 from kopf.structs.handlers import Activity, ActivityHandler, HandlerId
 
 
-def test_activity_error_exception():
-    outcome = HandlerOutcome(final=True)
+@pytest.fixture()
+def handler():
+    return Mock(id=HandlerId('id'), spec_set=['id'])
+
+
+def test_activity_error_exception(handler):
+    outcome = HandlerOutcome(final=True, handler=handler)
     outcomes: Mapping[HandlerId, HandlerOutcome]
-    outcomes = {HandlerId('id'): outcome}
+    outcomes = {handler.id: outcome}
     error = ActivityError("message", outcomes=outcomes)
     assert str(error) == "message"
     assert error.outcomes == outcomes

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -28,6 +28,7 @@ async def test_skipped_with_no_handlers(
         errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
         annotations=None, labels=None, when=None, field=None,
         deleted=None, initial=None, requires_finalizer=None,
+        status_prefix=None,
     ))
 
     await process_resource_event(
@@ -82,6 +83,7 @@ async def test_stealth_mode_with_mismatching_handlers(
         errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
         annotations=annotations, labels=labels, when=when, field=None,
         deleted=deleted, initial=initial, requires_finalizer=None,
+        status_prefix=None,
     ))
 
     await process_resource_event(

--- a/tests/lifecycles/test_handler_selection.py
+++ b/tests/lifecycles/test_handler_selection.py
@@ -98,9 +98,9 @@ def test_asap_takes_the_least_retried(mocker):
 
     # Set the pre-existing state, and verify that it was set properly.
     state = State.from_scratch().with_handlers([handler1, handler2, handler3])
-    state = state.with_outcomes({handler1.id: HandlerOutcome(final=False)})
-    state = state.with_outcomes({handler1.id: HandlerOutcome(final=False)})
-    state = state.with_outcomes({handler3.id: HandlerOutcome(final=False)})
+    state = state.with_outcomes({handler1.id: HandlerOutcome(final=False, handler=handler1)})
+    state = state.with_outcomes({handler1.id: HandlerOutcome(final=False, handler=handler1)})
+    state = state.with_outcomes({handler3.id: HandlerOutcome(final=False, handler=handler3)})
     assert state[handler1.id].retries == 2
     assert state[handler2.id].retries == 0
     assert state[handler3.id].retries == 1

--- a/tests/persistence/test_outcomes.py
+++ b/tests/persistence/test_outcomes.py
@@ -1,9 +1,18 @@
+from unittest.mock import Mock
+
+import pytest
+
 from kopf.storage.states import HandlerOutcome
 from kopf.structs.callbacks import Result
 
 
-def test_creation_for_ignored_handlers():
-    outcome = HandlerOutcome(final=True)
+@pytest.fixture()
+def handler():
+    return Mock(id='id', spec_set=['id'])
+
+
+def test_creation_for_ignored_handlers(handler):
+    outcome = HandlerOutcome(final=True, handler=handler)
     assert outcome.final
     assert outcome.delay is None
     assert outcome.result is None
@@ -11,9 +20,9 @@ def test_creation_for_ignored_handlers():
     assert not outcome.subrefs
 
 
-def test_creation_for_results():
+def test_creation_for_results(handler):
     result = Result(object())
-    outcome = HandlerOutcome(final=True, result=result)
+    outcome = HandlerOutcome(final=True, handler=handler, result=result)
     assert outcome.final
     assert outcome.delay is None
     assert outcome.result is result
@@ -21,9 +30,9 @@ def test_creation_for_results():
     assert not outcome.subrefs
 
 
-def test_creation_for_permanent_errors():
+def test_creation_for_permanent_errors(handler):
     error = Exception()
-    outcome = HandlerOutcome(final=True, exception=error)
+    outcome = HandlerOutcome(final=True, handler=handler, exception=error)
     assert outcome.final
     assert outcome.delay is None
     assert outcome.result is None
@@ -31,9 +40,9 @@ def test_creation_for_permanent_errors():
     assert not outcome.subrefs
 
 
-def test_creation_for_temporary_errors():
+def test_creation_for_temporary_errors(handler):
     error = Exception()
-    outcome = HandlerOutcome(final=False, exception=error, delay=123)
+    outcome = HandlerOutcome(final=False, handler=handler, exception=error, delay=123)
     assert not outcome.final
     assert outcome.delay == 123
     assert outcome.result is None
@@ -41,6 +50,6 @@ def test_creation_for_temporary_errors():
     assert not outcome.subrefs
 
 
-def test_creation_with_subrefs():
-    outcome = HandlerOutcome(final=True, subrefs=['sub1', 'sub2'])
+def test_creation_with_subrefs(handler):
+    outcome = HandlerOutcome(final=True, handler=handler, subrefs=['sub1', 'sub2'])
     assert outcome.subrefs == ['sub1', 'sub2']

--- a/tests/persistence/test_states.py
+++ b/tests/persistence/test_states.py
@@ -242,7 +242,7 @@ def test_set_awake_time(storage, handler, expected, body, delay):
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
     state = state.with_handlers([handler])
-    state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=False, delay=delay)})
+    state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=False, handler=handler, delay=delay)})
     state.store(patch=patch, body=Body(body), storage=storage)
     assert patch['status']['kopf']['progress']['some-id'].get('delayed') == expected
 
@@ -265,7 +265,7 @@ def test_set_retry_time(storage, handler, expected_retries, expected_delayed, bo
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
     state = state.with_handlers([handler])
-    state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=False, delay=delay)})
+    state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=False, handler=handler, delay=delay)})
     state.store(patch=patch, body=Body(body), storage=storage)
     assert patch['status']['kopf']['progress']['some-id']['retries'] == expected_retries
     assert patch['status']['kopf']['progress']['some-id']['delayed'] == expected_delayed
@@ -276,7 +276,7 @@ def test_subrefs_added_to_empty_state(storage, handler):
     patch = Patch()
     outcome_subrefs = ['sub2/b', 'sub2/a', 'sub2', 'sub1', 'sub3']
     expected_subrefs = ['sub1', 'sub2', 'sub2/a', 'sub2/b', 'sub3']
-    outcome = HandlerOutcome(final=True, subrefs=outcome_subrefs)
+    outcome = HandlerOutcome(final=True, handler=handler, subrefs=outcome_subrefs)
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
     state = state.with_handlers([handler])
     state = state.with_outcomes(outcomes={handler.id: outcome})
@@ -289,7 +289,7 @@ def test_subrefs_added_to_preexisting_subrefs(storage, handler):
     patch = Patch()
     outcome_subrefs = ['sub2/b', 'sub2/a', 'sub2', 'sub1', 'sub3']
     expected_subrefs = ['sub1', 'sub2', 'sub2/a', 'sub2/b', 'sub3', 'sub9/1', 'sub9/2']
-    outcome = HandlerOutcome(final=True, subrefs=outcome_subrefs)
+    outcome = HandlerOutcome(final=True, handler=handler, subrefs=outcome_subrefs)
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
     state = state.with_handlers([handler])
     state = state.with_outcomes(outcomes={handler.id: outcome})
@@ -300,7 +300,7 @@ def test_subrefs_added_to_preexisting_subrefs(storage, handler):
 def test_subrefs_ignored_when_not_specified(storage, handler):
     body = {}
     patch = Patch()
-    outcome = HandlerOutcome(final=True, subrefs=[])
+    outcome = HandlerOutcome(final=True, handler=handler, subrefs=[])
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
     state = state.with_handlers([handler])
     state = state.with_outcomes(outcomes={handler.id: outcome})
@@ -318,7 +318,7 @@ def test_store_failure(storage, handler, expected_retries, expected_stopped, bod
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
     state = state.with_handlers([handler])
-    state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=True, exception=error)})
+    state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=True, handler=handler, exception=error)})
     state.store(patch=patch, body=Body(body), storage=storage)
     assert patch['status']['kopf']['progress']['some-id']['success'] is False
     assert patch['status']['kopf']['progress']['some-id']['failure'] is True
@@ -336,7 +336,7 @@ def test_store_success(storage, handler, expected_retries, expected_stopped, bod
     patch = Patch()
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
     state = state.with_handlers([handler])
-    state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=True)})
+    state = state.with_outcomes(outcomes={handler.id: HandlerOutcome(final=True, handler=handler)})
     state.store(patch=patch, body=Body(body), storage=storage)
     assert patch['status']['kopf']['progress']['some-id']['success'] is True
     assert patch['status']['kopf']['progress']['some-id']['failure'] is False
@@ -352,7 +352,7 @@ def test_store_success(storage, handler, expected_retries, expected_stopped, bod
 ])
 def test_store_result(handler, expected_patch, result):
     patch = Patch()
-    outcomes = {handler.id: HandlerOutcome(final=True, result=result)}
+    outcomes = {handler.id: HandlerOutcome(final=True, handler=handler, result=result)}
     deliver_results(outcomes=outcomes, patch=patch)
     assert patch == expected_patch
 

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -59,7 +59,7 @@ def parent_handler():
         errors=None, retries=None, timeout=None, backoff=None, cooldown=None,
         labels=None, annotations=None, when=None,
         initial=None, deleted=None, requires_finalizer=None,
-        reason=None, field=None,
+        reason=None, field=None, status_prefix=None,
     )
 
 

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -82,6 +82,7 @@ def test_on_resume_minimal(reason, cause_factory):
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
     assert handlers[0].when is None
+    assert handlers[0].status_prefix == True
 
 
 def test_on_create_minimal(cause_factory):
@@ -105,6 +106,7 @@ def test_on_create_minimal(cause_factory):
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
     assert handlers[0].when is None
+    assert handlers[0].status_prefix == True
 
 
 def test_on_update_minimal(cause_factory):
@@ -128,6 +130,7 @@ def test_on_update_minimal(cause_factory):
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
     assert handlers[0].when is None
+    assert handlers[0].status_prefix == True
 
 
 def test_on_delete_minimal(cause_factory):
@@ -151,6 +154,7 @@ def test_on_delete_minimal(cause_factory):
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
     assert handlers[0].when is None
+    assert handlers[0].status_prefix == True
 
 
 def test_on_field_minimal(cause_factory):
@@ -175,6 +179,7 @@ def test_on_field_minimal(cause_factory):
     assert handlers[0].labels is None
     assert handlers[0].annotations is None
     assert handlers[0].when is None
+    assert handlers[0].status_prefix == True
 
 
 def test_on_field_fails_without_field():
@@ -260,7 +265,7 @@ def test_on_resume_with_all_kwargs(mocker, reason, cause_factory):
                     deleted=True,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'},
-                    when=when)
+                    when=when, status_prefix=False)
     def fn(**_):
         pass
 
@@ -278,6 +283,7 @@ def test_on_resume_with_all_kwargs(mocker, reason, cause_factory):
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
     assert handlers[0].when == when
+    assert handlers[0].status_prefix == False
 
 
 def test_on_create_with_all_kwargs(mocker, cause_factory):
@@ -293,7 +299,7 @@ def test_on_create_with_all_kwargs(mocker, cause_factory):
                     errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'},
-                    when=when)
+                    when=when, status_prefix=False)
     def fn(**_):
         pass
 
@@ -310,6 +316,7 @@ def test_on_create_with_all_kwargs(mocker, cause_factory):
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
     assert handlers[0].when == when
+    assert handlers[0].status_prefix == False
 
 
 def test_on_update_with_all_kwargs(mocker, cause_factory):
@@ -325,7 +332,7 @@ def test_on_update_with_all_kwargs(mocker, cause_factory):
                     errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'},
-                    when=when)
+                    when=when, status_prefix=False)
     def fn(**_):
         pass
 
@@ -342,6 +349,7 @@ def test_on_update_with_all_kwargs(mocker, cause_factory):
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
     assert handlers[0].when == when
+    assert handlers[0].status_prefix == False
 
 
 @pytest.mark.parametrize('optional', [
@@ -362,7 +370,7 @@ def test_on_delete_with_all_kwargs(mocker, cause_factory, optional):
                     optional=optional,
                     labels={'somelabel': 'somevalue'},
                     annotations={'someanno': 'somevalue'},
-                    when=when)
+                    when=when, status_prefix=False)
     def fn(**_):
         pass
 
@@ -379,6 +387,7 @@ def test_on_delete_with_all_kwargs(mocker, cause_factory, optional):
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
     assert handlers[0].when == when
+    assert handlers[0].status_prefix == False
 
 
 def test_on_field_with_all_kwargs(mocker, cause_factory):
@@ -395,7 +404,7 @@ def test_on_field_with_all_kwargs(mocker, cause_factory):
                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                    labels={'somelabel': 'somevalue'},
                    annotations={'someanno': 'somevalue'},
-                   when=when)
+                   when=when, status_prefix=False)
     def fn(**_):
         pass
 
@@ -412,6 +421,7 @@ def test_on_field_with_all_kwargs(mocker, cause_factory):
     assert handlers[0].labels == {'somelabel': 'somevalue'}
     assert handlers[0].annotations == {'someanno': 'somevalue'}
     assert handlers[0].when == when
+    assert handlers[0].status_prefix == False
 
 
 def test_subhandler_fails_with_no_parent_handler():
@@ -444,6 +454,7 @@ def test_subhandler_declaratively(parent_handler, cause_factory):
     handlers = registry.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
+    assert handlers[0].status_prefix == parent_handler.status_prefix
 
 
 def test_subhandler_imperatively(parent_handler, cause_factory):
@@ -461,6 +472,23 @@ def test_subhandler_imperatively(parent_handler, cause_factory):
     handlers = registry.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
+
+
+def test_subhandler_with_all_kwargs(parent_handler, cause_factory):
+    cause = cause_factory(reason=Reason.UPDATE)
+
+    registry = ResourceChangingRegistry()
+    subregistry_var.set(registry)
+
+    with context([(handler_var, parent_handler)]):
+        @kopf.on.this(status_prefix = False)
+        def fn(**_):
+            pass
+
+    handlers = registry.get_handlers(cause)
+    assert len(handlers) == 1
+    assert handlers[0].fn is fn
+    assert handlers[0].status_prefix == False
 
 
 @pytest.mark.parametrize('decorator, kwargs', [

--- a/tests/registries/test_handler_matching.py
+++ b/tests/registries/test_handler_matching.py
@@ -59,7 +59,7 @@ def handler_factory(registry, resource):
             fn=some_fn, id='a',
             errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
             initial=None, deleted=None, requires_finalizer=None,
-            annotations=None, labels=None, when=None, field=None,
+            annotations=None, labels=None, when=None, field=None, status_prefix=None,
             reason=None,
         ), **kwargs))
         registry.resource_changing_handlers[resource].append(handler)


### PR DESCRIPTION
## What do these changes do?

This ports a PR that was originally raised (https://github.com/zalando-incubator/kopf/pull/320) on the Zalando repository.
Thanks @lack!

Adding an optional parameter to the decorators for resource change handlers that allows the return value to be stored directly onto the `status` key on the resource in question.

## Description

Implements the proposal in issue https://github.com/nolar/kopf/issues/319.

## Issues/PRs

https://github.com/nolar/kopf/issues/319

## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

I can't take credit for the code itself since it was already written here: https://github.com/zalando-incubator/kopf/pull/320

I'm not sure if we've covered all the cases here, would be good to know if I've missed something.