### PR TITLE
Convert namespaces from strings to their own types

### DIFF
--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -8,7 +8,7 @@ import click
 from kopf.clients import auth
 from kopf.engines import loggers, peering
 from kopf.reactor import activities, registries, running
-from kopf.structs import configuration, credentials, primitives
+from kopf.structs import configuration, credentials, primitives, references
 from kopf.utilities import loaders
 
 
@@ -79,7 +79,7 @@ def run(
         peering_name: Optional[str],
         priority: Optional[int],
         standalone: Optional[bool],
-        namespace: Optional[str],
+        namespace: references.Namespace,
         liveness_endpoint: Optional[str],
 ) -> None:
     """ Start an operator process and handle all the requests. """
@@ -116,7 +116,7 @@ def freeze(
         id: Optional[str],
         message: Optional[str],
         lifetime: int,
-        namespace: Optional[str],
+        namespace: references.Namespace,
         peering_name: str,
         priority: int,
 ) -> None:
@@ -147,7 +147,7 @@ def freeze(
 @click.option('-P', '--peering', 'peering_name', required=True, envvar='KOPF_RESUME_PEERING')
 def resume(
         id: Optional[str],
-        namespace: Optional[str],
+        namespace: references.Namespace,
         peering_name: str,
 ) -> None:
     """ Resume the resource handling in the cluster. """

--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -38,7 +38,8 @@ async def post_event(
 
     # See #164. For cluster-scoped objects, use the current namespace from the current context.
     # It could be "default", but in some systems, we are limited to one specific namespace only.
-    namespace: str = ref.get('namespace') or context.default_namespace or 'default'
+    namespace_name: str = ref.get('namespace') or context.default_namespace or 'default'
+    namespace = references.NamespaceName(namespace_name)
     full_ref: bodies.ObjectReference = copy.copy(ref)
     full_ref['namespace'] = namespace
 

--- a/kopf/clients/fetching.py
+++ b/kopf/clients/fetching.py
@@ -17,7 +17,7 @@ class _UNSET(enum.Enum):
 async def read_obj(
         *,
         resource: references.Resource,
-        namespace: Optional[str],
+        namespace: references.Namespace,
         name: Optional[str],
         default: Union[_T, _UNSET] = _UNSET.token,
         context: Optional[auth.APIContext] = None,  # injected by the decorator
@@ -43,7 +43,7 @@ async def read_obj(
 async def list_objs_rv(
         *,
         resource: references.Resource,
-        namespace: Optional[str] = None,
+        namespace: references.Namespace,
         context: Optional[auth.APIContext] = None,  # injected by the decorator
 ) -> Tuple[Collection[bodies.RawBody], str]:
     """

--- a/kopf/clients/patching.py
+++ b/kopf/clients/patching.py
@@ -8,7 +8,7 @@ from kopf.structs import bodies, patches, references
 async def patch_obj(
         *,
         resource: references.Resource,
-        namespace: Optional[str],
+        namespace: references.Namespace,
         name: Optional[str],
         patch: patches.Patch,
         context: Optional[auth.APIContext] = None,  # injected by the decorator

--- a/kopf/clients/watching.py
+++ b/kopf/clients/watching.py
@@ -43,7 +43,7 @@ async def infinite_watch(
         *,
         settings: configuration.OperatorSettings,
         resource: references.Resource,
-        namespace: Optional[str],
+        namespace: references.Namespace,
         freeze_checker: Optional[primitives.ToggleSet] = None,
         _iterations: Optional[int] = None,  # used in tests/mocks/fixtures
 ) -> AsyncIterator[bodies.RawEvent]:
@@ -85,7 +85,7 @@ async def infinite_watch(
 async def streaming_block(
         *,
         resource: references.Resource,
-        namespace: Optional[str],
+        namespace: references.Namespace,
         freeze_checker: Optional[primitives.ToggleSet],
 ) -> AsyncIterator[aiotasks.Future]:
     """
@@ -144,7 +144,7 @@ async def continuous_watch(
         *,
         settings: configuration.OperatorSettings,
         resource: references.Resource,
-        namespace: Optional[str],
+        namespace: references.Namespace,
         freeze_waiter: aiotasks.Future,
 ) -> AsyncIterator[bodies.RawEvent]:
 
@@ -161,7 +161,8 @@ async def continuous_watch(
         # Then, watch the resources starting from the list's resource version.
         stream = watch_objs(
             settings=settings,
-            resource=resource, namespace=namespace,
+            resource=resource,
+            namespace=namespace,
             timeout=settings.watching.server_timeout,
             since=resource_version,
             freeze_waiter=freeze_waiter,
@@ -200,7 +201,7 @@ async def watch_objs(
         *,
         settings: configuration.OperatorSettings,
         resource: references.Resource,
-        namespace: Optional[str],
+        namespace: references.Namespace,
         timeout: Optional[float] = None,
         since: Optional[str] = None,
         context: Optional[auth.APIContext] = None,  # injected by the decorator

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -92,7 +92,7 @@ class Peer:
 async def process_peering_event(
         *,
         raw_event: bodies.RawEvent,
-        namespace: Optional[str],
+        namespace: references.Namespace,
         identity: Identity,
         settings: configuration.OperatorSettings,
         autoclean: bool = True,
@@ -156,7 +156,7 @@ async def process_peering_event(
 
 async def keepalive(
         *,
-        namespace: Optional[str],
+        namespace: references.Namespace,
         identity: Identity,
         settings: configuration.OperatorSettings,
 ) -> NoReturn:
@@ -191,7 +191,7 @@ async def touch(
         *,
         identity: Identity,
         settings: configuration.OperatorSettings,
-        namespace: Optional[str],
+        namespace: references.Namespace,
         lifetime: Optional[int] = None,
 ) -> None:
     name = settings.peering.name
@@ -217,7 +217,7 @@ async def clean(
         *,
         peers: Iterable[Peer],
         settings: configuration.OperatorSettings,
-        namespace: Optional[str],
+        namespace: references.Namespace,
 ) -> None:
     name = settings.peering.name
     resource = guess_resource(namespace=namespace)
@@ -230,7 +230,7 @@ async def clean(
 async def detect_presence(
         *,
         settings: configuration.OperatorSettings,
-        namespace: Optional[str],
+        namespace: references.Namespace,
 ) -> Optional[bool]:
 
     if settings.peering.standalone:
@@ -279,5 +279,5 @@ def detect_own_id(*, manual: bool) -> Identity:
     return Identity(f'{user}@{host}' if manual else f'{user}@{host}/{now}/{rnd}')
 
 
-def guess_resource(namespace: Optional[str]) -> references.Resource:
+def guess_resource(namespace: references.Namespace) -> references.Resource:
     return CLUSTER_PEERING_RESOURCE if namespace is None else NAMESPACED_PEERING_RESOURCE

--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -124,7 +124,7 @@ def get_uid(raw_event: bodies.RawEvent) -> ObjectUid:
 
 async def watcher(
         *,
-        namespace: Union[None, str],
+        namespace: references.Namespace,
         settings: configuration.OperatorSettings,
         resource: references.Resource,
         processor: WatchStreamProcessor,

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -9,7 +9,7 @@ from typing import Any, Collection, Coroutine, MutableSequence, Optional, Sequen
 from kopf.clients import auth
 from kopf.engines import peering, posting, probing
 from kopf.reactor import activities, daemons, lifecycles, processing, queueing, registries
-from kopf.structs import configuration, containers, credentials, handlers, primitives
+from kopf.structs import configuration, containers, credentials, handlers, primitives, references
 from kopf.utilities import aiotasks
 
 logger = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ def run(
         priority: Optional[int] = None,
         peering_name: Optional[str] = None,
         liveness_endpoint: Optional[str] = None,
-        namespace: Optional[str] = None,
+        namespace: Optional[references.Namespace] = None,
         stop_flag: Optional[primitives.Flag] = None,
         ready_flag: Optional[primitives.Flag] = None,
         vault: Optional[credentials.Vault] = None,
@@ -110,7 +110,7 @@ async def operator(
         priority: Optional[int] = None,
         peering_name: Optional[str] = None,
         liveness_endpoint: Optional[str] = None,
-        namespace: Optional[str] = None,
+        namespace: Optional[references.Namespace] = None,
         stop_flag: Optional[primitives.Flag] = None,
         ready_flag: Optional[primitives.Flag] = None,
         vault: Optional[credentials.Vault] = None,
@@ -151,7 +151,7 @@ async def spawn_tasks(
         priority: Optional[int] = None,
         peering_name: Optional[str] = None,
         liveness_endpoint: Optional[str] = None,
-        namespace: Optional[str] = None,
+        namespace: Optional[references.Namespace] = None,
         stop_flag: Optional[primitives.Flag] = None,
         ready_flag: Optional[primitives.Flag] = None,
         vault: Optional[credentials.Vault] = None,

--- a/kopf/structs/bodies.py
+++ b/kopf/structs/bodies.py
@@ -45,7 +45,7 @@ from typing import Any, List, Mapping, MutableMapping, Optional, Union, cast
 
 from typing_extensions import Literal, TypedDict
 
-from kopf.structs import dicts
+from kopf.structs import dicts, references
 
 #
 # Everything marked "raw" is a plain unwrapped unprocessed data as JSON-decoded
@@ -152,8 +152,8 @@ class Meta(dicts.MappingView[str, Any]):
         return cast(Optional[str], self.get('name'))
 
     @property
-    def namespace(self) -> Optional[str]:
-        return cast(Optional[str], self.get('namespace'))
+    def namespace(self) -> references.Namespace:
+        return cast(references.Namespace, self.get('namespace'))
 
     @property
     def creation_timestamp(self) -> Optional[str]:

--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -1,6 +1,13 @@
 import dataclasses
 import urllib.parse
-from typing import List, Mapping, Optional
+from typing import List, Mapping, NewType, Optional
+
+# A specific really existing addressable namespace (at least, the one assumed to be so).
+# Made as a NewType for stricter type-checking to avoid collisions with patterns and other strings.
+NamespaceName = NewType('NamespaceName', str)
+
+# A namespace reference usable in the API calls. `None` means cluster-wide API calls.
+Namespace = Optional[NamespaceName]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -22,7 +29,7 @@ class Resource:
             self,
             *,
             server: Optional[str] = None,
-            namespace: Optional[str] = None,
+            namespace: Namespace = None,
             name: Optional[str] = None,
             subresource: Optional[str] = None,
             params: Optional[Mapping[str, str]] = None,


### PR DESCRIPTION
The namespaces are still strings or Nones, but the type is more specialised — to avoid potential collisions with other strings. The exact specific name is also separated from the API reference, as the reference can be `None` — for clarity.
