### PR TITLE
Use Python's defaulting for resources, stop simulating it

### DIFF
--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -121,7 +121,7 @@ class Resource:
     categories: Collection[str] = ()
     subresources: Collection[str] = ()
     namespaced: Optional[bool] = None
-    preferred: Optional[bool] = None
+    preferred: bool = True  # against conventions, but makes versionless selectors match by default.
     verbs: Collection[str] = ()
 
     def __hash__(self) -> int:

--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -115,14 +115,14 @@ class Resource:
     version: str
     plural: str
 
-    kind: str
-    singular: str
-    shortcuts: Collection[str]
-    categories: Collection[str]
-    subresources: Collection[str]
-    namespaced: bool
-    preferred: bool
-    verbs: Collection[str]
+    kind: Optional[str] = None
+    singular: Optional[str] = None
+    shortcuts: Collection[str] = ()
+    categories: Collection[str] = ()
+    subresources: Collection[str] = ()
+    namespaced: Optional[bool] = None
+    preferred: Optional[bool] = None
+    verbs: Collection[str] = ()
 
     def __hash__(self) -> int:
         return hash((self.group, self.version, self.plural))

--- a/tests/basic-structs/test_resource.py
+++ b/tests/basic-structs/test_resource.py
@@ -2,11 +2,6 @@ import pytest
 
 from kopf.structs.references import Resource
 
-DEFAULTS = dict(
-    kind='...', singular='...', namespaced=True, preferred=True,
-    shortcuts=[], categories=[], subresources=[], verbs=[],
-)
-
 
 def test_creation_with_no_args():
     with pytest.raises(TypeError):
@@ -41,126 +36,126 @@ def test_creation_with_all_kwargs():
 
 
 def test_api_version_of_custom_resource():
-    resource = Resource('group', 'version', 'plural', **DEFAULTS)
+    resource = Resource('group', 'version', 'plural')
     api_version = resource.api_version
     assert api_version == 'group/version'
 
 
 def test_api_version_of_builtin_resource():
-    resource = Resource('', 'v1', 'plural', **DEFAULTS)
+    resource = Resource('', 'v1', 'plural')
     api_version = resource.api_version
     assert api_version == 'v1'
 
 
 def test_name_of_custom_resource():
-    resource = Resource('group', 'version', 'plural', **DEFAULTS)
+    resource = Resource('group', 'version', 'plural')
     name = resource.name
     assert name == 'plural.group'
 
 
 def test_name_of_builtin_resource():
-    resource = Resource('', 'v1', 'plural', **DEFAULTS)
+    resource = Resource('', 'v1', 'plural')
     name = resource.name
     assert name == 'plural'
 
 
 def test_url_of_custom_resource_list_cluster_scoped():
-    resource = Resource('group', 'version', 'plural', **DEFAULTS)
+    resource = Resource('group', 'version', 'plural')
     url = resource.get_url()
     assert url == '/apis/group/version/plural'
 
 
 def test_url_of_custom_resource_list_namespaced():
-    resource = Resource('group', 'version', 'plural', **DEFAULTS)
+    resource = Resource('group', 'version', 'plural')
     url = resource.get_url(namespace='ns-a.b')
     assert url == '/apis/group/version/namespaces/ns-a.b/plural'
 
 
 def test_url_of_custom_resource_item_cluster_scoped():
-    resource = Resource('group', 'version', 'plural', **DEFAULTS)
+    resource = Resource('group', 'version', 'plural')
     url = resource.get_url(name='name-a.b')
     assert url == '/apis/group/version/plural/name-a.b'
 
 
 def test_url_of_custom_resource_item_namespaced():
-    resource = Resource('group', 'version', 'plural', **DEFAULTS)
+    resource = Resource('group', 'version', 'plural')
     url = resource.get_url(namespace='ns-a.b', name='name-a.b')
     assert url == '/apis/group/version/namespaces/ns-a.b/plural/name-a.b'
 
 
 def test_url_of_builtin_resource_list_cluster_scoped():
-    resource = Resource('', 'v1', 'plural', **DEFAULTS)
+    resource = Resource('', 'v1', 'plural')
     url = resource.get_url()
     assert url == '/api/v1/plural'
 
 
 def test_url_of_builtin_resource_list_namespaced():
-    resource = Resource('', 'v1', 'plural', **DEFAULTS)
+    resource = Resource('', 'v1', 'plural')
     url = resource.get_url(namespace='ns-a.b')
     assert url == '/api/v1/namespaces/ns-a.b/plural'
 
 
 def test_url_of_builtin_resource_item_cluster_scoped():
-    resource = Resource('', 'v1', 'plural', **DEFAULTS)
+    resource = Resource('', 'v1', 'plural')
     url = resource.get_url(name='name-a.b')
     assert url == '/api/v1/plural/name-a.b'
 
 
 def test_url_of_builtin_resource_item_namespaced():
-    resource = Resource('', 'v1', 'plural', **DEFAULTS)
+    resource = Resource('', 'v1', 'plural')
     url = resource.get_url(namespace='ns-a.b', name='name-a.b')
     assert url == '/api/v1/namespaces/ns-a.b/plural/name-a.b'
 
 
 def test_url_with_arbitrary_params():
-    resource = Resource('group', 'version', 'plural', **DEFAULTS)
+    resource = Resource('group', 'version', 'plural')
     url = resource.get_url(params=dict(watch='true', resourceVersion='abc%def xyz'))
     assert url == '/apis/group/version/plural?watch=true&resourceVersion=abc%25def+xyz'
 
 
 def test_url_of_custom_resource_list_cluster_scoped_with_subresource():
-    resource = Resource('group', 'version', 'plural', **DEFAULTS)
+    resource = Resource('group', 'version', 'plural')
     with pytest.raises(ValueError):
         resource.get_url(subresource='status')
 
 
 def test_url_of_custom_resource_list_namespaced_with_subresource():
-    resource = Resource('group', 'version', 'plural', **DEFAULTS)
+    resource = Resource('group', 'version', 'plural')
     with pytest.raises(ValueError):
         resource.get_url(namespace='ns-a.b', subresource='status')
 
 
 def test_url_of_custom_resource_item_cluster_scoped_with_subresource():
-    resource = Resource('group', 'version', 'plural', **DEFAULTS)
+    resource = Resource('group', 'version', 'plural')
     url = resource.get_url(name='name-a.b', subresource='status')
     assert url == '/apis/group/version/plural/name-a.b/status'
 
 
 def test_url_of_custom_resource_item_namespaced_with_subresource():
-    resource = Resource('group', 'version', 'plural', **DEFAULTS)
+    resource = Resource('group', 'version', 'plural')
     url = resource.get_url(name='name-a.b', namespace='ns-a.b', subresource='status')
     assert url == '/apis/group/version/namespaces/ns-a.b/plural/name-a.b/status'
 
 
 def test_url_of_builtin_resource_list_cluster_scoped_with_subresource():
-    resource = Resource('', 'v1', 'plural', **DEFAULTS)
+    resource = Resource('', 'v1', 'plural')
     with pytest.raises(ValueError):
         resource.get_url(subresource='status')
 
 
 def test_url_of_builtin_resource_list_namespaced_with_subresource():
-    resource = Resource('', 'v1', 'plural', **DEFAULTS)
+    resource = Resource('', 'v1', 'plural')
     with pytest.raises(ValueError):
         resource.get_url(namespace='ns-a.b', subresource='status')
 
 
 def test_url_of_builtin_resource_item_cluster_scoped_with_subresource():
-    resource = Resource('', 'v1', 'plural', **DEFAULTS)
+    resource = Resource('', 'v1', 'plural')
     url = resource.get_url(name='name-a.b', subresource='status')
     assert url == '/api/v1/plural/name-a.b/status'
 
 
 def test_url_of_builtin_resource_item_namespaced_with_subresource():
-    resource = Resource('', 'v1', 'plural', **DEFAULTS)
+    resource = Resource('', 'v1', 'plural')
     url = resource.get_url(name='name-a.b', namespace='ns-a.b', subresource='status')
     assert url == '/api/v1/namespaces/ns-a.b/plural/name-a.b/status'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,12 +92,7 @@ def enforce_asyncio_mocker():
 @pytest.fixture()
 def resource():
     """ The resource used in the tests. Usually mocked, so it does not matter. """
-    return Resource(
-        group='zalando.org', version='v1', namespaced=True, preferred=True,
-        plural='kopfexamples', singular='kopfexample', kind='KopfExample',
-        shortcuts=['kex'], categories=['kopf', 'all'], subresources=[],
-        verbs=['get', 'list', 'watch', 'patch', 'create', 'delete'],
-    )
+    return Resource('zalando.org', 'v1', 'kopfexamples')
 
 
 @pytest.fixture()

--- a/tests/k8s/test_events.py
+++ b/tests/k8s/test_events.py
@@ -5,9 +5,7 @@ from kopf.clients.events import post_event
 from kopf.structs.bodies import build_object_reference
 from kopf.structs.references import Resource
 
-EVENTS = Resource('', 'v1', 'events',
-                  kind='...', singular='...', namespaced=True, preferred=True,
-                  shortcuts=[], categories=[], subresources=[], verbs=[])
+EVENTS = Resource('', 'v1', 'events')
 
 
 async def test_posting(

--- a/tests/observation/test_processing_of_resources.py
+++ b/tests/observation/test_processing_of_resources.py
@@ -9,12 +9,6 @@ from kopf.reactor.observation import process_discovered_resource_event
 from kopf.structs.bodies import RawBody, RawEvent
 from kopf.structs.references import NAMESPACES, Insights, Resource
 
-DEFAULTS = dict(
-    kind='...', singular='...', namespaced=True, preferred=True,
-    shortcuts=[], categories=[], subresources=[],
-    verbs=['list', 'watch', 'patch'],
-)
-
 # Implementation awareness: the events only trigger the re-scan, so the fields can be reduced
 # to only the group name which is being rescanned. Other fields are ignored in the events.
 # The actual data is taken from the API. It is tested elsewhere, so we rely on its correctness here.
@@ -124,7 +118,7 @@ async def test_initial_listing_is_ignored(registry, apis_mock, group1_mock):
 @pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED'])
 async def test_followups_for_addition(registry, apis_mock, group1_mock, timer, etype):
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1')
     insights = Insights()
 
     async def delayed_injection(delay: float):
@@ -147,7 +141,7 @@ async def test_followups_for_addition(registry, apis_mock, group1_mock, timer, e
 @pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED', 'DELETED'])
 async def test_followups_for_deletion_of_resource(registry, apis_mock, group1_empty_mock, timer, etype):
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1')
     insights = Insights()
     insights.resources.add(r1)
 
@@ -171,7 +165,7 @@ async def test_followups_for_deletion_of_resource(registry, apis_mock, group1_em
 @pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED', 'DELETED'])
 async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mock, timer, etype):
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1')
     insights = Insights()
     insights.resources.add(r1)
 
@@ -195,7 +189,7 @@ async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mo
 @pytest.mark.parametrize('etype', ['DELETED'])
 async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mock, timer, etype):
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1')
     insights = Insights()
     insights.resources.add(r1)
 

--- a/tests/observation/test_revision_of_resources.py
+++ b/tests/observation/test_revision_of_resources.py
@@ -60,8 +60,8 @@ def test_replacing_a_new_group(registry):
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_ambiguity_in_specific_selectors(registry, decorator, caplog, assert_logs):
-    r1 = Resource(group='g1', version='v1', plural='plural', verbs=VERBS, preferred=True)
-    r2 = Resource(group='g2', version='v2', plural='plural', verbs=VERBS, preferred=True)
+    r1 = Resource(group='g1', version='v1', plural='plural', verbs=VERBS)
+    r2 = Resource(group='g2', version='v2', plural='plural', verbs=VERBS)
 
     @decorator(plural='plural')
     def fn(**_): ...
@@ -77,8 +77,8 @@ def test_ambiguity_in_specific_selectors(registry, decorator, caplog, assert_log
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_corev1_overrides_ambuigity(registry, decorator, caplog, assert_logs):
-    r1 = Resource(group='', version='v1', plural='pods', verbs=VERBS, preferred=True)
-    r2 = Resource(group='metrics.k8s.io', version='v1', plural='pods', verbs=VERBS, preferred=True)
+    r1 = Resource(group='', version='v1', plural='pods', verbs=VERBS)
+    r2 = Resource(group='metrics.k8s.io', version='v1', plural='pods', verbs=VERBS)
 
     @decorator(plural='pods')
     def fn(**_): ...
@@ -94,8 +94,8 @@ def test_corev1_overrides_ambuigity(registry, decorator, caplog, assert_logs):
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_no_ambiguity_in_generic_selector(registry, decorator, caplog, assert_logs):
-    r1 = Resource(group='g1', version='v1', plural='plural', verbs=VERBS, preferred=True)
-    r2 = Resource(group='g2', version='v2', plural='plural', verbs=VERBS, preferred=True)
+    r1 = Resource(group='g1', version='v1', plural='plural', verbs=VERBS)
+    r2 = Resource(group='g2', version='v2', plural='plural', verbs=VERBS)
 
     @decorator(EVERYTHING)
     def fn(**_): ...

--- a/tests/observation/test_revision_of_resources.py
+++ b/tests/observation/test_revision_of_resources.py
@@ -4,11 +4,7 @@ import kopf
 from kopf.reactor.observation import revise_resources
 from kopf.structs.references import EVERYTHING, Insights, Resource
 
-DEFAULTS = dict(
-    kind='...', singular='...', namespaced=True, preferred=True,
-    shortcuts=[], categories=[], subresources=[],
-    verbs=['list', 'watch', 'patch'],
-)
+VERBS = ['list', 'watch', 'patch']
 
 
 @pytest.fixture(params=[
@@ -23,7 +19,7 @@ def handlers(request, registry):
 
 @pytest.mark.usefixtures('handlers')
 def test_initial_population(registry):
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1', verbs=VERBS)
     insights = Insights()
     revise_resources(registry=registry, insights=insights, group=None, resources=[r1])
     assert insights.resources == {r1}
@@ -31,8 +27,8 @@ def test_initial_population(registry):
 
 @pytest.mark.usefixtures('handlers')
 def test_replacing_all_insights(registry):
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
-    r2 = Resource(group='group2', version='version2', plural='plural2', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1', verbs=VERBS)
+    r2 = Resource(group='group2', version='version2', plural='plural2', verbs=VERBS)
     insights = Insights()
     revise_resources(registry=registry, insights=insights, group=None, resources=[r1])
     revise_resources(registry=registry, insights=insights, group=None, resources=[r2])
@@ -41,8 +37,8 @@ def test_replacing_all_insights(registry):
 
 @pytest.mark.usefixtures('handlers')
 def test_replacing_an_existing_group(registry):
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
-    r2 = Resource(group='group2', version='version2', plural='plural2', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1', verbs=VERBS)
+    r2 = Resource(group='group2', version='version2', plural='plural2', verbs=VERBS)
     insights = Insights()
     revise_resources(registry=registry, insights=insights, group=None, resources=[r1])
     revise_resources(registry=registry, insights=insights, group='group1', resources=[r2])
@@ -51,8 +47,8 @@ def test_replacing_an_existing_group(registry):
 
 @pytest.mark.usefixtures('handlers')
 def test_replacing_a_new_group(registry):
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
-    r2 = Resource(group='group2', version='version2', plural='plural2', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1', verbs=VERBS)
+    r2 = Resource(group='group2', version='version2', plural='plural2', verbs=VERBS)
     insights = Insights()
     revise_resources(registry=registry, insights=insights, group=None, resources=[r1])
     revise_resources(registry=registry, insights=insights, group='group2', resources=[r2])
@@ -64,8 +60,8 @@ def test_replacing_a_new_group(registry):
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_ambiguity_in_specific_selectors(registry, decorator, caplog, assert_logs):
-    r1 = Resource(group='g1', version='v1', plural='plural', **DEFAULTS)
-    r2 = Resource(group='g2', version='v2', plural='plural', **DEFAULTS)
+    r1 = Resource(group='g1', version='v1', plural='plural', verbs=VERBS, preferred=True)
+    r2 = Resource(group='g2', version='v2', plural='plural', verbs=VERBS, preferred=True)
 
     @decorator(plural='plural')
     def fn(**_): ...
@@ -81,8 +77,8 @@ def test_ambiguity_in_specific_selectors(registry, decorator, caplog, assert_log
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_corev1_overrides_ambuigity(registry, decorator, caplog, assert_logs):
-    r1 = Resource(group='', version='v1', plural='pods', **DEFAULTS)
-    r2 = Resource(group='metrics.k8s.io', version='v1beta1', plural='pods', **DEFAULTS)
+    r1 = Resource(group='', version='v1', plural='pods', verbs=VERBS, preferred=True)
+    r2 = Resource(group='metrics.k8s.io', version='v1', plural='pods', verbs=VERBS, preferred=True)
 
     @decorator(plural='pods')
     def fn(**_): ...
@@ -98,8 +94,8 @@ def test_corev1_overrides_ambuigity(registry, decorator, caplog, assert_logs):
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_no_ambiguity_in_generic_selector(registry, decorator, caplog, assert_logs):
-    r1 = Resource(group='g1', version='v1', plural='plural', **DEFAULTS)
-    r2 = Resource(group='g2', version='v2', plural='plural', **DEFAULTS)
+    r1 = Resource(group='g1', version='v1', plural='plural', verbs=VERBS, preferred=True)
+    r2 = Resource(group='g2', version='v2', plural='plural', verbs=VERBS, preferred=True)
 
     @decorator(EVERYTHING)
     def fn(**_): ...
@@ -115,8 +111,8 @@ def test_no_ambiguity_in_generic_selector(registry, decorator, caplog, assert_lo
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_selectors_with_no_resources(registry, decorator, caplog, assert_logs):
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
-    r2 = Resource(group='group2', version='version2', plural='plural2', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1', verbs=VERBS)
+    r2 = Resource(group='group2', version='version2', plural='plural2', verbs=VERBS)
 
     @decorator(plural='plural3')
     def fn(**_): ...
@@ -132,8 +128,7 @@ def test_selectors_with_no_resources(registry, decorator, caplog, assert_logs):
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_nonwatchable_excluded(registry, decorator, caplog, assert_logs):
-    defaults = dict(DEFAULTS, verbs=[])
-    r1 = Resource(group='group1', version='version1', plural='plural1', **defaults)
+    r1 = Resource(group='group1', version='version1', plural='plural1', verbs=[])
 
     @decorator('group1', 'version1', 'plural1')
     def fn(**_): ...
@@ -149,8 +144,7 @@ def test_nonwatchable_excluded(registry, decorator, caplog, assert_logs):
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_nonpatchable_excluded(registry, decorator, caplog, assert_logs):
-    defaults = dict(DEFAULTS, verbs=['watch', 'list'])
-    r1 = Resource(group='group1', version='version1', plural='plural1', **defaults)
+    r1 = Resource(group='group1', version='version1', plural='plural1', verbs=['watch', 'list'])
 
     @decorator('group1', 'version1', 'plural1')  # because it patches!
     def fn(**_): ...

--- a/tests/orchestration/test_task_adjustments.py
+++ b/tests/orchestration/test_task_adjustments.py
@@ -10,15 +10,6 @@ from kopf.structs import bodies, primitives
 from kopf.structs.references import Insights, Resource
 from kopf.utilities import aiotasks
 
-DEFAULTS = dict(
-    kind='...', singular='...', namespaced=True, preferred=True,
-    shortcuts=[], categories=[], subresources=[],
-    verbs=['list', 'watch', 'patch'],
-)
-
-NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', **DEFAULTS)
-CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings', **DEFAULTS)
-
 
 async def processor(*, raw_event: bodies.RawEvent, replenished: asyncio.Event) -> None:
     pass
@@ -44,7 +35,7 @@ def k8s_mocked(mocker, resp_mocker):
 ], ids=['cluster-peering', 'namespaced-peering'])
 def peering_resource(request, settings):
     settings.peering.namespaced = request.param[0]
-    return Resource('zalando.org', 'v1', request.param[1], **DEFAULTS)
+    return Resource('zalando.org', 'v1', request.param[1], namespaced=request.param[0])
 
 
 @pytest.fixture()
@@ -87,8 +78,8 @@ async def test_empty_insights_cause_no_adjustments(
 async def test_new_resources_and_namespaces_spawn_new_tasks(
         settings, ensemble: Ensemble, insights: Insights, peering_resource):
 
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
-    r2 = Resource(group='group2', version='version2', plural='plural2', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1', namespaced=True)
+    r2 = Resource(group='group2', version='version2', plural='plural2', namespaced=True)
     insights.resources.add(r1)
     insights.resources.add(r2)
     insights.namespaces.add('ns1')
@@ -117,8 +108,8 @@ async def test_new_resources_and_namespaces_spawn_new_tasks(
 async def test_gone_resources_and_namespaces_stop_running_tasks(
         settings, ensemble: Ensemble, insights: Insights, peering_resource):
 
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
-    r2 = Resource(group='group2', version='version2', plural='plural2', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1', namespaced=True)
+    r2 = Resource(group='group2', version='version2', plural='plural2', namespaced=True)
     insights.resources.add(r1)
     insights.resources.add(r2)
     insights.namespaces.add('ns1')
@@ -164,8 +155,8 @@ async def test_gone_resources_and_namespaces_stop_running_tasks(
 async def test_cluster_tasks_continue_running_on_namespace_deletion(
         settings, ensemble: Ensemble, insights: Insights, peering_resource):
 
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
-    r2 = Resource(group='group2', version='version2', plural='plural2', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1', namespaced=True)
+    r2 = Resource(group='group2', version='version2', plural='plural2', namespaced=True)
     insights.resources.add(r1)
     insights.resources.add(r2)
     insights.namespaces.add(None)
@@ -209,7 +200,7 @@ async def test_no_peering_tasks_with_no_peering_resources(
 
     settings.peering.mandatory = False
     insights = Insights()
-    r1 = Resource(group='group1', version='version1', plural='plural1', **DEFAULTS)
+    r1 = Resource(group='group1', version='version1', plural='plural1', namespaced=True)
     insights.resources.add(r1)
     insights.namespaces.add('ns1')
 

--- a/tests/peering/conftest.py
+++ b/tests/peering/conftest.py
@@ -2,14 +2,8 @@ import pytest
 
 from kopf.structs.references import Resource
 
-DEFAULTS = dict(
-    kind='...', singular='...', namespaced=True, preferred=True,
-    shortcuts=[], categories=[], subresources=[],
-    verbs=['list', 'watch', 'patch'],
-)
-
-NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', **DEFAULTS)
-CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings', **DEFAULTS)
+NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', namespaced=True)
+CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings', namespaced=False)
 
 
 @pytest.fixture(autouse=True)
@@ -20,7 +14,6 @@ def _autouse_fake_vault(fake_vault):
 @pytest.fixture()
 def with_cluster_crd(hostname, aresponses):
     result = {'resources': [{
-        **DEFAULTS,
         'group': CLUSTER_PEERING_RESOURCE.group,
         'version': CLUSTER_PEERING_RESOURCE.version,
         'name': CLUSTER_PEERING_RESOURCE.plural,
@@ -33,7 +26,6 @@ def with_cluster_crd(hostname, aresponses):
 @pytest.fixture()
 def with_namespaced_crd(hostname, aresponses):
     result = {'resources': [{
-        **DEFAULTS,
         'group': NAMESPACED_PEERING_RESOURCE.group,
         'version': NAMESPACED_PEERING_RESOURCE.version,
         'name': NAMESPACED_PEERING_RESOURCE.plural,
@@ -46,13 +38,11 @@ def with_namespaced_crd(hostname, aresponses):
 @pytest.fixture()
 def with_both_crds(hostname, aresponses):
     result = {'resources': [{
-        **DEFAULTS,
         'group': CLUSTER_PEERING_RESOURCE.group,
         'version': CLUSTER_PEERING_RESOURCE.version,
         'name': CLUSTER_PEERING_RESOURCE.plural,
         'namespaced': False,
     }, {
-        **DEFAULTS,
         'group': NAMESPACED_PEERING_RESOURCE.group,
         'version': NAMESPACED_PEERING_RESOURCE.version,
         'name': NAMESPACED_PEERING_RESOURCE.plural,

--- a/tests/peering/test_freeze_mode.py
+++ b/tests/peering/test_freeze_mode.py
@@ -9,13 +9,7 @@ from kopf.engines.peering import process_peering_event
 from kopf.structs import bodies, primitives
 from kopf.structs.references import Resource
 
-DEFAULTS = dict(
-    kind='...', singular='...', namespaced=True, preferred=True,
-    shortcuts=[], categories=[], subresources=[],
-    verbs=['list', 'watch', 'patch'],
-)
-
-NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', **DEFAULTS)
+NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', namespaced=True)
 
 
 @dataclasses.dataclass(frozen=True, eq=False)

--- a/tests/peering/test_keepalive.py
+++ b/tests/peering/test_keepalive.py
@@ -3,13 +3,7 @@ import pytest
 from kopf.engines.peering import Peer, keepalive
 from kopf.structs.references import Resource
 
-DEFAULTS = dict(
-    kind='...', singular='...', namespaced=True, preferred=True,
-    shortcuts=[], categories=[], subresources=[],
-    verbs=['list', 'watch', 'patch'],
-)
-
-NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', **DEFAULTS)
+NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', namespaced=True)
 
 
 class StopInfiniteCycleException(Exception):

--- a/tests/peering/test_peer_patching.py
+++ b/tests/peering/test_peer_patching.py
@@ -5,14 +5,8 @@ import pytest
 from kopf.engines.peering import Peer, clean, touch
 from kopf.structs.references import Resource
 
-DEFAULTS = dict(
-    kind='...', singular='...', namespaced=True, preferred=True,
-    shortcuts=[], categories=[], subresources=[],
-    verbs=['list', 'watch', 'patch'],
-)
-
-NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', **DEFAULTS)
-CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings', **DEFAULTS)
+NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', namespaced=True)
+CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings', namespaced=False)
 
 
 @pytest.mark.usefixtures('with_both_crds')

--- a/tests/posting/test_poster.py
+++ b/tests/posting/test_poster.py
@@ -18,9 +18,7 @@ OBJ2 = {'apiVersion': 'group2/version2', 'kind': 'Kind2',
 REF2 = {'apiVersion': 'group2/version2', 'kind': 'Kind2',
         'uid': 'uid2', 'name': 'name2', 'namespace': 'ns2'}
 
-EVENTS = Resource('', 'v1', 'events',
-                  kind='...', singular='...', namespaced=True, preferred=True,
-                  shortcuts=[], categories=[], subresources=[], verbs=[])
+EVENTS = Resource('', 'v1', 'events')
 
 
 @pytest.fixture(autouse=True)

--- a/tests/references/test_backbone.py
+++ b/tests/references/test_backbone.py
@@ -6,11 +6,6 @@ import pytest
 from kopf.structs.references import CLUSTER_PEERINGS, CRDS, EVENTS, NAMESPACED_PEERINGS, \
                                     NAMESPACES, Backbone, Resource, Selector
 
-DEFAULTS = dict(
-    kind='...', singular='...', namespaced=True, preferred=True,
-    shortcuts=[], categories=[], subresources=[], verbs=[],
-)
-
 
 @pytest.mark.parametrize('selector', [
     CRDS, EVENTS, NAMESPACES, CLUSTER_PEERINGS, NAMESPACED_PEERINGS,
@@ -24,13 +19,13 @@ def test_empty_backbone(selector: Selector):
 
 
 @pytest.mark.parametrize('selector, resource', [
-    (CRDS, Resource('apiextensions.k8s.io', 'v1beta1', 'customresourcedefinitions', **DEFAULTS)),
-    (CRDS, Resource('apiextensions.k8s.io', 'v1', 'customresourcedefinitions', **DEFAULTS)),
-    (CRDS, Resource('apiextensions.k8s.io', 'vX', 'customresourcedefinitions', **DEFAULTS)),
-    (EVENTS, Resource('', 'v1', 'events', **DEFAULTS)),
-    (NAMESPACES, Resource('', 'v1', 'namespaces', **DEFAULTS)),
-    (CLUSTER_PEERINGS, Resource('zalando.org', 'v1', 'clusterkopfpeerings', **DEFAULTS)),
-    (NAMESPACED_PEERINGS, Resource('zalando.org', 'v1', 'kopfpeerings', **DEFAULTS)),
+    (CRDS, Resource('apiextensions.k8s.io', 'v1beta1', 'customresourcedefinitions')),
+    (CRDS, Resource('apiextensions.k8s.io', 'v1', 'customresourcedefinitions')),
+    (CRDS, Resource('apiextensions.k8s.io', 'vX', 'customresourcedefinitions')),
+    (EVENTS, Resource('', 'v1', 'events')),
+    (NAMESPACES, Resource('', 'v1', 'namespaces')),
+    (CLUSTER_PEERINGS, Resource('zalando.org', 'v1', 'clusterkopfpeerings')),
+    (NAMESPACED_PEERINGS, Resource('zalando.org', 'v1', 'kopfpeerings')),
 ])
 async def test_refill_populates_the_resources(selector: Selector, resource: Resource):
     backbone = Backbone()
@@ -42,8 +37,8 @@ async def test_refill_populates_the_resources(selector: Selector, resource: Reso
 
 async def test_refill_is_cumulative_ie_does_not_reset():
     backbone = Backbone()
-    await backbone.fill(resources=[Resource('', 'v1', 'namespaces', **DEFAULTS)])
-    await backbone.fill(resources=[Resource('', 'v1', 'events', **DEFAULTS)])
+    await backbone.fill(resources=[Resource('', 'v1', 'namespaces')])
+    await backbone.fill(resources=[Resource('', 'v1', 'events')])
     assert len(backbone) == 2
     assert set(backbone) == {NAMESPACES, EVENTS}
 
@@ -57,7 +52,7 @@ async def test_waiting_for_absent_resources_never_ends(timer):
 
 
 async def test_waiting_for_preexisting_resources_ends_instantly(timer):
-    resource = Resource('', 'v1', 'namespaces', **DEFAULTS)
+    resource = Resource('', 'v1', 'namespaces')
     backbone = Backbone()
     await backbone.fill(resources=[resource])
     async with timer, async_timeout.timeout(1):
@@ -67,7 +62,7 @@ async def test_waiting_for_preexisting_resources_ends_instantly(timer):
 
 
 async def test_waiting_for_delayed_resources_ends_once_delivered(timer):
-    resource = Resource('', 'v1', 'namespaces', **DEFAULTS)
+    resource = Resource('', 'v1', 'namespaces')
     backbone = Backbone()
 
     async def delayed_injection(delay: float):

--- a/tests/references/test_selector_matching.py
+++ b/tests/references/test_selector_matching.py
@@ -10,7 +10,6 @@ def resource():
         plural='plural1', singular='singular1', kind='kind1',
         shortcuts=['shortcut1', 'shortcut2'],
         categories=['category1', 'category2'],
-        subresources=[], verbs=[], namespaced=True,  # not used in matching
     )
 
 
@@ -21,7 +20,6 @@ def v1_resource():
         plural='plural1', singular='singular1', kind='kind1',
         shortcuts=['shortcut1', 'shortcut2'],
         categories=['category1', 'category2'],
-        subresources=[], verbs=[], namespaced=True,  # not used in matching
     )
 
 
@@ -118,7 +116,6 @@ def test_catchall_versions_are_ignored_for_nonpreferred_resources():
         plural='plural1', singular='singular1', kind='kind1',
         shortcuts=['shortcut1', 'shortcut2'],
         categories=['category1', 'category2'],
-        subresources=[], verbs=[], namespaced=True,  # not used in matching
     )
     selector = Selector(EVERYTHING)
     matches = selector.check(resource)
@@ -131,11 +128,7 @@ def test_catchall_versions_are_ignored_for_nonpreferred_resources():
     pytest.param(['', 'v1', 'events'], id='with-groupversion'),
 ])
 def test_events_are_matched_when_explicitly_named(selector_args):
-    resource = Resource(
-        group='', version='v1', preferred=True, namespaced=True,
-        plural='events', singular='event', kind='Event',
-        shortcuts=[], categories=[], subresources=[], verbs=[],
-    )
+    resource = Resource('', 'v1', 'events')
     selector = Selector(*selector_args)
     matches = selector.check(resource)
     assert matches
@@ -154,11 +147,7 @@ def test_events_are_matched_when_explicitly_named(selector_args):
     pytest.param(dict(group='events.k8s.io', version='v1beta1'), id='k8sio-v1beta1'),
 ])
 def test_events_are_excluded_from_everything(resource_kwargs, selector_args):
-    resource = Resource(
-        **resource_kwargs, preferred=True, namespaced=True,
-        plural='events', singular='event', kind='Event',
-        shortcuts=[], categories=[], subresources=[], verbs=[],
-    )
+    resource = Resource(**resource_kwargs, plural='events')
     selector = Selector(*selector_args)
     matches = selector.check(resource)
     assert not matches

--- a/tests/registries/test_matching_of_resources.py
+++ b/tests/registries/test_matching_of_resources.py
@@ -3,15 +3,10 @@ from unittest.mock import Mock
 from kopf.reactor.registries import _matches_resource
 from kopf.structs.references import Resource, Selector
 
-DEFAULTS = dict(
-    kind='...', singular='...', namespaced=True, preferred=True,
-    shortcuts=[], categories=[], subresources=[], verbs=[],
-)
-
 
 def test_different_resource():
     selector = Selector('group1', 'version1', 'plural1')
-    resource = Resource('group2', 'version2', 'plural2', **DEFAULTS)
+    resource = Resource('group2', 'version2', 'plural2', preferred=True)
     handler = Mock(selector=selector)
     matches = _matches_resource(handler, resource)
     assert not matches
@@ -19,14 +14,14 @@ def test_different_resource():
 
 def test_equivalent_resources():
     selector = Selector('group1', 'version1', 'plural1')
-    resource = Resource('group1', 'version1', 'plural1', **DEFAULTS)
+    resource = Resource('group1', 'version1', 'plural1', preferred=True)
     handler = Mock(selector=selector)
     matches = _matches_resource(handler, resource)
     assert matches
 
 
 def test_catchall_with_none():
-    resource = Resource('group2', 'version2', 'plural2', **DEFAULTS)
+    resource = Resource('group2', 'version2', 'plural2')
     handler = Mock(selector=None)
     matches = _matches_resource(handler, resource)
     assert matches

--- a/tests/registries/test_matching_of_resources.py
+++ b/tests/registries/test_matching_of_resources.py
@@ -6,7 +6,7 @@ from kopf.structs.references import Resource, Selector
 
 def test_different_resource():
     selector = Selector('group1', 'version1', 'plural1')
-    resource = Resource('group2', 'version2', 'plural2', preferred=True)
+    resource = Resource('group2', 'version2', 'plural2')
     handler = Mock(selector=selector)
     matches = _matches_resource(handler, resource)
     assert not matches
@@ -14,7 +14,7 @@ def test_different_resource():
 
 def test_equivalent_resources():
     selector = Selector('group1', 'version1', 'plural1')
-    resource = Resource('group1', 'version1', 'plural1', preferred=True)
+    resource = Resource('group1', 'version1', 'plural1')
     handler = Mock(selector=selector)
     matches = _matches_resource(handler, resource)
     assert matches


### PR DESCRIPTION
The mandatory fields were added to make sure that all fields are passed in all places. As a result, it ended up trying to outsmart Python itself by using our own defaults as dicts/kwargs all over the codebase.

Revert this approach back to using Python's features, specifically the default values for data classes. If anything important is really missing at the creation of a resource object —which happens only in one place in the whole codebase— it should be tested there explicitly (it is), or detected by breaking some features that rely on that information (which should be tested too).
