### PR TITLE
Split the freeze toggles and checkers

### DIFF
--- a/kopf/clients/watching.py
+++ b/kopf/clients/watching.py
@@ -106,14 +106,14 @@ async def streaming_block(
     # Block until unfrozen before even starting the API communication.
     if freeze_mode is not None and freeze_mode.is_on():
         logger.debug("Freezing the watch-stream for %r", resource)
-        await freeze_mode.wait_for_off()
+        await freeze_mode.wait_for(False)
         logger.debug("Resuming the watch-stream for %r", resource)
 
     # Create the signalling future that the freeze is on again.
     freeze_waiter: aiotasks.Future
     if freeze_mode is not None:
         freeze_waiter = aiotasks.create_task(
-            freeze_mode.wait_for_on(),
+            freeze_mode.wait_for(True),
             name=f'freeze-waiter for {resource.name} @ {namespace or "cluster-wide"}')
     else:
         freeze_waiter = asyncio.Future()  # a dummy just to have it

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -92,12 +92,12 @@ class Peer:
 async def process_peering_event(
         *,
         raw_event: bodies.RawEvent,
-        freeze_mode: primitives.Toggle,
         namespace: Optional[str],
         identity: Identity,
         settings: configuration.OperatorSettings,
         autoclean: bool = True,
         replenished: asyncio.Event,
+        freeze_toggle: primitives.Toggle,
 ) -> None:
     """
     Handle a single update of the peers by us or by other operators.
@@ -128,18 +128,18 @@ async def process_peering_event(
         await clean(peers=dead_peers, settings=settings, namespace=namespace)
 
     if prio_peers:
-        if freeze_mode.is_off():
+        if freeze_toggle.is_off():
             logger.info(f"Freezing operations in favour of {prio_peers}.")
-            await freeze_mode.turn_to(True)
+            await freeze_toggle.turn_to(True)
     elif same_peers:
         logger.warning(f"Possibly conflicting operators with the same priority: {same_peers}.")
-        if freeze_mode.is_off():
+        if freeze_toggle.is_off():
             logger.warning(f"Freezing all operators, including self: {peers}")
-            await freeze_mode.turn_to(True)
+            await freeze_toggle.turn_to(True)
     else:
-        if freeze_mode.is_on():
+        if freeze_toggle.is_on():
             logger.info(f"Resuming operations after the freeze. Conflicting operators with the same priority are gone.")
-            await freeze_mode.turn_to(False)
+            await freeze_toggle.turn_to(False)
 
     # Either wait for external updates (and exit when they arrive), or until the blocking peers
     # are expected to expire, and force the immediate re-evaluation by a certain change of self.

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -130,16 +130,16 @@ async def process_peering_event(
     if prio_peers:
         if freeze_mode.is_off():
             logger.info(f"Freezing operations in favour of {prio_peers}.")
-            await freeze_mode.turn_on()
+            await freeze_mode.turn_to(True)
     elif same_peers:
         logger.warning(f"Possibly conflicting operators with the same priority: {same_peers}.")
         if freeze_mode.is_off():
             logger.warning(f"Freezing all operators, including self: {peers}")
-            await freeze_mode.turn_on()
+            await freeze_mode.turn_to(True)
     else:
         if freeze_mode.is_on():
             logger.info(f"Resuming operations after the freeze. Conflicting operators with the same priority are gone.")
-            await freeze_mode.turn_off()
+            await freeze_mode.turn_to(False)
 
     # Either wait for external updates (and exit when they arrive), or until the blocking peers
     # are expected to expire, and force the immediate re-evaluation by a certain change of self.

--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -128,7 +128,7 @@ async def watcher(
         settings: configuration.OperatorSettings,
         resource: resources.Resource,
         processor: WatchStreamProcessor,
-        freeze_mode: Optional[primitives.Toggle] = None,
+        freeze_checker: Optional[primitives.ToggleSet] = None,
 ) -> None:
     """
     The watchers watches for the resource events via the API, and spawns the workers for every object.
@@ -170,7 +170,7 @@ async def watcher(
         stream = watching.infinite_watch(
             settings=settings,
             resource=resource, namespace=namespace,
-            freeze_mode=freeze_mode,
+            freeze_checker=freeze_checker,
         )
         async for raw_event in stream:
             key: ObjectRef = (resource, get_uid(raw_event))

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -171,7 +171,8 @@ async def spawn_tasks(
     vault = vault if vault is not None else global_vault
     vault = vault if vault is not None else credentials.Vault()
     event_queue: posting.K8sEventQueue = asyncio.Queue()
-    freeze_mode: primitives.Toggle = primitives.Toggle()
+    freeze_checker = primitives.ToggleSet()
+    freeze_toggle = await freeze_checker.make_toggle()
     signal_flag: aiotasks.Future = asyncio.Future()
     started_flag: asyncio.Event = asyncio.Event()
     tasks: MutableSequence[aiotasks.Task] = []
@@ -263,7 +264,7 @@ async def spawn_tasks(
                                             namespace=namespace,
                                             settings=settings,
                                             identity=identity,
-                                            freeze_mode=freeze_mode))))
+                                            freeze_toggle=freeze_toggle))))
 
     # Resource event handling, only once for every known resource (de-duplicated).
     for resource in registry.resources:
@@ -273,7 +274,7 @@ async def spawn_tasks(
                 namespace=namespace,
                 settings=settings,
                 resource=resource,
-                freeze_mode=freeze_mode,
+                freeze_checker=freeze_checker,
                 processor=functools.partial(processing.process_resource_event,
                                             lifecycle=lifecycle,
                                             registry=registry,

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -171,8 +171,9 @@ async def spawn_tasks(
     vault = vault if vault is not None else global_vault
     vault = vault if vault is not None else credentials.Vault()
     event_queue: posting.K8sEventQueue = asyncio.Queue()
+    freeze_name = f"{peering_name!r}@{namespace}" if namespace else f"cluster-wide {peering_name!r}"
     freeze_checker = primitives.ToggleSet()
-    freeze_toggle = await freeze_checker.make_toggle()
+    freeze_toggle = await freeze_checker.make_toggle(name=freeze_name)
     signal_flag: aiotasks.Future = asyncio.Future()
     started_flag: asyncio.Event = asyncio.Event()
     tasks: MutableSequence[aiotasks.Task] = []

--- a/tests/authentication/test_vault.py
+++ b/tests/authentication/test_vault.py
@@ -18,23 +18,20 @@ async def test_evals_as_true_when_filled():
 
 async def test_yielding_after_creation(mocker):
     vault = Vault()
-    mocker.patch.object(vault._ready, 'wait_for_on')
-    mocker.patch.object(vault._ready, 'wait_for_off')
+    mocker.patch.object(vault._ready, 'wait_for')
 
     with pytest.raises(LoginError):
         async for _, _ in vault:
             pass
 
-    assert vault._ready.wait_for_on.called
-    assert vault._ready.wait_for_on.awaited
+    assert vault._ready.wait_for.await_args_list == [((True,),)]
 
 
 async def test_yielding_after_population(mocker):
     key1 = VaultKey('some-key')
     info1 = ConnectionInfo(server='https://expected/')
     vault = Vault()
-    mocker.patch.object(vault._ready, 'wait_for_on')
-    mocker.patch.object(vault._ready, 'wait_for_off')
+    mocker.patch.object(vault._ready, 'wait_for')
 
     await vault.populate({key1: info1})
 
@@ -52,30 +49,26 @@ async def test_invalidation_reraises_if_nothing_is_left_with_exception(mocker):
     key1 = VaultKey('some-key')
     info1 = ConnectionInfo(server='https://expected/')
     vault = Vault()
-    mocker.patch.object(vault._ready, 'wait_for_on')
-    mocker.patch.object(vault._ready, 'wait_for_off')
+    mocker.patch.object(vault._ready, 'wait_for')
 
     await vault.populate({key1: info1})
     with pytest.raises(Exception) as e:
         await vault.invalidate(key1, exc=exc)
 
     assert e.value is exc
-    assert vault._ready.wait_for_on.called
-    assert vault._ready.wait_for_on.awaited
+    assert vault._ready.wait_for.await_args_list == [((True,),)]
 
 
 async def test_invalidation_continues_if_nothing_is_left_without_exception(mocker):
     key1 = VaultKey('some-key')
     info1 = ConnectionInfo(server='https://expected/')
     vault = Vault()
-    mocker.patch.object(vault._ready, 'wait_for_on')
-    mocker.patch.object(vault._ready, 'wait_for_off')
+    mocker.patch.object(vault._ready, 'wait_for')
 
     await vault.populate({key1: info1})
     await vault.invalidate(key1)
 
-    assert vault._ready.wait_for_on.called
-    assert vault._ready.wait_for_on.awaited
+    assert vault._ready.wait_for.await_args_list == [((True,),)]
 
 
 async def test_invalidation_continues_if_something_is_left():
@@ -103,8 +96,7 @@ async def test_yielding_after_invalidation(mocker):
     key1 = VaultKey('some-key')
     info1 = ConnectionInfo(server='https://expected/')
     vault = Vault()
-    mocker.patch.object(vault._ready, 'wait_for_on')
-    mocker.patch.object(vault._ready, 'wait_for_off')
+    mocker.patch.object(vault._ready, 'wait_for')
 
     await vault.populate({key1: info1})
     await vault.invalidate(key1)
@@ -119,8 +111,7 @@ async def test_duplicates_are_remembered(mocker):
     info1 = ConnectionInfo(server='https://expected/')
     info2 = ConnectionInfo(server='https://expected/')  # another instance, same fields
     vault = Vault()
-    mocker.patch.object(vault._ready, 'wait_for_on')
-    mocker.patch.object(vault._ready, 'wait_for_off')
+    mocker.patch.object(vault._ready, 'wait_for')
 
     await vault.populate({key1: info1})
     await vault.invalidate(key1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,8 +360,7 @@ def fake_vault(mocker, hostname):
     info = ConnectionInfo(server=f'https://{hostname}')
     vault = Vault({key: info})
     token = auth.vault_var.set(vault)
-    mocker.patch.object(vault._ready, 'wait_for_on')
-    mocker.patch.object(vault._ready, 'wait_for_off')
+    mocker.patch.object(vault._ready, 'wait_for')
     try:
         yield vault
     finally:

--- a/tests/k8s/test_watching_with_freezes.py
+++ b/tests/k8s/test_watching_with_freezes.py
@@ -5,20 +5,21 @@ import async_timeout
 import pytest
 
 from kopf.clients.watching import streaming_block
-from kopf.structs.primitives import Toggle
+from kopf.structs.primitives import Toggle, ToggleSet
 
 
 async def test_freezing_is_ignored_if_turned_off(
         resource, namespace, timer, caplog, assert_logs):
     caplog.set_level(logging.DEBUG)
 
-    freeze_mode = Toggle(False)
+    freeze_checker = ToggleSet()
+    await freeze_checker.make_toggle(False)
 
     async with timer, async_timeout.timeout(0.5) as timeout:
         async with streaming_block(
             resource=resource,
             namespace=namespace,
-            freeze_mode=freeze_mode,
+            freeze_checker=freeze_checker,
         ):
             pass
 
@@ -34,14 +35,15 @@ async def test_freezing_waits_forever_if_not_resumed(
         resource, namespace, timer, caplog, assert_logs):
     caplog.set_level(logging.DEBUG)
 
-    freeze_mode = Toggle(True)
+    freeze_checker = ToggleSet()
+    await freeze_checker.make_toggle(True)
 
     with pytest.raises(asyncio.TimeoutError):
         async with timer, async_timeout.timeout(0.5) as timeout:
             async with streaming_block(
                 resource=resource,
                 namespace=namespace,
-                freeze_mode=freeze_mode,
+                freeze_checker=freeze_checker,
             ):
                 pass
 
@@ -58,18 +60,19 @@ async def test_freezing_waits_until_resumed(
         resource, namespace, timer, caplog, assert_logs):
     caplog.set_level(logging.DEBUG)
 
-    freeze_mode = Toggle(True)
+    freeze_checker = ToggleSet()
+    freeze_toggle = await freeze_checker.make_toggle(True)
 
     async def delayed_resuming(delay: float):
         await asyncio.sleep(delay)
-        await freeze_mode.turn_to(False)
+        await freeze_toggle.turn_to(False)
 
     async with timer, async_timeout.timeout(1.0) as timeout:
         asyncio.create_task(delayed_resuming(0.2))
         async with streaming_block(
             resource=resource,
             namespace=namespace,
-            freeze_mode=freeze_mode,
+            freeze_checker=freeze_checker,
         ):
             pass
 

--- a/tests/k8s/test_watching_with_freezes.py
+++ b/tests/k8s/test_watching_with_freezes.py
@@ -62,7 +62,7 @@ async def test_freezing_waits_until_resumed(
 
     async def delayed_resuming(delay: float):
         await asyncio.sleep(delay)
-        await freeze_mode.turn_off()
+        await freeze_mode.turn_to(False)
 
     async with timer, async_timeout.timeout(1.0) as timeout:
         asyncio.create_task(delayed_resuming(0.2))

--- a/tests/peering/test_freeze_mode.py
+++ b/tests/peering/test_freeze_mode.py
@@ -61,7 +61,7 @@ async def test_other_peering_objects_are_ignored(
     settings.peering.name = our_name
     await process_peering_event(
         raw_event=event,
-        freeze_mode=primitives.Toggle(),
+        freeze_toggle=primitives.Toggle(),
         replenished=replenished,
         autoclean=False,
         identity='id',
@@ -92,21 +92,21 @@ async def test_toggled_on_for_higher_priority_peer_when_initially_off(
     settings.peering.name = 'name'
     settings.peering.priority = 100
 
-    freeze_mode = primitives.Toggle(False)
+    freeze_toggle = primitives.Toggle(False)
     wait_for = mocker.patch('asyncio.wait_for')
 
     caplog.set_level(0)
-    assert freeze_mode.is_off()
+    assert freeze_toggle.is_off()
     await process_peering_event(
         raw_event=event,
-        freeze_mode=freeze_mode,
+        freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
         identity='id',
         settings=settings,
     )
-    assert freeze_mode.is_on()
+    assert freeze_toggle.is_on()
     assert wait_for.call_count == 1
     assert 9 < wait_for.call_args[1]['timeout'] < 10
     assert not k8s_mocked.patch_obj.called
@@ -136,21 +136,21 @@ async def test_ignored_for_higher_priority_peer_when_already_on(
     settings.peering.name = 'name'
     settings.peering.priority = 100
 
-    freeze_mode = primitives.Toggle(True)
+    freeze_toggle = primitives.Toggle(True)
     wait_for = mocker.patch('asyncio.wait_for')
 
     caplog.set_level(0)
-    assert freeze_mode.is_on()
+    assert freeze_toggle.is_on()
     await process_peering_event(
         raw_event=event,
-        freeze_mode=freeze_mode,
+        freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
         identity='id',
         settings=settings,
     )
-    assert freeze_mode.is_on()
+    assert freeze_toggle.is_on()
     assert wait_for.call_count == 1
     assert 9 < wait_for.call_args[1]['timeout'] < 10
     assert not k8s_mocked.patch_obj.called
@@ -181,21 +181,21 @@ async def test_toggled_off_for_lower_priority_peer_when_initially_on(
     settings.peering.name = 'name'
     settings.peering.priority = 100
 
-    freeze_mode = primitives.Toggle(True)
+    freeze_toggle = primitives.Toggle(True)
     wait_for = mocker.patch('asyncio.wait_for')
 
     caplog.set_level(0)
-    assert freeze_mode.is_on()
+    assert freeze_toggle.is_on()
     await process_peering_event(
         raw_event=event,
-        freeze_mode=freeze_mode,
+        freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
         identity='id',
         settings=settings,
     )
-    assert freeze_mode.is_off()
+    assert freeze_toggle.is_off()
     assert wait_for.call_count == 0
     assert not k8s_mocked.patch_obj.called
     assert_logs(["Resuming operations after the freeze"], prohibited=[
@@ -224,21 +224,21 @@ async def test_ignored_for_lower_priority_peer_when_already_off(
     settings.peering.name = 'name'
     settings.peering.priority = 100
 
-    freeze_mode = primitives.Toggle(False)
+    freeze_toggle = primitives.Toggle(False)
     wait_for = mocker.patch('asyncio.wait_for')
 
     caplog.set_level(0)
-    assert freeze_mode.is_off()
+    assert freeze_toggle.is_off()
     await process_peering_event(
         raw_event=event,
-        freeze_mode=freeze_mode,
+        freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
         identity='id',
         settings=settings,
     )
-    assert freeze_mode.is_off()
+    assert freeze_toggle.is_off()
     assert wait_for.call_count == 0
     assert not k8s_mocked.patch_obj.called
     assert_logs([], prohibited=[
@@ -268,21 +268,21 @@ async def test_toggled_on_for_same_priority_peer_when_initially_off(
     settings.peering.name = 'name'
     settings.peering.priority = 100
 
-    freeze_mode = primitives.Toggle(False)
+    freeze_toggle = primitives.Toggle(False)
     wait_for = mocker.patch('asyncio.wait_for')
 
     caplog.set_level(0)
-    assert freeze_mode.is_off()
+    assert freeze_toggle.is_off()
     await process_peering_event(
         raw_event=event,
-        freeze_mode=freeze_mode,
+        freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
         identity='id',
         settings=settings,
     )
-    assert freeze_mode.is_on()
+    assert freeze_toggle.is_on()
     assert wait_for.call_count == 1
     assert 9 < wait_for.call_args[1]['timeout'] < 10
     assert not k8s_mocked.patch_obj.called
@@ -314,21 +314,21 @@ async def test_ignored_for_same_priority_peer_when_already_on(
     settings.peering.name = 'name'
     settings.peering.priority = 100
 
-    freeze_mode = primitives.Toggle(True)
+    freeze_toggle = primitives.Toggle(True)
     wait_for = mocker.patch('asyncio.wait_for')
 
     caplog.set_level(0)
-    assert freeze_mode.is_on()
+    assert freeze_toggle.is_on()
     await process_peering_event(
         raw_event=event,
-        freeze_mode=freeze_mode,
+        freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
         identity='id',
         settings=settings,
     )
-    assert freeze_mode.is_on()
+    assert freeze_toggle.is_on()
     assert wait_for.call_count == 1
     assert 9 < wait_for.call_args[1]['timeout'] < 10
     assert not k8s_mocked.patch_obj.called
@@ -361,21 +361,21 @@ async def test_resumes_immediately_on_expiration_of_blocking_peers(
     settings.peering.name = 'name'
     settings.peering.priority = 100
 
-    freeze_mode = primitives.Toggle(True)
+    freeze_toggle = primitives.Toggle(True)
     wait_for = mocker.patch('asyncio.wait_for', side_effect=asyncio.TimeoutError)
 
     caplog.set_level(0)
-    assert freeze_mode.is_on()
+    assert freeze_toggle.is_on()
     await process_peering_event(
         raw_event=event,
-        freeze_mode=freeze_mode,
+        freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
         identity='id',
         settings=settings,
     )
-    assert freeze_mode.is_on()
+    assert freeze_toggle.is_on()
     assert wait_for.call_count == 1
     assert 9 < wait_for.call_args[1]['timeout'] < 10
     assert k8s_mocked.patch_obj.called

--- a/tests/primitives/test_toggles.py
+++ b/tests/primitives/test_toggles.py
@@ -8,65 +8,53 @@ from kopf.structs.primitives import Toggle
 
 async def test_created_as_off():
     toggle = Toggle()
-
-    assert not toggle
     assert not toggle.is_on()
     assert toggle.is_off()
 
 
 async def test_initialised_as_off():
     toggle = Toggle(False)
-
-    assert not toggle
     assert not toggle.is_on()
     assert toggle.is_off()
 
 
 async def test_initialised_as_on():
     toggle = Toggle(True)
-
-    assert toggle
     assert toggle.is_on()
     assert not toggle.is_off()
 
 
 async def test_turning_on():
     toggle = Toggle(False)
-    await toggle.turn_on()
-
-    assert toggle
+    await toggle.turn_to(True)
     assert toggle.is_on()
     assert not toggle.is_off()
 
 
 async def test_turning_off():
     toggle = Toggle(True)
-    await toggle.turn_off()
-
-    assert not toggle
+    await toggle.turn_to(False)
     assert not toggle.is_on()
     assert toggle.is_off()
 
 
 async def test_waiting_until_on_fails_when_not_turned_on():
     toggle = Toggle(False)
-
     with pytest.raises(asyncio.TimeoutError):
         async with async_timeout.timeout(0.1) as timeout:
-            await toggle.wait_for_on()
+            await toggle.wait_for(True)
 
-    assert not toggle
+    assert toggle.is_off()
     assert timeout.expired
 
 
 async def test_waiting_until_off_fails_when_not_turned_off():
     toggle = Toggle(True)
-
     with pytest.raises(asyncio.TimeoutError):
         async with async_timeout.timeout(0.1) as timeout:
-            await toggle.wait_for_off()
+            await toggle.wait_for(False)
 
-    assert toggle
+    assert toggle.is_on()
     assert timeout.expired
 
 
@@ -75,13 +63,13 @@ async def test_waiting_until_on_wakes_when_turned_on(timer):
 
     async def delayed_turning_on(delay: float):
         await asyncio.sleep(delay)
-        await toggle.turn_on()
+        await toggle.turn_to(True)
 
     async with timer, async_timeout.timeout(1.0) as timeout:
         asyncio.create_task(delayed_turning_on(0.05))
-        await toggle.wait_for_on()
+        await toggle.wait_for(True)
 
-    assert toggle
+    assert toggle.is_on()
     assert not timeout.expired
     assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead
 
@@ -91,12 +79,18 @@ async def test_waiting_until_off_wakes_when_turned_off(timer):
 
     async def delayed_turning_off(delay: float):
         await asyncio.sleep(delay)
-        await toggle.turn_off()
+        await toggle.turn_to(False)
 
     async with timer, async_timeout.timeout(1.0) as timeout:
         asyncio.create_task(delayed_turning_off(0.05))
-        await toggle.wait_for_off()
+        await toggle.wait_for(False)
 
-    assert not toggle
+    assert toggle.is_off()
     assert not timeout.expired
     assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead
+
+
+async def test_secures_against_usage_as_a_boolean():
+    toggle = Toggle()
+    with pytest.raises(NotImplementedError):
+        bool(toggle)

--- a/tests/primitives/test_toggles.py
+++ b/tests/primitives/test_toggles.py
@@ -94,3 +94,27 @@ async def test_secures_against_usage_as_a_boolean():
     toggle = Toggle()
     with pytest.raises(NotImplementedError):
         bool(toggle)
+
+
+async def test_repr_when_unnamed_and_off():
+    toggle = Toggle(False)
+    assert toggle.name is None
+    assert repr(toggle) == "<Toggle: off>"
+
+
+async def test_repr_when_unnamed_and_on():
+    toggle = Toggle(True)
+    assert toggle.name is None
+    assert repr(toggle) == "<Toggle: on>"
+
+
+async def test_repr_when_named_and_off():
+    toggle = Toggle(False, name='xyz')
+    assert toggle.name == 'xyz'
+    assert repr(toggle) == "<Toggle: xyz: off>"
+
+
+async def test_repr_when_named_and_on():
+    toggle = Toggle(True, name='xyz')
+    assert toggle.name == 'xyz'
+    assert repr(toggle) == "<Toggle: xyz: on>"

--- a/tests/primitives/test_togglesets.py
+++ b/tests/primitives/test_togglesets.py
@@ -187,3 +187,32 @@ async def test_secures_against_usage_as_a_boolean():
     toggle = ToggleSet()
     with pytest.raises(NotImplementedError):
         bool(toggle)
+
+
+async def test_repr_when_empty():
+    toggleset = ToggleSet()
+    assert repr(toggleset) == "set()"
+
+
+async def test_repr_when_unnamed_and_off():
+    toggleset = ToggleSet()
+    await toggleset.make_toggle(False)
+    assert repr(toggleset) == "{<Toggle: off>}"
+
+
+async def test_repr_when_unnamed_and_on():
+    toggleset = ToggleSet()
+    await toggleset.make_toggle(True)
+    assert repr(toggleset) == "{<Toggle: on>}"
+
+
+async def test_repr_when_named_and_off():
+    toggleset = ToggleSet()
+    await toggleset.make_toggle(False, name='xyz')
+    assert repr(toggleset) == "{<Toggle: xyz: off>}"
+
+
+async def test_repr_when_named_and_on():
+    toggleset = ToggleSet()
+    await toggleset.make_toggle(True, name='xyz')
+    assert repr(toggleset) == "{<Toggle: xyz: on>}"

--- a/tests/primitives/test_togglesets.py
+++ b/tests/primitives/test_togglesets.py
@@ -1,0 +1,189 @@
+import asyncio
+
+import pytest
+
+from kopf.structs.primitives import Toggle, ToggleSet
+
+
+async def test_created_as_off():
+    toggleset = ToggleSet()
+    assert len(toggleset) == 0
+    assert set(toggleset) == set()
+    assert Toggle() not in toggleset
+    assert not toggleset.is_on()
+    assert toggleset.is_off()
+
+
+async def test_making_a_default_toggle():
+    toggleset = ToggleSet()
+    toggle = await toggleset.make_toggle()
+    assert len(toggleset) == 1
+    assert set(toggleset) == {toggle}
+    assert toggle in toggleset
+    assert Toggle() not in toggleset
+    assert not toggleset.is_on()
+    assert toggleset.is_off()
+
+
+async def test_making_a_turned_off_toggle():
+    toggleset = ToggleSet()
+    toggle = await toggleset.make_toggle(False)
+    assert len(toggleset) == 1
+    assert set(toggleset) == {toggle}
+    assert toggle in toggleset
+    assert Toggle() not in toggleset
+    assert not toggleset.is_on()
+    assert toggleset.is_off()
+
+
+async def test_making_a_turned_on_toggle():
+    toggleset = ToggleSet()
+    toggle = await toggleset.make_toggle(True)
+    assert len(toggleset) == 1
+    assert set(toggleset) == {toggle}
+    assert toggle in toggleset
+    assert Toggle() not in toggleset
+    assert toggleset.is_on()
+    assert not toggleset.is_off()
+
+
+async def test_dropping_a_turned_off_toggle():
+    toggleset = ToggleSet()
+    toggle = await toggleset.make_toggle(False)
+    await toggle.turn_to(True)
+    await toggleset.drop_toggle(toggle)
+    assert len(toggleset) == 0
+    assert set(toggleset) == set()
+    assert toggle not in toggleset
+    assert not toggleset.is_on()
+    assert toggleset.is_off()
+
+
+async def test_dropping_a_turned_on_toggle():
+    toggleset = ToggleSet()
+    toggle = await toggleset.make_toggle(True)
+    await toggleset.drop_toggle(toggle)
+    assert len(toggleset) == 0
+    assert set(toggleset) == set()
+    assert toggle not in toggleset
+    assert not toggleset.is_on()
+    assert toggleset.is_off()
+
+
+async def test_dropping_an_unexistent_toggle():
+    toggleset = ToggleSet()
+    toggle = Toggle()
+    await toggleset.drop_toggle(toggle)
+    assert len(toggleset) == 0
+    assert set(toggleset) == set()
+    assert toggle not in toggleset
+    assert not toggleset.is_on()
+    assert toggleset.is_off()
+
+
+async def test_turning_a_toggle_on_turns_the_toggleset_on():
+    toggleset = ToggleSet()
+    toggle = await toggleset.make_toggle(False)
+    assert not toggleset.is_on()
+    assert toggleset.is_off()
+
+    await toggle.turn_to(True)
+    assert toggleset.is_on()
+    assert not toggleset.is_off()
+
+
+async def test_turning_a_toggle_off_turns_the_toggleset_off():
+    toggleset = ToggleSet()
+    toggle = await toggleset.make_toggle(True)
+    assert toggleset.is_on()
+    assert not toggleset.is_off()
+
+    await toggle.turn_to(False)
+    assert not toggleset.is_on()
+    assert toggleset.is_off()
+
+
+async def test_any_toggle_must_be_on_for_toggleset_to_be_on():
+    toggleset = ToggleSet()
+    toggle1 = await toggleset.make_toggle(False)
+    toggle2 = await toggleset.make_toggle(False)
+    assert not toggleset.is_on()
+    assert toggleset.is_off()
+
+    await toggle1.turn_to(True)
+    assert toggleset.is_on()
+    assert not toggleset.is_off()
+
+    await toggle2.turn_to(True)
+    assert toggleset.is_on()
+    assert not toggleset.is_off()
+
+
+async def test_all_toggles_must_be_off_for_toggleset_to_be_off():
+    toggleset = ToggleSet()
+    toggle1 = await toggleset.make_toggle(True)
+    toggle2 = await toggleset.make_toggle(True)
+    assert toggleset.is_on()
+    assert not toggleset.is_off()
+
+    await toggle1.turn_to(False)
+    assert toggleset.is_on()
+    assert not toggleset.is_off()
+
+    await toggle2.turn_to(False)
+    assert not toggleset.is_on()
+    assert toggleset.is_off()
+
+
+async def test_waiting_until_on_fails_when_not_turned_on():
+    toggleset = ToggleSet()
+    await toggleset.make_toggle(False)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(toggleset.wait_for(True), timeout=0.1)
+    assert toggleset.is_off()
+
+
+async def test_waiting_until_off_fails_when_not_turned_off():
+    toggleset = ToggleSet()
+    await toggleset.make_toggle(True)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(toggleset.wait_for(False), timeout=0.1)
+    assert toggleset.is_on()
+
+
+async def test_waiting_until_on_wakes_when_turned_on(timer):
+    toggleset = ToggleSet()
+    toggle = await toggleset.make_toggle(False)
+
+    async def delayed_turning_on(delay: float):
+        await asyncio.sleep(delay)
+        await toggle.turn_to(True)
+
+    with timer:
+        asyncio.create_task(delayed_turning_on(0.05))
+        await asyncio.wait_for(toggleset.wait_for(True), timeout=1.0)
+
+    assert toggleset.is_on()
+    assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead
+
+
+async def test_waiting_until_off_wakes_when_turned_off(timer):
+    toggleset = ToggleSet()
+    toggle = await toggleset.make_toggle(True)
+
+    async def delayed_turning_off(delay: float):
+        await asyncio.sleep(delay)
+        await toggle.turn_to(False)
+
+    with timer:
+        asyncio.create_task(delayed_turning_off(0.05))
+        await asyncio.wait_for(toggleset.wait_for(False), timeout=1.0)
+
+    assert toggleset.is_off()
+    assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead
+
+
+async def test_secures_against_usage_as_a_boolean():
+    toggle = ToggleSet()
+    with pytest.raises(NotImplementedError):
+        bool(toggle)


### PR DESCRIPTION
In preparation for the coming changes when there are multiple peering objects from multiple namespaces monitored for a single operator, it is crucial that the freeze-checkers and freeze-toggle are split and managed separately.

Previously, it was a single flag, which was either on or off.

Now, it is multiple flags, each is in its own state, and one checker, which is off when all toggles are off, or on when at least one toggle is on — i.e. if there is at least one peering/namespace with a conflicting operator.

However, in the current codebase, only one freeze flag is possible, as the operator can handle one and only one namespace (or be cluster-wide); multiple namespaces are not yet supported.

_The change is essentially an extracted preparation for a bigger PR to make it smaller and more readable._

Relies on #608 and #609. 

