### PR TITLE
Convert per-resource registries to all-resource registries

### DIFF
--- a/kopf/on.py
+++ b/kopf/on.py
@@ -162,12 +162,12 @@ def resume(  # lgtm[py/similar-function]
         handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            labels=labels, annotations=annotations, when=when,
+            resource=real_resource, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=None, new=None, field_needs_change=False,
             initial=True, deleted=deleted, requires_finalizer=None,
             reason=None,
         )
-        real_registry.resource_changing_handlers[real_resource].append(handler)
+        real_registry.resource_changing_handlers.append(handler)
         return fn
     return decorator
 
@@ -202,12 +202,12 @@ def create(  # lgtm[py/similar-function]
         handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            labels=labels, annotations=annotations, when=when,
+            resource=real_resource, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=None, new=None, field_needs_change=False,
             initial=None, deleted=None, requires_finalizer=None,
             reason=handlers.Reason.CREATE,
         )
-        real_registry.resource_changing_handlers[real_resource].append(handler)
+        real_registry.resource_changing_handlers.append(handler)
         return fn
     return decorator
 
@@ -244,12 +244,12 @@ def update(  # lgtm[py/similar-function]
         handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            labels=labels, annotations=annotations, when=when,
+            resource=real_resource, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=old, new=new, field_needs_change=True,
             initial=None, deleted=None, requires_finalizer=None,
             reason=handlers.Reason.UPDATE,
         )
-        real_registry.resource_changing_handlers[real_resource].append(handler)
+        real_registry.resource_changing_handlers.append(handler)
         return fn
     return decorator
 
@@ -285,12 +285,12 @@ def delete(  # lgtm[py/similar-function]
         handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            labels=labels, annotations=annotations, when=when,
+            resource=real_resource, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=None, new=None, field_needs_change=False,
             initial=None, deleted=None, requires_finalizer=bool(not optional),
             reason=handlers.Reason.DELETE,
         )
-        real_registry.resource_changing_handlers[real_resource].append(handler)
+        real_registry.resource_changing_handlers.append(handler)
         return fn
     return decorator
 
@@ -333,12 +333,12 @@ def field(  # lgtm[py/similar-function]
         handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            labels=labels, annotations=annotations, when=when,
+            resource=real_resource, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=old, new=new, field_needs_change=True,
             initial=None, deleted=None, requires_finalizer=None,
             reason=None,
         )
-        real_registry.resource_changing_handlers[real_resource].append(handler)
+        real_registry.resource_changing_handlers.append(handler)
         return fn
     return decorator
 
@@ -368,9 +368,10 @@ def event(  # lgtm[py/similar-function]
         handler = handlers.ResourceWatchingHandler(
             fn=fn, id=real_id,
             errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
-            labels=labels, annotations=annotations, when=when, field=real_field, value=value,
+            resource=real_resource, labels=labels, annotations=annotations, when=when,
+            field=real_field, value=value,
         )
-        real_registry.resource_watching_handlers[real_resource].append(handler)
+        real_registry.resource_watching_handlers.append(handler)
         return fn
     return decorator
 
@@ -409,13 +410,14 @@ def daemon(  # lgtm[py/similar-function]
         handler = handlers.ResourceDaemonHandler(
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            labels=labels, annotations=annotations, when=when, field=real_field, value=value,
+            resource=real_resource, labels=labels, annotations=annotations, when=when,
+            field=real_field, value=value,
             initial_delay=initial_delay, requires_finalizer=True,
             cancellation_backoff=cancellation_backoff,
             cancellation_timeout=cancellation_timeout,
             cancellation_polling=cancellation_polling,
         )
-        real_registry.resource_spawning_handlers[real_resource].append(handler)
+        real_registry.resource_spawning_handlers.append(handler)
         return fn
     return decorator
 
@@ -454,11 +456,12 @@ def timer(  # lgtm[py/similar-function]
         handler = handlers.ResourceTimerHandler(
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            labels=labels, annotations=annotations, when=when, field=real_field, value=value,
+            resource=real_resource, labels=labels, annotations=annotations, when=when,
+            field=real_field, value=value,
             initial_delay=initial_delay, requires_finalizer=True,
             sharp=sharp, idle=idle, interval=interval,
         )
-        real_registry.resource_spawning_handlers[real_resource].append(handler)
+        real_registry.resource_spawning_handlers.append(handler)
         return fn
     return decorator
 
@@ -525,7 +528,7 @@ def subhandler(  # lgtm[py/similar-function]
         handler = handlers.ResourceChangingHandler(
             fn=fn, id=real_id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            labels=labels, annotations=annotations, when=when,
+            resource=None, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=old, new=new,
             field_needs_change=parent_handler.field_needs_change, # inherit dymaically
             initial=None, deleted=None, requires_finalizer=None,

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -102,7 +102,7 @@ async def execute(
             handler = handlers_.ResourceChangingHandler(
                 fn=fn, id=real_id,
                 errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
-                labels=None, annotations=None, when=None,
+                resource=None, labels=None, annotations=None, when=None,
                 initial=None, deleted=None, requires_finalizer=None,
                 reason=None, field=None, value=None, old=None, new=None,
                 field_needs_change=None,
@@ -116,7 +116,7 @@ async def execute(
             handler = handlers_.ResourceChangingHandler(
                 fn=fn, id=real_id,
                 errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
-                labels=None, annotations=None, when=None,
+                resource=None, labels=None, annotations=None, when=None,
                 initial=None, deleted=None, requires_finalizer=None,
                 reason=None, field=None, value=None, old=None, new=None,
                 field_needs_change=None,
@@ -151,7 +151,7 @@ async def execute(
 
     # Execute the real handlers (all or few or one of them, as per the lifecycle).
     settings: configuration.OperatorSettings = subsettings_var.get()
-    owned_handlers = subregistry.get_all_handlers()
+    owned_handlers = subregistry.get_resource_handlers(resource=cause.resource)
     cause_handlers = subregistry.get_handlers(cause=cause)
     storage = settings.persistence.progress_storage
     state = states.State.from_storage(body=cause.body, storage=storage, handlers=owned_handlers)

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -12,7 +12,6 @@ Both are used in the `kopf.reactor.handling` to retrieve the list
 of the handlers to be executed on each reaction cycle.
 """
 import abc
-import collections
 import enum
 import functools
 import warnings
@@ -117,8 +116,12 @@ class ResourceRegistry(
 
     def has_handlers(
             self,
+            resource: resources_.Resource,
     ) -> bool:
-        return bool(self._handlers)
+        for handler in self._handlers:
+            if _matches_resource(handler, resource):
+                return True
+        return False
 
     def get_handlers(
             self,
@@ -137,15 +140,18 @@ class ResourceRegistry(
 
     def get_extra_fields(
             self,
+            resource: resources_.Resource,
     ) -> Set[dicts.FieldPath]:
-        return set(self.iter_extra_fields())
+        return set(self.iter_extra_fields(resource=resource))
 
     def iter_extra_fields(
             self,
+            resource: resources_.Resource,
     ) -> Iterator[dicts.FieldPath]:
         for handler in self._handlers:
-            if handler.field:
-                yield handler.field
+            if _matches_resource(handler, resource):
+                if handler.field:
+                    yield handler.field
 
     def requires_finalizer(
             self,
@@ -162,6 +168,23 @@ class ResourceRegistry(
                     return True
         return False
 
+    # DEPRECATED (all mapping-like methods below): used to maintain the illusion of per-resource
+    # registries in the all-resource registries in the OperatorRegistry, which is the public API.
+    def __len__(self) -> int:
+        warnings.warn("Direct usage of registries is deprecated.", DeprecationWarning)
+        return len({h.resource for h in self._handlers if h.resource})
+
+    def __iter__(self) -> Iterator[resources_.Resource]:
+        warnings.warn("Direct usage of registries is deprecated.", DeprecationWarning)
+        return iter({h.resource for h in self._handlers if h.resource})
+
+    def __getitem__(
+            self: "ResourceRegistry[CauseT, HandlerFnT, ResourceHandlerT]",
+            _: resources_.Resource,
+    ) -> "ResourceRegistry[CauseT, HandlerFnT, ResourceHandlerT]":
+        warnings.warn("Direct usage of registries is deprecated.", DeprecationWarning)
+        return self
+
 
 class ResourceWatchingRegistry(ResourceRegistry[
         causation.ResourceWatchingCause,
@@ -172,6 +195,7 @@ class ResourceWatchingRegistry(ResourceRegistry[
             self,
             fn: callbacks.ResourceWatchingFn,
             *,
+            resource: resources_.Resource,
             id: Optional[str] = None,
             errors: Optional[handlers.ErrorsMode] = None,
             timeout: Optional[float] = None,
@@ -190,7 +214,8 @@ class ResourceWatchingRegistry(ResourceRegistry[
         handler = handlers.ResourceWatchingHandler(
             id=real_id, fn=fn,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
-            labels=labels, annotations=annotations, when=when, field=None, value=None,
+            resource=resource, labels=labels, annotations=annotations, when=when,
+            field=None, value=None,
         )
         self.append(handler)
         return fn
@@ -211,7 +236,6 @@ class ResourceSpawningRegistry(ResourceRegistry[
         callbacks.ResourceSpawningFn,
         handlers.ResourceSpawningHandler]):
 
-    @abc.abstractmethod
     def iter_handlers(
             self,
             cause: causation.ResourceSpawningCause,
@@ -232,6 +256,7 @@ class ResourceChangingRegistry(ResourceRegistry[
             self,
             fn: callbacks.ResourceChangingFn,
             *,
+            resource: resources_.Resource,
             id: Optional[str] = None,
             reason: Optional[handlers.Reason] = None,
             event: Optional[str] = None,  # deprecated, use `reason`
@@ -261,7 +286,7 @@ class ResourceChangingRegistry(ResourceRegistry[
             id=real_id, fn=fn, reason=reason,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             initial=initial, deleted=deleted, requires_finalizer=requires_finalizer,
-            labels=labels, annotations=annotations, when=when,
+            resource=resource, labels=labels, annotations=annotations, when=when,
             field=real_field, value=None, old=None, new=None, field_needs_change=None,
         )
 
@@ -292,6 +317,16 @@ class ResourceChangingRegistry(ResourceRegistry[
                 return True
         return False
 
+    def get_resource_handlers(
+            self,
+            resource: resources_.Resource,
+    ) -> Sequence[handlers.ResourceChangingHandler]:
+        found_handlers: List[handlers.ResourceChangingHandler] = []
+        for handler in self._handlers:
+            if _matches_resource(handler, resource):
+                found_handlers.append(handler)
+        return list(_deduplicated(found_handlers))
+
 
 class OperatorRegistry:
     """
@@ -301,23 +336,25 @@ class OperatorRegistry:
     be explicitly created and used in the embedded operators.
     """
     activity_handlers: ActivityRegistry
-    resource_watching_handlers: MutableMapping[resources_.Resource, ResourceWatchingRegistry]
-    resource_spawning_handlers: MutableMapping[resources_.Resource, ResourceSpawningRegistry]
-    resource_changing_handlers: MutableMapping[resources_.Resource, ResourceChangingRegistry]
+    resource_watching_handlers: ResourceWatchingRegistry
+    resource_spawning_handlers: ResourceSpawningRegistry
+    resource_changing_handlers: ResourceChangingRegistry
 
     def __init__(self) -> None:
         super().__init__()
         self.activity_handlers = ActivityRegistry()
-        self.resource_watching_handlers = collections.defaultdict(ResourceWatchingRegistry)
-        self.resource_spawning_handlers = collections.defaultdict(ResourceSpawningRegistry)
-        self.resource_changing_handlers = collections.defaultdict(ResourceChangingRegistry)
+        self.resource_watching_handlers = ResourceWatchingRegistry()
+        self.resource_spawning_handlers = ResourceSpawningRegistry()
+        self.resource_changing_handlers = ResourceChangingRegistry()
 
     @property
     def resources(self) -> FrozenSet[resources_.Resource]:
         """ All known resources in the registry. """
-        return (frozenset(self.resource_watching_handlers) |
-                frozenset(self.resource_spawning_handlers) |
-                frozenset(self.resource_changing_handlers))
+        return frozenset(
+            {h.resource for h in self.resource_watching_handlers.get_all_handlers() if h.resource} |
+            {h.resource for h in self.resource_spawning_handlers.get_all_handlers() if h.resource} |
+            {h.resource for h in self.resource_changing_handlers.get_all_handlers() if h.resource}
+        )
 
     #
     # Everything below is deprecated and will be removed in the next major release.
@@ -363,9 +400,9 @@ class OperatorRegistry:
                       "use @kopf.on... decorators with registry= kwarg.",
                       DeprecationWarning)
         resource = resources_.Resource(group, version, plural)
-        return self.resource_watching_handlers[resource].register(
+        return self.resource_watching_handlers.register(
             fn=fn, id=id,
-            labels=labels, annotations=annotations, when=when,
+            resource=resource, labels=labels, annotations=annotations, when=when,
         )
 
     def register_resource_changing_handler(
@@ -397,11 +434,11 @@ class OperatorRegistry:
                       "use @kopf.on... decorators with registry= kwarg.",
                       DeprecationWarning)
         resource = resources_.Resource(group, version, plural)
-        return self.resource_changing_handlers[resource].register(
+        return self.resource_changing_handlers.register(
             reason=reason, event=event, field=field, fn=fn, id=id,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             initial=initial, deleted=deleted, requires_finalizer=requires_finalizer,
-            labels=labels, annotations=annotations, when=when,
+            resource=resource, labels=labels, annotations=annotations, when=when,
         )
 
     def has_activity_handlers(
@@ -419,7 +456,7 @@ class OperatorRegistry:
         warnings.warn("registry.has_resource_watching_handlers() is deprecated; "
                       "please cease using the internal registries directly.",
                       DeprecationWarning)
-        return self.resource_watching_handlers[resource].has_handlers()
+        return self.resource_watching_handlers.has_handlers(resource=resource)
 
     def has_resource_changing_handlers(
             self,
@@ -428,7 +465,7 @@ class OperatorRegistry:
         warnings.warn("registry.has_resource_changing_handlers() is deprecated; "
                       "please cease using the internal registries directly.",
                       DeprecationWarning)
-        return self.resource_changing_handlers[resource].has_handlers()
+        return self.resource_changing_handlers.has_handlers(resource=resource)
 
     def get_activity_handlers(
             self,
@@ -447,7 +484,7 @@ class OperatorRegistry:
         warnings.warn("registry.get_resource_watching_handlers() is deprecated; "
                       "please cease using the internal registries directly.",
                       DeprecationWarning)
-        return self.resource_watching_handlers[cause.resource].get_handlers(cause=cause)
+        return self.resource_watching_handlers.get_handlers(cause=cause)
 
     def get_resource_changing_handlers(
             self,
@@ -456,7 +493,7 @@ class OperatorRegistry:
         warnings.warn("registry.get_resource_changing_handlers() is deprecated; "
                       "please cease using the internal registries directly.",
                       DeprecationWarning)
-        return self.resource_changing_handlers[cause.resource].get_handlers(cause=cause)
+        return self.resource_changing_handlers.get_handlers(cause=cause)
 
     def iter_activity_handlers(
             self,
@@ -478,7 +515,7 @@ class OperatorRegistry:
         warnings.warn("registry.iter_resource_watching_handlers() is deprecated; "
                       "please cease using the internal registries directly.",
                       DeprecationWarning)
-        yield from self.resource_watching_handlers[cause.resource].iter_handlers(cause=cause)
+        yield from self.resource_watching_handlers.iter_handlers(cause=cause)
 
     def iter_resource_changing_handlers(
             self,
@@ -490,7 +527,7 @@ class OperatorRegistry:
         warnings.warn("registry.iter_resource_changing_handlers() is deprecated; "
                       "please cease using the internal registries directly.",
                       DeprecationWarning)
-        yield from self.resource_changing_handlers[cause.resource].iter_handlers(cause=cause)
+        yield from self.resource_changing_handlers.iter_handlers(cause=cause)
 
     def get_extra_fields(
             self,
@@ -500,9 +537,9 @@ class OperatorRegistry:
                       "please cease using the internal registries directly.",
                       DeprecationWarning)
         return (
-            self.resource_watching_handlers[resource].get_extra_fields() |
-            self.resource_changing_handlers[resource].get_extra_fields() |
-            self.resource_spawning_handlers[resource].get_extra_fields())
+            self.resource_watching_handlers.get_extra_fields(resource=resource) |
+            self.resource_changing_handlers.get_extra_fields(resource=resource) |
+            self.resource_spawning_handlers.get_extra_fields(resource=resource))
 
     def iter_extra_fields(
             self,
@@ -511,9 +548,9 @@ class OperatorRegistry:
         warnings.warn("registry.iter_extra_fields() is deprecated; "
                       "please cease using the internal registries directly.",
                       DeprecationWarning)
-        yield from self.resource_watching_handlers[resource].iter_extra_fields()
-        yield from self.resource_changing_handlers[resource].iter_extra_fields()
-        yield from self.resource_spawning_handlers[resource].iter_extra_fields()
+        yield from self.resource_watching_handlers.iter_extra_fields(resource=resource)
+        yield from self.resource_changing_handlers.iter_extra_fields(resource=resource)
+        yield from self.resource_spawning_handlers.iter_extra_fields(resource=resource)
 
     def requires_finalizer(
             self,
@@ -526,7 +563,7 @@ class OperatorRegistry:
         warnings.warn("registry.requires_finalizer() is deprecated; "
                       "please cease using the internal registries directly.",
                       DeprecationWarning)
-        return self.resource_changing_handlers[resource].requires_finalizer(cause=cause)
+        return self.resource_changing_handlers.requires_finalizer(cause=cause)
 
 
 class SmartOperatorRegistry(OperatorRegistry):
@@ -634,6 +671,7 @@ def prematch(
     # Kwargs are lazily evaluated on the first _actual_ use, and shared for all filters since then.
     kwargs: MutableMapping[str, Any] = {}
     return all([
+        _matches_resource(handler, cause.resource),
         _matches_labels(handler, cause, kwargs),
         _matches_annotations(handler, cause, kwargs),
         _matches_field_values(handler, cause, kwargs),
@@ -648,12 +686,21 @@ def match(
     # Kwargs are lazily evaluated on the first _actual_ use, and shared for all filters since then.
     kwargs: MutableMapping[str, Any] = {}
     return all([
+        _matches_resource(handler, cause.resource),
         _matches_labels(handler, cause, kwargs),
         _matches_annotations(handler, cause, kwargs),
         _matches_field_values(handler, cause, kwargs),
         _matches_field_changes(handler, cause, kwargs),
         _matches_filter_callback(handler, cause, kwargs),
     ])
+
+
+def _matches_resource(
+        handler: handlers.ResourceHandler,
+        resource: resources_.Resource,
+) -> bool:
+    return (handler.resource is None or
+            handler.resource == resource)
 
 
 def _matches_labels(

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -3,7 +3,7 @@ import enum
 import warnings
 from typing import Any, NewType, Optional
 
-from kopf.structs import callbacks, dicts, filters
+from kopf.structs import callbacks, dicts, filters, resources
 
 # Strings are taken from the users, but then tainted as this type for stricter type-checking:
 # to prevent usage of some other strings (e.g. operator id) as the handlers ids.
@@ -109,6 +109,7 @@ class ActivityHandler(BaseHandler):
 
 @dataclasses.dataclass
 class ResourceHandler(BaseHandler):
+    resource: Optional[resources.Resource]  # None is used only in sub-handlers & LegacyAllPurposeResourcerHandler
     labels: Optional[filters.MetaFilter]
     annotations: Optional[filters.MetaFilter]
     when: Optional[callbacks.WhenFilterFn]

--- a/kopf/toolkits/legacy_registries.py
+++ b/kopf/toolkits/legacy_registries.py
@@ -109,7 +109,7 @@ class SimpleRegistry(BaseRegistry, registries.ResourceRegistry[
             reason=reason,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff, cooldown=cooldown,
             initial=initial, deleted=deleted, requires_finalizer=requires_finalizer,
-            labels=labels, annotations=annotations, when=when,
+            resource=None, labels=labels, annotations=annotations, when=when,
             field=real_field, value=None, old=None, new=None, field_needs_change=None,
         )
         self.append(handler)

--- a/tests/basic-structs/test_handlers.py
+++ b/tests/basic-structs/test_handlers.py
@@ -39,6 +39,7 @@ def test_activity_handler_with_all_args(mocker):
 def test_resource_handler_with_all_args(mocker):
     fn = mocker.Mock()
     id = mocker.Mock()
+    resource = mocker.Mock()
     reason = mocker.Mock()
     errors = mocker.Mock()
     timeout = mocker.Mock()
@@ -58,6 +59,7 @@ def test_resource_handler_with_all_args(mocker):
     handler = ResourceChangingHandler(
         fn=fn,
         id=id,
+        resource=resource,
         reason=reason,
         errors=errors,
         timeout=timeout,
@@ -78,6 +80,7 @@ def test_resource_handler_with_all_args(mocker):
     )
     assert handler.fn is fn
     assert handler.id is id
+    assert handler.resource is resource
     assert handler.reason is reason
     assert handler.errors is errors
     assert handler.timeout is timeout

--- a/tests/basic-structs/test_handlers_deprecated_cooldown.py
+++ b/tests/basic-structs/test_handlers_deprecated_cooldown.py
@@ -40,6 +40,7 @@ def test_activity_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
 def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
     fn = mocker.Mock()
     id = mocker.Mock()
+    resource = mocker.Mock()
     reason = mocker.Mock()
     errors = mocker.Mock()
     timeout = mocker.Mock()
@@ -61,6 +62,7 @@ def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
         handler = ResourceChangingHandler(
             fn=fn,
             id=id,
+            resource=resource,
             reason=reason,
             errors=errors,
             timeout=timeout,
@@ -82,6 +84,7 @@ def test_resource_handler_with_deprecated_cooldown_instead_of_backoff(mocker):
 
     assert handler.fn is fn
     assert handler.id is id
+    assert handler.resource is resource
     assert handler.reason is reason
     assert handler.errors is errors
     assert handler.timeout is timeout

--- a/tests/cli/test_preloading.py
+++ b/tests/cli/test_preloading.py
@@ -15,8 +15,7 @@ def test_one_file(invoke, real_run):
 
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
-    resource = list(registry.resources)[0]
-    handlers = registry.resource_changing_handlers[resource]._handlers
+    handlers = registry.resource_changing_handlers.get_all_handlers()
     assert len(handlers) == 1
     assert handlers[0].id == 'create_fn'
 
@@ -27,8 +26,7 @@ def test_two_files(invoke, real_run):
 
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
-    resource = list(registry.resources)[0]
-    handlers = registry.resource_changing_handlers[resource]._handlers
+    handlers = registry.resource_changing_handlers.get_all_handlers()
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'
@@ -40,8 +38,7 @@ def test_one_module(invoke, real_run):
 
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
-    resource = list(registry.resources)[0]
-    handlers = registry.resource_changing_handlers[resource]._handlers
+    handlers = registry.resource_changing_handlers.get_all_handlers()
     assert len(handlers) == 1
     assert handlers[0].id == 'create_fn'
 
@@ -52,8 +49,7 @@ def test_two_modules(invoke, real_run):
 
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
-    resource = list(registry.resources)[0]
-    handlers = registry.resource_changing_handlers[resource]._handlers
+    handlers = registry.resource_changing_handlers.get_all_handlers()
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'
@@ -65,8 +61,7 @@ def test_mixed_sources(invoke, real_run):
 
     registry = kopf.get_default_registry()
     assert len(registry.resources) == 1
-    resource = list(registry.resources)[0]
-    handlers = registry.resource_changing_handlers[resource]._handlers
+    handlers = registry.resource_changing_handlers.get_all_handlers()
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,7 +168,7 @@ async def enforced_session(enforced_context: APIContext):
 # Note: Unused `fake_vault` is to ensure that the client wrappers have the credentials.
 # Note: Unused `enforced_session` is to ensure that the session is closed for every test.
 @pytest.fixture()
-def resp_mocker(fake_vault, enforced_session, resource, aresponses):
+def resp_mocker(fake_vault, enforced_session, aresponses):
     """
     A factory of server-side callbacks for `aresponses` with mocking/spying.
 

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -163,7 +163,7 @@ def extrahandlers(clear_default_registry, handlers):
 
 
 @pytest.fixture()
-def cause_mock(mocker, settings, resource):
+def cause_mock(mocker, settings):
     """
     Mock the resulting _cause_ of the resource change detection logic.
 

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -21,12 +21,12 @@ async def test_skipped_with_no_handlers(
     event_body = {'metadata': {'finalizers': []}}
     cause_mock.reason = cause_type
 
-    assert not registry.resource_changing_handlers[resource].has_handlers()  # prerequisite
-    registry.resource_changing_handlers[resource].append(ResourceChangingHandler(
+    assert not registry.resource_changing_handlers.has_handlers(resource=resource)  # prerequisite
+    registry.resource_changing_handlers.append(ResourceChangingHandler(
         reason='a-non-existent-cause-type',
         fn=lambda **_: None, id='id',
         errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
-        annotations=None, labels=None, when=None,
+        resource=resource, annotations=None, labels=None, when=None,
         field=None, value=None, old=None, new=None, field_needs_change=None,
         deleted=None, initial=None, requires_finalizer=None,
     ))
@@ -76,12 +76,12 @@ async def test_stealth_mode_with_mismatching_handlers(
     event_body = {'metadata': {'finalizers': []}}
     cause_mock.reason = cause_type
 
-    assert not registry.resource_changing_handlers[resource].has_handlers()  # prerequisite
-    registry.resource_changing_handlers[resource].append(ResourceChangingHandler(
+    assert not registry.resource_changing_handlers.has_handlers(resource=resource)  # prerequisite
+    registry.resource_changing_handlers.append(ResourceChangingHandler(
         reason=None,
         fn=lambda **_: None, id='id',
         errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
-        annotations=annotations, labels=labels, when=when,
+        resource=resource, annotations=annotations, labels=labels, when=when,
         field=None, value=None, old=None, new=None, field_needs_change=None,
         deleted=deleted, initial=initial, requires_finalizer=None,
     ))

--- a/tests/k8s/test_errors.py
+++ b/tests/k8s/test_errors.py
@@ -35,7 +35,7 @@ def test_exception_with_payload():
 
 @pytest.mark.parametrize('status', [200, 202, 300, 304])
 async def test_no_error_on_success(
-        resp_mocker, aresponses, hostname, resource, status):
+        resp_mocker, aresponses, hostname, status):
 
     resp = aresponses.Response(
         status=status,
@@ -56,7 +56,7 @@ async def test_no_error_on_success(
     (666, APIError),
 ])
 async def test_error_with_payload(
-        resp_mocker, aresponses, hostname, resource, status, exctype):
+        resp_mocker, aresponses, hostname, status, exctype):
 
     resp = aresponses.Response(
         status=status,
@@ -78,7 +78,7 @@ async def test_error_with_payload(
 
 @pytest.mark.parametrize('status', [400, 500, 666])
 async def test_error_with_nonjson_payload(
-        resp_mocker, aresponses, hostname, resource, status):
+        resp_mocker, aresponses, hostname, status):
 
     resp = aresponses.Response(
         status=status,
@@ -98,7 +98,7 @@ async def test_error_with_nonjson_payload(
 
 @pytest.mark.parametrize('status', [400, 500, 666])
 async def test_error_with_parseable_nonk8s_payload(
-        resp_mocker, aresponses, hostname, resource, status):
+        resp_mocker, aresponses, hostname, status):
 
     resp = aresponses.Response(
         status=status,

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -50,7 +50,7 @@ def operator_registry_cls(request):
 
 
 @pytest.fixture()
-def parent_handler():
+def parent_handler(resource):
 
     def parent_fn(**_):
         pass
@@ -58,7 +58,7 @@ def parent_handler():
     return ResourceChangingHandler(
         fn=parent_fn, id=HandlerId('parent_fn'),
         errors=None, retries=None, timeout=None, backoff=None, cooldown=None,
-        labels=None, annotations=None, when=None,
+        resource=resource, labels=None, annotations=None, when=None,
         field=None, value=None, old=None, new=None, field_needs_change=None,
         initial=None, deleted=None, requires_finalizer=None,
         reason=None,

--- a/tests/registries/legacy-1/test_legacy1_handler_matching.py
+++ b/tests/registries/legacy-1/test_legacy1_handler_matching.py
@@ -100,7 +100,7 @@ def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_labels_satisfied(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -114,7 +114,7 @@ def test_catchall_handlers_with_labels_satisfied(
     pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_labels_not_satisfied(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -127,7 +127,7 @@ def test_catchall_handlers_with_labels_not_satisfied(
     pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_labels_exist(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -140,7 +140,7 @@ def test_catchall_handlers_with_labels_exist(
     pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_labels_not_exist(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -156,7 +156,7 @@ def test_catchall_handlers_with_labels_not_exist(
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_without_labels(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels=None)
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -169,7 +169,7 @@ def test_catchall_handlers_without_labels(
     pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_with_annotations_satisfied(
-        cause_factory, registry, register_fn, resource, annotations):
+        cause_factory, registry, register_fn, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -183,7 +183,7 @@ def test_catchall_handlers_with_annotations_satisfied(
     pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_annotations_not_satisfied(
-        cause_factory, registry, register_fn, resource, annotations):
+        cause_factory, registry, register_fn, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -196,7 +196,7 @@ def test_catchall_handlers_with_annotations_not_satisfied(
     pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_annotations_exist(
-        cause_factory, registry, register_fn, resource, annotations):
+        cause_factory, registry, register_fn, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -209,7 +209,7 @@ def test_catchall_handlers_with_annotations_exist(
     pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_annotations_not_exist(
-        cause_factory, registry, register_fn, resource, annotations):
+        cause_factory, registry, register_fn, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -225,7 +225,7 @@ def test_catchall_handlers_with_annotations_not_exist(
     pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_without_annotations(
-        cause_factory, registry, register_fn, resource, annotations):
+        cause_factory, registry, register_fn, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations=None)
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -240,7 +240,7 @@ def test_catchall_handlers_without_annotations(
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-label-extra-annotation'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_satisfied(
-        cause_factory, registry, register_fn, resource, labels, annotations):
+        cause_factory, registry, register_fn, labels, annotations):
     cause = cause_factory(body={'metadata': {'labels': labels, 'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -256,7 +256,7 @@ def test_catchall_handlers_with_labels_and_annotations_satisfied(
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):

--- a/tests/registries/legacy-2/test_legacy2_handler_matching.py
+++ b/tests/registries/legacy-2/test_legacy2_handler_matching.py
@@ -98,7 +98,7 @@ def test_catchall_handlers_with_field_ignored(cause_no_diff, registry, register_
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_labels_satisfied(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -112,7 +112,7 @@ def test_catchall_handlers_with_labels_satisfied(
     pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_labels_not_satisfied(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -125,7 +125,7 @@ def test_catchall_handlers_with_labels_not_satisfied(
     pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_labels_exist(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -138,7 +138,7 @@ def test_catchall_handlers_with_labels_exist(
     pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_labels_not_exist(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': None})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -154,7 +154,7 @@ def test_catchall_handlers_with_labels_not_exist(
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_without_labels(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels=None)
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -167,7 +167,7 @@ def test_catchall_handlers_without_labels(
     pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_with_annotations_satisfied(
-        cause_factory, registry, register_fn, resource, annotations):
+        cause_factory, registry, register_fn, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -181,7 +181,7 @@ def test_catchall_handlers_with_annotations_satisfied(
     pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_annotations_not_satisfied(
-        cause_factory, registry, register_fn, resource, annotations):
+        cause_factory, registry, register_fn, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -194,7 +194,7 @@ def test_catchall_handlers_with_annotations_not_satisfied(
     pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_annotations_exist(
-        cause_factory, registry, register_fn, resource, annotations):
+        cause_factory, registry, register_fn, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -207,7 +207,7 @@ def test_catchall_handlers_with_annotations_exist(
     pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_annotations_not_exist(
-        cause_factory, registry, register_fn, resource, annotations):
+        cause_factory, registry, register_fn, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations={'someannotation': None})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -223,7 +223,7 @@ def test_catchall_handlers_with_annotations_not_exist(
     pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_without_annotations(
-        cause_factory, registry, register_fn, resource, annotations):
+        cause_factory, registry, register_fn, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, annotations=None)
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -238,7 +238,7 @@ def test_catchall_handlers_without_annotations(
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-label-extra-annotation'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_satisfied(
-        cause_factory, registry, register_fn, resource, labels, annotations):
+        cause_factory, registry, register_fn, labels, annotations):
     cause = cause_factory(body={'metadata': {'labels': labels, 'annotations': annotations}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -254,7 +254,7 @@ def test_catchall_handlers_with_labels_and_annotations_satisfied(
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
-        cause_factory, registry, register_fn, resource, labels):
+        cause_factory, registry, register_fn, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     register_fn(some_fn, reason=None, field=None, labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -268,7 +268,7 @@ def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
     pytest.param(lambda **_: True, id='with-other-when'),
 ])
 def test_catchall_handlers_with_when_match(
-        cause_factory, registry, register_fn, resource, when):
+        cause_factory, registry, register_fn, when):
     cause = cause_factory(body={'spec': {'name': 'test'}})
     register_fn(some_fn, reason=None, field=None, when=when)
     with pytest.deprecated_call(match=r"cease using the internal registries"):
@@ -281,7 +281,7 @@ def test_catchall_handlers_with_when_match(
     pytest.param(lambda **_: False, id='with-other-when'),
 ])
 def test_catchall_handlers_with_when_not_match(
-        cause_factory, registry, register_fn, resource, when):
+        cause_factory, registry, register_fn, when):
     cause = cause_factory(body={'spec': {'name': 'test'}})
     register_fn(some_fn, reason=None, field=None, when=when)
     with pytest.deprecated_call(match=r"cease using the internal registries"):

--- a/tests/registries/legacy-2/test_legacy2_registering.py
+++ b/tests/registries/legacy-2/test_legacy2_registering.py
@@ -40,6 +40,7 @@ def test_generic_registry_via_list(
     assert not handlers
 
 
+@pytest.mark.skip("Impossible since resource-registries require a resource-kwarg.")
 def test_generic_registry_with_minimal_signature(
         generic_registry_cls, cause_factory):
 

--- a/tests/registries/legacy-2/test_legacy2_requires_finalizer.py
+++ b/tests/registries/legacy-2/test_legacy2_requires_finalizer.py
@@ -1,7 +1,6 @@
 import pytest
 
 import kopf
-from kopf.reactor.causation import ResourceCause
 from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.filters import MetaFilterToken
 from kopf.structs.resources import Resource
@@ -20,21 +19,15 @@ OBJECT_BODY = {
     }
 }
 
-CAUSE = ResourceCause(
-    logger=None,
-    resource=None,
-    patch=None,
-    body=OBJECT_BODY,
-    memo=None
-)
 
 @pytest.mark.parametrize('optional, expected', [
     pytest.param(True, False, id='optional'),
     pytest.param(False, True, id='mandatory'),
 ])
-def test_requires_finalizer_deletion_handler(optional, expected):
+def test_requires_finalizer_deletion_handler(optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.delete('group', 'version', 'plural',
                     registry=registry, optional=optional)
@@ -42,7 +35,7 @@ def test_requires_finalizer_deletion_handler(optional, expected):
         pass
 
     with pytest.deprecated_call(match=r"cease using the internal registries"):
-        requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
+        requires_finalizer = registry.requires_finalizer(resource=resource, cause=cause)
     assert requires_finalizer == expected
 
 
@@ -50,9 +43,10 @@ def test_requires_finalizer_deletion_handler(optional, expected):
     pytest.param(True, False, id='optional'),
     pytest.param(False, True, id='mandatory'),
 ])
-def test_requires_finalizer_multiple_handlers(optional, expected):
+def test_requires_finalizer_multiple_handlers(optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.create('group', 'version', 'plural',
                     registry=registry)
@@ -65,13 +59,14 @@ def test_requires_finalizer_multiple_handlers(optional, expected):
         pass
 
     with pytest.deprecated_call(match=r"cease using the internal registries"):
-        requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
+        requires_finalizer = registry.requires_finalizer(resource=resource, cause=cause)
     assert requires_finalizer == expected
 
 
-def test_requires_finalizer_no_deletion_handler():
+def test_requires_finalizer_no_deletion_handler(cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.create('group', 'version', 'plural',
                     registry=registry)
@@ -79,7 +74,7 @@ def test_requires_finalizer_no_deletion_handler():
         pass
 
     with pytest.deprecated_call(match=r"cease using the internal registries"):
-        requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
+        requires_finalizer = registry.requires_finalizer(resource=resource, cause=cause)
     assert requires_finalizer is False
 
 
@@ -91,9 +86,10 @@ def test_requires_finalizer_no_deletion_handler():
     pytest.param({'key': 'value'}, id='value-matches'),
     pytest.param({'key': MetaFilterToken.PRESENT}, id='key-exists'),
 ])
-def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, expected):
+def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.delete('group', 'version', 'plural',
                     labels=labels,
@@ -102,7 +98,7 @@ def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, ex
         pass
 
     with pytest.deprecated_call(match=r"cease using the internal registries"):
-        requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
+        requires_finalizer = registry.requires_finalizer(resource=resource, cause=cause)
     assert requires_finalizer == expected
 
 
@@ -114,9 +110,10 @@ def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, ex
     pytest.param({'key': 'othervalue'}, id='value-mismatch'),
     pytest.param({'otherkey': MetaFilterToken.PRESENT}, id='key-doesnt-exist'),
 ])
-def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional, expected):
+def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.delete('group', 'version', 'plural',
                     labels=labels,
@@ -125,7 +122,7 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional,
         pass
 
     with pytest.deprecated_call(match=r"cease using the internal registries"):
-        requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
+        requires_finalizer = registry.requires_finalizer(resource=resource, cause=cause)
     assert requires_finalizer == expected
 
 
@@ -137,9 +134,10 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional,
     pytest.param({'key': 'value'}, id='value-matches'),
     pytest.param({'key': MetaFilterToken.PRESENT}, id='key-exists'),
 ])
-def test_requires_finalizer_deletion_handler_matches_annotations(annotations, optional, expected):
+def test_requires_finalizer_deletion_handler_matches_annotations(annotations, optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.delete('group', 'version', 'plural',
                     annotations=annotations,
@@ -148,7 +146,7 @@ def test_requires_finalizer_deletion_handler_matches_annotations(annotations, op
         pass
 
     with pytest.deprecated_call(match=r"cease using the internal registries"):
-        requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
+        requires_finalizer = registry.requires_finalizer(resource=resource, cause=cause)
     assert requires_finalizer == expected
 
 
@@ -160,9 +158,10 @@ def test_requires_finalizer_deletion_handler_matches_annotations(annotations, op
     pytest.param({'key': 'othervalue'}, id='value-mismatch'),
     pytest.param({'otherkey': MetaFilterToken.PRESENT}, id='key-doesnt-exist'),
 ])
-def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations, optional, expected):
+def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations, optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.delete('group', 'version', 'plural',
                     annotations=annotations,
@@ -171,5 +170,5 @@ def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations,
         pass
 
     with pytest.deprecated_call(match=r"cease using the internal registries"):
-        requires_finalizer = registry.requires_finalizer(resource=resource, cause=CAUSE)
+        requires_finalizer = registry.requires_finalizer(resource=resource, cause=cause)
     assert requires_finalizer == expected

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -70,7 +70,7 @@ def test_on_resume_minimal(reason, cause_factory):
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason is None
@@ -96,7 +96,7 @@ def test_on_create_minimal(cause_factory):
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.CREATE
@@ -122,7 +122,7 @@ def test_on_update_minimal(cause_factory):
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.UPDATE
@@ -148,7 +148,7 @@ def test_on_delete_minimal(cause_factory):
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.DELETE
@@ -176,7 +176,7 @@ def test_on_field_minimal(cause_factory):
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason is None
@@ -205,7 +205,7 @@ def test_on_field_warns_with_positional(cause_factory):
         def fn(**_):
             pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].field == ('field', 'subfield')
 
@@ -297,7 +297,7 @@ def test_on_resume_with_most_kwargs(mocker, reason, cause_factory):
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason is None
@@ -333,7 +333,7 @@ def test_on_create_with_most_kwargs(mocker, cause_factory):
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.CREATE
@@ -368,7 +368,7 @@ def test_on_update_with_most_kwargs(mocker, cause_factory):
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.UPDATE
@@ -408,7 +408,7 @@ def test_on_delete_with_most_kwargs(mocker, cause_factory, optional):
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason == Reason.DELETE
@@ -445,7 +445,7 @@ def test_on_field_with_most_kwargs(mocker, cause_factory):
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].reason is None
@@ -570,7 +570,7 @@ def test_field_with_value(mocker, cause_factory, decorator, causeargs, handlers_
         pass
 
     handlers_registry = getattr(registry, handlers_prop)
-    handlers = handlers_registry[resource].get_handlers(cause)
+    handlers = handlers_registry.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].field == ('spec', 'field')
     assert handlers[0].value == 'value'
@@ -592,7 +592,7 @@ def test_field_with_oldnew(mocker, cause_factory, decorator, causeargs, handlers
         pass
 
     handlers_registry = getattr(registry, handlers_prop)
-    handlers = handlers_registry[resource].get_handlers(cause)
+    handlers = handlers_registry.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].field == ('spec', 'field')
     assert handlers[0].value is None
@@ -645,7 +645,7 @@ def test_invalid_oldnew_for_inappropriate_subhandlers(resource, decorator, regis
             pass
 
     subregistry = ResourceChangingRegistry()
-    handler = registry.resource_changing_handlers[resource].get_all_handlers()[0]
+    handler = registry.resource_changing_handlers.get_all_handlers()[0]
     with context([(handler_var, handler), (subregistry_var, subregistry)]):
         with pytest.raises(TypeError, match="can only be used in update handlers"):
             handler.fn()

--- a/tests/registries/test_decorators_deprecated_cooldown.py
+++ b/tests/registries/test_decorators_deprecated_cooldown.py
@@ -69,7 +69,7 @@ def test_on_resume_with_cooldown(mocker, reason, cause_factory):
         def fn(**_):
             pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].backoff == 78
@@ -89,7 +89,7 @@ def test_on_create_with_cooldown(mocker, cause_factory):
         def fn(**_):
             pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].backoff == 78
@@ -109,7 +109,7 @@ def test_on_update_with_cooldown(mocker, cause_factory):
         def fn(**_):
             pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].backoff == 78
@@ -133,7 +133,7 @@ def test_on_delete_with_cooldown(mocker, optional, cause_factory):
         def fn(**_):
             pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].backoff == 78
@@ -154,7 +154,7 @@ def test_on_field_with_cooldown(mocker, cause_factory):
         def fn(**_):
             pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
     assert handlers[0].backoff == 78

--- a/tests/registries/test_handler_getting.py
+++ b/tests/registries/test_handler_getting.py
@@ -57,11 +57,11 @@ def test_operator_registry_with_activity_via_iter(
 
 
 def test_operator_registry_with_resource_watching_via_iter(
-        operator_registry_cls, resource, cause_factory):
+        operator_registry_cls, cause_factory):
 
     cause = cause_factory(ResourceWatchingCause)
     registry = operator_registry_cls()
-    iterator = registry.resource_watching_handlers[resource].iter_handlers(cause)
+    iterator = registry.resource_watching_handlers.iter_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
     assert not isinstance(iterator, collections.abc.Collection)
@@ -73,11 +73,11 @@ def test_operator_registry_with_resource_watching_via_iter(
 
 
 def test_operator_registry_with_resource_changing_via_iter(
-        operator_registry_cls, resource, cause_factory):
+        operator_registry_cls, cause_factory):
 
     cause = cause_factory(ResourceChangingCause)
     registry = operator_registry_cls()
-    iterator = registry.resource_changing_handlers[resource].iter_handlers(cause)
+    iterator = registry.resource_changing_handlers.iter_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
     assert not isinstance(iterator, collections.abc.Collection)
@@ -102,11 +102,11 @@ def test_operator_registry_with_activity_via_list(
 
 
 def test_operator_registry_with_resource_watching_via_list(
-        operator_registry_cls, resource, cause_factory):
+        operator_registry_cls, cause_factory):
 
     cause = cause_factory(ResourceWatchingCause)
     registry = operator_registry_cls()
-    handlers = registry.resource_watching_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
     assert isinstance(handlers, collections.abc.Container)
@@ -115,11 +115,11 @@ def test_operator_registry_with_resource_watching_via_list(
 
 
 def test_operator_registry_with_resource_changing_via_list(
-        operator_registry_cls, resource, cause_factory):
+        operator_registry_cls, cause_factory):
 
     cause = cause_factory(ResourceChangingCause)
     registry = operator_registry_cls()
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
     assert isinstance(handlers, collections.abc.Container)

--- a/tests/registries/test_matching_for_watching.py
+++ b/tests/registries/test_matching_for_watching.py
@@ -28,10 +28,10 @@ def handler_factory(registry, resource):
         handler = ResourceWatchingHandler(**dict(dict(
             fn=some_fn, id='a',
             errors=None, timeout=None, retries=None, backoff=None, cooldown=None,
-            annotations=None, labels=None, when=None,
+            resource=resource, annotations=None, labels=None, when=None,
             field=None, value=None,
         ), **kwargs))
-        registry.resource_watching_handlers[resource].append(handler)
+        registry.resource_watching_handlers.append(handler)
         return handler
     return factory
 
@@ -79,7 +79,7 @@ def test_catchall_handlers_without_field_found(
         cause_any_field, registry, handler_factory):
     cause = cause_any_field
     handler_factory(field=None)
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -87,7 +87,7 @@ def test_catchall_handlers_with_field_found(
         cause_with_field, registry, handler_factory):
     cause = cause_with_field
     handler_factory(field=parse_field('some-field'))
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -95,7 +95,7 @@ def test_catchall_handlers_with_field_ignored(
         cause_no_field, registry, handler_factory):
     cause = cause_no_field
     handler_factory(field=parse_field('some-field'))
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -104,10 +104,10 @@ def test_catchall_handlers_with_field_ignored(
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_exact_labels_satisfied(
-        cause_factory, registry, handler_factory, resource, labels):
+        cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'somelabel': 'somevalue'})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -117,10 +117,10 @@ def test_catchall_handlers_with_exact_labels_satisfied(
     pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_exact_labels_not_satisfied(
-        cause_factory, registry, handler_factory, resource, labels):
+        cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'somelabel': 'somevalue'})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -129,10 +129,10 @@ def test_catchall_handlers_with_exact_labels_not_satisfied(
     pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_desired_labels_present(
-        cause_factory, registry, handler_factory, resource, labels):
+        cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'somelabel': MetaFilterToken.PRESENT})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -141,10 +141,10 @@ def test_catchall_handlers_with_desired_labels_present(
     pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_desired_labels_absent(
-        cause_factory, registry, handler_factory, resource, labels):
+        cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'somelabel': MetaFilterToken.PRESENT})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -153,10 +153,10 @@ def test_catchall_handlers_with_desired_labels_absent(
     pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_undesired_labels_present(
-        cause_factory, registry, handler_factory, resource, labels):
+        cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'somelabel': MetaFilterToken.ABSENT})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -165,10 +165,10 @@ def test_catchall_handlers_with_undesired_labels_present(
     pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_undesired_labels_absent(
-        cause_factory, registry, handler_factory, resource, labels):
+        cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'somelabel': MetaFilterToken.ABSENT})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -178,10 +178,10 @@ def test_catchall_handlers_with_undesired_labels_absent(
     pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_labels_callback_says_true(
-        cause_factory, registry, handler_factory, resource, labels):
+        cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'somelabel': _always})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -191,10 +191,10 @@ def test_catchall_handlers_with_labels_callback_says_true(
     pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_labels_callback_says_false(
-        cause_factory, registry, handler_factory, resource, labels):
+        cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'somelabel': _never})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -206,10 +206,10 @@ def test_catchall_handlers_with_labels_callback_says_false(
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_without_labels(
-        cause_factory, registry, handler_factory, resource, labels):
+        cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels=None)
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -218,10 +218,10 @@ def test_catchall_handlers_without_labels(
     pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_with_exact_annotations_satisfied(
-        cause_factory, registry, handler_factory, resource, annotations):
+        cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'someannotation': 'somevalue'})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -231,10 +231,10 @@ def test_catchall_handlers_with_exact_annotations_satisfied(
     pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_exact_annotations_not_satisfied(
-        cause_factory, registry, handler_factory, resource, annotations):
+        cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'someannotation': 'somevalue'})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -243,10 +243,10 @@ def test_catchall_handlers_with_exact_annotations_not_satisfied(
     pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_desired_annotations_present(
-        cause_factory, registry, handler_factory, resource, annotations):
+        cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'someannotation': MetaFilterToken.PRESENT})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -255,10 +255,10 @@ def test_catchall_handlers_with_desired_annotations_present(
     pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_desired_annotations_absent(
-        cause_factory, registry, handler_factory, resource, annotations):
+        cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'someannotation': MetaFilterToken.PRESENT})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -267,10 +267,10 @@ def test_catchall_handlers_with_desired_annotations_absent(
     pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_undesired_annotations_present(
-        cause_factory, registry, handler_factory, resource, annotations):
+        cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'someannotation': MetaFilterToken.ABSENT})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -279,10 +279,10 @@ def test_catchall_handlers_with_undesired_annotations_present(
     pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_undesired_annotations_absent(
-        cause_factory, registry, handler_factory, resource, annotations):
+        cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'someannotation': MetaFilterToken.ABSENT})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -292,10 +292,10 @@ def test_catchall_handlers_with_undesired_annotations_absent(
     pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_annotations_callback_says_true(
-        cause_factory, registry, handler_factory, resource, annotations):
+        cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'someannotation': _always})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -305,10 +305,10 @@ def test_catchall_handlers_with_annotations_callback_says_true(
     pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_annotations_callback_says_false(
-        cause_factory, registry, handler_factory, resource, annotations):
+        cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'someannotation': _never})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -320,10 +320,10 @@ def test_catchall_handlers_with_annotations_callback_says_false(
     pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_without_annotations(
-        cause_factory, registry, handler_factory, resource, annotations):
+        cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory()
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -334,10 +334,10 @@ def test_catchall_handlers_without_annotations(
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-label-extra-annotation'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_satisfied(
-        cause_factory, registry, handler_factory, resource, labels, annotations):
+        cause_factory, registry, handler_factory, labels, annotations):
     cause = cause_factory(body={'metadata': {'labels': labels, 'annotations': annotations}})
     handler_factory(labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -349,10 +349,10 @@ def test_catchall_handlers_with_labels_and_annotations_satisfied(
     pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
-        cause_factory, registry, handler_factory, resource, labels):
+        cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -362,10 +362,10 @@ def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
     pytest.param(lambda **_: True, id='with-other-when'),
 ])
 def test_catchall_handlers_with_when_callback_matching(
-        cause_factory, registry, handler_factory, resource, when):
+        cause_factory, registry, handler_factory, when):
     cause = cause_factory(body={'spec': {'name': 'test'}})
     handler_factory(when=when)
-    handlers = registry.resource_watching_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -374,10 +374,10 @@ def test_catchall_handlers_with_when_callback_matching(
     pytest.param(lambda **_: False, id='with-other-when'),
 ])
 def test_catchall_handlers_with_when_callback_mismatching(
-        cause_factory, registry, handler_factory, resource, when):
+        cause_factory, registry, handler_factory, when):
     cause = cause_factory(body={'spec': {'name': 'test'}})
     handler_factory(when=when)
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -389,7 +389,7 @@ def test_decorator_without_field_found(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -401,7 +401,7 @@ def test_decorator_with_field_found(
     def some_fn(**_): ...
 
     cause = cause_with_field
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -413,7 +413,7 @@ def test_decorator_with_field_ignored(
     def some_fn(**_): ...
 
     cause = cause_no_field
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -425,7 +425,7 @@ def test_decorator_with_labels_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -437,7 +437,7 @@ def test_decorator_with_labels_not_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -449,7 +449,7 @@ def test_decorator_with_annotations_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -461,7 +461,7 @@ def test_decorator_with_annotations_not_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers
 
 
@@ -473,7 +473,7 @@ def test_decorator_with_filter_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert handlers
 
 
@@ -485,5 +485,5 @@ def test_decorator_with_filter_not_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry.resource_watching_handlers[cause.resource].get_handlers(cause)
+    handlers = registry.resource_watching_handlers.get_handlers(cause)
     assert not handlers

--- a/tests/registries/test_matching_of_resources.py
+++ b/tests/registries/test_matching_of_resources.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock
+
+from kopf.reactor.registries import _matches_resource
+from kopf.structs.resources import Resource
+
+
+def test_different_resource():
+    resource1 = Resource('group1', 'version1', 'plural1')
+    resource2 = Resource('group2', 'version2', 'plural2')
+    handler1 = Mock(resource=resource1)
+    matches = _matches_resource(handler1, resource2)
+    assert not matches
+
+
+def test_equivalent_resources():
+    resource1 = Resource('group1', 'version1', 'plural1')
+    resource2 = Resource('group1', 'version1', 'plural1')
+    handler1 = Mock(resource=resource1)
+    matches = _matches_resource(handler1, resource2)
+    assert matches
+
+
+def test_catchall_with_none():
+    resource2 = Resource('group2', 'version2', 'plural2')
+    handler1 = Mock(resource=None)
+    matches = _matches_resource(handler1, resource2)
+    assert matches

--- a/tests/registries/test_operator_resources.py
+++ b/tests/registries/test_operator_resources.py
@@ -6,16 +6,16 @@ from kopf.structs.resources import Resource
 
 
 def test_resources():
-    handler = Mock()
-
     resource1 = Resource('group1', 'version1', 'plural1')
     resource2 = Resource('group2', 'version2', 'plural2')
+    handler1 = Mock(resource=resource1)
+    handler2 = Mock(resource=resource2)
 
     registry = OperatorRegistry()
-    registry.resource_watching_handlers[resource1].append(handler)
-    registry.resource_changing_handlers[resource2].append(handler)
-    registry.resource_watching_handlers[resource2].append(handler)
-    registry.resource_changing_handlers[resource1].append(handler)
+    registry.resource_watching_handlers.append(handler1)
+    registry.resource_changing_handlers.append(handler2)
+    registry.resource_watching_handlers.append(handler2)
+    registry.resource_changing_handlers.append(handler1)
 
     resources = registry.resources
 

--- a/tests/registries/test_requires_finalizer.py
+++ b/tests/registries/test_requires_finalizer.py
@@ -1,7 +1,6 @@
 import pytest
 
 import kopf
-from kopf.reactor.causation import ResourceCause
 from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.filters import MetaFilterToken
 from kopf.structs.resources import Resource
@@ -20,28 +19,22 @@ OBJECT_BODY = {
     }
 }
 
-CAUSE = ResourceCause(
-    logger=None,
-    resource=None,
-    patch=None,
-    body=OBJECT_BODY,
-    memo=None
-)
 
 @pytest.mark.parametrize('optional, expected', [
     pytest.param(True, False, id='optional'),
     pytest.param(False, True, id='mandatory'),
 ])
-def test_requires_finalizer_deletion_handler(optional, expected):
+def test_requires_finalizer_deletion_handler(optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.delete('group', 'version', 'plural',
                     registry=registry, optional=optional)
     def fn(**_):
         pass
 
-    requires_finalizer = registry.resource_changing_handlers[resource].requires_finalizer(CAUSE)
+    requires_finalizer = registry.resource_changing_handlers.requires_finalizer(cause)
     assert requires_finalizer == expected
 
 
@@ -49,9 +42,10 @@ def test_requires_finalizer_deletion_handler(optional, expected):
     pytest.param(True, False, id='optional'),
     pytest.param(False, True, id='mandatory'),
 ])
-def test_requires_finalizer_multiple_handlers(optional, expected):
+def test_requires_finalizer_multiple_handlers(optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.create('group', 'version', 'plural',
                     registry=registry)
@@ -63,20 +57,21 @@ def test_requires_finalizer_multiple_handlers(optional, expected):
     def fn2(**_):
         pass
 
-    requires_finalizer = registry.resource_changing_handlers[resource].requires_finalizer(CAUSE)
+    requires_finalizer = registry.resource_changing_handlers.requires_finalizer(cause)
     assert requires_finalizer == expected
 
 
-def test_requires_finalizer_no_deletion_handler():
+def test_requires_finalizer_no_deletion_handler(cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.create('group', 'version', 'plural',
                     registry=registry)
     def fn1(**_):
         pass
 
-    requires_finalizer = registry.resource_changing_handlers[resource].requires_finalizer(CAUSE)
+    requires_finalizer = registry.resource_changing_handlers.requires_finalizer(cause)
     assert requires_finalizer is False
 
 
@@ -88,9 +83,10 @@ def test_requires_finalizer_no_deletion_handler():
     pytest.param({'key': 'value'}, id='value-matches'),
     pytest.param({'key': MetaFilterToken.PRESENT}, id='key-exists'),
 ])
-def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, expected):
+def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.delete('group', 'version', 'plural',
                     labels=labels,
@@ -98,7 +94,7 @@ def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, ex
     def fn(**_):
         pass
 
-    requires_finalizer = registry.resource_changing_handlers[resource].requires_finalizer(CAUSE)
+    requires_finalizer = registry.resource_changing_handlers.requires_finalizer(cause)
     assert requires_finalizer == expected
 
 
@@ -110,9 +106,10 @@ def test_requires_finalizer_deletion_handler_matches_labels(labels, optional, ex
     pytest.param({'key': 'othervalue'}, id='value-mismatch'),
     pytest.param({'otherkey': MetaFilterToken.PRESENT}, id='key-doesnt-exist'),
 ])
-def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional, expected):
+def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.delete('group', 'version', 'plural',
                     labels=labels,
@@ -120,7 +117,7 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional,
     def fn(**_):
         pass
 
-    requires_finalizer = registry.resource_changing_handlers[resource].requires_finalizer(CAUSE)
+    requires_finalizer = registry.resource_changing_handlers.requires_finalizer(cause)
     assert requires_finalizer == expected
 
 
@@ -132,9 +129,10 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(labels, optional,
     pytest.param({'key': 'value'}, id='value-matches'),
     pytest.param({'key': MetaFilterToken.PRESENT}, id='key-exists'),
 ])
-def test_requires_finalizer_deletion_handler_matches_annotations(annotations, optional, expected):
+def test_requires_finalizer_deletion_handler_matches_annotations(annotations, optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.delete('group', 'version', 'plural',
                     annotations=annotations,
@@ -142,7 +140,7 @@ def test_requires_finalizer_deletion_handler_matches_annotations(annotations, op
     def fn(**_):
         pass
 
-    requires_finalizer = registry.resource_changing_handlers[resource].requires_finalizer(CAUSE)
+    requires_finalizer = registry.resource_changing_handlers.requires_finalizer(cause)
     assert requires_finalizer == expected
 
 
@@ -154,9 +152,10 @@ def test_requires_finalizer_deletion_handler_matches_annotations(annotations, op
     pytest.param({'key': 'othervalue'}, id='value-mismatch'),
     pytest.param({'otherkey': MetaFilterToken.PRESENT}, id='key-doesnt-exist'),
 ])
-def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations, optional, expected):
+def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations, optional, expected, cause_factory):
     registry = OperatorRegistry()
     resource = Resource('group', 'version', 'plural')
+    cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
     @kopf.on.delete('group', 'version', 'plural',
                     annotations=annotations,
@@ -164,5 +163,5 @@ def test_requires_finalizer_deletion_handler_mismatches_annotations(annotations,
     def fn(**_):
         pass
 
-    requires_finalizer = registry.resource_changing_handlers[resource].requires_finalizer(CAUSE)
+    requires_finalizer = registry.resource_changing_handlers.requires_finalizer(cause)
     assert requires_finalizer == expected

--- a/tests/registries/test_resumes_mixed_in.py
+++ b/tests/registries/test_resumes_mixed_in.py
@@ -19,7 +19,7 @@ def test_resumes_ignored_for_non_initial_causes(
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 0
 
 
@@ -35,7 +35,7 @@ def test_resumes_selected_for_initial_non_deletions(
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
 
@@ -53,7 +53,7 @@ def test_resumes_ignored_for_initial_deletions_by_default(
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 0
 
 
@@ -70,6 +70,6 @@ def test_resumes_selected_for_initial_deletions_when_explicitly_marked(
     def fn(**_):
         pass
 
-    handlers = registry.resource_changing_handlers[resource].get_handlers(cause)
+    handlers = registry.resource_changing_handlers.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn


### PR DESCRIPTION
As a preparatory refactoring, the per-resource registries cease to exist and are replaced by all-resource registries. The matching now additionally include resource matching — in addition to labels, annotations, callbacks, and other filters.

The final goal is that the resources are split into resource selectors (criteria) & actual resources (specifics) so that one spec could match multiple refs — within one and only one handler. In this context, such "all-resource" structure of registries becomes unavoidable.

**[SEMI-BREAKING]** The old way of accessing the registries by resources-as-keys is supported for backward compatibility, but it returns the whole all-resource registry itself, which may contain handlers unrelated to the requested resource — proper methods should be used instead, which check for resource spec. If this is not done, handlers for unrelated resources can be exposed. Nevertheless, **this edge-case breakage is acceptable**: registries were exposed by mistake (they are not the value that this framework delivers), and are already deprecated.