### PR TITLE
Validate the resource scope against requested namespace

### DIFF
--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -161,13 +161,17 @@ class Resource:
     ) -> str:
         if subresource is not None and name is None:
             raise ValueError("Subresources can be used only with specific resources by their name.")
+        if not self.namespaced and namespace is not None:
+            raise ValueError(f"Specific namespaces are not supported for cluster-scoped resources.")
+        if self.namespaced and namespace is None and name is not None:
+            raise ValueError("Specific namespaces are required for specific namespaced resources.")
 
         return self._build_url(server, params, [
             '/api' if self.group == '' and self.version == 'v1' else '/apis',
             self.group,
             self.version,
-            'namespaces' if namespace is not None else None,
-            namespace,
+            'namespaces' if self.namespaced and namespace is not None else None,
+            namespace if self.namespaced and namespace is not None else None,
             self.plural,
             name,
             subresource,

--- a/tests/authentication/test_reauthentication.py
+++ b/tests/authentication/test_reauthentication.py
@@ -25,11 +25,11 @@ async def stream_fn(
 
 
 async def test_session_is_injected_to_request(
-        fake_vault, resp_mocker, aresponses, hostname, resource):
+        fake_vault, resp_mocker, aresponses, hostname, resource, namespace):
 
     result = {}
     get_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
-    aresponses.add(hostname, resource.get_url(namespace=None, name='xyz'), 'get', get_mock)
+    aresponses.add(hostname, resource.get_url(namespace=namespace, name='xyz'), 'get', get_mock)
 
     context, result = await request_fn(1)
 
@@ -39,11 +39,11 @@ async def test_session_is_injected_to_request(
 
 
 async def test_session_is_injected_to_stream(
-        fake_vault, resp_mocker, aresponses, hostname, resource):
+        fake_vault, resp_mocker, aresponses, hostname, resource, namespace):
 
     result = {}
     get_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
-    aresponses.add(hostname, resource.get_url(namespace=None, name='xyz'), 'get', get_mock)
+    aresponses.add(hostname, resource.get_url(namespace=namespace, name='xyz'), 'get', get_mock)
 
     context = None
     counter = 0
@@ -57,11 +57,11 @@ async def test_session_is_injected_to_stream(
 
 
 async def test_session_is_passed_through_to_request(
-        fake_vault, resp_mocker, aresponses, hostname, resource):
+        fake_vault, resp_mocker, aresponses, hostname, resource, namespace):
 
     result = {}
     get_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
-    aresponses.add(hostname, resource.get_url(namespace=None, name='xyz'), 'get', get_mock)
+    aresponses.add(hostname, resource.get_url(namespace=namespace, name='xyz'), 'get', get_mock)
 
     explicit_context = APIContext(ConnectionInfo(server='http://irrelevant/'))
     context, result = await request_fn(1, context=explicit_context)
@@ -72,11 +72,11 @@ async def test_session_is_passed_through_to_request(
 
 
 async def test_session_is_passed_through_to_stream(
-        fake_vault, resp_mocker, aresponses, hostname, resource):
+        fake_vault, resp_mocker, aresponses, hostname, resource, namespace):
 
     result = {}
     get_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
-    aresponses.add(hostname, resource.get_url(namespace=None, name='xyz'), 'get', get_mock)
+    aresponses.add(hostname, resource.get_url(namespace=namespace, name='xyz'), 'get', get_mock)
 
     explicit_context = APIContext(ConnectionInfo(server='http://irrelevant/'))
     counter = 0

--- a/tests/basic-structs/test_resource.py
+++ b/tests/basic-structs/test_resource.py
@@ -41,7 +41,7 @@ def test_api_version_of_custom_resource():
     assert api_version == 'group/version'
 
 
-def test_api_version_of_builtin_resource():
+def test_api_version_of_corev1_resource():
     resource = Resource('', 'v1', 'plural')
     api_version = resource.api_version
     assert api_version == 'v1'
@@ -53,55 +53,55 @@ def test_name_of_custom_resource():
     assert name == 'plural.group'
 
 
-def test_name_of_builtin_resource():
+def test_name_of_corev1_resource():
     resource = Resource('', 'v1', 'plural')
     name = resource.name
     assert name == 'plural'
 
 
-def test_url_of_custom_resource_list_cluster_scoped():
+def test_url_for_a_list_of_custom_resources_clusterwide():
     resource = Resource('group', 'version', 'plural')
-    url = resource.get_url()
+    url = resource.get_url(namespace=None)
     assert url == '/apis/group/version/plural'
 
 
-def test_url_of_custom_resource_list_namespaced():
+def test_url_for_a_list_of_custom_resources_in_a_namespace():
     resource = Resource('group', 'version', 'plural')
     url = resource.get_url(namespace='ns-a.b')
     assert url == '/apis/group/version/namespaces/ns-a.b/plural'
 
 
-def test_url_of_custom_resource_item_cluster_scoped():
+def test_url_for_a_specific_custom_resource_clusterwide():
     resource = Resource('group', 'version', 'plural')
-    url = resource.get_url(name='name-a.b')
+    url = resource.get_url(namespace=None, name='name-a.b')
     assert url == '/apis/group/version/plural/name-a.b'
 
 
-def test_url_of_custom_resource_item_namespaced():
+def test_url_for_a_specific_custom_resource_in_a_namespace():
     resource = Resource('group', 'version', 'plural')
     url = resource.get_url(namespace='ns-a.b', name='name-a.b')
     assert url == '/apis/group/version/namespaces/ns-a.b/plural/name-a.b'
 
 
-def test_url_of_builtin_resource_list_cluster_scoped():
+def test_url_for_a_list_of_corev1_resources_clusterwide():
     resource = Resource('', 'v1', 'plural')
-    url = resource.get_url()
+    url = resource.get_url(namespace=None)
     assert url == '/api/v1/plural'
 
 
-def test_url_of_builtin_resource_list_namespaced():
+def test_url_for_a_list_of_corev1_resources_in_a_namespace():
     resource = Resource('', 'v1', 'plural')
     url = resource.get_url(namespace='ns-a.b')
     assert url == '/api/v1/namespaces/ns-a.b/plural'
 
 
-def test_url_of_builtin_resource_item_cluster_scoped():
+def test_url_of_a_specific_corev1_resource_clusterwide():
     resource = Resource('', 'v1', 'plural')
-    url = resource.get_url(name='name-a.b')
+    url = resource.get_url(namespace=None, name='name-a.b')
     assert url == '/api/v1/plural/name-a.b'
 
 
-def test_url_of_builtin_resource_item_namespaced():
+def test_url_of_a_specific_corev1_resource_in_a_namespace():
     resource = Resource('', 'v1', 'plural')
     url = resource.get_url(namespace='ns-a.b', name='name-a.b')
     assert url == '/api/v1/namespaces/ns-a.b/plural/name-a.b'
@@ -113,49 +113,49 @@ def test_url_with_arbitrary_params():
     assert url == '/apis/group/version/plural?watch=true&resourceVersion=abc%25def+xyz'
 
 
-def test_url_of_custom_resource_list_cluster_scoped_with_subresource():
+def test_url_for_a_list_of_custom_subresources_clusterwide():
     resource = Resource('group', 'version', 'plural')
     with pytest.raises(ValueError):
-        resource.get_url(subresource='status')
+        resource.get_url(namespace=None, subresource='status')
 
 
-def test_url_of_custom_resource_list_namespaced_with_subresource():
+def test_url_for_a_specific_custom_subresource_in_a_namespace():
     resource = Resource('group', 'version', 'plural')
     with pytest.raises(ValueError):
         resource.get_url(namespace='ns-a.b', subresource='status')
 
 
-def test_url_of_custom_resource_item_cluster_scoped_with_subresource():
+def test_url_for_a_specific_custom_subresource_clusterwide():
     resource = Resource('group', 'version', 'plural')
-    url = resource.get_url(name='name-a.b', subresource='status')
+    url = resource.get_url(namespace=None, name='name-a.b', subresource='status')
     assert url == '/apis/group/version/plural/name-a.b/status'
 
 
-def test_url_of_custom_resource_item_namespaced_with_subresource():
+def test_url_for_a_specific_custom_subresource_in_a_namespace():
     resource = Resource('group', 'version', 'plural')
-    url = resource.get_url(name='name-a.b', namespace='ns-a.b', subresource='status')
+    url = resource.get_url(namespace='ns-a.b', name='name-a.b', subresource='status')
     assert url == '/apis/group/version/namespaces/ns-a.b/plural/name-a.b/status'
 
 
-def test_url_of_builtin_resource_list_cluster_scoped_with_subresource():
+def test_url_for_a_list_of_corev1_subresources_clusterwide():
     resource = Resource('', 'v1', 'plural')
     with pytest.raises(ValueError):
-        resource.get_url(subresource='status')
+        resource.get_url(namespace=None, subresource='status')
 
 
-def test_url_of_builtin_resource_list_namespaced_with_subresource():
+def test_url_for_a_list_of_corev1_subresources_in_a_namespace():
     resource = Resource('', 'v1', 'plural')
     with pytest.raises(ValueError):
         resource.get_url(namespace='ns-a.b', subresource='status')
 
 
-def test_url_of_builtin_resource_item_cluster_scoped_with_subresource():
+def test_url_for_a_specific_corev1_subresource_clusterwide():
     resource = Resource('', 'v1', 'plural')
-    url = resource.get_url(name='name-a.b', subresource='status')
+    url = resource.get_url(namespace=None, name='name-a.b', subresource='status')
     assert url == '/api/v1/plural/name-a.b/status'
 
 
-def test_url_of_builtin_resource_item_namespaced_with_subresource():
+def test_url_for_a_specific_corev1_subresource_in_a_namespace():
     resource = Resource('', 'v1', 'plural')
-    url = resource.get_url(name='name-a.b', namespace='ns-a.b', subresource='status')
+    url = resource.get_url(namespace='ns-a.b', name='name-a.b', subresource='status')
     assert url == '/api/v1/namespaces/ns-a.b/plural/name-a.b/status'

--- a/tests/basic-structs/test_resource.py
+++ b/tests/basic-structs/test_resource.py
@@ -59,50 +59,104 @@ def test_name_of_corev1_resource():
     assert name == 'plural'
 
 
-def test_url_for_a_list_of_custom_resources_clusterwide():
-    resource = Resource('group', 'version', 'plural')
+def test_url_for_a_list_of_clusterscoped_custom_resources_clusterwide():
+    resource = Resource('group', 'version', 'plural', namespaced=False)
     url = resource.get_url(namespace=None)
     assert url == '/apis/group/version/plural'
 
 
-def test_url_for_a_list_of_custom_resources_in_a_namespace():
-    resource = Resource('group', 'version', 'plural')
+def test_url_for_a_list_of_clusterscoped_custom_resources_in_a_namespace():
+    resource = Resource('group', 'version', 'plural', namespaced=False)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace='ns')
+    assert str(err.value) == "Specific namespaces are not supported for cluster-scoped resources."
+
+
+def test_url_for_a_list_of_namespaced_custom_resources_clusterwide():
+    resource = Resource('group', 'version', 'plural', namespaced=True)
+    url = resource.get_url(namespace=None)
+    assert url == '/apis/group/version/plural'
+
+
+def test_url_for_a_list_of_namespaced_custom_resources_in_a_namespace():
+    resource = Resource('group', 'version', 'plural', namespaced=True)
     url = resource.get_url(namespace='ns-a.b')
     assert url == '/apis/group/version/namespaces/ns-a.b/plural'
 
 
-def test_url_for_a_specific_custom_resource_clusterwide():
-    resource = Resource('group', 'version', 'plural')
+def test_url_for_a_specific_clusterscoped_custom_resource_clusterwide():
+    resource = Resource('group', 'version', 'plural', namespaced=False)
     url = resource.get_url(namespace=None, name='name-a.b')
     assert url == '/apis/group/version/plural/name-a.b'
 
 
-def test_url_for_a_specific_custom_resource_in_a_namespace():
-    resource = Resource('group', 'version', 'plural')
+def test_url_for_a_specific_clusterscoped_custom_resource_in_a_namespace():
+    resource = Resource('group', 'version', 'plural', namespaced=False)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace='ns', name='name-a.b')
+    assert str(err.value) == "Specific namespaces are not supported for cluster-scoped resources."
+
+
+def test_url_for_a_specific_namespaced_custom_resource_clusterwide():
+    resource = Resource('group', 'version', 'plural', namespaced=True)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace=None, name='name-a.b')
+    assert str(err.value) == "Specific namespaces are required for specific namespaced resources."
+
+
+def test_url_for_a_specific_namespaced_custom_resource_in_a_namespace():
+    resource = Resource('group', 'version', 'plural', namespaced=True)
     url = resource.get_url(namespace='ns-a.b', name='name-a.b')
     assert url == '/apis/group/version/namespaces/ns-a.b/plural/name-a.b'
 
 
-def test_url_for_a_list_of_corev1_resources_clusterwide():
-    resource = Resource('', 'v1', 'plural')
+def test_url_for_a_list_of_clusterscoped_corev1_resources_clusterwide():
+    resource = Resource('', 'v1', 'plural', namespaced=False)
     url = resource.get_url(namespace=None)
     assert url == '/api/v1/plural'
 
 
-def test_url_for_a_list_of_corev1_resources_in_a_namespace():
-    resource = Resource('', 'v1', 'plural')
+def test_url_for_a_list_of_clusterscoped_corev1_resources_in_a_namespace():
+    resource = Resource('', 'v1', 'plural', namespaced=False)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace='ns')
+    assert str(err.value) == "Specific namespaces are not supported for cluster-scoped resources."
+
+
+def test_url_for_a_list_of_namespaced_corev1_resources_clusterwide():
+    resource = Resource('', 'v1', 'plural', namespaced=True)
+    url = resource.get_url(namespace=None)
+    assert url == '/api/v1/plural'
+
+
+def test_url_for_a_list_of_namespaced_corev1_resources_in_a_namespace():
+    resource = Resource('', 'v1', 'plural', namespaced=True)
     url = resource.get_url(namespace='ns-a.b')
     assert url == '/api/v1/namespaces/ns-a.b/plural'
 
 
-def test_url_of_a_specific_corev1_resource_clusterwide():
-    resource = Resource('', 'v1', 'plural')
+def test_url_of_a_specific_clusterscoped_corev1_resource_clusterwide():
+    resource = Resource('', 'v1', 'plural', namespaced=False)
     url = resource.get_url(namespace=None, name='name-a.b')
     assert url == '/api/v1/plural/name-a.b'
 
 
-def test_url_of_a_specific_corev1_resource_in_a_namespace():
-    resource = Resource('', 'v1', 'plural')
+def test_url_of_a_specific_clusterscoped_corev1_resource_in_a_namespace():
+    resource = Resource('', 'v1', 'plural', namespaced=False)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace='ns', name='name-a.b')
+    assert str(err.value) == "Specific namespaces are not supported for cluster-scoped resources."
+
+
+def test_url_of_a_specific_namespaced_corev1_resource_clusterwide():
+    resource = Resource('', 'v1', 'plural', namespaced=True)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace=None, name='name-a.b')
+    assert str(err.value) == "Specific namespaces are required for specific namespaced resources."
+
+
+def test_url_of_a_specific_namespaced_corev1_resource_in_a_namespace():
+    resource = Resource('', 'v1', 'plural', namespaced=True)
     url = resource.get_url(namespace='ns-a.b', name='name-a.b')
     assert url == '/api/v1/namespaces/ns-a.b/plural/name-a.b'
 
@@ -113,49 +167,115 @@ def test_url_with_arbitrary_params():
     assert url == '/apis/group/version/plural?watch=true&resourceVersion=abc%25def+xyz'
 
 
-def test_url_for_a_list_of_custom_subresources_clusterwide():
-    resource = Resource('group', 'version', 'plural')
-    with pytest.raises(ValueError):
+def test_url_for_a_list_of_clusterscoped_custom_subresources_clusterwide():
+    resource = Resource('group', 'version', 'plural', namespaced=False)
+    with pytest.raises(ValueError) as err:
         resource.get_url(namespace=None, subresource='status')
+    assert str(err.value) == "Subresources can be used only with specific resources by their name."
 
 
-def test_url_for_a_specific_custom_subresource_in_a_namespace():
-    resource = Resource('group', 'version', 'plural')
-    with pytest.raises(ValueError):
+def test_url_for_a_list_of_clusterscoped_custom_subresources_in_a_namespace():
+    resource = Resource('group', 'version', 'plural', namespaced=False)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace='ns', subresource='status')
+    assert str(err.value) in {
+        "Specific namespaces are not supported for cluster-scoped resources.",
+        "Subresources can be used only with specific resources by their name.",
+    }
+
+
+def test_url_for_a_list_of_namespaced_custom_subresources_clusterwide():
+    resource = Resource('group', 'version', 'plural', namespaced=True)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace=None, subresource='status')
+    assert str(err.value) == "Subresources can be used only with specific resources by their name."
+
+
+def test_url_for_a_list_of_namespaced_custom_subresources_in_a_namespace():
+    resource = Resource('group', 'version', 'plural', namespaced=True)
+    with pytest.raises(ValueError) as err:
         resource.get_url(namespace='ns-a.b', subresource='status')
+    assert str(err.value) == "Subresources can be used only with specific resources by their name."
 
 
-def test_url_for_a_specific_custom_subresource_clusterwide():
-    resource = Resource('group', 'version', 'plural')
+def test_url_for_a_specific_clusterscoped_custom_subresource_clusterwide():
+    resource = Resource('group', 'version', 'plural', namespaced=False)
     url = resource.get_url(namespace=None, name='name-a.b', subresource='status')
     assert url == '/apis/group/version/plural/name-a.b/status'
 
 
-def test_url_for_a_specific_custom_subresource_in_a_namespace():
-    resource = Resource('group', 'version', 'plural')
+def test_url_for_a_specific_clusterscoped_custom_subresource_in_a_namespace():
+    resource = Resource('group', 'version', 'plural', namespaced=False)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace='ns', name='name-a.b', subresource='status')
+    assert str(err.value) == "Specific namespaces are not supported for cluster-scoped resources."
+
+
+def test_url_for_a_specific_namespaced_custom_subresource_clusterwide():
+    resource = Resource('group', 'version', 'plural', namespaced=True)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace=None, name='name-a.b', subresource='status')
+    assert str(err.value) == "Specific namespaces are required for specific namespaced resources."
+
+
+def test_url_for_a_specific_namespaced_custom_subresource_in_a_namespace():
+    resource = Resource('group', 'version', 'plural', namespaced=True)
     url = resource.get_url(namespace='ns-a.b', name='name-a.b', subresource='status')
     assert url == '/apis/group/version/namespaces/ns-a.b/plural/name-a.b/status'
 
 
-def test_url_for_a_list_of_corev1_subresources_clusterwide():
-    resource = Resource('', 'v1', 'plural')
-    with pytest.raises(ValueError):
+def test_url_for_a_list_of_clusterscoped_corev1_subresources_clusterwide():
+    resource = Resource('', 'v1', 'plural', namespaced=False)
+    with pytest.raises(ValueError) as err:
         resource.get_url(namespace=None, subresource='status')
+    assert str(err.value) == "Subresources can be used only with specific resources by their name."
 
 
-def test_url_for_a_list_of_corev1_subresources_in_a_namespace():
-    resource = Resource('', 'v1', 'plural')
-    with pytest.raises(ValueError):
+def test_url_for_a_list_of_clusterscoped_corev1_subresources_in_a_namespace():
+    resource = Resource('', 'v1', 'plural', namespaced=False)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace='ns', subresource='status')
+    assert str(err.value) in {
+        "Specific namespaces are not supported for cluster-scoped resources.",
+        "Subresources can be used only with specific resources by their name.",
+    }
+
+
+def test_url_for_a_list_of_namespaced_corev1_subresources_clusterwide():
+    resource = Resource('', 'v1', 'plural', namespaced=True)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace=None, subresource='status')
+    assert str(err.value) == "Subresources can be used only with specific resources by their name."
+
+
+def test_url_for_a_list_of_namespaced_corev1_subresources_in_a_namespace():
+    resource = Resource('', 'v1', 'plural', namespaced=True)
+    with pytest.raises(ValueError) as err:
         resource.get_url(namespace='ns-a.b', subresource='status')
+    assert str(err.value) == "Subresources can be used only with specific resources by their name."
 
 
-def test_url_for_a_specific_corev1_subresource_clusterwide():
-    resource = Resource('', 'v1', 'plural')
+def test_url_for_a_specific_clusterscoped_corev1_subresource_clusterwide():
+    resource = Resource('', 'v1', 'plural', namespaced=False)
     url = resource.get_url(namespace=None, name='name-a.b', subresource='status')
     assert url == '/api/v1/plural/name-a.b/status'
 
 
-def test_url_for_a_specific_corev1_subresource_in_a_namespace():
-    resource = Resource('', 'v1', 'plural')
+def test_url_for_a_specific_clusterscoped_corev1_subresource_in_a_namespace():
+    resource = Resource('', 'v1', 'plural', namespaced=False)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace='ns', name='name-a.b', subresource='status')
+    assert str(err.value) == "Specific namespaces are not supported for cluster-scoped resources."
+
+
+def test_url_for_a_specific_namespaced_corev1_subresource_clusterwide():
+    resource = Resource('', 'v1', 'plural', namespaced=True)
+    with pytest.raises(ValueError) as err:
+        resource.get_url(namespace=None, name='name-a.b', subresource='status')
+    assert str(err.value) == "Specific namespaces are required for specific namespaced resources."
+
+
+def test_url_for_a_specific_namespaced_corev1_subresource_in_a_namespace():
+    resource = Resource('', 'v1', 'plural', namespaced=True)
     url = resource.get_url(namespace='ns-a.b', name='name-a.b', subresource='status')
     assert url == '/api/v1/namespaces/ns-a.b/plural/name-a.b/status'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,6 @@ from kopf.structs.references import Resource, Selector
 
 def pytest_configure(config):
     config.addinivalue_line('markers', "e2e: end-to-end tests with real operators.")
-    config.addinivalue_line('markers', "resource_clustered: (internal parameterizatiom mark).")
 
     # Unexpected warnings should fail the tests. Use `-Wignore` to explicitly disable it.
     config.addinivalue_line('filterwarnings', 'error')
@@ -90,15 +89,32 @@ def enforce_asyncio_mocker():
 
 
 @pytest.fixture()
-def resource():
+def namespaced_resource():
     """ The resource used in the tests. Usually mocked, so it does not matter. """
-    return Resource('zalando.org', 'v1', 'kopfexamples')
+    return Resource('zalando.org', 'v1', 'kopfexamples', namespaced=True)
+
+
+@pytest.fixture()
+def cluster_resource():
+    """ The resource used in the tests. Usually mocked, so it does not matter. """
+    return Resource('zalando.org', 'v1', 'kopfexamples', namespaced=False)
+
+
+@pytest.fixture(params=[True, False], ids=['namespaced', 'cluster'])
+def resource(request):
+    """ The resource used in the tests. Usually mocked, so it does not matter. """
+    return Resource('zalando.org', 'v1', 'kopfexamples', namespaced=request.param)
 
 
 @pytest.fixture()
 def selector(resource):
     """ The selector used in the tests. Usually mocked, so it does not matter. """
     return Selector(group=resource.group, version=resource.version, plural=resource.plural)
+
+
+@pytest.fixture()
+def namespace(resource):
+    return 'ns' if resource.namespaced else None
 
 
 @pytest.fixture()

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -4,11 +4,3 @@ import pytest
 @pytest.fixture(autouse=True)
 def _autouse_resp_mocker(resp_mocker, version_api):
     pass
-
-
-@pytest.fixture(params=[
-    pytest.param('something', id='namespace'),
-    pytest.param(None, id='cluster'),
-])
-def namespace(request):
-    return request.param

--- a/tests/k8s/test_events.py
+++ b/tests/k8s/test_events.py
@@ -5,7 +5,7 @@ from kopf.clients.events import post_event
 from kopf.structs.bodies import build_object_reference
 from kopf.structs.references import Resource
 
-EVENTS = Resource('', 'v1', 'events')
+EVENTS = Resource('', 'v1', 'events', namespaced=True)
 
 
 async def test_posting(

--- a/tests/k8s/test_patching.py
+++ b/tests/k8s/test_patching.py
@@ -8,31 +8,14 @@ from kopf.clients.patching import patch_obj
 from kopf.structs.patches import Patch
 
 
-@pytest.mark.resource_clustered  # see `resp_mocker`
-async def test_clustered(
-        resp_mocker, aresponses, hostname, resource):
+async def test_without_subresources(
+        resp_mocker, aresponses, hostname, resource, namespace):
 
     patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    aresponses.add(hostname, resource.get_url(namespace=None, name='name1'), 'patch', patch_mock)
+    aresponses.add(hostname, resource.get_url(namespace=namespace, name='name1'), 'patch', patch_mock)
 
     patch = Patch({'x': 'y'})
-    await patch_obj(resource=resource, namespace=None, name='name1', patch=patch)
-
-    assert patch_mock.called
-    assert patch_mock.call_count == 1
-
-    data = patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
-    assert data == {'x': 'y'}
-
-
-async def test_namespaced(
-        resp_mocker, aresponses, hostname, resource):
-
-    patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    aresponses.add(hostname, resource.get_url(namespace='ns1', name='name1'), 'patch', patch_mock)
-
-    patch = Patch({'x': 'y'})
-    await patch_obj(resource=resource, namespace='ns1', name='name1', patch=patch)
+    await patch_obj(resource=resource, namespace=namespace, name='name1', patch=patch)
 
     assert patch_mock.called
     assert patch_mock.call_count == 1
@@ -42,7 +25,7 @@ async def test_namespaced(
 
 
 async def test_status_as_subresource_with_combined_payload(
-        resp_mocker, aresponses, hostname, resource):
+        resp_mocker, aresponses, hostname, resource, namespace):
     resource = dataclasses.replace(resource, subresources=['status'])
 
     # Simulate Kopf's initial state and intention.
@@ -54,14 +37,14 @@ async def test_status_as_subresource_with_combined_payload(
                        'status': '...'}
     status_response = {'status': {'s': 't', 'extra': '789'}}
 
-    object_url = resource.get_url(namespace='ns1', name='name1')
-    status_url = resource.get_url(namespace='ns1', name='name1', subresource='status')
+    object_url = resource.get_url(namespace=namespace, name='name1')
+    status_url = resource.get_url(namespace=namespace, name='name1', subresource='status')
     object_patch_mock = resp_mocker(return_value=aiohttp.web.json_response(object_response))
     status_patch_mock = resp_mocker(return_value=aiohttp.web.json_response(status_response))
     aresponses.add(hostname, object_url, 'patch', object_patch_mock)
     aresponses.add(hostname, status_url, 'patch', status_patch_mock)
 
-    reconstructed = await patch_obj(resource=resource, namespace='ns1', name='name1', patch=patch)
+    reconstructed = await patch_obj(resource=resource, namespace=namespace, name='name1', patch=patch)
 
     assert object_patch_mock.called
     assert object_patch_mock.call_count == 1
@@ -79,7 +62,7 @@ async def test_status_as_subresource_with_combined_payload(
 
 
 async def test_status_as_subresource_with_object_fields_only(
-        resp_mocker, aresponses, hostname, resource):
+        resp_mocker, aresponses, hostname, resource, namespace):
     resource = dataclasses.replace(resource, subresources=['status'])
 
     # Simulate Kopf's initial state and intention.
@@ -91,14 +74,14 @@ async def test_status_as_subresource_with_object_fields_only(
                        'status': '...'}
     status_response = {'status': {'s': 't', 'extra': '789'}}
 
-    object_url = resource.get_url(namespace='ns1', name='name1')
-    status_url = resource.get_url(namespace='ns1', name='name1', subresource='status')
+    object_url = resource.get_url(namespace=namespace, name='name1')
+    status_url = resource.get_url(namespace=namespace, name='name1', subresource='status')
     object_patch_mock = resp_mocker(return_value=aiohttp.web.json_response(object_response))
     status_patch_mock = resp_mocker(return_value=aiohttp.web.json_response(status_response))
     aresponses.add(hostname, object_url, 'patch', object_patch_mock)
     aresponses.add(hostname, status_url, 'patch', status_patch_mock)
 
-    reconstructed = await patch_obj(resource=resource, namespace='ns1', name='name1', patch=patch)
+    reconstructed = await patch_obj(resource=resource, namespace=namespace, name='name1', patch=patch)
 
     assert object_patch_mock.called
     assert object_patch_mock.call_count == 1
@@ -113,7 +96,7 @@ async def test_status_as_subresource_with_object_fields_only(
 
 
 async def test_status_as_subresource_with_status_fields_only(
-        resp_mocker, aresponses, hostname, resource):
+        resp_mocker, aresponses, hostname, resource, namespace):
     resource = dataclasses.replace(resource, subresources=['status'])
 
     # Simulate Kopf's initial state and intention.
@@ -125,14 +108,14 @@ async def test_status_as_subresource_with_status_fields_only(
                        'status': '...'}
     status_response = {'status': {'s': 't', 'extra': '789'}}
 
-    object_url = resource.get_url(namespace='ns1', name='name1')
-    status_url = resource.get_url(namespace='ns1', name='name1', subresource='status')
+    object_url = resource.get_url(namespace=namespace, name='name1')
+    status_url = resource.get_url(namespace=namespace, name='name1', subresource='status')
     object_patch_mock = resp_mocker(return_value=aiohttp.web.json_response(object_response))
     status_patch_mock = resp_mocker(return_value=aiohttp.web.json_response(status_response))
     aresponses.add(hostname, object_url, 'patch', object_patch_mock)
     aresponses.add(hostname, status_url, 'patch', status_patch_mock)
 
-    reconstructed = await patch_obj(resource=resource, namespace='ns1', name='name1', patch=patch)
+    reconstructed = await patch_obj(resource=resource, namespace=namespace, name='name1', patch=patch)
 
     assert not object_patch_mock.called
     assert status_patch_mock.called
@@ -145,7 +128,7 @@ async def test_status_as_subresource_with_status_fields_only(
 
 
 async def test_status_as_body_field_with_combined_payload(
-        resp_mocker, aresponses, hostname, resource):
+        resp_mocker, aresponses, hostname, resource, namespace):
 
     # Simulate Kopf's initial state and intention.
     patch = Patch({'spec': {'x': 'y'}, 'status': {'s': 't'}})
@@ -156,14 +139,14 @@ async def test_status_as_body_field_with_combined_payload(
                        'status': '...'}
     status_response = {'s': 't', 'extra': '789'}
 
-    object_url = resource.get_url(namespace='ns1', name='name1')
-    status_url = resource.get_url(namespace='ns1', name='name1', subresource='status')
+    object_url = resource.get_url(namespace=namespace, name='name1')
+    status_url = resource.get_url(namespace=namespace, name='name1', subresource='status')
     object_patch_mock = resp_mocker(return_value=aiohttp.web.json_response(object_response))
     status_patch_mock = resp_mocker(return_value=aiohttp.web.json_response(status_response))
     aresponses.add(hostname, object_url, 'patch', object_patch_mock)
     aresponses.add(hostname, status_url, 'patch', status_patch_mock)
 
-    reconstructed = await patch_obj(resource=resource, namespace='ns1', name='name1', patch=patch)
+    reconstructed = await patch_obj(resource=resource, namespace=namespace, name='name1', patch=patch)
 
     assert object_patch_mock.called
     assert object_patch_mock.call_count == 1
@@ -177,14 +160,16 @@ async def test_status_as_body_field_with_combined_payload(
                              'status': '...'}
 
 
-@pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])
 @pytest.mark.parametrize('status', [404])
 async def test_ignores_absent_objects(
-        resp_mocker, aresponses, hostname, resource, namespace, status):
+        resp_mocker, aresponses, hostname, status, resource, namespace,
+        cluster_resource, namespaced_resource):
 
     patch_mock = resp_mocker(return_value=aresponses.Response(status=status))
-    aresponses.add(hostname, resource.get_url(namespace=None, name='name1'), 'patch', patch_mock)
-    aresponses.add(hostname, resource.get_url(namespace='ns1', name='name1'), 'patch', patch_mock)
+    cluster_url = cluster_resource.get_url(namespace=None, name='name1')
+    namespaced_url = namespaced_resource.get_url(namespace='ns', name='name1')
+    aresponses.add(hostname, cluster_url, 'patch', patch_mock)
+    aresponses.add(hostname, namespaced_url, 'patch', patch_mock)
 
     patch = {'x': 'y'}
     result = await patch_obj(resource=resource, namespace=namespace, name='name1', patch=patch)
@@ -192,14 +177,16 @@ async def test_ignores_absent_objects(
     assert result is None
 
 
-@pytest.mark.parametrize('namespace', [None, 'ns1'], ids=['without-namespace', 'with-namespace'])
 @pytest.mark.parametrize('status', [400, 401, 403, 500, 666])
 async def test_raises_api_errors(
-        resp_mocker, aresponses, hostname, resource, namespace, status):
+        resp_mocker, aresponses, hostname, status, resource, namespace,
+        cluster_resource, namespaced_resource):
 
     patch_mock = resp_mocker(return_value=aresponses.Response(status=status))
-    aresponses.add(hostname, resource.get_url(namespace=None, name='name1'), 'patch', patch_mock)
-    aresponses.add(hostname, resource.get_url(namespace='ns1', name='name1'), 'patch', patch_mock)
+    cluster_url = cluster_resource.get_url(namespace=None, name='name1')
+    namespaced_url = namespaced_resource.get_url(namespace='ns', name='name1')
+    aresponses.add(hostname, cluster_url, 'patch', patch_mock)
+    aresponses.add(hostname, namespaced_url, 'patch', patch_mock)
 
     patch = {'x': 'y'}
     with pytest.raises(APIError) as e:

--- a/tests/reactor/test_patching_inconsistencies.py
+++ b/tests/reactor/test_patching_inconsistencies.py
@@ -42,16 +42,16 @@ from kopf.structs.patches import Patch
 
 ])
 async def test_patching_without_inconsistencies(
-        resource, settings, caplog, assert_logs, version_api,
+        resource, namespace, settings, caplog, assert_logs, version_api,
         aresponses, hostname, resp_mocker,
         patch, response):
     caplog.set_level(logging.DEBUG)
 
-    url = resource.get_url(namespace='ns1', name='name1')
+    url = resource.get_url(namespace=namespace, name='name1')
     patch_mock = resp_mocker(return_value=aiohttp.web.json_response(response))
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    body = Body({'metadata': {'namespace': 'ns1', 'name': 'name1'}})
+    body = Body({'metadata': {'namespace': namespace, 'name': 'name1'}})
     logger = LocalObjectLogger(body=body, settings=settings)
     await patch_and_check(
         resource=resource,
@@ -104,16 +104,16 @@ async def test_patching_without_inconsistencies(
 
 ])
 async def test_patching_with_inconsistencies(
-        resource, settings, caplog, assert_logs, version_api,
+        resource, namespace, settings, caplog, assert_logs, version_api,
         aresponses, hostname, resp_mocker,
         patch, response):
     caplog.set_level(logging.DEBUG)
 
-    url = resource.get_url(namespace='ns1', name='name1')
+    url = resource.get_url(namespace=namespace, name='name1')
     patch_mock = resp_mocker(return_value=aiohttp.web.json_response(response))
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    body = Body({'metadata': {'namespace': 'ns1', 'name': 'name1'}})
+    body = Body({'metadata': {'namespace': namespace, 'name': 'name1'}})
     logger = LocalObjectLogger(body=body, settings=settings)
     await patch_and_check(
         resource=resource,
@@ -129,16 +129,16 @@ async def test_patching_with_inconsistencies(
 
 
 async def test_patching_with_disappearance(
-        resource, settings, caplog, assert_logs, version_api,
+        resource, namespace, settings, caplog, assert_logs, version_api,
         aresponses, hostname, resp_mocker):
     caplog.set_level(logging.DEBUG)
 
     patch = {'spec': {'x': 'y'}, 'status': {'s': 't'}}  # irrelevant
-    url = resource.get_url(namespace='ns1', name='name1')
+    url = resource.get_url(namespace=namespace, name='name1')
     patch_mock = resp_mocker(return_value=aresponses.Response(status=404))
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    body = Body({'metadata': {'namespace': 'ns1', 'name': 'name1'}})
+    body = Body({'metadata': {'namespace': namespace, 'name': 'name1'}})
     logger = LocalObjectLogger(body=body, settings=settings)
     await patch_and_check(
         resource=resource,


### PR DESCRIPTION
Essentially, two things:

* Cluster-scoped resources cannot have namespaced URLs, even if a namespace is accidentally provided.
* Namespace-scoped resources cannot miss the namespace for individual resources (but can miss it for lists).

Both cases are considered errors with no fallbacks. It is the caller's responsibility to ensure that the namespace matches the resource's scope. In the framework's code, it serves as an additional validation of the correctness of resource management (observations, orchestration).

Besides, test _everything_ with both namespaced and cluster-scoped resources, to make sure both work fine with all units and aspects — but mostly to make this namespaced vs. cluster-scoped separation work with other tests (previously, there were assumptions on the passed namespace to match the resource's namespace-ability, which hypothetically can be wrong).