### PR TITLE
Inject the script as a module for other libraries to detect it

### DIFF
--- a/kopf/utilities/loaders.py
+++ b/kopf/utilities/loaders.py
@@ -29,11 +29,12 @@ def preload(
     Ensure the handlers are registered by loading/importing the files/modules.
     """
 
-    for path in paths:
+    for idx, path in enumerate(paths):
         sys.path.insert(0, os.path.abspath(os.path.dirname(path)))
-        name, _ = os.path.splitext(os.path.basename(path))
+        name = f'__kopf_script_{idx}__{path}'  # same pseudo-name as '__main__'
         spec = importlib.util.spec_from_file_location(name, path)
         module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
         spec.loader.exec_module(module)  # type: ignore
 
     for name in modules:


### PR DESCRIPTION
Pydantic was failing while trying to access `sys.modules[...]` with the name of the script file somewhere in its metaclasses.

I'm not sure this is the proper way to inject modules, but it solves the problem, and it is how it is documented by example e.g. here (with the `sys.modules` injection):

* https://docs.python.org/3/library/importlib.html#checking-if-a-module-can-be-imported

A uniqueness is checked to prevent 2+ same-named scripts from being loaded from different paths — for extra safety. Another option was to inject them with the fake names like `"_kopf_script_{idx}_{path}"` — and it also worked. But this might interfere with the usual importing logic, which does not simulate these names.

#631 