### PR TITLE
Deprecate any usage of internal registries

### DIFF
--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -136,7 +136,7 @@ async def process_resource_causes(
         patch=patch,
         body=body,
         memo=memory.memo,
-    ) if registry.resource_watching_handlers[resource] else None
+    ) if registry.resource_watching_handlers[resource].has_handlers() else None
 
     resource_spawning_cause = causation.detect_resource_spawning_cause(
         resource=resource,
@@ -145,7 +145,7 @@ async def process_resource_causes(
         body=body,
         memo=memory.memo,
         reset=bool(diff),  # only essential changes reset idling, not every event
-    ) if registry.resource_spawning_handlers[resource] else None
+    ) if registry.resource_spawning_handlers[resource].has_handlers() else None
 
     resource_changing_cause = causation.detect_resource_changing_cause(
         finalizer=finalizer,
@@ -159,7 +159,7 @@ async def process_resource_causes(
         diff=diff,
         memo=memory.memo,
         initial=memory.noticed_by_listing and not memory.fully_handled_once,
-    ) if registry.resource_changing_handlers[resource] else None
+    ) if registry.resource_changing_handlers[resource].has_handlers() else None
 
     # If there are any handlers for this resource kind in general, but not for this specific object
     # due to filters, then be blind to it, store no state, and log nothing about the handling cycle.

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -45,6 +45,9 @@ class GenericRegistry(Generic[HandlerFnT, HandlerT]):
         self._handlers = []
 
     def __bool__(self) -> bool:
+        warnings.warn("bool(registry) is deprecated; "
+                      "please cease using the internal registries directly.",
+                      DeprecationWarning)
         return bool(self._handlers)
 
     def append(self, handler: HandlerT) -> None:
@@ -111,6 +114,11 @@ class ActivityRegistry(GenericRegistry[
 class ResourceRegistry(
         GenericRegistry[HandlerFnT, ResourceHandlerT],
         Generic[CauseT, HandlerFnT, ResourceHandlerT]):
+
+    def has_handlers(
+            self,
+    ) -> bool:
+        return bool(self._handlers)
 
     def get_handlers(
             self,
@@ -400,7 +408,7 @@ class OperatorRegistry:
             self,
     ) -> bool:
         warnings.warn("registry.has_activity_handlers() is deprecated; "
-                      "use registry.activity_handlers directly.",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
         return bool(self.activity_handlers)
 
@@ -409,18 +417,18 @@ class OperatorRegistry:
             resource: resources_.Resource,
     ) -> bool:
         warnings.warn("registry.has_resource_watching_handlers() is deprecated; "
-                      "use registry.resource_watching_handlers[resource] directly.",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
-        return bool(self.resource_watching_handlers[resource])
+        return self.resource_watching_handlers[resource].has_handlers()
 
     def has_resource_changing_handlers(
             self,
             resource: resources_.Resource,
     ) -> bool:
         warnings.warn("registry.has_resource_changing_handlers() is deprecated; "
-                      "use registry.resource_changing_handlers[resource] directly.",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
-        return bool(self.resource_changing_handlers[resource])
+        return self.resource_changing_handlers[resource].has_handlers()
 
     def get_activity_handlers(
             self,
@@ -428,7 +436,7 @@ class OperatorRegistry:
             activity: handlers.Activity,
     ) -> Sequence[handlers.ActivityHandler]:
         warnings.warn("registry.get_activity_handlers() is deprecated; "
-                      "use registry.activity_handlers.get_handlers().",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
         return self.activity_handlers.get_handlers(activity=activity)
 
@@ -437,7 +445,7 @@ class OperatorRegistry:
             cause: causation.ResourceWatchingCause,
     ) -> Sequence[handlers.ResourceWatchingHandler]:
         warnings.warn("registry.get_resource_watching_handlers() is deprecated; "
-                      "use registry.resource_watching_handlers[resource].get_handlers().",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
         return self.resource_watching_handlers[cause.resource].get_handlers(cause=cause)
 
@@ -446,7 +454,7 @@ class OperatorRegistry:
             cause: causation.ResourceChangingCause,
     ) -> Sequence[handlers.ResourceChangingHandler]:
         warnings.warn("registry.get_resource_changing_handlers() is deprecated; "
-                      "use registry.resource_changing_handlers[resource].get_handlers().",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
         return self.resource_changing_handlers[cause.resource].get_handlers(cause=cause)
 
@@ -456,7 +464,7 @@ class OperatorRegistry:
             activity: handlers.Activity,
     ) -> Iterator[handlers.ActivityHandler]:
         warnings.warn("registry.iter_activity_handlers() is deprecated; "
-                      "use registry.activity_handlers.iter_handlers().",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
         yield from self.activity_handlers.iter_handlers(activity=activity)
 
@@ -468,7 +476,7 @@ class OperatorRegistry:
         Iterate all handlers for the low-level events.
         """
         warnings.warn("registry.iter_resource_watching_handlers() is deprecated; "
-                      "use registry.resource_watching_handlers[resource].iter_handlers().",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
         yield from self.resource_watching_handlers[cause.resource].iter_handlers(cause=cause)
 
@@ -480,7 +488,7 @@ class OperatorRegistry:
         Iterate all handlers that match this cause/event, in the order they were registered (even if mixed).
         """
         warnings.warn("registry.iter_resource_changing_handlers() is deprecated; "
-                      "use registry.resource_changing_handlers[resource].iter_handlers().",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
         yield from self.resource_changing_handlers[cause.resource].iter_handlers(cause=cause)
 
@@ -489,7 +497,7 @@ class OperatorRegistry:
             resource: resources_.Resource,
     ) -> Set[dicts.FieldPath]:
         warnings.warn("registry.get_extra_fields() is deprecated; "
-                      "use registry.resource_changing_handlers[resource].get_extra_fields().",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
         return (
             self.resource_watching_handlers[resource].get_extra_fields() |
@@ -501,7 +509,7 @@ class OperatorRegistry:
             resource: resources_.Resource,
     ) -> Iterator[dicts.FieldPath]:
         warnings.warn("registry.iter_extra_fields() is deprecated; "
-                      "use registry.resource_changing_handlers[resource].iter_extra_fields().",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
         yield from self.resource_watching_handlers[resource].iter_extra_fields()
         yield from self.resource_changing_handlers[resource].iter_extra_fields()
@@ -516,7 +524,7 @@ class OperatorRegistry:
         Check whether a finalizer should be added to the given resource or not.
         """
         warnings.warn("registry.requires_finalizer() is deprecated; "
-                      "use registry.resource_changing_handlers[resource].requires_finalizer().",
+                      "please cease using the internal registries directly.",
                       DeprecationWarning)
         return self.resource_changing_handlers[resource].requires_finalizer(cause=cause)
 

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -129,8 +129,9 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
             resource: resources_.Resource,
             event: bodies.RawEvent,
     ) -> Sequence[handlers.ResourceWatchingHandler]:
-        warnings.warn("SimpleRegistry.get_event_handlers() is deprecated; use "
-                      "ResourceWatchingRegistry.get_handlers().", DeprecationWarning)
+        warnings.warn("SimpleRegistry.get_event_handlers() is deprecated; "
+                      "please cease using the internal registries directly.",
+                      DeprecationWarning)
         return list(registries._deduplicated(self.iter_event_handlers(
             resource=resource, event=event)))
 
@@ -138,8 +139,9 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
             self,
             cause: causation.ResourceChangingCause,
     ) -> Sequence[handlers.ResourceChangingHandler]:
-        warnings.warn("SimpleRegistry.get_cause_handlers() is deprecated; use "
-                      "ResourceChangingRegistry.get_handlers().", DeprecationWarning)
+        warnings.warn("SimpleRegistry.get_cause_handlers() is deprecated; "
+                      "please cease using the internal registries directly.",
+                      DeprecationWarning)
         return list(registries._deduplicated(self.iter_cause_handlers(cause=cause)))
 
     def iter_event_handlers(
@@ -147,8 +149,9 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
             resource: resources_.Resource,
             event: bodies.RawEvent,
     ) -> Iterator[handlers.ResourceWatchingHandler]:
-        warnings.warn("SimpleRegistry.iter_event_handlers() is deprecated; use "
-                      "ResourceWatchingRegistry.iter_handlers().", DeprecationWarning)
+        warnings.warn("SimpleRegistry.iter_event_handlers() is deprecated; "
+                      "please cease using the internal registries directly.",
+                      DeprecationWarning)
 
         cause = _create_watching_cause(resource, event)
         for handler in self._handlers:
@@ -161,8 +164,9 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
             self,
             cause: causation.ResourceChangingCause,
     ) -> Iterator[handlers.ResourceChangingHandler]:
-        warnings.warn("SimpleRegistry.iter_cause_handlers() is deprecated; use "
-                      "ResourceChangingRegistry.iter_handlers().", DeprecationWarning)
+        warnings.warn("SimpleRegistry.iter_cause_handlers() is deprecated; "
+                      "please cease using the internal registries directly.",
+                      DeprecationWarning)
 
         for handler in self._handlers:
             if not isinstance(handler, handlers.ResourceChangingHandler):
@@ -182,23 +186,27 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
     """
 
     def register_event_handler(self, *args: Any, **kwargs: Any) -> Any:
-        warnings.warn("GlobalRegistry.register_event_handler() is deprecated; use "
-                      "OperatorRegistry.register_resource_watching_handler().", DeprecationWarning)
+        warnings.warn("GlobalRegistry.register_event_handler() is deprecated; "
+                      "use @kopf.on... decorators with registry= kwarg.",
+                      DeprecationWarning)
         return self.register_resource_watching_handler(*args, **kwargs)
 
     def register_cause_handler(self, *args: Any, **kwargs: Any) -> Any:
-        warnings.warn("GlobalRegistry.register_cause_handler() is deprecated; use "
-                      "OperatorRegistry.register_resource_changing_handler().", DeprecationWarning)
+        warnings.warn("GlobalRegistry.register_cause_handler() is deprecated; "
+                      "use @kopf.on... decorators with registry= kwarg.",
+                      DeprecationWarning)
         return self.register_resource_changing_handler(*args, **kwargs)
 
     def has_event_handlers(self, *args: Any, **kwargs: Any) -> Any:
-        warnings.warn("GlobalRegistry.has_event_handlers() is deprecated; use "
-                      "OperatorRegistry.has_resource_watching_handlers().", DeprecationWarning)
+        warnings.warn("GlobalRegistry.has_event_handlers() is deprecated; "
+                      "please cease using the internal registries directly.",
+                      DeprecationWarning)
         return self.has_resource_watching_handlers(*args, **kwargs)
 
     def has_cause_handlers(self, *args: Any, **kwargs: Any) -> Any:
-        warnings.warn("GlobalRegistry.has_cause_handlers() is deprecated; use "
-                      "OperatorRegistry.has_resource_changing_handlers().", DeprecationWarning)
+        warnings.warn("GlobalRegistry.has_cause_handlers() is deprecated; "
+                      "please cease using the internal registries directly.",
+                      DeprecationWarning)
         return self.has_resource_changing_handlers(*args, **kwargs)
 
     def get_event_handlers(
@@ -206,8 +214,9 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
             resource: resources_.Resource,
             event: bodies.RawEvent,
     ) -> Sequence[handlers.ResourceWatchingHandler]:
-        warnings.warn("GlobalRegistry.get_event_handlers() is deprecated; use "
-                      "OperatorRegistry.get_resource_watching_handlers().", DeprecationWarning)
+        warnings.warn("GlobalRegistry.get_event_handlers() is deprecated; "
+                      "please cease using the internal registries directly.",
+                      DeprecationWarning)
         cause = _create_watching_cause(resource=resource, event=event)
         return self.get_resource_watching_handlers(cause=cause)
 
@@ -215,8 +224,9 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
             self,
             cause: causation.ResourceChangingCause,
     ) -> Sequence[handlers.ResourceChangingHandler]:
-        warnings.warn("GlobalRegistry.get_cause_handlers() is deprecated; use "
-                      "OperatorRegistry.get_resource_changing_handlers().", DeprecationWarning)
+        warnings.warn("GlobalRegistry.get_cause_handlers() is deprecated; "
+                      "please cease using the internal registries directly.",
+                      DeprecationWarning)
         return self.get_resource_changing_handlers(cause=cause)
 
     def iter_event_handlers(
@@ -224,8 +234,9 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
             resource: resources_.Resource,
             event: bodies.RawEvent,
     ) -> Iterator[handlers.ResourceWatchingHandler]:
-        warnings.warn("GlobalRegistry.iter_event_handlers() is deprecated; use "
-                      "OperatorRegistry.iter_resource_watching_handlers().", DeprecationWarning)
+        warnings.warn("GlobalRegistry.iter_event_handlers() is deprecated; "
+                      "please cease using the internal registries directly.",
+                      DeprecationWarning)
         cause = _create_watching_cause(resource=resource, event=event)
         yield from self.iter_resource_watching_handlers(cause=cause)
 
@@ -233,8 +244,9 @@ class GlobalRegistry(BaseRegistry, registries.OperatorRegistry):
             self,
             cause: causation.ResourceChangingCause,
     ) -> Iterator[handlers.ResourceChangingHandler]:
-        warnings.warn("GlobalRegistry.iter_cause_handlers() is deprecated; use "
-                      "OperatorRegistry.iter_resource_changing_handlers().", DeprecationWarning)
+        warnings.warn("GlobalRegistry.iter_cause_handlers() is deprecated; "
+                      "please cease using the internal registries directly.",
+                      DeprecationWarning)
         yield from self.iter_resource_changing_handlers(cause=cause)
 
 

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -21,7 +21,7 @@ async def test_skipped_with_no_handlers(
     event_body = {'metadata': {'finalizers': []}}
     cause_mock.reason = cause_type
 
-    assert not registry.resource_changing_handlers[resource]  # prerequisite
+    assert not registry.resource_changing_handlers[resource].has_handlers()  # prerequisite
     registry.resource_changing_handlers[resource].append(ResourceChangingHandler(
         reason='a-non-existent-cause-type',
         fn=lambda **_: None, id='id',
@@ -76,7 +76,7 @@ async def test_stealth_mode_with_mismatching_handlers(
     event_body = {'metadata': {'finalizers': []}}
     cause_mock.reason = cause_type
 
-    assert not registry.resource_changing_handlers[resource]  # prerequisite
+    assert not registry.resource_changing_handlers[resource].has_handlers()  # prerequisite
     registry.resource_changing_handlers[resource].append(ResourceChangingHandler(
         reason=None,
         fn=lambda **_: None, id='id',

--- a/tests/registries/legacy-1/test_legacy1_decorators.py
+++ b/tests/registries/legacy-1/test_legacy1_decorators.py
@@ -17,7 +17,7 @@ def test_on_create_minimal(cause_factory):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use OperatorRegistry.get_resource_changing_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
@@ -39,7 +39,7 @@ def test_on_update_minimal(cause_factory):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use OperatorRegistry.get_resource_changing_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
@@ -61,7 +61,7 @@ def test_on_delete_minimal(cause_factory):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use OperatorRegistry.get_resource_changing_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
@@ -85,7 +85,7 @@ def test_on_field_minimal(cause_factory):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use OperatorRegistry.get_resource_changing_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
@@ -121,7 +121,7 @@ def test_on_create_with_all_kwargs(mocker, cause_factory):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use OperatorRegistry.get_resource_changing_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
@@ -150,7 +150,7 @@ def test_on_update_with_all_kwargs(mocker, cause_factory):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use OperatorRegistry.get_resource_changing_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
@@ -184,7 +184,7 @@ def test_on_delete_with_all_kwargs(mocker, optional, cause_factory):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use OperatorRegistry.get_resource_changing_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
@@ -216,7 +216,7 @@ def test_on_field_with_all_kwargs(mocker, cause_factory):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use OperatorRegistry.get_resource_changing_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
@@ -257,7 +257,7 @@ def test_subhandler_declaratively(parent_handler, cause_factory):
         def fn(**_):
             pass
 
-    with pytest.deprecated_call(match=r"use ResourceChangingRegistry.get_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
@@ -276,7 +276,7 @@ def test_subhandler_imperatively(parent_handler, cause_factory):
     with context([(handler_var, parent_handler)]):
         kopf.register(fn)
 
-    with pytest.deprecated_call(match=r"use ResourceChangingRegistry.get_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1

--- a/tests/registries/legacy-1/test_legacy1_global_registry.py
+++ b/tests/registries/legacy-1/test_legacy1_global_registry.py
@@ -14,9 +14,9 @@ def some_fn():
 def test_resources():
     registry = GlobalRegistry()
 
-    with pytest.deprecated_call(match=r"use OperatorRegistry.register_resource_changing_handler"):
+    with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register_cause_handler('group1', 'version1', 'plural1', some_fn)
-    with pytest.deprecated_call(match=r"use OperatorRegistry.register_resource_changing_handler"):
+    with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register_cause_handler('group2', 'version2', 'plural2', some_fn)
 
     resources = registry.resources

--- a/tests/registries/legacy-1/test_legacy1_handler_matching.py
+++ b/tests/registries/legacy-1/test_legacy1_handler_matching.py
@@ -22,10 +22,10 @@ def registry(request):
 @pytest.fixture()
 def register_fn(registry, resource):
     if isinstance(registry, SimpleRegistry):
-        with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
+        with pytest.deprecated_call(match=r"use @kopf.on"):
             yield registry.register
     elif isinstance(registry, GlobalRegistry):
-        with pytest.deprecated_call(match=r"GlobalRegistry.register_cause_handler\(\) is deprecated"):
+        with pytest.deprecated_call(match=r"use @kopf.on"):
             yield functools.partial(registry.register_cause_handler, resource.group, resource.version, resource.plural)
     else:
         raise Exception(f"Unsupported registry type: {registry}")
@@ -76,21 +76,21 @@ def cause_any_diff(request, cause_factory):
 
 def test_catchall_handlers_without_field_found(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field=None)
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_found(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field='some-field')
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_with_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field='some-field')
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_no_diff)
     assert not handlers
 
@@ -103,7 +103,7 @@ def test_catchall_handlers_with_labels_satisfied(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -117,7 +117,7 @@ def test_catchall_handlers_with_labels_not_satisfied(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert not handlers
 
@@ -130,7 +130,7 @@ def test_catchall_handlers_with_labels_exist(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -143,7 +143,7 @@ def test_catchall_handlers_with_labels_not_exist(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert not handlers
 
@@ -159,7 +159,7 @@ def test_catchall_handlers_without_labels(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels=None)
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -172,7 +172,7 @@ def test_catchall_handlers_with_annotations_satisfied(
         cause_factory, registry, register_fn, resource, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -186,7 +186,7 @@ def test_catchall_handlers_with_annotations_not_satisfied(
         cause_factory, registry, register_fn, resource, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert not handlers
 
@@ -199,7 +199,7 @@ def test_catchall_handlers_with_annotations_exist(
         cause_factory, registry, register_fn, resource, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -212,7 +212,7 @@ def test_catchall_handlers_with_annotations_not_exist(
         cause_factory, registry, register_fn, resource, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert not handlers
 
@@ -228,7 +228,7 @@ def test_catchall_handlers_without_annotations(
         cause_factory, registry, register_fn, resource, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations=None)
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -243,7 +243,7 @@ def test_catchall_handlers_with_labels_and_annotations_satisfied(
         cause_factory, registry, register_fn, resource, labels, annotations):
     cause = cause_factory(body={'metadata': {'labels': labels, 'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert handlers
 
@@ -259,7 +259,7 @@ def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
     assert not handlers
 
@@ -273,90 +273,90 @@ def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
 
 def test_relevant_handlers_without_field_found(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason')
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_found(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', field='some-field')
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_with_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', field='some-field')
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_no_diff)
     assert not handlers
 
 
 def test_relevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', labels={'somelabel': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', labels={'otherlabel': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_relevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', annotations={'someannotation': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', annotations={'otherannotation': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_without_field_ignored(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason')
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_field_ignored(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', field='another-field')
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 def test_irrelevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', labels={'somelabel': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', labels={'otherlabel': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', annotations={'someannotation': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', annotations={'otherannotation': None})
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_any_diff)
     assert not handlers
 
@@ -373,7 +373,7 @@ def test_order_persisted_a(cause_with_diff, registry, register_fn):
     register_fn(functools.partial(some_fn, 4), reason=None, field='filtered-out-reason')
     register_fn(functools.partial(some_fn, 5), reason=None, field='some-field')
 
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
@@ -393,7 +393,7 @@ def test_order_persisted_b(cause_with_diff, registry, register_fn):
     register_fn(functools.partial(some_fn, 4), reason='some-reason')
     register_fn(functools.partial(some_fn, 5), reason=None)
 
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
@@ -414,7 +414,7 @@ def test_deduplicated(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason=None, id='a')
     register_fn(some_fn, reason=None, id='b')
 
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause_with_diff)
 
     assert len(handlers) == 1

--- a/tests/registries/legacy-1/test_legacy1_id_detection.py
+++ b/tests/registries/legacy-1/test_legacy1_id_detection.py
@@ -76,9 +76,9 @@ def test_with_no_hints(mocker, cause_factory):
     cause = cause_factory()
 
     registry = SimpleRegistry()
-    with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register(some_fn)
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert get_fn_id.called
@@ -94,9 +94,9 @@ def test_with_prefix(mocker, cause_factory):
     cause = cause_factory()
 
     registry = SimpleRegistry()
-    with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register(some_fn)
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert get_fn_id.called
@@ -113,9 +113,9 @@ def test_with_suffix(mocker, field, cause_factory):
     cause = cause_factory(old=old, new=new, body=new)
 
     registry = SimpleRegistry()
-    with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register(some_fn, field=field)
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert get_fn_id.called
@@ -132,9 +132,9 @@ def test_with_prefix_and_suffix(mocker, field, cause_factory):
     cause = cause_factory(diff=diff)
 
     registry = SimpleRegistry(prefix='some-prefix')
-    with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register(some_fn, field=field)
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert get_fn_id.called
@@ -151,9 +151,9 @@ def test_with_explicit_id_and_prefix_and_suffix(mocker, field, cause_factory):
     cause = cause_factory(diff=diff)
 
     registry = SimpleRegistry(prefix='some-prefix')
-    with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register(some_fn, id='explicit-id', field=field)
-    with pytest.deprecated_call(match=r"get_cause_handlers\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert not get_fn_id.called

--- a/tests/registries/legacy-1/test_legacy1_registering.py
+++ b/tests/registries/legacy-1/test_legacy1_registering.py
@@ -21,7 +21,7 @@ def test_simple_registry_via_iter(cause_factory):
     assert not isinstance(iterator, collections.abc.Container)
     assert not isinstance(iterator, (list, tuple))
 
-    with pytest.deprecated_call(match=r"use ResourceChangingRegistry.iter_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = list(iterator)
     assert not handlers
 
@@ -30,7 +30,7 @@ def test_simple_registry_via_list(cause_factory):
 
     cause = cause_factory()
     registry = SimpleRegistry()
-    with pytest.deprecated_call(match=r"use ResourceChangingRegistry.get_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
@@ -43,9 +43,9 @@ def test_simple_registry_with_minimal_signature(cause_factory):
 
     cause = cause_factory()
     registry = SimpleRegistry()
-    with pytest.deprecated_call(match=r"registry.register\(\) is deprecated"):
+    with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register(some_fn)
-    with pytest.deprecated_call(match=r"use ResourceChangingRegistry.get_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1
@@ -63,7 +63,7 @@ def test_global_registry_via_iter(cause_factory):
     assert not isinstance(iterator, collections.abc.Container)
     assert not isinstance(iterator, (list, tuple))
 
-    with pytest.deprecated_call(match=r"use OperatorRegistry.iter_resource_changing_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = list(iterator)
     assert not handlers
 
@@ -72,7 +72,7 @@ def test_global_registry_via_list(cause_factory):
 
     cause = cause_factory()
     registry = GlobalRegistry()
-    with pytest.deprecated_call(match=r"use OperatorRegistry.get_resource_changing_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
@@ -85,9 +85,9 @@ def test_global_registry_with_minimal_signature(cause_factory, resource):
 
     cause = cause_factory()
     registry = GlobalRegistry()
-    with pytest.deprecated_call(match=r"use OperatorRegistry.register_resource_changing_handler\(\)"):
+    with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register_cause_handler(resource.group, resource.version, resource.plural, some_fn)
-    with pytest.deprecated_call(match=r"use OperatorRegistry.get_resource_changing_handlers\(\)"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_cause_handlers(cause)
 
     assert len(handlers) == 1

--- a/tests/registries/legacy-1/test_legacy1_requires_finalizer.py
+++ b/tests/registries/legacy-1/test_legacy1_requires_finalizer.py
@@ -41,7 +41,7 @@ def test_requires_finalizer_deletion_handler(optional, expected):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
@@ -64,7 +64,7 @@ def test_requires_finalizer_multiple_handlers(optional, expected):
     def fn2(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
@@ -78,7 +78,7 @@ def test_requires_finalizer_no_deletion_handler():
     def fn1(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer is False
 
@@ -101,7 +101,7 @@ def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, ex
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
@@ -124,7 +124,7 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional,
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
@@ -147,7 +147,7 @@ def test_requires_finalizer_deletion_handler_matches_annotations(annotations, op
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
@@ -170,6 +170,6 @@ def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations,
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected

--- a/tests/registries/legacy-2/test_legacy2_decorators.py
+++ b/tests/registries/legacy-2/test_legacy2_decorators.py
@@ -15,7 +15,7 @@ def test_on_startup_minimal():
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.activity_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_activity_handlers(activity=Activity.STARTUP)
 
     assert len(handlers) == 1
@@ -34,7 +34,7 @@ def test_on_cleanup_minimal():
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.activity_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_activity_handlers(activity=Activity.CLEANUP)
 
     assert len(handlers) == 1
@@ -53,7 +53,7 @@ def test_on_probe_minimal():
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.activity_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_activity_handlers(activity=Activity.PROBE)
 
     assert len(handlers) == 1
@@ -78,7 +78,7 @@ def test_on_resume_minimal(
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
@@ -105,7 +105,7 @@ def test_on_create_minimal(
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
@@ -132,7 +132,7 @@ def test_on_update_minimal(
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
@@ -159,7 +159,7 @@ def test_on_delete_minimal(
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
@@ -188,7 +188,7 @@ def test_on_field_minimal(
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
@@ -220,7 +220,7 @@ def test_on_startup_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.activity_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_activity_handlers(activity=Activity.STARTUP)
 
     assert len(handlers) == 1
@@ -242,7 +242,7 @@ def test_on_cleanup_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.activity_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_activity_handlers(activity=Activity.CLEANUP)
 
     assert len(handlers) == 1
@@ -264,7 +264,7 @@ def test_on_probe_with_all_kwargs(mocker):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.activity_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_activity_handlers(activity=Activity.PROBE)
 
     assert len(handlers) == 1
@@ -299,7 +299,7 @@ def test_on_resume_with_all_kwargs(
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
@@ -336,7 +336,7 @@ def test_on_create_with_all_kwargs(
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
@@ -372,7 +372,7 @@ def test_on_update_with_all_kwargs(
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
@@ -413,7 +413,7 @@ def test_on_delete_with_all_kwargs(
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1
@@ -450,7 +450,7 @@ def test_on_field_with_all_kwargs(
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1

--- a/tests/registries/legacy-2/test_legacy2_handler_matching.py
+++ b/tests/registries/legacy-2/test_legacy2_handler_matching.py
@@ -74,21 +74,21 @@ def cause_any_diff(request, cause_factory):
 
 def test_catchall_handlers_without_field_found(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field=None)
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_found(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field='some-field')
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_with_diff)
     assert handlers
 
 
 def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
     register_fn(some_fn, reason=None, field='some-field')
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_no_diff)
     assert not handlers
 
@@ -101,7 +101,7 @@ def test_catchall_handlers_with_labels_satisfied(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
@@ -115,7 +115,7 @@ def test_catchall_handlers_with_labels_not_satisfied(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert not handlers
 
@@ -128,7 +128,7 @@ def test_catchall_handlers_with_labels_exist(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
@@ -141,7 +141,7 @@ def test_catchall_handlers_with_labels_not_exist(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert not handlers
 
@@ -157,7 +157,7 @@ def test_catchall_handlers_without_labels(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels=None)
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
@@ -170,7 +170,7 @@ def test_catchall_handlers_with_annotations_satisfied(
         cause_factory, registry, register_fn, resource, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
@@ -184,7 +184,7 @@ def test_catchall_handlers_with_annotations_not_satisfied(
         cause_factory, registry, register_fn, resource, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert not handlers
 
@@ -197,7 +197,7 @@ def test_catchall_handlers_with_annotations_exist(
         cause_factory, registry, register_fn, resource, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
@@ -210,7 +210,7 @@ def test_catchall_handlers_with_annotations_not_exist(
         cause_factory, registry, register_fn, resource, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert not handlers
 
@@ -226,7 +226,7 @@ def test_catchall_handlers_without_annotations(
         cause_factory, registry, register_fn, resource, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations=None)
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
@@ -241,7 +241,7 @@ def test_catchall_handlers_with_labels_and_annotations_satisfied(
         cause_factory, registry, register_fn, resource, labels, annotations):
     cause = cause_factory(body={'metadata': {'labels': labels, 'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
@@ -257,7 +257,7 @@ def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
         cause_factory, registry, register_fn, resource, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert not handlers
 
@@ -271,7 +271,7 @@ def test_catchall_handlers_with_when_match(
         cause_factory, registry, register_fn, resource, when):
     cause = cause_factory(body={'spec': {'name': 'test'}})
     register_fn(some_fn, reason=None, field=None, when=when)
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert handlers
 
@@ -284,7 +284,7 @@ def test_catchall_handlers_with_when_not_match(
         cause_factory, registry, register_fn, resource, when):
     cause = cause_factory(body={'spec': {'name': 'test'}})
     register_fn(some_fn, reason=None, field=None, when=when)
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert not handlers
 
@@ -298,119 +298,119 @@ def test_catchall_handlers_with_when_not_match(
 
 def test_relevant_handlers_without_field_found(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason')
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_found(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', field='some-field')
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_with_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_field_ignored(cause_no_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', field='some-field')
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_no_diff)
     assert not handlers
 
 
 def test_relevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', labels={'somelabel': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', labels={'otherlabel': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_relevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', annotations={'someannotation': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', annotations={'otherannotation': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_relevant_handlers_with_filter_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', when=lambda **_: True)
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert handlers
 
 
 def test_relevant_handlers_with_filter_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='some-reason', when=lambda **_: False)
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_without_field_ignored(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason')
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_field_ignored(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', field='another-field')
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_labels_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', labels={'somelabel': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_labels_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', labels={'otherlabel': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_annotations_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', annotations={'someannotation': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_annotations_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', annotations={'otherannotation': None})
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_when_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', when=lambda **_: True)
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
 
 def test_irrelevant_handlers_with_when_not_satisfied(cause_any_diff, registry, register_fn):
     register_fn(some_fn, reason='another-reason', when=lambda **_: False)
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_any_diff)
     assert not handlers
 
@@ -426,7 +426,7 @@ def test_order_persisted_a(cause_with_diff, registry, register_fn):
     register_fn(functools.partial(some_fn, 4), reason=None, field='filtered-out-reason')
     register_fn(functools.partial(some_fn, 5), reason=None, field='some-field')
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
@@ -446,7 +446,7 @@ def test_order_persisted_b(cause_with_diff, registry, register_fn):
     register_fn(functools.partial(some_fn, 4), reason='some-reason')
     register_fn(functools.partial(some_fn, 5), reason=None)
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_with_diff)
 
     # Order must be preserved -- same as registered.
@@ -467,7 +467,7 @@ def test_deduplicated(cause_with_diff, registry, register_fn):
     register_fn(some_fn, reason=None, id='a')
     register_fn(some_fn, reason=None, id='b')
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause_with_diff)
 
     assert len(handlers) == 1

--- a/tests/registries/legacy-2/test_legacy2_registering.py
+++ b/tests/registries/legacy-2/test_legacy2_registering.py
@@ -65,7 +65,7 @@ def test_operator_registry_with_activity_via_iter(
     assert not isinstance(iterator, collections.abc.Container)
     assert not isinstance(iterator, (list, tuple))
 
-    with pytest.deprecated_call(match=r"use registry.activity_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = list(iterator)
     assert not handlers
 
@@ -82,7 +82,7 @@ def test_operator_registry_with_resource_watching_via_iter(
     assert not isinstance(iterator, collections.abc.Container)
     assert not isinstance(iterator, (list, tuple))
 
-    with pytest.deprecated_call(match=r"use registry.resource_watching_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = list(iterator)
     assert not handlers
 
@@ -99,7 +99,7 @@ def test_operator_registry_with_resource_changing_via_iter(
     assert not isinstance(iterator, collections.abc.Container)
     assert not isinstance(iterator, (list, tuple))
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = list(iterator)
     assert not handlers
 
@@ -109,7 +109,7 @@ def test_operator_registry_with_activity_via_list(
         operator_registry_cls, activity):
 
     registry = operator_registry_cls()
-    with pytest.deprecated_call(match=r"use registry.activity_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_activity_handlers(activity=activity)
 
     assert isinstance(handlers, collections.abc.Iterable)
@@ -124,7 +124,7 @@ def test_operator_registry_with_resource_watching_via_list(
     cause = cause_factory(ResourceWatchingCause)
     registry = operator_registry_cls()
 
-    with pytest.deprecated_call(match=r"use registry.resource_watching_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_watching_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
@@ -139,7 +139,7 @@ def test_operator_registry_with_resource_changing_via_list(
     cause = cause_factory(ResourceChangingCause)
     registry = operator_registry_cls()
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
@@ -155,7 +155,7 @@ def test_operator_registry_with_activity_with_minimal_signature(
     registry = operator_registry_cls()
     with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register_activity_handler(some_fn)
-    with pytest.deprecated_call(match=r"use registry.activity_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_activity_handlers(activity=activity)
 
     assert len(handlers) == 1
@@ -170,7 +170,7 @@ def test_operator_registry_with_resource_watching_with_minimal_signature(
 
     with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register_resource_watching_handler(resource.group, resource.version, resource.plural, some_fn)
-    with pytest.deprecated_call(match=r"use registry.resource_watching_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_watching_handlers(cause)
 
     assert len(handlers) == 1
@@ -185,7 +185,7 @@ def test_operator_registry_with_resource_changing_with_minimal_signature(
 
     with pytest.deprecated_call(match=r"use @kopf.on"):
         registry.register_resource_changing_handler(resource.group, resource.version, resource.plural, some_fn)
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
 
     assert len(handlers) == 1

--- a/tests/registries/legacy-2/test_legacy2_requires_finalizer.py
+++ b/tests/registries/legacy-2/test_legacy2_requires_finalizer.py
@@ -41,7 +41,7 @@ def test_requires_finalizer_deletion_handler(optional, expected):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
@@ -64,7 +64,7 @@ def test_requires_finalizer_multiple_handlers(optional, expected):
     def fn2(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
@@ -78,7 +78,7 @@ def test_requires_finalizer_no_deletion_handler():
     def fn1(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer is False
 
@@ -101,7 +101,7 @@ def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, ex
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
@@ -124,7 +124,7 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional,
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
@@ -147,7 +147,7 @@ def test_requires_finalizer_deletion_handler_matches_annotations(annotations, op
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected
 
@@ -170,6 +170,6 @@ def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations,
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
     assert requires_finalizer == expected

--- a/tests/registries/legacy-2/test_legacy2_resumes_mixed_in.py
+++ b/tests/registries/legacy-2/test_legacy2_resumes_mixed_in.py
@@ -17,7 +17,7 @@ def test_resumes_ignored_for_non_initial_causes(reason, deleted, cause_factory):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 0
 
@@ -32,7 +32,7 @@ def test_resumes_selected_for_initial_non_deletions(reason, cause_factory):
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
@@ -49,7 +49,7 @@ def test_resumes_ignored_for_initial_deletions_by_default(reason, cause_factory)
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 0
 
@@ -65,7 +65,7 @@ def test_resumes_selected_for_initial_deletions_when_explicitly_marked(reason, c
     def fn(**_):
         pass
 
-    with pytest.deprecated_call(match=r"use registry.resource_changing_handlers"):
+    with pytest.deprecated_call(match=r"cease using the internal registries"):
         handlers = registry.get_resource_changing_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn


### PR DESCRIPTION
Internal registries are supposed for internal use only. They change the protocols and signatures all the time. Backward compatibility will not be ensured in the future.

The only usable registries are `OperatorRegistry` and `SmartOperatorRegistry`, and only to the extent that they can be created and used in the `registry=` kwarg to `@kopf.on...` decorators and `operator()` coroutine and related functions. All public fields and methods of these classes — selecting the handlers or extra-fields, adding new handlers, deleting the handlers, etc — are now deprecated.

It requires too much effort to maintain the internal registries backwards compatible despite they are neither a primary nor a secondary feature of the framework — more like a side-effect of how there are (were) implemented.
