### PR TITLE
Time-limit the tests with async-timeout if possible

### DIFF
--- a/examples/10-builtins/test_example_10.py
+++ b/examples/10-builtins/test_example_10.py
@@ -25,22 +25,24 @@ def test_pods_reacted():
 
 def _create_pod():
     api = pykube.HTTPClient(pykube.KubeConfig.from_file())
-    pod = pykube.Pod(api, {
-        'apiVersion': 'v1',
-        'kind': 'Pod',
-        'metadata': {'generateName': 'kopf-pod-', 'namespace': 'default'},
-        'spec': {
-            'containers': [{
-                'name': 'the-only-one',
-                'image': 'busybox',
-                'command': ["sh", "-x", "-c", "sleep 1"],
-            }]},
-    })
-    pod.create()
-    return pod.name
+    with api.session:
+        pod = pykube.Pod(api, {
+            'apiVersion': 'v1',
+            'kind': 'Pod',
+            'metadata': {'generateName': 'kopf-pod-', 'namespace': 'default'},
+            'spec': {
+                'containers': [{
+                    'name': 'the-only-one',
+                    'image': 'busybox',
+                    'command': ["sh", "-x", "-c", "sleep 1"],
+                }]},
+        })
+        pod.create()
+        return pod.name
 
 
 def _delete_pod(name):
     api = pykube.HTTPClient(pykube.KubeConfig.from_file())
-    pod = pykube.Pod.objects(api, namespace='default').get_by_name(name)
-    pod.delete()
+    with api.session:
+        pod = pykube.Pod.objects(api, namespace='default').get_by_name(name)
+        pod.delete()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -497,6 +497,12 @@ class Timer(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._te = time.perf_counter()
 
+    async def __aenter__(self):
+        return self.__enter__()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return self.__exit__(exc_type, exc_val, exc_tb)
+
     def __int__(self):
         return int(self.seconds)
 

--- a/tests/peering/test_freeze_mode.py
+++ b/tests/peering/test_freeze_mode.py
@@ -23,10 +23,11 @@ def k8s_mocked(mocker, resp_mocker):
 
 
 @pytest.fixture
-async def replenished():
+async def replenished(mocker):
     # Make sure that freeze-sleeps are not actually executed, i.e. exit instantly.
     replenished = asyncio.Event()
     replenished.set()
+    mocker.patch.object(replenished, 'wait')  # to avoid RuntimeWarnings for unwaited coroutines
     return replenished
 
 

--- a/tests/posting/test_poster.py
+++ b/tests/posting/test_poster.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 
+import async_timeout
 import pytest
 from asynctest import call
 
@@ -36,10 +37,10 @@ async def test_poster_polls_and_posts(mocker):
             raise asyncio.CancelledError()
     post_event = mocker.patch('kopf.clients.events.post_event', side_effect=_cancel)
 
-    # A way to cancel `whole True` cycle by timing, event if routines are not called.
+    # A way to cancel a `while True` cycle by timing, even if the routines are not called.
     with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(
-            poster(event_queue=event_queue), timeout=0.5)
+        async with async_timeout.timeout(0.5):
+            await poster(event_queue=event_queue)
 
     assert post_event.call_count == 2
     assert post_event.await_count == 2

--- a/tests/primitives/test_flags.py
+++ b/tests/primitives/test_flags.py
@@ -2,6 +2,7 @@ import asyncio
 import concurrent.futures
 import threading
 
+import async_timeout
 import pytest
 
 from kopf.structs.primitives import check_flag, raise_flag, wait_flag
@@ -134,17 +135,19 @@ async def test_waiting_of_none_does_nothing():
 
 
 async def test_waiting_for_unraised_times_out(flag, timer):
-    with timer:
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(wait_flag(flag), timeout=0.1)
+    with pytest.raises(asyncio.TimeoutError):
+        async with timer, async_timeout.timeout(0.1) as timeout:
+            await wait_flag(flag)
     assert timer.seconds >= 0.1
+    assert timeout.expired
 
 
 async def test_waiting_for_preraised_is_instant(flag, timer):
     await raise_flag(flag)  # tested separately above
-    with timer:
-        await asyncio.wait_for(wait_flag(flag), timeout=1.0)
+    async with timer, async_timeout.timeout(1.0) as timeout:
+        await wait_flag(flag)
     assert timer.seconds < 0.5  # near-instant, plus code overhead
+    assert not timeout.expired
 
 
 async def test_waiting_for_raised_during_the_wait(flag, timer):
@@ -154,6 +157,7 @@ async def test_waiting_for_raised_during_the_wait(flag, timer):
         await raise_flag(flag)  # tested separately above
 
     asyncio.create_task(raise_delayed(0.2))
-    with timer:
-        await asyncio.wait_for(wait_flag(flag), timeout=1.0)
+    async with timer, async_timeout.timeout(1.0) as timeout:
+        await wait_flag(flag)
     assert 0.2 <= timer.seconds < 0.5  # near-instant once raised
+    assert not timeout.expired

--- a/tests/primitives/test_toggles.py
+++ b/tests/primitives/test_toggles.py
@@ -1,5 +1,6 @@
 import asyncio
 
+import async_timeout
 import pytest
 
 from kopf.structs.primitives import Toggle
@@ -51,18 +52,22 @@ async def test_waiting_until_on_fails_when_not_turned_on():
     toggle = Toggle(False)
 
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(toggle.wait_for_on(), timeout=0.1)
+        async with async_timeout.timeout(0.1) as timeout:
+            await toggle.wait_for_on()
 
     assert not toggle
+    assert timeout.expired
 
 
 async def test_waiting_until_off_fails_when_not_turned_off():
     toggle = Toggle(True)
 
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(toggle.wait_for_off(), timeout=0.1)
+        async with async_timeout.timeout(0.1) as timeout:
+            await toggle.wait_for_off()
 
     assert toggle
+    assert timeout.expired
 
 
 async def test_waiting_until_on_wakes_when_turned_on(timer):
@@ -72,11 +77,12 @@ async def test_waiting_until_on_wakes_when_turned_on(timer):
         await asyncio.sleep(delay)
         await toggle.turn_on()
 
-    with timer:
+    async with timer, async_timeout.timeout(1.0) as timeout:
         asyncio.create_task(delayed_turning_on(0.05))
-        await asyncio.wait_for(toggle.wait_for_on(), timeout=1.0)
+        await toggle.wait_for_on()
 
     assert toggle
+    assert not timeout.expired
     assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead
 
 
@@ -87,9 +93,10 @@ async def test_waiting_until_off_wakes_when_turned_off(timer):
         await asyncio.sleep(delay)
         await toggle.turn_off()
 
-    with timer:
+    async with timer, async_timeout.timeout(1.0) as timeout:
         asyncio.create_task(delayed_turning_off(0.05))
-        await asyncio.wait_for(toggle.wait_for_off(), timeout=1.0)
+        await toggle.wait_for_off()
 
     assert not toggle
+    assert not timeout.expired
     assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead

--- a/tests/timing/test_sleeping.py
+++ b/tests/timing/test_sleeping.py
@@ -1,28 +1,32 @@
 import asyncio
 
+import async_timeout
 import pytest
 
 from kopf.reactor.effects import sleep_or_wait
 
 
 async def test_the_only_delay_is_awaited(timer):
-    with timer:
-        unslept = await asyncio.wait_for(sleep_or_wait(0.10), timeout=1.0)
+    async with timer, async_timeout.timeout(1.0) as timeout:
+        unslept = await sleep_or_wait(0.10)
     assert 0.10 <= timer.seconds < 0.11
+    assert not timeout.expired
     assert unslept is None
 
 
 async def test_the_shortest_delay_is_awaited(timer):
-    with timer:
-        unslept = await asyncio.wait_for(sleep_or_wait([0.10, 0.20]), timeout=1.0)
+    async with timer, async_timeout.timeout(1.0) as timeout:
+        unslept = await sleep_or_wait([0.10, 0.20])
     assert 0.10 <= timer.seconds < 0.11
+    assert not timeout.expired
     assert unslept is None
 
 
 async def test_specific_delays_only_are_awaited(timer):
-    with timer:
-        unslept = await asyncio.wait_for(sleep_or_wait([0.10, None]), timeout=1.0)
+    async with timer, async_timeout.timeout(1.0) as timeout:
+        unslept = await sleep_or_wait([0.10, None])
     assert 0.10 <= timer.seconds < 0.11
+    assert not timeout.expired
     assert unslept is None
 
 
@@ -32,9 +36,10 @@ async def test_specific_delays_only_are_awaited(timer):
     pytest.param(-10, id='alone'),
 ])
 async def test_negative_delays_skip_sleeping(timer, delays):
-    with timer:
-        unslept = await asyncio.wait_for(sleep_or_wait(delays), timeout=1.0)
+    async with timer, async_timeout.timeout(1.0) as timeout:
+        unslept = await sleep_or_wait(delays)
     assert timer.seconds < 0.01
+    assert not timeout.expired
     assert unslept is None
 
 
@@ -43,35 +48,39 @@ async def test_negative_delays_skip_sleeping(timer, delays):
     pytest.param([None], id='list-of-none'),
 ])
 async def test_no_delays_skip_sleeping(timer, delays):
-    with timer:
-        unslept = await asyncio.wait_for(sleep_or_wait(delays), timeout=1.0)
+    async with timer, async_timeout.timeout(1.0) as timeout:
+        unslept = await sleep_or_wait(delays)
     assert timer.seconds < 0.01
+    assert not timeout.expired
     assert unslept is None
 
 
 async def test_by_event_set_before_time_comes(timer):
     event = asyncio.Event()
     asyncio.get_running_loop().call_later(0.07, event.set)
-    with timer:
-        unslept = await asyncio.wait_for(sleep_or_wait(0.10, event), timeout=1.0)
+    async with timer, async_timeout.timeout(1.0) as timeout:
+        unslept = await sleep_or_wait(0.10, event)
     assert unslept is not None
     assert 0.02 <= unslept <= 0.04
     assert 0.06 <= timer.seconds <= 0.08
+    assert not timeout.expired
 
 
 async def test_with_zero_time_and_event_initially_cleared(timer):
     event = asyncio.Event()
     event.clear()
-    with timer:
-        unslept = await asyncio.wait_for(sleep_or_wait(0, event), timeout=1.0)
+    async with timer, async_timeout.timeout(1.0) as timeout:
+        unslept = await sleep_or_wait(0, event)
     assert timer.seconds <= 0.01
+    assert not timeout.expired
     assert unslept is None
 
 
 async def test_with_zero_time_and_event_initially_set(timer):
     event = asyncio.Event()
     event.set()
-    with timer:
-        unslept = await asyncio.wait_for(sleep_or_wait(0, event), timeout=1.0)
+    async with timer, async_timeout.timeout(1.0) as timeout:
+        unslept = await sleep_or_wait(0, event)
     assert timer.seconds <= 0.01
+    assert not timeout.expired
     assert not unslept  # 0/None; undefined for such case: both goals reached.

--- a/tests/utilities/aiotasks/test_task_stopping.py
+++ b/tests/utilities/aiotasks/test_task_stopping.py
@@ -41,7 +41,7 @@ async def test_stop_immediately_with_finishing(assert_logs, caplog):
     caplog.set_level(0)
     task1 = create_task(simple())
     task2 = create_task(simple())
-    with async_timeout.timeout(1):
+    async with async_timeout.timeout(1):  # extra test safety
         done, pending = await stop([task1, task2], title='sample', logger=logger, cancelled=False)
     assert done
     assert not pending
@@ -55,7 +55,7 @@ async def test_stop_immediately_with_cancelling(assert_logs, caplog):
     caplog.set_level(0)
     task1 = create_task(simple())
     task2 = create_task(simple())
-    with async_timeout.timeout(1):
+    async with async_timeout.timeout(1):  # extra test safety
         done, pending = await stop([task1, task2], title='sample', logger=logger, cancelled=True)
     assert done
     assert not pending
@@ -72,7 +72,7 @@ async def test_stop_iteratively(assert_logs, caplog, cancelled):
     task2 = create_task(stuck())
     stask = create_task(stop([task1, task2], title='sample', logger=logger, interval=0.01, cancelled=cancelled))
 
-    with async_timeout.timeout(1):
+    async with async_timeout.timeout(1):  # extra test safety
         done, pending = await asyncio.wait({stask}, timeout=0.011)
     assert not done
     assert task1.done()
@@ -80,7 +80,7 @@ async def test_stop_iteratively(assert_logs, caplog, cancelled):
 
     task2.cancel()
 
-    with async_timeout.timeout(1):
+    async with async_timeout.timeout(1):  # extra test safety
         done, pending = await asyncio.wait({stask}, timeout=0.011)
     assert done
     assert task1.done()
@@ -100,7 +100,7 @@ async def test_stop_itself_is_cancelled(assert_logs, caplog, cancelled):
     task2 = create_task(stuck())
     stask = create_task(stop([task1, task2], title='sample', logger=logger, interval=0.01, cancelled=cancelled))
 
-    with async_timeout.timeout(1):
+    async with async_timeout.timeout(1):  # extra test safety
         done, pending = await asyncio.wait({stask}, timeout=0.011)
     assert not done
     assert task1.done()
@@ -108,7 +108,7 @@ async def test_stop_itself_is_cancelled(assert_logs, caplog, cancelled):
 
     stask.cancel()
 
-    with async_timeout.timeout(1):
+    async with async_timeout.timeout(1):  # extra test safety
         done, pending = await asyncio.wait({stask}, timeout=0.011)
     assert done
     assert task1.done()
@@ -122,7 +122,7 @@ async def test_stop_itself_is_cancelled(assert_logs, caplog, cancelled):
     ])
 
     task2.cancel()
-    with async_timeout.timeout(1):
+    async with async_timeout.timeout(1):  # extra test safety
         done, pending = await asyncio.wait({task1, task2})
     assert done
     assert task1.done()


### PR DESCRIPTION
We already do the time-limiting with `asyncio.wait_for()`, but it looks much better with `async-timeout`. It also separates the test restrictions from the async coroutines being tested.

The requirement is already there, both directly and as a sub-dependency, so why not utilise it to the full strength?