### PR TITLE
Assemble predefined resources/selectors in one place

### DIFF
--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -10,9 +10,6 @@ from kopf.structs import bodies, references
 
 logger = logging.getLogger(__name__)
 
-EVENTS_V1BETA1_CRD = references.Resource('events.k8s.io', 'v1beta1', 'events')
-EVENTS_CORE_V1_CRD = references.Resource('', 'v1', 'events')
-
 MAX_MESSAGE_LENGTH = 1024
 CUT_MESSAGE_INFIX = '...'
 
@@ -24,6 +21,7 @@ async def post_event(
         type: str,
         reason: str,
         message: str = '',
+        resource: references.Resource,
         context: Optional[auth.APIContext] = None,  # injected by the decorator
 ) -> None:
     """
@@ -75,7 +73,7 @@ async def post_event(
 
     try:
         response = await context.session.post(
-            url=EVENTS_CORE_V1_CRD.get_url(server=context.server, namespace=namespace),
+            url=resource.get_url(server=context.server, namespace=namespace),
             headers={'Content-Type': 'application/json'},
             json=body,
         )

--- a/kopf/clients/fetching.py
+++ b/kopf/clients/fetching.py
@@ -6,8 +6,6 @@ from kopf.structs import bodies, references
 
 _T = TypeVar('_T')
 
-CRD_CRD = references.Resource('apiextensions.k8s.io', 'v1beta1', 'customresourcedefinitions')
-
 
 class _UNSET(enum.Enum):
     token = enum.auto()

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -282,15 +282,23 @@ def detect_own_id(*, manual: bool) -> Identity:
     return Identity(f'{user}@{host}' if manual else f'{user}@{host}/{now}/{rnd}')
 
 
-def guess_resource(settings: configuration.OperatorSettings) -> Optional[references.Resource]:
+def guess_selector(settings: configuration.OperatorSettings) -> Optional[references.Selector]:
     if settings.peering.standalone:
         return None
     elif settings.peering.clusterwide:
-        return references.CLUSTER_PEERING_RESOURCE
+        return references.CLUSTER_PEERINGS
     elif settings.peering.namespaced:
-        return references.NAMESPACED_PEERING_RESOURCE
+        return references.NAMESPACED_PEERINGS
     else:
         raise TypeError("Unidentified peering mode (none of standalone/cluster/namespaced).")
+
+
+def guess_resource(settings: configuration.OperatorSettings) -> Optional[references.Resource]:
+    selector = guess_selector(settings=settings)
+    if selector is not None:
+        return references.Resource(selector.group, selector.version, selector.plural)
+    else:
+        return None
 
 
 async def touch_command(

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -45,10 +45,6 @@ from kopf.utilities import aiotasks, hostnames
 
 logger = logging.getLogger(__name__)
 
-# The CRD info on the special sync-object.
-CLUSTER_PEERING_RESOURCE = references.Resource('zalando.org', 'v1', 'clusterkopfpeerings')
-NAMESPACED_PEERING_RESOURCE = references.Resource('zalando.org', 'v1', 'kopfpeerings')
-
 Identity = NewType('Identity', str)
 
 
@@ -290,9 +286,9 @@ def guess_resource(settings: configuration.OperatorSettings) -> Optional[referen
     if settings.peering.standalone:
         return None
     elif settings.peering.clusterwide:
-        return CLUSTER_PEERING_RESOURCE
+        return references.CLUSTER_PEERING_RESOURCE
     elif settings.peering.namespaced:
-        return NAMESPACED_PEERING_RESOURCE
+        return references.NAMESPACED_PEERING_RESOURCE
     else:
         raise TypeError("Unidentified peering mode (none of standalone/cluster/namespaced).")
 

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -227,7 +227,7 @@ async def clean(
     await patching.patch_obj(resource=resource, namespace=namespace, name=name, patch=patch)
 
 
-async def detect_presence(
+async def detect(
         *,
         settings: configuration.OperatorSettings,
         namespace: references.Namespace,

--- a/kopf/engines/posting.py
+++ b/kopf/engines/posting.py
@@ -159,7 +159,8 @@ async def poster(
     This task is defined in this module only because all other tasks are here,
     so we keep all forever-running tasks together.
     """
-    resource = references.EVENTS_RESOURCE
+    selector = references.EVENTS
+    resource = references.Resource(selector.group, selector.version, selector.plural)
     while True:
         posted_event = await event_queue.get()
         await events.post_event(

--- a/kopf/engines/posting.py
+++ b/kopf/engines/posting.py
@@ -21,7 +21,7 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, Iterable, Iterator, NamedTuple, NoReturn, Optional, Union, cast
 
 from kopf.clients import events
-from kopf.structs import bodies, configuration, dicts
+from kopf.structs import bodies, configuration, dicts, references
 
 if TYPE_CHECKING:
     K8sEventQueue = asyncio.Queue["K8sEvent"]
@@ -159,10 +159,12 @@ async def poster(
     This task is defined in this module only because all other tasks are here,
     so we keep all forever-running tasks together.
     """
+    resource = references.EVENTS_RESOURCE
     while True:
         posted_event = await event_queue.get()
         await events.post_event(
             ref=posted_event.ref,
             type=posted_event.type,
             reason=posted_event.reason,
-            message=posted_event.message)
+            message=posted_event.message,
+            resource=resource)

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -214,7 +214,7 @@ async def spawn_tasks(
     else:
 
         # Monitor the peers, unless explicitly disabled.
-        if await peering.detect_presence(namespace=namespace, settings=settings):
+        if await peering.detect(namespace=namespace, settings=settings):
             identity = peering.detect_own_id(manual=False)
             tasks.append(aiotasks.create_guarded_task(
                 name="peering keepalive", flag=started_flag, logger=logger,

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import signal
 import threading
-from typing import Collection, Coroutine, MutableSequence, Optional, Sequence
+from typing import Collection, Coroutine, Iterable, MutableSequence, Optional, Sequence
 
 from kopf.clients import auth
 from kopf.engines import peering, posting, probing
@@ -130,9 +130,6 @@ async def spawn_tasks(
     memories = memories if memories is not None else containers.ResourceMemories()
     vault = vault if vault is not None else credentials.Vault()
     event_queue: posting.K8sEventQueue = asyncio.Queue()
-    freeze_name = f"{peering_name!r}@{namespace}" if namespace else f"cluster-wide {peering_name!r}"
-    freeze_checker = primitives.ToggleSet()
-    freeze_toggle = await freeze_checker.make_toggle(name=freeze_name)
     signal_flag: aiotasks.Future = asyncio.Future()
     started_flag: asyncio.Event = asyncio.Event()
     tasks: MutableSequence[aiotasks.Task] = []
@@ -141,6 +138,8 @@ async def spawn_tasks(
     if peering_name is not None:
         settings.peering.mandatory = True
         settings.peering.name = peering_name
+    if namespace is None:
+        settings.peering.clusterwide = True
     if standalone is not None:
         settings.peering.standalone = standalone
     if priority is not None:
@@ -212,27 +211,35 @@ async def spawn_tasks(
             name="the command", flag=started_flag, logger=logger, finishable=True,
             coro=_command))
     else:
+        resources: Iterable[references.Resource]
 
         # Monitor the peers, unless explicitly disabled.
-        if await peering.detect(namespace=namespace, settings=settings):
-            identity = peering.detect_own_id(manual=False)
-            tasks.append(aiotasks.create_guarded_task(
-                name="peering keepalive", flag=started_flag, logger=logger,
-                coro=peering.keepalive(
-                    namespace=namespace,
-                    settings=settings,
-                    identity=identity)))
-            tasks.append(aiotasks.create_guarded_task(
-                name="watcher of peering", flag=started_flag, logger=logger,
-                coro=queueing.watcher(
-                    namespace=namespace,
-                    settings=settings,
-                    resource=peering.guess_resource(namespace=namespace),
-                    processor=functools.partial(peering.process_peering_event,
-                                                namespace=namespace,
-                                                settings=settings,
-                                                identity=identity,
-                                                freeze_toggle=freeze_toggle))))
+        freeze_checker = primitives.ToggleSet()
+        identity = peering.detect_own_id(manual=False)
+        resource = peering.guess_resource(settings=settings)
+        resources = {resource} if resource is not None else ()
+        for resource in resources:
+            if await peering.detect(namespace=namespace, resource=resource, settings=settings):
+                freeze_toggle = await freeze_checker.make_toggle(name=f"{peering_name!r}")
+                tasks.append(aiotasks.create_guarded_task(
+                    name="peering keepalive", flag=started_flag, logger=logger,
+                    coro=peering.keepalive(
+                        namespace=namespace,
+                        settings=settings,
+                        resource=resource,
+                        identity=identity)))
+                tasks.append(aiotasks.create_guarded_task(
+                    name="watcher of peering", flag=started_flag, logger=logger,
+                    coro=queueing.watcher(
+                        namespace=namespace,
+                        settings=settings,
+                        resource=resource,
+                        processor=functools.partial(peering.process_peering_event,
+                                                    namespace=namespace,
+                                                    settings=settings,
+                                                    resource=resource,
+                                                    identity=identity,
+                                                    freeze_toggle=freeze_toggle))))
 
         # Resource event handling, only once for every known resource (de-duplicated).
         resources = (registry._resource_watching.resources |

--- a/kopf/structs/configuration.py
+++ b/kopf/structs/configuration.py
@@ -140,6 +140,26 @@ class PeeringSettings:
     But they can be forced to either mode (standalone or mandatory peering).
     """
 
+    clusterwide: bool = False
+    """
+    Should the peering be clusterwide or namespaced?
+
+    Usually, the peering has the same mode as the operator, using the peering
+    objects either in the served namespaces or cluster-wide accordingly.
+
+    In exceptional cases, the peering can mismatch the operator's mode:
+    e.g. using the cluster-wide peering while the operator is namespaced.
+    """
+
+    @property
+    def namespaced(self) -> bool:
+        """ An inverse of ``clusterwide``, for code readability. """
+        return not self.clusterwide
+
+    @namespaced.setter
+    def namespaced(self, value: bool) -> None:
+        self.clusterwide = not value
+
 
 @dataclasses.dataclass
 class WatchingSettings:

--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -85,3 +85,9 @@ class Selector:
         self_tuple = (self.group, self.version, self.plural)
         other_tuple = (resource.group, resource.version, resource.plural)
         return self_tuple == other_tuple
+
+
+# Some predefined API endpoints that we use in the framework itself (not exposed to the operators).
+EVENTS_RESOURCE = Resource('', 'v1', 'events')
+CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings')
+NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings')

--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -88,6 +88,6 @@ class Selector:
 
 
 # Some predefined API endpoints that we use in the framework itself (not exposed to the operators).
-EVENTS_RESOURCE = Resource('', 'v1', 'events')
-CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings')
-NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings')
+EVENTS = Selector('', 'v1', 'events')
+CLUSTER_PEERINGS = Selector('zalando.org', 'v1', 'clusterkopfpeerings')
+NAMESPACED_PEERINGS = Selector('zalando.org', 'v1', 'kopfpeerings')

--- a/tests/k8s/test_events.py
+++ b/tests/k8s/test_events.py
@@ -1,7 +1,7 @@
 import aiohttp.web
 import pytest
 
-from kopf.clients.events import EVENTS_CORE_V1_CRD, EVENTS_V1BETA1_CRD, post_event
+from kopf.clients.events import EVENTS_RESOURCE, post_event
 from kopf.structs.bodies import build_object_reference
 
 
@@ -9,7 +9,7 @@ async def test_posting(
         resp_mocker, aresponses, hostname):
 
     post_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    aresponses.add(hostname, EVENTS_CORE_V1_CRD.get_url(namespace='ns'), 'post', post_mock)
+    aresponses.add(hostname, EVENTS_RESOURCE.get_url(namespace='ns'), 'post', post_mock)
 
     obj = {'apiVersion': 'group/version',
            'kind': 'kind',
@@ -37,31 +37,11 @@ async def test_posting(
     assert data['involvedObject']['uid'] == 'uid'
 
 
-async def test_type_is_v1_not_v1beta1(
-        resp_mocker, aresponses, hostname):
-
-    core_v1_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    v1beta1_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    aresponses.add(hostname, EVENTS_CORE_V1_CRD.get_url(namespace='ns'), 'post', core_v1_mock)
-    aresponses.add(hostname, EVENTS_V1BETA1_CRD.get_url(namespace='ns'), 'post', v1beta1_mock)
-
-    obj = {'apiVersion': 'group/version',
-           'kind': 'kind',
-           'metadata': {'namespace': 'ns',
-                        'name': 'name',
-                        'uid': 'uid'}}
-    ref = build_object_reference(obj)
-    await post_event(ref=ref, type='type', reason='reason', message='message')
-
-    assert core_v1_mock.called
-    assert not v1beta1_mock.called
-
-
 async def test_api_errors_logged_but_suppressed(
         resp_mocker, aresponses, hostname, assert_logs):
 
     post_mock = resp_mocker(return_value=aresponses.Response(status=555))
-    aresponses.add(hostname, EVENTS_CORE_V1_CRD.get_url(namespace='ns'), 'post', post_mock)
+    aresponses.add(hostname, EVENTS_RESOURCE.get_url(namespace='ns'), 'post', post_mock)
 
     obj = {'apiVersion': 'group/version',
            'kind': 'kind',
@@ -98,7 +78,7 @@ async def test_message_is_cut_to_max_length(
         resp_mocker, aresponses, hostname):
 
     post_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    aresponses.add(hostname, EVENTS_CORE_V1_CRD.get_url(namespace='ns'), 'post', post_mock)
+    aresponses.add(hostname, EVENTS_RESOURCE.get_url(namespace='ns'), 'post', post_mock)
 
     obj = {'apiVersion': 'group/version',
            'kind': 'kind',
@@ -121,7 +101,7 @@ async def test_headers_are_not_leaked(
         resp_mocker, aresponses, hostname, assert_logs, status):
 
     post_mock = resp_mocker(return_value=aresponses.Response(status=status))
-    aresponses.add(hostname, EVENTS_CORE_V1_CRD.get_url(namespace='ns'), 'post', post_mock)
+    aresponses.add(hostname, EVENTS_RESOURCE.get_url(namespace='ns'), 'post', post_mock)
 
     obj = {'apiVersion': 'group/version',
            'kind': 'kind',

--- a/tests/peering/conftest.py
+++ b/tests/peering/conftest.py
@@ -1,6 +1,9 @@
 import pytest
 
-from kopf.engines.peering import CLUSTER_PEERING_RESOURCE, NAMESPACED_PEERING_RESOURCE
+from kopf.structs.references import Resource
+
+NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings')
+CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings')
 
 
 @pytest.fixture(autouse=True)

--- a/tests/peering/test_freeze_mode.py
+++ b/tests/peering/test_freeze_mode.py
@@ -7,6 +7,10 @@ import pytest
 
 from kopf.engines.peering import process_peering_event
 from kopf.structs import bodies, primitives
+from kopf.structs.references import Resource
+
+NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings')
+CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings')
 
 
 @dataclasses.dataclass(frozen=True, eq=False)
@@ -43,9 +47,10 @@ async def replenished(mocker):
     ['our-name', None, 'our-name', 'their-namespace'],
     ['our-name', None, 'their-name', 'our-namespace'],
 ])
+@pytest.mark.parametrize('peering_resource', [NAMESPACED_PEERING_RESOURCE, CLUSTER_PEERING_RESOURCE])
 async def test_other_peering_objects_are_ignored(
         mocker, k8s_mocked, settings, replenished,
-        our_name, our_namespace, their_name, their_namespace):
+        peering_resource, our_name, our_namespace, their_name, their_namespace):
 
     status = mocker.Mock()
     status.items.side_effect = Exception("This should not be called.")
@@ -65,6 +70,7 @@ async def test_other_peering_objects_are_ignored(
         replenished=replenished,
         autoclean=False,
         identity='id',
+        resource=peering_resource,
         settings=settings,
         namespace=our_namespace,
     )
@@ -103,6 +109,7 @@ async def test_toggled_on_for_higher_priority_peer_when_initially_off(
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
+        resource=NAMESPACED_PEERING_RESOURCE,
         identity='id',
         settings=settings,
     )
@@ -147,6 +154,7 @@ async def test_ignored_for_higher_priority_peer_when_already_on(
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
+        resource=NAMESPACED_PEERING_RESOURCE,
         identity='id',
         settings=settings,
     )
@@ -192,6 +200,7 @@ async def test_toggled_off_for_lower_priority_peer_when_initially_on(
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
+        resource=NAMESPACED_PEERING_RESOURCE,
         identity='id',
         settings=settings,
     )
@@ -235,6 +244,7 @@ async def test_ignored_for_lower_priority_peer_when_already_off(
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
+        resource=NAMESPACED_PEERING_RESOURCE,
         identity='id',
         settings=settings,
     )
@@ -279,6 +289,7 @@ async def test_toggled_on_for_same_priority_peer_when_initially_off(
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
+        resource=NAMESPACED_PEERING_RESOURCE,
         identity='id',
         settings=settings,
     )
@@ -325,6 +336,7 @@ async def test_ignored_for_same_priority_peer_when_already_on(
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
+        resource=NAMESPACED_PEERING_RESOURCE,
         identity='id',
         settings=settings,
     )
@@ -372,6 +384,7 @@ async def test_resumes_immediately_on_expiration_of_blocking_peers(
         replenished=replenished,
         autoclean=False,
         namespace='namespace',
+        resource=NAMESPACED_PEERING_RESOURCE,
         identity='id',
         settings=settings,
     )

--- a/tests/peering/test_keepalive.py
+++ b/tests/peering/test_keepalive.py
@@ -1,6 +1,9 @@
 import pytest
 
-from kopf.engines.peering import Peer, keepalive
+from kopf.engines.peering import keepalive
+from kopf.structs.references import Resource
+
+NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings')
 
 
 class StopInfiniteCycleException(Exception):
@@ -18,7 +21,8 @@ async def test_background_task_runs(mocker, settings):
 
     settings.peering.lifetime = 33
     with pytest.raises(StopInfiniteCycleException):
-        await keepalive(settings=settings, identity='id', namespace='namespace')
+        await keepalive(settings=settings, identity='id',
+                        resource=NAMESPACED_PEERING_RESOURCE, namespace='namespace')
 
     assert randint_mock.call_count == 3  # only to be sure that we test the right thing
     assert sleep_mock.call_count == 3

--- a/tests/peering/test_peer_detection.py
+++ b/tests/peering/test_peer_detection.py
@@ -2,7 +2,11 @@ import re
 
 import pytest
 
-from kopf.engines.peering import CLUSTER_PEERING_RESOURCE, NAMESPACED_PEERING_RESOURCE, detect
+from kopf.engines.peering import detect
+from kopf.structs.references import Resource
+
+NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings')
+CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings')
 
 
 @pytest.fixture()

--- a/tests/peering/test_peer_detection.py
+++ b/tests/peering/test_peer_detection.py
@@ -2,8 +2,7 @@ import re
 
 import pytest
 
-from kopf.engines.peering import CLUSTER_PEERING_RESOURCE, \
-                                 NAMESPACED_PEERING_RESOURCE, detect_presence
+from kopf.engines.peering import CLUSTER_PEERING_RESOURCE, NAMESPACED_PEERING_RESOURCE, detect
 
 
 @pytest.fixture()
@@ -28,7 +27,7 @@ async def test_standalone(mandatory, namespace, name, settings):
     settings.peering.standalone = True
     settings.peering.mandatory = mandatory
     settings.peering.name = name
-    peering = await detect_presence(settings=settings, namespace=namespace)
+    peering = await detect(settings=settings, namespace=namespace)
     assert peering is None
 
 
@@ -38,7 +37,7 @@ async def test_standalone(mandatory, namespace, name, settings):
 async def test_cluster_scoped_when_existent(mandatory, settings):
     settings.peering.mandatory = mandatory
     settings.peering.name = 'existent'
-    peering = await detect_presence(settings=settings, namespace=None)
+    peering = await detect(settings=settings, namespace=None)
     assert peering is True
 
 
@@ -48,7 +47,7 @@ async def test_cluster_scoped_when_existent(mandatory, settings):
 async def test_namespace_scoped_when_existent(mandatory, settings):
     settings.peering.mandatory = mandatory
     settings.peering.name = 'existent'
-    peering = await detect_presence(settings=settings, namespace='namespace')
+    peering = await detect(settings=settings, namespace='namespace')
     assert peering is True
 
 
@@ -58,7 +57,7 @@ async def test_cluster_scoped_when_absent(hostname, aresponses, settings):
     settings.peering.name = 'absent'
     aresponses.add(hostname, re.compile(r'.*'), 'get', aresponses.Response(status=404), repeat=999)
     with pytest.raises(Exception, match=r"The mandatory peering 'absent' was not found") as e:
-        await detect_presence(settings=settings, namespace=None)
+        await detect(settings=settings, namespace=None)
 
 
 @pytest.mark.usefixtures('with_namespaced_crd')
@@ -67,7 +66,7 @@ async def test_namespace_scoped_when_absent(hostname, aresponses, settings):
     settings.peering.name = 'absent'
     aresponses.add(hostname, re.compile(r'.*'), 'get', aresponses.Response(status=404), repeat=999)
     with pytest.raises(Exception, match=r"The mandatory peering 'absent' was not found") as e:
-        await detect_presence(settings=settings, namespace='namespace')
+        await detect(settings=settings, namespace='namespace')
 
 
 @pytest.mark.usefixtures('with_cluster_crd')
@@ -75,7 +74,7 @@ async def test_fallback_with_cluster_scoped(hostname, aresponses, assert_logs, c
     settings.peering.mandatory = False
     settings.peering.name = 'absent'
     aresponses.add(hostname, re.compile(r'.*'), 'get', aresponses.Response(status=404), repeat=999)
-    peering = await detect_presence(settings=settings, namespace=None)
+    peering = await detect(settings=settings, namespace=None)
     assert peering is False
     assert_logs([
         "Default peering object is not found, falling back to the standalone mode."
@@ -87,7 +86,7 @@ async def test_fallback_with_namespace_scoped(hostname, aresponses, assert_logs,
     settings.peering.mandatory = False
     settings.peering.name = 'absent'
     aresponses.add(hostname, re.compile(r'.*'), 'get', aresponses.Response(status=404), repeat=999)
-    peering = await detect_presence(settings=settings, namespace='namespace')
+    peering = await detect(settings=settings, namespace='namespace')
     assert peering is False
     assert_logs([
         "Default peering object is not found, falling back to the standalone mode."

--- a/tests/peering/test_peer_patching.py
+++ b/tests/peering/test_peer_patching.py
@@ -25,7 +25,7 @@ async def test_cleaning_peers_purges_them(
     aresponses.add(hostname, url, 'patch', patch_mock)
 
     peer = Peer(identity='id1', lastseen=lastseen)
-    await clean(peers=[peer], settings=settings, namespace=namespace)
+    await clean(peers=[peer], resource=peering_resource, settings=settings, namespace=namespace)
 
     assert patch_mock.called
     patch = await patch_mock.call_args_list[0][0][0].json()
@@ -47,7 +47,7 @@ async def test_touching_a_peer_stores_it(
     url = peering_resource.get_url(name='name0', namespace=namespace)
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    await touch(identity='id1', settings=settings, namespace=namespace)
+    await touch(identity='id1', resource=peering_resource, settings=settings, namespace=namespace)
 
     assert patch_mock.called
     patch = await patch_mock.call_args_list[0][0][0].json()
@@ -71,7 +71,7 @@ async def test_expiring_a_peer_purges_it(
     url = peering_resource.get_url(name='name0', namespace=namespace)
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    await touch(identity='id1', settings=settings, namespace=namespace, lifetime=0)
+    await touch(identity='id1', resource=peering_resource, settings=settings, namespace=namespace, lifetime=0)
 
     assert patch_mock.called
     patch = await patch_mock.call_args_list[0][0][0].json()
@@ -96,7 +96,7 @@ async def test_logs_are_skipped_in_stealth_mode(
     url = peering_resource.get_url(name='name0', namespace=namespace)
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    await touch(identity='id1', settings=settings, namespace=namespace)
+    await touch(identity='id1', resource=peering_resource, settings=settings, namespace=namespace)
 
     assert_logs([], prohibited=[
         "Keep-alive in",
@@ -119,7 +119,7 @@ async def test_logs_are_logged_in_exposed_mode(
     url = peering_resource.get_url(name='name0', namespace=namespace)
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    await touch(identity='id1', settings=settings, namespace=namespace)
+    await touch(identity='id1', resource=peering_resource, settings=settings, namespace=namespace)
 
     assert_logs([
         r"Keep-alive in 'name0' (in 'ns'|cluster-wide): ok",
@@ -143,7 +143,7 @@ async def test_logs_are_logged_when_absent(
     url = peering_resource.get_url(name='name0', namespace=namespace)
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    await touch(identity='id1', settings=settings, namespace=namespace)
+    await touch(identity='id1', resource=peering_resource, settings=settings, namespace=namespace)
 
     assert_logs([
         r"Keep-alive in 'name0' (in 'ns'|cluster-wide): not found",

--- a/tests/peering/test_peer_patching.py
+++ b/tests/peering/test_peer_patching.py
@@ -2,8 +2,11 @@ import aiohttp.web
 import freezegun
 import pytest
 
-from kopf.engines.peering import CLUSTER_PEERING_RESOURCE, \
-                                 NAMESPACED_PEERING_RESOURCE, Peer, clean, touch
+from kopf.engines.peering import Peer, clean, touch
+from kopf.structs.references import Resource
+
+NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings')
+CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings')
 
 
 @pytest.mark.usefixtures('with_both_crds')

--- a/tests/peering/test_resource_guessing.py
+++ b/tests/peering/test_resource_guessing.py
@@ -1,13 +1,14 @@
 import pytest
 
-from kopf.engines.peering import CLUSTER_PEERING_RESOURCE, \
-                                 NAMESPACED_PEERING_RESOURCE, guess_resource
+from kopf.engines.peering import guess_selector
+from kopf.structs.references import CLUSTER_PEERINGS, NAMESPACED_PEERINGS
 
 
-@pytest.mark.parametrize('namespace, expected_resource', [
-    (None, CLUSTER_PEERING_RESOURCE),
-    ('ns', NAMESPACED_PEERING_RESOURCE),
+@pytest.mark.parametrize('namespaced, expected_selector', [
+    (False, CLUSTER_PEERINGS),
+    (True, NAMESPACED_PEERINGS),
 ])
-def test_resource(namespace, expected_resource):
-    resource = guess_resource(namespace=namespace)
-    assert resource == expected_resource
+def test_guessing(settings, namespaced, expected_selector):
+    settings.peering.namespaced = namespaced
+    selector = guess_selector(settings=settings)
+    assert selector == expected_selector


### PR DESCRIPTION
Assemble all predefined resources into one module, and redefine them as selectors, and use them as selectors across the code.

Besides, guess the peering resource/selector only once at the top level, and propagate it down the call stack — instead of guessing it at every operation call.