### PR TITLE
Fallback to lowercased kinds for empty singulars

### DIFF
--- a/kopf/clients/scanning.py
+++ b/kopf/clients/scanning.py
@@ -88,13 +88,15 @@ async def _read_version(
         # has been deleted, the whole group/version is gone, and we rescan it.
         return set()
     else:
+        # Note: builtins' singulars are empty strings in K3s (reasons unknown):
+        # fall back to the lowercased kind so that the selectors could match.
         return {
             references.Resource(
                 group=group,
                 version=version,
                 kind=resource['kind'],
                 plural=resource['name'],
-                singular=resource['singularName'],
+                singular=resource['singularName'] or resource['kind'].lower(),
                 shortcuts=frozenset(resource.get('shortNames', [])),
                 categories=frozenset(resource.get('categories', [])),
                 subresources=frozenset(

--- a/tests/observation/test_processing_of_resources.py
+++ b/tests/observation/test_processing_of_resources.py
@@ -133,11 +133,11 @@ async def test_followups_for_addition(registry, apis_mock, group1_mock, timer, e
             insights=insights, raw_event=e1, registry=registry, replenished=asyncio.Event())
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1.0):
         async with insights.revised:
             await insights.revised.wait()
     await task
-    assert 0.1 < timer.seconds < 0.2
+    assert 0.1 < timer.seconds < 1.0
     assert insights.resources == {r1}
     assert apis_mock.called
     assert group1_mock.called
@@ -157,11 +157,11 @@ async def test_followups_for_deletion_of_resource(registry, apis_mock, group1_em
             insights=insights, raw_event=e1, registry=registry, replenished=asyncio.Event())
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1.0):
         async with insights.revised:
             await insights.revised.wait()
     await task
-    assert 0.1 < timer.seconds < 0.2
+    assert 0.1 < timer.seconds < 1.0
     assert not insights.resources
     assert apis_mock.called
     assert group1_empty_mock.called
@@ -181,11 +181,11 @@ async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mo
             insights=insights, raw_event=e1, registry=registry, replenished=asyncio.Event())
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1.0):
         async with insights.revised:
             await insights.revised.wait()
     await task
-    assert 0.1 < timer.seconds < 0.2
+    assert 0.1 < timer.seconds < 1.0
     assert not insights.resources
     assert apis_mock.called
     assert group1_404mock.called
@@ -205,11 +205,11 @@ async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mo
             insights=insights, raw_event=e1, registry=registry, replenished=asyncio.Event())
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1.0):
         async with insights.revised:
             await insights.revised.wait()
     await task
-    assert 0.1 < timer.seconds < 0.2
+    assert 0.1 < timer.seconds < 1.0
     assert not insights.resources
     assert apis_mock.called
     assert group1_404mock.called
@@ -226,10 +226,10 @@ async def test_backbone_is_filled(registry, core_mock, corev1_mock, timer, etype
             insights=insights, raw_event=e1, registry=registry, replenished=asyncio.Event())
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1.0):
         await insights.backbone.wait_for(NAMESPACES)
     await task
-    assert 0.1 < timer.seconds < 0.2
+    assert 0.1 < timer.seconds < 1.0
     assert NAMESPACES in insights.backbone
     assert core_mock.called
     assert corev1_mock.called


### PR DESCRIPTION
K3s has all builtins with empty singulars (reasons of this are not known). To still match the selectors that use `singular=...` or `any_name=...` with a singular value, fall back to lowercased kinds (in the assumption that they are the same as singulars, but CamelCased).

```
$ z get --raw /api/v1 | jq
………
    {
      "name": "pods",
      "singularName": "",          <<<<<<<<<<<
      "namespaced": true,
      "kind": "Pod",
      "verbs": [
        "create",
        "delete",
        "deletecollection",
        "get",
        "list",
        "patch",
        "update",
        "watch"
      ],
      "shortNames": [
        "po"
      ],
      "categories": [
        "all"
      ],
      "storageVersionHash": "xPOwRZ+Yhw8="
    },
………
    {
      "name": "services",
      "singularName": "",          <<<<<<<<<<<
      "namespaced": true,
      "kind": "Service",
      "verbs": [
        "create",
        "delete",
        "get",
        "list",
        "patch",
        "update",
        "watch"
      ],
      "shortNames": [
        "svc"
      ],
      "categories": [
        "all"
      ],
      "storageVersionHash": "0/CO1lhkEBI="
    },
………
```

_A follow-up for #600._