### PR TITLE
Support resources with no uid, and maybe with no name

### DIFF
--- a/kopf/structs/bodies.py
+++ b/kopf/structs/bodies.py
@@ -145,23 +145,23 @@ class Meta(dicts.MappingView[str, Any]):
 
     @property
     def uid(self) -> Optional[str]:
-        return cast(Optional[str], self.get('uid', None))
+        return cast(Optional[str], self.get('uid'))
 
     @property
     def name(self) -> Optional[str]:
-        return cast(Optional[str], self.get('name', None))
+        return cast(Optional[str], self.get('name'))
 
     @property
     def namespace(self) -> Optional[str]:
-        return cast(Optional[str], self.get('namespace', None))
+        return cast(Optional[str], self.get('namespace'))
 
     @property
     def creation_timestamp(self) -> Optional[str]:
-        return cast(Optional[str], self.get('creationTimestamp', None))
+        return cast(Optional[str], self.get('creationTimestamp'))
 
     @property
     def deletion_timestamp(self) -> Optional[str]:
-        return cast(Optional[str], self.get('deletionTimestamp', None))
+        return cast(Optional[str], self.get('deletionTimestamp'))
 
 
 class Spec(dicts.MappingView[str, Any]):

--- a/tests/reactor/test_uids.py
+++ b/tests/reactor/test_uids.py
@@ -1,0 +1,30 @@
+from kopf.reactor.queueing import get_uid
+
+
+def test_uid_is_used_if_present():
+    raw_event = {'type': ..., 'object': {'metadata': {'uid': '123'}}}
+    uid = get_uid(raw_event)
+
+    assert isinstance(uid, str)
+    assert uid == '123'
+
+
+def test_uid_is_simulated_if_absent():
+    raw_event = {'type': ...,
+                 'object': {
+                     'apiVersion': 'group/v1',
+                     'kind': 'Kind1',
+                     'metadata': {
+                         'name': 'name1',
+                         'namespace': 'namespace1',
+                         'creationTimestamp': 'created1',
+                     }}}
+    uid = get_uid(raw_event)
+
+    # The exact order is irrelevant.
+    assert isinstance(uid, str)
+    assert 'created1' in uid
+    assert 'name1' in uid
+    assert 'namespace' in uid
+    assert 'Kind1' in uid
+    assert 'group/v1' in uid


### PR DESCRIPTION
This goes slightly against K8s API specification, but the reality is that some resources, e.g. `v1/ComponentStatus`, do not have uids. Thos should not fail the operator.

For such cases, use a fallback scenario, where a sufficiently unique pseudo-uid is generated from those parts of the resource, that do not change over time, and ensure its time-space uniqueness (i.e. if a resource is deleted and a new one is created with the same name, it should be a different pseudo-uid).
