### PR TITLE
Disable CI builds after the merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,6 @@
 # a representative selection of environments.
 name: CI
 on:
-  push:
-    branches:
-      - master
-      - release/**
   pull_request:
     branches:
       - master


### PR DESCRIPTION
In #582, it was configured slightly improperly — with duplicate runs of unit-tests and K3s tests after the merge: both in "CI" and "Thorough" workflows.

This PR disables the "CI" workflow for the merges, as all its jobs are already present in the "Thorough" workflow.