### PR TITLE
Add note in tutorial for "x-kubernetes-preserve-unkown-fields"

### DIFF
--- a/docs/walkthrough/updates.rst
+++ b/docs/walkthrough/updates.rst
@@ -66,6 +66,15 @@ We can see that with kubectl:
         pvc-name: my-claim
       kopf: {}
 
+.. note::
+    If the above change causes ``Patching failed with inconsistencies`` 
+    debug warnings and/or your EVC yaml doesn't show a ``.status`` field, make sure
+    you have set the ``x-kubernetes-preserve-unknown-fields: true`` field in your CRD
+    on either the entire object or just the ``.status`` field as detailed in :doc:`resources`. 
+    Without setting this field, Kubernetes will prune the ``.status`` field when Kopf tries to 
+    update it. For more info on field pruning, see `the Kubernetes docs  
+    <https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning>`_.
+
 Let's add a yet another handler, but for the "update" cause.
 This handler gets this stored PVC name from the creation handler,
 and patches the PVC with the new size from the EVC::


### PR DESCRIPTION
…." field, link to k8s docs on the topic

## What do these changes do?

<!-- Please give a short brief about these changes (1-3 sentences). -->
The result of discussion in #574 

Adds a note in the walkthrough tutorial about CRDs requiring the `x-kubernetes-preserve-unknown-fields: true` field to be set in the CRD schema, as well as linking to relevant k8s docs on field pruning.


## Description

<!-- What was the previous behaviour before the PR is merged? -->
The tutorial had not been updated to warn about Kubernetes silently pruning unknown fields, so this note should be helpful to anyone who brought their own CRD into the walkthrough and neglected to add the `x-kubernetes-preserve-unknown-fields` field to their schema, as I had.

<!-- What will be the new behaviour after the PR is merged? -->

<!-- A code snippet showing the new features added (if any)? -->

<!-- Does the change affect the end users or is it internal? -->

<!-- Why have you decided to solve the problem this way? What were the trade-offs? (If appropriate.) -->

<!-- Are there any breaking or risky changes? -->


## Issues/PRs

<!-- Cross-referencing is highly useful in hindsight. Put the main issue, and all the related/affected/causing/preceding issues and PRs related to this change. --> 

> Issues: #574

> Related:


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- Mostly documentation and examples (no code changes)



## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
