### PR TITLE
Ignore irrelevant handlers' states in superseding causes (e.g. deletion-during-creation, update-during-resume, etc)

### DIFF
--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -155,7 +155,7 @@ async def execute(
     cause_handlers = subregistry.get_handlers(cause=cause)
     storage = settings.persistence.progress_storage
     state = states.State.from_storage(body=cause.body, storage=storage, handlers=owned_handlers)
-    state = state.with_handlers(cause_handlers)
+    state = state.with_purpose(cause.reason).with_handlers(cause_handlers)
     outcomes = await execute_handlers_once(
         lifecycle=lifecycle,
         settings=settings,

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -342,11 +342,29 @@ async def process_resource_changing_cause(
         title = handlers_.TITLES.get(cause.reason, repr(cause.reason))
 
         resource_registry = registry.resource_changing_handlers[cause.resource]
-        cause_handlers = resource_registry.get_handlers(cause=cause)
         owned_handlers = resource_registry.get_all_handlers()
+        cause_handlers = resource_registry.get_handlers(cause=cause)
         storage = settings.persistence.progress_storage
         state = states.State.from_storage(body=cause.body, storage=storage, handlers=owned_handlers)
-        state = state.with_handlers(cause_handlers)
+        state = state.with_purpose(cause.reason).with_handlers(cause_handlers)
+
+        # Report the causes that have been superseded (intercepted, overridden) by the current one.
+        # The mix-in causes (i.e. resuming) is re-purposed if its handlers are still selected.
+        # To the next cycle, all extras are purged or re-purposed, so the message does not repeat.
+        for extra_reason, counters in state.extras.items():  # usually 0..1 items, rarely 2+.
+            extra_title = handlers_.TITLES.get(extra_reason, repr(extra_reason))
+            logger.info(f"{extra_title.capitalize()} is superseded by {title.lower()}: "
+                        f"{counters.success} succeeded; "
+                        f"{counters.failure} failed; "
+                        f"{counters.running} left to the moment.")
+            state = state.with_purpose(purpose=cause.reason, handlers=cause_handlers)
+
+        # Purge the now-irrelevant handlers if they were not re-purposed (extras are recalculated!).
+        # The current cause continues afterwards, and overrides its own pre-purged handler states.
+        # TODO: purge only the handlers that fell out of current purpose; but it is not critical
+        if state.extras:
+            state.purge(body=cause.body, patch=cause.patch,
+                        storage=storage, handlers=owned_handlers)
 
         # Inform on the current cause/event on every processing cycle. Even if there are
         # no handlers -- to show what has happened and why the diff-base is patched.
@@ -367,10 +385,10 @@ async def process_resource_changing_cause(
             states.deliver_results(outcomes=outcomes, patch=cause.patch)
 
             if state.done:
-                success_count, failure_count = state.counts
+                counters = state.counts  # calculate only once
                 logger.info(f"{title.capitalize()} is processed: "
-                            f"{success_count} succeeded; "
-                            f"{failure_count} failed.")
+                            f"{counters.success} succeeded; "
+                            f"{counters.failure} failed.")
                 state.purge(body=cause.body, patch=cause.patch,
                             storage=storage, handlers=owned_handlers)
 

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -54,6 +54,7 @@ class ProgressRecord(TypedDict, total=True):
     started: Optional[str]
     stopped: Optional[str]
     delayed: Optional[str]
+    purpose: Optional[str]
     retries: Optional[int]
     success: Optional[bool]
     failure: Optional[bool]

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -1,10 +1,13 @@
 import asyncio
+import datetime
 import logging
 
+import freezegun
 import pytest
 
 import kopf
 from kopf.reactor.processing import process_resource_event
+from kopf.storage.progress import StatusProgressStorage
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import ALL_REASONS, HANDLER_REASONS, Reason
 
@@ -90,4 +93,47 @@ async def test_diffs_not_logged_if_absent(registry, settings, resource, handlers
         "(Creation|Updating|Resuming|Deletion) is in progress: ",
     ], prohibited=[
         " diff: "
+    ])
+
+
+
+# Timestamps: time zero (0), before (B), after (A), and time zero+1s (1).
+TS0 = datetime.datetime(2020, 12, 31, 23, 59, 59, 123456)
+TS1_ISO = '2021-01-01T00:00:00.123456'
+
+
+@pytest.mark.parametrize('cause_types', [
+    # All combinations except for same-to-same (it is not an "extra" then).
+    (a, b) for a in HANDLER_REASONS for b in HANDLER_REASONS if a != b
+])
+@freezegun.freeze_time(TS0)
+async def test_supersession_is_logged(
+        registry, settings, resource, handlers, cause_types, cause_mock, caplog, assert_logs):
+    caplog.set_level(logging.DEBUG)
+
+    settings.persistence.progress_storage = StatusProgressStorage()
+    body = {'status': {'kopf': {'progress': {
+        'create_fn': {'purpose': cause_types[0]},
+        'update_fn': {'purpose': cause_types[0]},
+        'resume_fn': {'purpose': cause_types[0]},
+        'delete_fn': {'purpose': cause_types[0]},
+    }}}}
+
+    cause_mock.reason = cause_types[1]
+    event_type = None if cause_types[1] == Reason.RESUME else 'irrelevant'
+
+    await process_resource_event(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        memories=ResourceMemories(),
+        raw_event={'type': event_type, 'object': body},
+        replenished=asyncio.Event(),
+        event_queue=asyncio.Queue(),
+    )
+    assert_logs([
+        "(Creation|Updating|Resuming|Deletion) is superseded by (creation|updating|resuming|deletion): ",
+        "(Creation|Updating|Resuming|Deletion) is in progress: ",
+        "(Creation|Updating|Resuming|Deletion) is processed: ",
     ])


### PR DESCRIPTION
**This is the proper fix for #601 on the main branch. The 0.28.x hotfix is in #607.**

This fix is important only for the states restored from storage with specific handlers referenced: those handlers should be taken into account when purging the state (#557), but not for `.done` & `.delays` — these ones must be calculated only for the handlers currently in scope.

For log messages with counts of succeeded and failed handlers (#540), only the handlers relevant to the current cause should be counted. However, if there are irrelevant handlers, it means that one cause was interrupted (intercepted, overridden) by another: e.g., if deletion has happened while a creation/update/resume was being processed.

Technically, now, without the fix, this merges two unrelated causes and their handlers, since, from Kopf's point of view, the irrelevant handlers look the same as the relevant but filtered out handlers (e.g. by labels). To work around this, we introduce "purposes" of the handlers and persist them in the handlers' states.

For compatibility, if the purpose is not stored (`None`), treat it as a catch-all value, thus reproducing the same behaviour as before the fix. This will only be used if the operator is upgraded in the middle of the processing (e.g. due to temporary errors or intentional delays). All new handling cycles will be stored with the purpose. In case of a rollback, the purpose will be ignored, but also overwritten back to `None` by the old versions of Kopf. This is fine.

---

An example case (#601):

```python
import kopf

@kopf.on.create('zalando.org', 'v1', 'kopfexamples')
def create_fn1(**_):
    pass

@kopf.on.create('zalando.org', 'v1', 'kopfexamples')
def create_fn2(**_):
    raise kopf.TemporaryError("temporary failure", delay=5)

@kopf.on.delete('zalando.org', 'v1', 'kopfexamples')
def delete_fn1(**_):
    pass

@kopf.on.delete('zalando.org', 'v1', 'kopfexamples')
def delete_fn2(**_):
    pass
```

```
kubectl create -f examples/obj.yaml && sleep 2 && kubectl delete -f examples/obj.yaml
```

Here, on the object deletion, the state will be restored with 4 handlers: `create_fn1` & `create_fn2`& `delete_fn1` & `delete_fn2`. Since `create_fn2` was delayed and not finished, then, without the fix, it would yield its own delay and will prevent the `.done` from achieving `True` — while it is irrelevant anymore, and only `delete_fn1` & `delete_fn2` should be considered. However, all four should be purged from annotations when done.

Now, with this fix, the logs will report interruption of creation and the beginning of deletion — each with its own numbers.

```
Creation is in progress: …
Sleeping for 4.866814 seconds for the delayed handlers.
…
Sleeping was interrupted by new changes, 3.3 seconds left.
Creation is superseded by deletion: 1 succeeded; 0 failed; 1 left.
Deletion is in progress: …
…
Deletion is processed: 2 succeeded; 0 failed.
```

---

Note that only some transitions are possible due to external reasons, not all of them:

* creation/update/resume → deletion (when marked for deletion).
* resume → update (when changed; the resuming handlers are mixed into the updating process).

Other transitions within the creation/update/resume group are impossible due to their nature, except when initiated by the framework itself.

A transition back from deletion to creation/update/resume is impossible in practice but would work otherwise.