### PR TITLE
Document RBAC for runtime cluster observations

### DIFF
--- a/docs/deployment-rbac.yaml
+++ b/docs/deployment-rbac.yaml
@@ -16,6 +16,14 @@ rules:
     resources: [clusterkopfpeerings]
     verbs: [list, watch, patch, get]
 
+  # Framework: runtime observation of namespaces & CRDs (addition/deletion).
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [list, watch]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [list, watch]
+
   # Application: read-only access for watching cluster-wide.
   - apiGroups: [zalando.org]
     resources: [kopfexamples]

--- a/docs/deployment-rbac.yaml
+++ b/docs/deployment-rbac.yaml
@@ -15,9 +15,6 @@ rules:
   - apiGroups: [zalando.org]
     resources: [clusterkopfpeerings]
     verbs: [list, watch, patch, get]
-  - apiGroups: [apiextensions.k8s.io]
-    resources: [customresourcedefinitions]
-    verbs: [list, get]
 
   # Application: read-only access for watching cluster-wide.
   - apiGroups: [zalando.org]
@@ -37,9 +34,6 @@ rules:
     verbs: [list, watch, patch, get]
 
   # Framework: posting the events about the handlers progress/errors.
-  - apiGroups: [events.k8s.io]
-    resources: [events]
-    verbs: [create]
   - apiGroups: [""]
     resources: [events]
     verbs: [create]


### PR DESCRIPTION
The RBAC rules are optional (there are fallback scenarios if the permissions are not sufficient), but are good to have.

A follow-up for #600.