### PR TITLE
Unfreeze operators as soon as possible due to peers' expirations

### DIFF
--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -161,7 +161,10 @@ async def keepalive(
 
             # How often do we update. Keep limited to avoid k8s api flooding.
             # Should be slightly less than the lifetime, enough for a patch request to finish.
-            await asyncio.sleep(max(1, int(settings.peering.lifetime - 10)))
+            # A little jitter is added to evenly distribute the keep-alives over time.
+            lifetime = settings.peering.lifetime
+            duration = min(lifetime, max(1, lifetime - random.randint(5, 10)))
+            await asyncio.sleep(max(1, duration))
     finally:
         try:
             await asyncio.shield(touch(

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -35,7 +35,7 @@ import getpass
 import logging
 import os
 import random
-from typing import Any, Dict, Iterable, Mapping, NewType, NoReturn, Optional, Union, cast
+from typing import Any, Dict, Iterable, Mapping, NewType, NoReturn, Optional, cast
 
 import iso8601
 
@@ -61,31 +61,31 @@ class Peer:
             *,
             identity: Identity,
             priority: int = 0,
-            lastseen: Optional[Union[str, datetime.datetime]] = None,
-            lifetime: Union[int, datetime.timedelta] = 60,
+            lifetime: int = 60,
+            lastseen: Optional[str] = None,
             **_: Any,  # for the forward-compatibility with the new fields
     ):
         super().__init__()
         self.identity = identity
         self.priority = priority
-        self.lifetime = (lifetime if isinstance(lifetime, datetime.timedelta) else
-                         datetime.timedelta(seconds=int(lifetime)))
-        self.lastseen = (lastseen if isinstance(lastseen, datetime.datetime) else
-                         iso8601.parse_date(lastseen) if lastseen is not None else
+        self.lifetime = datetime.timedelta(seconds=int(lifetime))
+        self.lastseen = (iso8601.parse_date(lastseen) if lastseen is not None else
                          datetime.datetime.utcnow())
         self.lastseen = self.lastseen.replace(tzinfo=None)  # only the naive utc -- for comparison
         self.deadline = self.lastseen + self.lifetime
         self.is_dead = self.deadline <= datetime.datetime.utcnow()
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(identity={self.identity}, priority={self.priority}, lastseen={self.lastseen}, lifetime={self.lifetime})"
+        clsname = self.__class__.__name__
+        options = ", ".join(f"{key!s}={val!r}" for key, val in self.as_dict().items())
+        return f"<{clsname} {self.identity}: {options}>"
 
     def as_dict(self) -> Dict[str, Any]:
         # Only the non-calculated and non-identifying fields.
         return {
-            'priority': self.priority,
-            'lastseen': self.lastseen.isoformat(),
-            'lifetime': self.lifetime.total_seconds(),
+            'priority': int(self.priority),
+            'lifetime': int(self.lifetime.total_seconds()),
+            'lastseen': str(self.lastseen.isoformat()),
         }
 
 

--- a/kopf/structs/configuration.py
+++ b/kopf/structs/configuration.py
@@ -117,8 +117,13 @@ class PeeringSettings:
     For how long (in seconds) the operator's record is considered actual
     by other operators before assuming that the corresponding operator
     is not functioning and the freeze mode should be re-evaluated.
+
     The peered operators will update their records as long as they are running,
     slightly faster than their records expires (5-10 seconds earlier).
+
+    Note that it is the lifetime of the current operator. For operators that
+    do not communicate their lifetime (broken?), it is always assumed to be
+    60 seconds regardless of this operator's configuration (a hard-coded value).
     """
 
     mandatory: bool = False

--- a/tests/peering/test_keepalive.py
+++ b/tests/peering/test_keepalive.py
@@ -13,13 +13,17 @@ async def test_background_task_runs(mocker, settings):
     sleep_mock = mocker.patch('asyncio.sleep')
     sleep_mock.side_effect = [None, None, StopInfiniteCycleException]
 
+    randint_mock = mocker.patch('random.randint')
+    randint_mock.side_effect = [7, 5, 9]
+
     settings.peering.lifetime = 33
     with pytest.raises(StopInfiniteCycleException):
         await keepalive(settings=settings, identity='id', namespace='namespace')
 
+    assert randint_mock.call_count == 3  # only to be sure that we test the right thing
     assert sleep_mock.call_count == 3
-    assert sleep_mock.call_args_list[0][0][0] == 33 - 10
-    assert sleep_mock.call_args_list[1][0][0] == 33 - 10
-    assert sleep_mock.call_args_list[2][0][0] == 33 - 10
+    assert sleep_mock.call_args_list[0][0][0] == 33 - 7
+    assert sleep_mock.call_args_list[1][0][0] == 33 - 5
+    assert sleep_mock.call_args_list[2][0][0] == 33 - 9
 
     assert touch_mock.call_count == 4  # 3 updates + 1 clean-up

--- a/tests/peering/test_peers.py
+++ b/tests/peering/test_peers.py
@@ -17,12 +17,7 @@ def test_defaults():
 def test_repr():
     peer = Peer(identity='some-id')
     text = repr(peer)
-    assert text.startswith('Peer(')
-    assert text.endswith(')')
-    assert 'identity=some-id' in text
-    assert 'priority=0' in text
-    assert 'lastseen=' in text
-    assert 'lifetime=' in text
+    assert text == "<Peer some-id: priority=0, lifetime=60, lastseen='2020-12-31T23:59:59.123456'>"
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
@@ -38,12 +33,6 @@ def test_priority_unspecified():
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
-def test_creation_with_lifetime_as_timedelta():
-    peer = Peer(identity='id', lifetime=datetime.timedelta(seconds=123))
-    assert peer.lifetime == datetime.timedelta(seconds=123)
-
-
-@freezegun.freeze_time('2020-12-31T23:59:59.123456')
 def test_creation_with_lifetime_as_number():
     peer = Peer(identity='id', lifetime=123)
     assert peer.lifetime == datetime.timedelta(seconds=123)
@@ -53,12 +42,6 @@ def test_creation_with_lifetime_as_number():
 def test_creation_with_lifetime_unspecified():
     peer = Peer(identity='id')
     assert peer.lifetime == datetime.timedelta(seconds=60)
-
-
-@freezegun.freeze_time('2020-12-31T23:59:59.123456')
-def test_creation_with_lastseen_as_datetime():
-    peer = Peer(identity='id', lastseen=datetime.datetime(2020, 1, 1, 12, 34, 56, 789123))
-    assert peer.lastseen == datetime.datetime(2020, 1, 1, 12, 34, 56, 789123)
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')


### PR DESCRIPTION
Unfreeze operators when the blocking peers (other operators of the same "peering neighbourhood") are supposed to expire, not when the next keepalive happens as it was before.

This will reduce the waiting time for up to 60 seconds to much lower delay. However, delays of 60 seconds are **still possible but less probable**: if the blocking operators have sent their keepalives moments before exiting, they will be believed to exist for the next 60 second.

---

Besides, add a little jitter to the peering keepalives, so that they would distribute evenly after some time of functioning. There is already such an implicit jitter — the `PATCH` operation with varying duration (due to its networking nature). But it is not controllable, and the distribution in time happens slowly. With multiple namespaces served (each with its own peering keepalive), it would be better to distribute them faster to reduce the peak load on the K8s API.

And also some code cleanups: improve reprs of peers for readability; remove the constructor types that are not needed anymore (peers are used only internally, and we do not feed `timedelta`/`datetime` into them).

_This is an extraction of needed, useful, but unrelated changes from a bigger PR._