### PR TITLE
Drop JUnit results uploading as unused and tricky

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - run: pip install -r requirements.txt
       - run: mypy kopf --strict --pretty
-      - run: pytest --color=yes --cov=kopf --cov-branch --junit-xml=junit.xml
+      - run: pytest --color=yes --cov=kopf --cov-branch
 
       - name: Publish coverage to Coveralls.io
         if: ${{ success() }}
@@ -54,13 +54,6 @@ jobs:
         with:
           flags: unit
           env_vars: PYTHON
-      - name: Publish unit test results
-        uses: EnricoMi/publish-unit-test-result-action@v1.5
-        if: ${{ always() }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          comment_on_pr: false
-          files: junit.xml
 
   functional:
     strategy:

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - run: pip install -r requirements.txt
       - run: mypy kopf --strict --pretty
-      - run: pytest --color=yes --cov=kopf --cov-branch --junit-xml=junit.xml
+      - run: pytest --color=yes --cov=kopf --cov-branch
 
       - name: Publish coverage to Coveralls.io
         if: success()
@@ -58,13 +58,6 @@ jobs:
         with:
           flags: unit
           env_vars: PYTHON
-      - name: Publish unit test results
-        uses: EnricoMi/publish-unit-test-result-action@v1.5
-        if: always()
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          comment_on_pr: false
-          files: junit.xml
 
   functional:
     strategy:


### PR DESCRIPTION
JUnit.xml uploading requires some reconfiguration of the workflows and additional research on the token security.

Since it is not used actively, it is easier to drop it completely for now. The test results can be checked in the logs anyway.

This step causes the CI tests to fail when a corresponding PR is sent from a fork (not from an internal branch).

#593 