### PR TITLE
Prevent "explosions of events" when producing events while handling other events

### DIFF
--- a/docs/events.rst
+++ b/docs/events.rst
@@ -92,3 +92,20 @@ at the moment (and not event the children)::
     Events are not persistent.
     They are usually garbage-collected after some time, e.g. one hour.
     All the reported information must be only for a short-term use.
+
+
+Events for events
+=================
+
+As a rule of thumb, it is impossible to create "events for events".
+
+No error will be raised. The event creation will be silently skipped.
+
+As the primary purpose, this is done to prevent "event explosions"
+when handling the core v1 events, which creates new core v1 events,
+causing more handling, so on (similar to "fork-bombs").
+Such cases are possible, for example, when using ``kopf.EVERYTHING``
+(globally or for the v1 API), or when explicitly handling the core v1 events.
+
+As a side-effect, "events for events" are also silenced when manually created
+via :func:`kopf.event`, :func:`kopf.info`, :func:`kopf.warn`, etc.

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -133,6 +133,20 @@ Serving everything is better when it is used with filters:
     def fn(**_):
         pass
 
+.. note::
+
+    Core v1 events are excluded from ``EVERYTHING``: they are created during
+    handling of other resources in the implicit :doc:`events` from log messages,
+    so they would cause unnecessary handling cycles for every essential change.
+
+    To handle core v1 events, they must be named explicitly, e.g. like this:
+
+    .. code-block:: python
+
+        @kopf.on.event('v1', 'events')
+        def fn(**_):
+            pass
+
 The resource specifications do not support multiple values, masks or globs.
 To handle multiple independent resources, add multiple decorators
 to the same handler function -- as shown above.

--- a/kopf/clients/events.py
+++ b/kopf/clients/events.py
@@ -34,6 +34,11 @@ async def post_event(
     if context is None:
         raise RuntimeError("API instance is not injected by the decorator.")
 
+    # Prevent "event explosion", when core v1 events are handled and create other core v1 events.
+    # This can happen with `EVERYTHING` without additional filters, or by explicitly serving them.
+    if ref['apiVersion'] == 'v1' and ref['kind'] == 'Event':
+        return
+
     # See #164. For cluster-scoped objects, use the current namespace from the current context.
     # It could be "default", but in some systems, we are limited to one specific namespace only.
     namespace_name: str = ref.get('namespace') or context.default_namespace or 'default'

--- a/tests/k8s/test_events.py
+++ b/tests/k8s/test_events.py
@@ -42,6 +42,23 @@ async def test_posting(
     assert data['involvedObject']['uid'] == 'uid'
 
 
+async def test_no_events_for_events(
+        resp_mocker, aresponses, hostname):
+
+    post_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    aresponses.add(hostname, '/api/v1/namespaces/ns/events', 'post', post_mock)
+
+    obj = {'apiVersion': 'v1',
+           'kind': 'Event',
+           'metadata': {'namespace': 'ns',
+                        'name': 'name',
+                        'uid': 'uid'}}
+    ref = build_object_reference(obj)
+    await post_event(ref=ref, type='type', reason='reason', message='message', resource=EVENTS)
+
+    assert not post_mock.called
+
+
 async def test_api_errors_logged_but_suppressed(
         resp_mocker, aresponses, hostname, assert_logs):
 


### PR DESCRIPTION
1. Exclude `kind: Event` (of both core v1 API & `events.k8s.io` API) from "EVERYTHING". Require it to be explicitly listed if needs to be served. 

2. Prohibit (actually, silence) creation of events attached to other events. The "events-for-events" make little sense per se and cause the "events explosions" when there is an operator that explicitly or implicitly handles the events.

Reason: we produce a few of them when handling the resources (including events) in the implicit "out of the box" connector between Python logging and Kubernetes events, so we do not want to handle what we produce ourselves.

This does not affect the on-event low-level handlers, as they do not produce implicit events; only the high-level on-creation/update/deletion/resume do.