### PR TITLE
Make the tests shorter and cleaner

### DIFF
--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -141,6 +141,10 @@ class Resource:
         subs_text = f'/{"/".join(subs)}' if subs else ''
         return f'{name_text}{subs_text}'
 
+    # Mostly for tests, to be used as `@kopf.on.event(*resource, ...)`
+    def __iter__(self) -> Iterator[str]:
+        return iter((self.group, self.version, self.plural))
+
     @property
     def name(self) -> str:
         return f'{self.plural}.{self.group}'.strip('.')

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -9,7 +9,7 @@ from kopf.cli import main
 SCRIPT1 = """
 import kopf
 
-@kopf.on.create('zalando.org', 'v1', 'kopfexamples')
+@kopf.on.create('kopfexamples')
 def create_fn(spec, **_):
     print('Hello from create_fn!')
     print(repr(spec))
@@ -18,7 +18,7 @@ def create_fn(spec, **_):
 SCRIPT2 = """
 import kopf
 
-@kopf.on.update('zalando.org', 'v1', 'kopfexamples')
+@kopf.on.update('kopfexamples')
 def update_fn(spec, **_):
     print('Hello from create_fn!')
     print(repr(spec))

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,10 +5,18 @@ import subprocess
 
 import pytest
 
+from kopf.reactor.registries import SmartOperatorRegistry
+
 root_dir = os.path.relpath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 examples = sorted(glob.glob(os.path.join(root_dir, 'examples/*/')))
 assert examples  # if empty, it is just the detection failed
 examples = [path for path in examples if not glob.glob((os.path.join(path, 'test*.py')))]
+
+
+@pytest.fixture
+def registry_factory():
+    # Authentication is needed for the real e2e tests.
+    return SmartOperatorRegistry
 
 
 @pytest.fixture(params=examples, ids=[os.path.basename(path.rstrip('/')) for path in examples])

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -82,25 +82,25 @@ def handlers(registry):
     delete_mock = Mock(return_value=None)
     resume_mock = Mock(return_value=None)
 
-    @kopf.on.event('zalando.org', 'v1', 'kopfexamples', id='event_fn')
+    @kopf.on.event('kopfexamples', id='event_fn')
     async def event_fn(**kwargs):
         return event_mock(**kwargs)
 
     # Keep on-resume on top, to catch any issues with the test design (where it could be skipped).
-    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples', id='resume_fn', timeout=600, retries=100,
+    @kopf.on.resume('kopfexamples', id='resume_fn', timeout=600, retries=100,
                     deleted=True)  # only for resuming handles, to cover the resource being deleted.
     async def resume_fn(**kwargs):
         return resume_mock(**kwargs)
 
-    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', id='create_fn', timeout=600, retries=100)
+    @kopf.on.create('kopfexamples', id='create_fn', timeout=600, retries=100)
     async def create_fn(**kwargs):
         return create_mock(**kwargs)
 
-    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', id='update_fn', timeout=600, retries=100)
+    @kopf.on.update('kopfexamples', id='update_fn', timeout=600, retries=100)
     async def update_fn(**kwargs):
         return update_mock(**kwargs)
 
-    @kopf.on.delete('zalando.org', 'v1', 'kopfexamples', id='delete_fn', timeout=600, retries=100)
+    @kopf.on.delete('kopfexamples', id='delete_fn', timeout=600, retries=100)
     async def delete_fn(**kwargs):
         return delete_mock(**kwargs)
 
@@ -126,25 +126,25 @@ def extrahandlers(registry, handlers):
     delete_mock = Mock(return_value=None)
     resume_mock = Mock(return_value=None)
 
-    @kopf.on.event('zalando.org', 'v1', 'kopfexamples', id='event_fn2')
+    @kopf.on.event('kopfexamples', id='event_fn2')
     async def event_fn2(**kwargs):
         return event_mock(**kwargs)
 
     # Keep on-resume on top, to catch any issues with the test design (where it could be skipped).
-    @kopf.on.resume('zalando.org', 'v1', 'kopfexamples', id='resume_fn2',
-                    deleted=True)  # only for resuming handles, to cover the resource being deleted.
+    # Note: deleted=True -- only for resuming handles, to cover the resource being deleted.
+    @kopf.on.resume('kopfexamples', id='resume_fn2', deleted=True)
     async def resume_fn2(**kwargs):
         return resume_mock(**kwargs)
 
-    @kopf.on.create('zalando.org', 'v1', 'kopfexamples', id='create_fn2')
+    @kopf.on.create('kopfexamples', id='create_fn2')
     async def create_fn2(**kwargs):
         return create_mock(**kwargs)
 
-    @kopf.on.update('zalando.org', 'v1', 'kopfexamples', id='update_fn2')
+    @kopf.on.update('kopfexamples', id='update_fn2')
     async def update_fn2(**kwargs):
         return update_mock(**kwargs)
 
-    @kopf.on.delete('zalando.org', 'v1', 'kopfexamples', id='delete_fn2')
+    @kopf.on.delete('kopfexamples', id='delete_fn2')
     async def delete_fn2(**kwargs):
         return delete_mock(**kwargs)
 

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -75,7 +75,7 @@ class HandlersContainer:
 
 
 @pytest.fixture()
-def handlers(clear_default_registry):
+def handlers(registry):
     event_mock = Mock(return_value=None)
     create_mock = Mock(return_value=None)
     update_mock = Mock(return_value=None)
@@ -119,7 +119,7 @@ def handlers(clear_default_registry):
 
 
 @pytest.fixture()
-def extrahandlers(clear_default_registry, handlers):
+def extrahandlers(registry, handlers):
     event_mock = Mock(return_value=None)
     create_mock = Mock(return_value=None)
     update_mock = Mock(return_value=None)

--- a/tests/handling/daemons/test_daemon_errors.py
+++ b/tests/handling/daemons/test_daemon_errors.py
@@ -4,11 +4,10 @@ import kopf
 
 
 async def test_daemon_stopped_on_permanent_error(
-        registry, settings, resource, dummy, manual_time,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        settings, resource, dummy, manual_time, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  backoff=0.01)
     async def fn(**kwargs):
         dummy.mock()
@@ -36,11 +35,10 @@ async def test_daemon_stopped_on_permanent_error(
 
 
 async def test_daemon_stopped_on_arbitrary_errors_with_mode_permanent(
-        registry, settings, resource, dummy, manual_time,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        settings, resource, dummy, manual_time, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  errors=kopf.ErrorsMode.PERMANENT, backoff=0.01)
     async def fn(**kwargs):
         dummy.mock()
@@ -71,7 +69,7 @@ async def test_daemon_retried_on_temporary_error(
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  backoff=1.0)
     async def fn(retry, **kwargs):
         dummy.mock()
@@ -101,11 +99,10 @@ async def test_daemon_retried_on_temporary_error(
 
 
 async def test_daemon_retried_on_arbitrary_error_with_mode_temporary(
-        registry, settings, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
+        settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  errors=kopf.ErrorsMode.TEMPORARY, backoff=1.0)
     async def fn(retry, **kwargs):
         dummy.mock()
@@ -135,11 +132,10 @@ async def test_daemon_retried_on_arbitrary_error_with_mode_temporary(
 
 
 async def test_daemon_retried_until_retries_limit(
-        registry, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  retries=3)
     async def fn(**kwargs):
         dummy.kwargs = kwargs
@@ -157,11 +153,10 @@ async def test_daemon_retried_until_retries_limit(
 
 
 async def test_daemon_retried_until_timeout(
-        registry, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  timeout=3.0)
     async def fn(**kwargs):
         dummy.kwargs = kwargs

--- a/tests/handling/daemons/test_daemon_errors.py
+++ b/tests/handling/daemons/test_daemon_errors.py
@@ -1,6 +1,8 @@
 import logging
 
 import kopf
+from kopf.reactor.handling import PermanentError, TemporaryError
+from kopf.structs.handlers import ErrorsMode
 
 
 async def test_daemon_stopped_on_permanent_error(
@@ -13,7 +15,7 @@ async def test_daemon_stopped_on_permanent_error(
         dummy.mock()
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
-        raise kopf.PermanentError("boo!")
+        raise PermanentError("boo!")
 
     finalizer = settings.persistence.finalizer
     event_object = {'metadata': {'finalizers': [finalizer]}}
@@ -39,7 +41,7 @@ async def test_daemon_stopped_on_arbitrary_errors_with_mode_permanent(
     caplog.set_level(logging.DEBUG)
 
     @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 errors=kopf.ErrorsMode.PERMANENT, backoff=0.01)
+                 errors=ErrorsMode.PERMANENT, backoff=0.01)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -76,7 +78,7 @@ async def test_daemon_retried_on_temporary_error(
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
         if not retry:
-            raise kopf.TemporaryError("boo!", delay=1.0)
+            raise TemporaryError("boo!", delay=1.0)
         else:
             dummy.steps['finish'].set()
 
@@ -103,7 +105,7 @@ async def test_daemon_retried_on_arbitrary_error_with_mode_temporary(
     caplog.set_level(logging.DEBUG)
 
     @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 errors=kopf.ErrorsMode.TEMPORARY, backoff=1.0)
+                 errors=ErrorsMode.TEMPORARY, backoff=1.0)
     async def fn(retry, **kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -140,7 +142,7 @@ async def test_daemon_retried_until_retries_limit(
     async def fn(**kwargs):
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
-        raise kopf.TemporaryError("boo!", delay=1.0)
+        raise TemporaryError("boo!", delay=1.0)
 
     await simulate_cycle({})
     await dummy.steps['called'].wait()
@@ -161,7 +163,7 @@ async def test_daemon_retried_until_timeout(
     async def fn(**kwargs):
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
-        raise kopf.TemporaryError("boo!", delay=1.0)
+        raise TemporaryError("boo!", delay=1.0)
 
     await simulate_cycle({})
     await dummy.steps['called'].wait()

--- a/tests/handling/daemons/test_daemon_errors.py
+++ b/tests/handling/daemons/test_daemon_errors.py
@@ -9,8 +9,7 @@ async def test_daemon_stopped_on_permanent_error(
         settings, resource, dummy, manual_time, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 backoff=0.01)
+    @kopf.daemon(*resource, id='fn', backoff=0.01)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -40,8 +39,7 @@ async def test_daemon_stopped_on_arbitrary_errors_with_mode_permanent(
         settings, resource, dummy, manual_time, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 errors=ErrorsMode.PERMANENT, backoff=0.01)
+    @kopf.daemon(*resource, id='fn', errors=ErrorsMode.PERMANENT, backoff=0.01)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -71,8 +69,7 @@ async def test_daemon_retried_on_temporary_error(
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 backoff=1.0)
+    @kopf.daemon(*resource, id='fn', backoff=1.0)
     async def fn(retry, **kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -104,8 +101,7 @@ async def test_daemon_retried_on_arbitrary_error_with_mode_temporary(
         settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 errors=ErrorsMode.TEMPORARY, backoff=1.0)
+    @kopf.daemon(*resource, id='fn', errors=ErrorsMode.TEMPORARY, backoff=1.0)
     async def fn(retry, **kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -137,8 +133,7 @@ async def test_daemon_retried_until_retries_limit(
         resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 retries=3)
+    @kopf.daemon(*resource, id='fn', retries=3)
     async def fn(**kwargs):
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
@@ -158,8 +153,7 @@ async def test_daemon_retried_until_timeout(
         resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 timeout=3.0)
+    @kopf.daemon(*resource, id='fn', timeout=3.0)
     async def fn(**kwargs):
         dummy.kwargs = kwargs
         dummy.steps['called'].set()

--- a/tests/handling/daemons/test_daemon_filtration.py
+++ b/tests/handling/daemons/test_daemon_filtration.py
@@ -9,11 +9,10 @@ import kopf
 
 
 async def test_daemon_filtration_satisfied(
-        registry, settings, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  labels={'a': 'value', 'b': kopf.PRESENT, 'c': kopf.ABSENT},
                  annotations={'x': 'value', 'y': kopf.PRESENT, 'z': kopf.ABSENT})
     async def fn(**kwargs):
@@ -41,12 +40,12 @@ async def test_daemon_filtration_satisfied(
     ({'a': 'value'}, {'x': 'value', 'y': '...'}),
 ])
 async def test_daemon_filtration_mismatched(
-        registry, settings, resource, mocker, labels, annotations,
+        settings, resource, mocker, labels, annotations,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
     spawn_resource_daemons = mocker.patch('kopf.reactor.daemons.spawn_resource_daemons')
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  labels={'a': 'value', 'b': kopf.PRESENT, 'c': kopf.ABSENT},
                  annotations={'x': 'value', 'y': kopf.PRESENT, 'z': kopf.ABSENT})
     async def fn(**kwargs):

--- a/tests/handling/daemons/test_daemon_filtration.py
+++ b/tests/handling/daemons/test_daemon_filtration.py
@@ -12,7 +12,7 @@ async def test_daemon_filtration_satisfied(
         settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
+    @kopf.daemon(*resource, id='fn',
                  labels={'a': 'value', 'b': kopf.PRESENT, 'c': kopf.ABSENT},
                  annotations={'x': 'value', 'y': kopf.PRESENT, 'z': kopf.ABSENT})
     async def fn(**kwargs):
@@ -45,7 +45,7 @@ async def test_daemon_filtration_mismatched(
     caplog.set_level(logging.DEBUG)
     spawn_resource_daemons = mocker.patch('kopf.reactor.daemons.spawn_resource_daemons')
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
+    @kopf.daemon(*resource, id='fn',
                  labels={'a': 'value', 'b': kopf.PRESENT, 'c': kopf.ABSENT},
                  annotations={'x': 'value', 'y': kopf.PRESENT, 'z': kopf.ABSENT})
     async def fn(**kwargs):

--- a/tests/handling/daemons/test_daemon_rematching.py
+++ b/tests/handling/daemons/test_daemon_rematching.py
@@ -8,8 +8,7 @@ async def test_running_daemon_is_stopped_when_mismatches(
         resource, dummy, timer, mocker, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 when=lambda **_: is_matching)
+    @kopf.daemon(*resource, id='fn', when=lambda **_: is_matching)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs

--- a/tests/handling/daemons/test_daemon_rematching.py
+++ b/tests/handling/daemons/test_daemon_rematching.py
@@ -5,11 +5,10 @@ from kopf.structs.primitives import DaemonStoppingReason
 
 
 async def test_running_daemon_is_stopped_when_mismatches(
-        registry, resource, dummy, timer, mocker,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        resource, dummy, timer, mocker, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  when=lambda **_: is_matching)
     async def fn(**kwargs):
         dummy.mock()

--- a/tests/handling/daemons/test_daemon_spawning.py
+++ b/tests/handling/daemons/test_daemon_spawning.py
@@ -7,7 +7,7 @@ async def test_daemon_is_spawned_at_least_once(
         resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn')
+    @kopf.daemon(*resource, id='fn')
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -25,8 +25,7 @@ async def test_daemon_initial_delay_obeyed(
         resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 initial_delay=1.0)
+    @kopf.daemon(*resource, id='fn', initial_delay=1.0)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs

--- a/tests/handling/daemons/test_daemon_spawning.py
+++ b/tests/handling/daemons/test_daemon_spawning.py
@@ -4,11 +4,10 @@ import kopf
 
 
 async def test_daemon_is_spawned_at_least_once(
-        registry, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn')
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn')
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -23,11 +22,10 @@ async def test_daemon_is_spawned_at_least_once(
 
 
 async def test_daemon_initial_delay_obeyed(
-        registry, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  initial_delay=1.0)
     async def fn(**kwargs):
         dummy.mock()

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -12,7 +12,7 @@ async def test_daemon_exits_gracefully_and_instantly_via_stopper(
     caplog.set_level(logging.DEBUG)
 
     # A daemon-under-test.
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn')
+    @kopf.daemon(*resource, id='fn')
     async def fn(**kwargs):
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
@@ -46,8 +46,7 @@ async def test_daemon_exits_instantly_via_cancellation_with_backoff(
     dummy.steps['finish'].set()
 
     # A daemon-under-test.
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 cancellation_backoff=5, cancellation_timeout=10)
+    @kopf.daemon(*resource, id='fn', cancellation_backoff=5, cancellation_timeout=10)
     async def fn(**kwargs):
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
@@ -91,8 +90,7 @@ async def test_daemon_exits_slowly_via_cancellation_with_backoff(
     caplog.set_level(logging.DEBUG)
 
     # A daemon-under-test.
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 cancellation_backoff=5, cancellation_timeout=10)
+    @kopf.daemon(*resource, id='fn', cancellation_backoff=5, cancellation_timeout=10)
     async def fn(**kwargs):
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
@@ -146,8 +144,7 @@ async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
     caplog.set_level(logging.DEBUG)
 
     # A daemon-under-test.
-    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
-                 cancellation_timeout=10)
+    @kopf.daemon(*resource, id='fn', cancellation_timeout=10)
     async def fn(**kwargs):
         dummy.kwargs = kwargs
         dummy.steps['called'].set()

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -7,12 +7,12 @@ import kopf
 
 
 async def test_daemon_exits_gracefully_and_instantly_via_stopper(
-        registry, settings, resource, dummy, simulate_cycle,
+        settings, resource, dummy, simulate_cycle,
         caplog, assert_logs, k8s_mocked, frozen_time, mocker, timer):
     caplog.set_level(logging.DEBUG)
 
     # A daemon-under-test.
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn')
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn')
     async def fn(**kwargs):
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
@@ -40,13 +40,13 @@ async def test_daemon_exits_gracefully_and_instantly_via_stopper(
 
 
 async def test_daemon_exits_instantly_via_cancellation_with_backoff(
-        registry, settings, resource, dummy, simulate_cycle,
+        settings, resource, dummy, simulate_cycle,
         caplog, assert_logs, k8s_mocked, frozen_time, mocker):
     caplog.set_level(logging.DEBUG)
     dummy.steps['finish'].set()
 
     # A daemon-under-test.
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  cancellation_backoff=5, cancellation_timeout=10)
     async def fn(**kwargs):
         dummy.kwargs = kwargs
@@ -86,12 +86,12 @@ async def test_daemon_exits_instantly_via_cancellation_with_backoff(
 
 
 async def test_daemon_exits_slowly_via_cancellation_with_backoff(
-        registry, settings, resource, dummy, simulate_cycle,
+        settings, resource, dummy, simulate_cycle,
         caplog, assert_logs, k8s_mocked, frozen_time, mocker):
     caplog.set_level(logging.DEBUG)
 
     # A daemon-under-test.
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  cancellation_backoff=5, cancellation_timeout=10)
     async def fn(**kwargs):
         dummy.kwargs = kwargs
@@ -141,12 +141,12 @@ async def test_daemon_exits_slowly_via_cancellation_with_backoff(
 
 
 async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
-        registry, settings, resource, dummy, simulate_cycle,
+        settings, resource, dummy, simulate_cycle,
         caplog, assert_logs, k8s_mocked, frozen_time, mocker):
     caplog.set_level(logging.DEBUG)
 
     # A daemon-under-test.
-    @kopf.daemon(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.daemon(resource.group, resource.version, resource.plural, id='fn',
                  cancellation_timeout=10)
     async def fn(**kwargs):
         dummy.kwargs = kwargs

--- a/tests/handling/daemons/test_timer_errors.py
+++ b/tests/handling/daemons/test_timer_errors.py
@@ -4,11 +4,10 @@ import kopf
 
 
 async def test_timer_stopped_on_permanent_error(
-        registry, settings, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 backoff=0.01, interval=1.0)
     async def fn(**kwargs):
         dummy.mock()
@@ -35,11 +34,10 @@ async def test_timer_stopped_on_permanent_error(
 
 
 async def test_timer_stopped_on_arbitrary_errors_with_mode_permanent(
-        registry, settings, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 errors=kopf.ErrorsMode.PERMANENT, backoff=0.01, interval=1.0)
     async def fn(**kwargs):
         dummy.mock()
@@ -66,11 +64,11 @@ async def test_timer_stopped_on_arbitrary_errors_with_mode_permanent(
 
 
 async def test_timer_retried_on_temporary_error(
-        registry, settings, resource, dummy, manual_time,
+        settings, resource, dummy, manual_time,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 backoff=1.0, interval=1.0)
     async def fn(retry, **kwargs):
         dummy.mock()
@@ -100,11 +98,10 @@ async def test_timer_retried_on_temporary_error(
 
 
 async def test_timer_retried_on_arbitrary_error_with_mode_temporary(
-        registry, settings, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
+        settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 errors=kopf.ErrorsMode.TEMPORARY, backoff=1.0, interval=1.0)
     async def fn(retry, **kwargs):
         dummy.mock()
@@ -134,11 +131,10 @@ async def test_timer_retried_on_arbitrary_error_with_mode_temporary(
 
 
 async def test_timer_retried_until_retries_limit(
-        registry, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 retries=3, interval=1.0)
     async def fn(**kwargs):
         dummy.mock()
@@ -160,11 +156,10 @@ async def test_timer_retried_until_retries_limit(
 
 
 async def test_timer_retried_until_timeout(
-        registry, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 timeout=3.0, interval=1.0)
     async def fn(**kwargs):
         dummy.mock()

--- a/tests/handling/daemons/test_timer_errors.py
+++ b/tests/handling/daemons/test_timer_errors.py
@@ -9,8 +9,7 @@ async def test_timer_stopped_on_permanent_error(
         settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
-                backoff=0.01, interval=1.0)
+    @kopf.timer(*resource, id='fn', backoff=0.01, interval=1.0)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -39,8 +38,7 @@ async def test_timer_stopped_on_arbitrary_errors_with_mode_permanent(
         settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
-                errors=ErrorsMode.PERMANENT, backoff=0.01, interval=1.0)
+    @kopf.timer(*resource, id='fn', errors=ErrorsMode.PERMANENT, backoff=0.01, interval=1.0)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -70,8 +68,7 @@ async def test_timer_retried_on_temporary_error(
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
-                backoff=1.0, interval=1.0)
+    @kopf.timer(*resource, id='fn', backoff=1.0, interval=1.0)
     async def fn(retry, **kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -103,8 +100,7 @@ async def test_timer_retried_on_arbitrary_error_with_mode_temporary(
         settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
-                errors=ErrorsMode.TEMPORARY, backoff=1.0, interval=1.0)
+    @kopf.timer(*resource, id='fn', errors=ErrorsMode.TEMPORARY, backoff=1.0, interval=1.0)
     async def fn(retry, **kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -136,8 +132,7 @@ async def test_timer_retried_until_retries_limit(
         resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
-                retries=3, interval=1.0)
+    @kopf.timer(*resource, id='fn', retries=3, interval=1.0)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -161,8 +156,7 @@ async def test_timer_retried_until_timeout(
         resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
-                timeout=3.0, interval=1.0)
+    @kopf.timer(*resource, id='fn', timeout=3.0, interval=1.0)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs

--- a/tests/handling/daemons/test_timer_filtration.py
+++ b/tests/handling/daemons/test_timer_filtration.py
@@ -12,7 +12,7 @@ async def test_timer_filtration_satisfied(
         settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
+    @kopf.timer(*resource, id='fn',
                 labels={'a': 'value', 'b': kopf.PRESENT, 'c': kopf.ABSENT},
                 annotations={'x': 'value', 'y': kopf.PRESENT, 'z': kopf.ABSENT})
     async def fn(**kwargs):
@@ -44,7 +44,7 @@ async def test_timer_filtration_mismatched(
     caplog.set_level(logging.DEBUG)
     spawn_resource_daemons = mocker.patch('kopf.reactor.daemons.spawn_resource_daemons')
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
+    @kopf.timer(*resource, id='fn',
                 labels={'a': 'value', 'b': kopf.PRESENT, 'c': kopf.ABSENT},
                 annotations={'x': 'value', 'y': kopf.PRESENT, 'z': kopf.ABSENT})
     async def fn(**kwargs):

--- a/tests/handling/daemons/test_timer_filtration.py
+++ b/tests/handling/daemons/test_timer_filtration.py
@@ -9,11 +9,10 @@ import kopf
 
 
 async def test_timer_filtration_satisfied(
-        registry, settings, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 labels={'a': 'value', 'b': kopf.PRESENT, 'c': kopf.ABSENT},
                 annotations={'x': 'value', 'y': kopf.PRESENT, 'z': kopf.ABSENT})
     async def fn(**kwargs):
@@ -40,12 +39,12 @@ async def test_timer_filtration_satisfied(
     ({'a': 'value'}, {'x': 'value', 'y': '...'}),
 ])
 async def test_timer_filtration_mismatched(
-        registry, settings, resource, mocker, labels, annotations,
+        settings, resource, mocker, labels, annotations,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
     spawn_resource_daemons = mocker.patch('kopf.reactor.daemons.spawn_resource_daemons')
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 labels={'a': 'value', 'b': kopf.PRESENT, 'c': kopf.ABSENT},
                 annotations={'x': 'value', 'y': kopf.PRESENT, 'z': kopf.ABSENT})
     async def fn(**kwargs):

--- a/tests/handling/daemons/test_timer_intervals.py
+++ b/tests/handling/daemons/test_timer_intervals.py
@@ -6,11 +6,10 @@ import kopf
 
 
 async def test_timer_regular_interval(
-        registry, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle, frozen_time):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, frozen_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 interval=1.0, sharp=False)
     async def fn(**kwargs):
         dummy.mock()
@@ -32,11 +31,10 @@ async def test_timer_regular_interval(
 
 
 async def test_timer_sharp_interval(
-        registry, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle, frozen_time):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, frozen_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 interval=1.0, sharp=True)
     async def fn(**kwargs):
         dummy.mock()

--- a/tests/handling/daemons/test_timer_intervals.py
+++ b/tests/handling/daemons/test_timer_intervals.py
@@ -9,8 +9,7 @@ async def test_timer_regular_interval(
         resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, frozen_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
-                interval=1.0, sharp=False)
+    @kopf.timer(*resource, id='fn', interval=1.0, sharp=False)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -34,8 +33,7 @@ async def test_timer_sharp_interval(
         resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, frozen_time):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
-                interval=1.0, sharp=True)
+    @kopf.timer(*resource, id='fn', interval=1.0, sharp=True)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs

--- a/tests/handling/daemons/test_timer_triggering.py
+++ b/tests/handling/daemons/test_timer_triggering.py
@@ -4,11 +4,10 @@ import kopf
 
 
 async def test_timer_is_spawned_at_least_once(
-        registry, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 interval=1.0)
     async def fn(**kwargs):
         dummy.mock()
@@ -28,11 +27,10 @@ async def test_timer_is_spawned_at_least_once(
 
 
 async def test_timer_initial_delay_obeyed(
-        registry, resource, dummy,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, registry=registry, id='fn',
+    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
                 initial_delay=5.0, interval=1.0)
     async def fn(**kwargs):
         dummy.mock()

--- a/tests/handling/daemons/test_timer_triggering.py
+++ b/tests/handling/daemons/test_timer_triggering.py
@@ -7,8 +7,7 @@ async def test_timer_is_spawned_at_least_once(
         resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
-                interval=1.0)
+    @kopf.timer(*resource, id='fn', interval=1.0)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs
@@ -30,8 +29,7 @@ async def test_timer_initial_delay_obeyed(
         resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.timer(resource.group, resource.version, resource.plural, id='fn',
-                initial_delay=5.0, interval=1.0)
+    @kopf.timer(*resource, id='fn', initial_delay=5.0, interval=1.0)
     async def fn(**kwargs):
         dummy.mock()
         dummy.kwargs = kwargs

--- a/tests/handling/test_timing_consistency.py
+++ b/tests/handling/test_timing_consistency.py
@@ -38,7 +38,7 @@ async def test_consistent_awakening(registry, settings, resource, k8s_mocked, mo
     tsB_delivered = "2019-12-30T10:56:43.000001"
 
     # A dummy handler: it will not be selected for execution anyway, we just need to have it.
-    @kopf.on.create(resource.group, resource.version, resource.plural, id='some-id')
+    @kopf.on.create(*resource, id='some-id')
     def handler_fn(**_):
         pass
 

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -64,7 +64,7 @@ def test_on_resume_minimal(reason, cause_factory, resource):
     registry = kopf.get_default_registry()
     cause = cause_factory(resource=resource, reason=reason, initial=True)
 
-    @kopf.on.resume(resource.group, resource.version, resource.plural)
+    @kopf.on.resume(*resource)
     def fn(**_):
         pass
 
@@ -89,7 +89,7 @@ def test_on_create_minimal(cause_factory, resource):
     registry = kopf.get_default_registry()
     cause = cause_factory(resource=resource, reason=Reason.CREATE)
 
-    @kopf.on.create(resource.group, resource.version, resource.plural)
+    @kopf.on.create(*resource)
     def fn(**_):
         pass
 
@@ -114,7 +114,7 @@ def test_on_update_minimal(cause_factory, resource):
     registry = kopf.get_default_registry()
     cause = cause_factory(resource=resource, reason=Reason.UPDATE)
 
-    @kopf.on.update(resource.group, resource.version, resource.plural)
+    @kopf.on.update(*resource)
     def fn(**_):
         pass
 
@@ -139,7 +139,7 @@ def test_on_delete_minimal(cause_factory, resource):
     registry = kopf.get_default_registry()
     cause = cause_factory(resource=resource, reason=Reason.DELETE)
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural)
+    @kopf.on.delete(*resource)
     def fn(**_):
         pass
 
@@ -166,7 +166,7 @@ def test_on_field_minimal(cause_factory, resource):
     new = {'field': {'subfield': 'new'}}
     cause = cause_factory(resource=resource, reason=Reason.UPDATE, old=old, new=new, body=new)
 
-    @kopf.on.field(resource.group, resource.version, resource.plural, field='field.subfield')
+    @kopf.on.field(*resource, field='field.subfield')
     def fn(**_):
         pass
 
@@ -189,7 +189,7 @@ def test_on_field_minimal(cause_factory, resource):
 
 def test_on_field_fails_without_field(resource):
     with pytest.raises(TypeError):
-        @kopf.on.field(resource.group, resource.version, resource.plural)
+        @kopf.on.field(*resource)
         def fn(**_):
             pass
 
@@ -263,7 +263,7 @@ def test_on_resume_with_most_kwargs(mocker, reason, cause_factory, resource):
 
     when = lambda **_: False
 
-    @kopf.on.resume(resource.group, resource.version, resource.plural,
+    @kopf.on.resume(*resource,
                     id='id', registry=registry,
                     errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     deleted=True,
@@ -299,7 +299,7 @@ def test_on_create_with_most_kwargs(mocker, cause_factory, resource):
 
     when = lambda **_: False
 
-    @kopf.on.create(resource.group, resource.version, resource.plural,
+    @kopf.on.create(*resource,
                     id='id', registry=registry,
                     errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     labels={'somelabel': 'somevalue'},
@@ -333,7 +333,7 @@ def test_on_update_with_most_kwargs(mocker, cause_factory, resource):
 
     when = lambda **_: False
 
-    @kopf.on.update(resource.group, resource.version, resource.plural,
+    @kopf.on.update(*resource,
                     id='id', registry=registry,
                     errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     labels={'somelabel': 'somevalue'},
@@ -371,7 +371,7 @@ def test_on_delete_with_most_kwargs(mocker, cause_factory, optional, resource):
 
     when = lambda **_: False
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural,
+    @kopf.on.delete(*resource,
                     id='id', registry=registry,
                     errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                     optional=optional,
@@ -408,7 +408,7 @@ def test_on_field_with_most_kwargs(mocker, cause_factory, resource):
 
     when = lambda **_: False
 
-    @kopf.on.field(resource.group, resource.version, resource.plural, field='field.subfield',
+    @kopf.on.field(*resource, field='field.subfield',
                    id='id', registry=registry,
                    errors=ErrorsMode.PERMANENT, timeout=123, retries=456, backoff=78,
                    labels={'somelabel': 'somevalue'},
@@ -495,8 +495,7 @@ def test_subhandler_imperatively(parent_handler, cause_factory):
 def test_labels_filter_with_nones(resource, decorator, kwargs):
 
     with pytest.raises(ValueError):
-        @decorator(resource.group, resource.version, resource.plural, **kwargs,
-                   labels={'x': None})
+        @decorator(*resource, **kwargs, labels={'x': None})
         def fn(**_):
             pass
 
@@ -512,8 +511,7 @@ def test_labels_filter_with_nones(resource, decorator, kwargs):
 def test_annotations_filter_with_nones(resource, decorator, kwargs):
 
     with pytest.raises(ValueError):
-        @decorator(resource.group, resource.version, resource.plural, **kwargs,
-                   annotations={'x': None})
+        @decorator(*resource, **kwargs, annotations={'x': None})
         def fn(**_):
             pass
 
@@ -534,8 +532,7 @@ def test_field_with_value(mocker, cause_factory, decorator, causeargs, handlers_
     cause = cause_factory(resource=resource, old=old, new=new, body=new, **causeargs)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field='spec.field', value='value')
+    @decorator(*resource, field='spec.field', value='value')
     def fn(**_):
         pass
 
@@ -554,8 +551,7 @@ def test_field_with_oldnew(mocker, cause_factory, decorator, causeargs, handlers
     cause = cause_factory(resource=resource, **causeargs)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field='spec.field', old='old', new='new')
+    @decorator(*resource, field='spec.field', old='old', new='new')
     def fn(**_):
         pass
 
@@ -579,7 +575,7 @@ def test_field_with_oldnew(mocker, cause_factory, decorator, causeargs, handlers
 ])
 def test_missing_field_with_specified_value(resource, decorator):
     with pytest.raises(TypeError, match="without a mandatory field"):
-        @decorator(resource.group, resource.version, resource.plural, value='v')
+        @decorator(*resource, value='v')
         def fn(**_):
             pass
 
@@ -594,7 +590,7 @@ def test_missing_field_with_specified_value(resource, decorator):
 ])
 def test_conflicts_of_values_vs_oldnew(resource, decorator, kwargs):
     with pytest.raises(TypeError, match="Either value= or old=/new="):
-        @decorator(resource.group, resource.version, resource.plural, **kwargs)
+        @decorator(*resource, **kwargs)
         def fn(**_):
             pass
 
@@ -606,7 +602,7 @@ def test_conflicts_of_values_vs_oldnew(resource, decorator, kwargs):
 ])
 def test_invalid_oldnew_for_inappropriate_subhandlers(resource, decorator, registry):
 
-    @decorator(resource.group, resource.version, resource.plural)
+    @decorator(*resource)
     def fn(**_):
         @kopf.subhandler(field='f', old='x')
         def fn2(**_):

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -528,14 +528,13 @@ def test_annotations_filter_with_nones(resource, decorator, kwargs):
     pytest.param(kopf.daemon, dict(), '_resource_spawning', id='on-daemon'),
     pytest.param(kopf.timer, dict(), '_resource_spawning', id='on-timer'),
 ])
-def test_field_with_value(mocker, cause_factory, decorator, causeargs, handlers_prop, resource):
-    registry = OperatorRegistry()
+def test_field_with_value(mocker, cause_factory, decorator, causeargs, handlers_prop, resource, registry):
     old = {'field': {'subfield': 'old'}}
     new = {'field': {'subfield': 'new'}}
     cause = cause_factory(resource=resource, old=old, new=new, body=new, **causeargs)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field='spec.field', value='value')
     def fn(**_):
         pass
@@ -551,12 +550,11 @@ def test_field_with_value(mocker, cause_factory, decorator, causeargs, handlers_
     pytest.param(kopf.on.update, dict(reason=Reason.UPDATE), '_resource_changing', id='on-update'),
     pytest.param(kopf.on.field, dict(reason=Reason.UPDATE), '_resource_changing', id='on-field'),
 ])
-def test_field_with_oldnew(mocker, cause_factory, decorator, causeargs, handlers_prop, resource):
-    registry = OperatorRegistry()
+def test_field_with_oldnew(mocker, cause_factory, decorator, causeargs, handlers_prop, resource, registry):
     cause = cause_factory(resource=resource, **causeargs)
     mocker.patch('kopf.reactor.registries.match', return_value=True)
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field='spec.field', old='old', new='new')
     def fn(**_):
         pass

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -214,7 +214,7 @@ def test_on_startup_with_all_kwargs():
     assert handlers[0].backoff == 78
 
 
-def test_on_cleanup_with_all_kwargs(mocker):
+def test_on_cleanup_with_all_kwargs():
     registry = OperatorRegistry()
 
     @kopf.on.cleanup(
@@ -234,7 +234,7 @@ def test_on_cleanup_with_all_kwargs(mocker):
     assert handlers[0].backoff == 78
 
 
-def test_on_probe_with_all_kwargs(mocker):
+def test_on_probe_with_all_kwargs():
     registry = OperatorRegistry()
 
     @kopf.on.probe(

--- a/tests/registries/test_matching_for_changing.py
+++ b/tests/registries/test_matching_for_changing.py
@@ -428,8 +428,7 @@ def test_catchall_handlers_with_when_callback_mismatching(
 def test_relevant_handlers_without_field_found(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field=None)
+    @decorator(*resource, field=None)
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -442,8 +441,7 @@ def test_relevant_handlers_without_field_found(
 def test_relevant_handlers_with_field_found(
         cause_with_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field='some-field')
+    @decorator(*resource, field='some-field')
     def some_fn(**_): ...
 
     cause = cause_with_diff
@@ -456,8 +454,7 @@ def test_relevant_handlers_with_field_found(
 def test_relevant_handlers_with_field_ignored(
         cause_no_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field='some-field')
+    @decorator(*resource, field='some-field')
     def some_fn(**_): ...
 
     cause = cause_no_diff
@@ -470,8 +467,7 @@ def test_relevant_handlers_with_field_ignored(
 def test_relevant_handlers_with_labels_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               labels={'somelabel': PRESENT})
+    @decorator(*resource, labels={'somelabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -484,8 +480,7 @@ def test_relevant_handlers_with_labels_satisfied(
 def test_relevant_handlers_with_labels_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               labels={'otherlabel': PRESENT})
+    @decorator(*resource, labels={'otherlabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -498,8 +493,7 @@ def test_relevant_handlers_with_labels_not_satisfied(
 def test_relevant_handlers_with_annotations_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               annotations={'someannotation': PRESENT})
+    @decorator(*resource, annotations={'someannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -512,8 +506,7 @@ def test_relevant_handlers_with_annotations_satisfied(
 def test_relevant_handlers_with_annotations_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               annotations={'otherannotation': PRESENT})
+    @decorator(*resource, annotations={'otherannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -526,8 +519,7 @@ def test_relevant_handlers_with_annotations_not_satisfied(
 def test_relevant_handlers_with_filter_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               when=_always)
+    @decorator(*resource, when=_always)
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -540,8 +532,7 @@ def test_relevant_handlers_with_filter_satisfied(
 def test_relevant_handlers_with_filter_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               when=_never)
+    @decorator(*resource, when=_never)
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -554,7 +545,7 @@ def test_relevant_handlers_with_filter_not_satisfied(
 def test_irrelevant_handlers_without_field_ignored(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural)
+    @decorator(*resource)
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -567,8 +558,7 @@ def test_irrelevant_handlers_without_field_ignored(
 def test_irrelevant_handlers_with_field_ignored(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field='another-field')
+    @decorator(*resource, field='another-field')
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -581,8 +571,7 @@ def test_irrelevant_handlers_with_field_ignored(
 def test_irrelevant_handlers_with_labels_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               labels={'somelabel': PRESENT})
+    @decorator(*resource, labels={'somelabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -595,8 +584,7 @@ def test_irrelevant_handlers_with_labels_satisfied(
 def test_irrelevant_handlers_with_labels_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               labels={'otherlabel': PRESENT})
+    @decorator(*resource, labels={'otherlabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -609,8 +597,7 @@ def test_irrelevant_handlers_with_labels_not_satisfied(
 def test_irrelevant_handlers_with_annotations_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               annotations={'someannotation': PRESENT})
+    @decorator(*resource, annotations={'someannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -623,8 +610,7 @@ def test_irrelevant_handlers_with_annotations_satisfied(
 def test_irrelevant_handlers_with_annotations_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               annotations={'otherannotation': PRESENT})
+    @decorator(*resource, annotations={'otherannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -637,8 +623,7 @@ def test_irrelevant_handlers_with_annotations_not_satisfied(
 def test_irrelevant_handlers_with_when_callback_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               when=_always)
+    @decorator(*resource, when=_always)
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -651,8 +636,7 @@ def test_irrelevant_handlers_with_when_callback_satisfied(
 def test_irrelevant_handlers_with_when_callback_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               when=_never)
+    @decorator(*resource, when=_never)
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -668,8 +652,7 @@ def test_irrelevant_handlers_with_when_callback_not_satisfied(
 @matching_reason_and_decorator_with_field
 def test_field_same_as_diff(cause_with_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field='level1.level2')
+    @decorator(*resource, field='level1.level2')
     def some_fn(**_): ...
 
     cause = cause_with_diff
@@ -684,8 +667,7 @@ def test_field_same_as_diff(cause_with_diff, registry, resource, reason, decorat
 @matching_reason_and_decorator_with_field
 def test_field_shorter_than_diff(cause_with_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field='level1')
+    @decorator(*resource, field='level1')
     def some_fn(**_): ...
 
     cause = cause_with_diff
@@ -700,8 +682,7 @@ def test_field_shorter_than_diff(cause_with_diff, registry, resource, reason, de
 @matching_reason_and_decorator_with_field
 def test_field_longer_than_diff_for_wrong_field(cause_with_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field='level1.level2.level3')
+    @decorator(*resource, field='level1.level2.level3')
     def some_fn(**_): ...
 
     cause = cause_with_diff
@@ -725,8 +706,7 @@ def test_field_longer_than_diff_for_wrong_field(cause_with_diff, registry, resou
 @matching_reason_and_decorator_with_field
 def test_field_longer_than_diff_for_right_field(cause_with_diff, registry, resource, old, new, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field='level1.level2.level3')
+    @decorator(*resource, field='level1.level2.level3')
     def some_fn(**_): ...
 
     cause = cause_with_diff
@@ -745,19 +725,19 @@ def test_field_longer_than_diff_for_right_field(cause_with_diff, registry, resou
 
 def test_order_persisted_a(cause_with_diff, registry, resource):
 
-    @kopf.on.create(resource.group, resource.version, resource.plural)
+    @kopf.on.create(*resource)
     def some_fn_1(**_): ...  # used
 
-    @kopf.on.update(resource.group, resource.version, resource.plural)
+    @kopf.on.update(*resource)
     def some_fn_2(**_): ...  # filtered out
 
-    @kopf.on.create(resource.group, resource.version, resource.plural)
+    @kopf.on.create(*resource)
     def some_fn_3(**_): ...  # used
 
-    @kopf.on.field(resource.group, resource.version, resource.plural, field='filtered-out-field')
+    @kopf.on.field(*resource, field='filtered-out-field')
     def some_fn_4(**_): ...  # filtered out
 
-    @kopf.on.field(resource.group, resource.version, resource.plural, field='some-field')
+    @kopf.on.field(*resource, field='some-field')
     def some_fn_5(**_): ...  # used
 
     cause = cause_with_diff
@@ -773,22 +753,19 @@ def test_order_persisted_a(cause_with_diff, registry, resource):
 
 def test_order_persisted_b(cause_with_diff, registry, resource):
 
-    # TODO: add registering by just `resource` or `resource.name`
-    # TODO: remake it to `registry.on.field(...)`, and make `kopf.on` decorators as aliases for a default registry.
-    # @registry.on.field(resource.group, resource.version, resource.plural, field='some-field')
-    @kopf.on.field(resource.group, resource.version, resource.plural, field='some-field')
+    @kopf.on.field(*resource, field='some-field')
     def some_fn_1(**_): ...  # used
 
-    @kopf.on.field(resource.group, resource.version, resource.plural, field='filtered-out-field')
+    @kopf.on.field(*resource, field='filtered-out-field')
     def some_fn_2(**_): ...  # filtered out
 
-    @kopf.on.create(resource.group, resource.version, resource.plural)
+    @kopf.on.create(*resource)
     def some_fn_3(**_): ...  # used
 
-    @kopf.on.update(resource.group, resource.version, resource.plural)
+    @kopf.on.update(*resource)
     def some_fn_4(**_): ...  # filtered out
 
-    @kopf.on.create(resource.group, resource.version, resource.plural)
+    @kopf.on.create(*resource)
     def some_fn_5(**_): ...  # used
 
     cause = cause_with_diff
@@ -811,8 +788,8 @@ def test_deduplicated(
         cause_with_diff, registry, resource, reason, decorator):
 
     # Note: the decorators are applied bottom-up -- hence, the order of ids:
-    @decorator(resource.group, resource.version, resource.plural, id='b')
-    @decorator(resource.group, resource.version, resource.plural, id='a')
+    @decorator(*resource, id='b')
+    @decorator(*resource, id='a')
     def some_fn(**_): ...
 
     cause = cause_with_diff

--- a/tests/registries/test_matching_for_changing.py
+++ b/tests/registries/test_matching_for_changing.py
@@ -7,7 +7,6 @@ from kopf.structs.bodies import Body
 from kopf.structs.dicts import parse_field
 from kopf.structs.filters import MetaFilterToken
 from kopf.structs.handlers import ALL_REASONS, Reason, ResourceChangingHandler
-from kopf.structs.references import Selector
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.

--- a/tests/registries/test_matching_for_changing.py
+++ b/tests/registries/test_matching_for_changing.py
@@ -428,7 +428,7 @@ def test_catchall_handlers_with_when_callback_mismatching(
 def test_relevant_handlers_without_field_found(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field=None)
     def some_fn(**_): ...
 
@@ -442,7 +442,7 @@ def test_relevant_handlers_without_field_found(
 def test_relevant_handlers_with_field_found(
         cause_with_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field='some-field')
     def some_fn(**_): ...
 
@@ -456,7 +456,7 @@ def test_relevant_handlers_with_field_found(
 def test_relevant_handlers_with_field_ignored(
         cause_no_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field='some-field')
     def some_fn(**_): ...
 
@@ -470,7 +470,7 @@ def test_relevant_handlers_with_field_ignored(
 def test_relevant_handlers_with_labels_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                labels={'somelabel': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -484,7 +484,7 @@ def test_relevant_handlers_with_labels_satisfied(
 def test_relevant_handlers_with_labels_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                labels={'otherlabel': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -498,7 +498,7 @@ def test_relevant_handlers_with_labels_not_satisfied(
 def test_relevant_handlers_with_annotations_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                annotations={'someannotation': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -512,7 +512,7 @@ def test_relevant_handlers_with_annotations_satisfied(
 def test_relevant_handlers_with_annotations_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                annotations={'otherannotation': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -526,7 +526,7 @@ def test_relevant_handlers_with_annotations_not_satisfied(
 def test_relevant_handlers_with_filter_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                when=_always)
     def some_fn(**_): ...
 
@@ -540,7 +540,7 @@ def test_relevant_handlers_with_filter_satisfied(
 def test_relevant_handlers_with_filter_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                when=_never)
     def some_fn(**_): ...
 
@@ -554,7 +554,7 @@ def test_relevant_handlers_with_filter_not_satisfied(
 def test_irrelevant_handlers_without_field_ignored(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry)
+    @decorator(resource.group, resource.version, resource.plural)
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -567,7 +567,7 @@ def test_irrelevant_handlers_without_field_ignored(
 def test_irrelevant_handlers_with_field_ignored(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field='another-field')
     def some_fn(**_): ...
 
@@ -581,7 +581,7 @@ def test_irrelevant_handlers_with_field_ignored(
 def test_irrelevant_handlers_with_labels_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                labels={'somelabel': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -595,7 +595,7 @@ def test_irrelevant_handlers_with_labels_satisfied(
 def test_irrelevant_handlers_with_labels_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                labels={'otherlabel': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -609,7 +609,7 @@ def test_irrelevant_handlers_with_labels_not_satisfied(
 def test_irrelevant_handlers_with_annotations_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                annotations={'someannotation': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -623,7 +623,7 @@ def test_irrelevant_handlers_with_annotations_satisfied(
 def test_irrelevant_handlers_with_annotations_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                annotations={'otherannotation': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -637,7 +637,7 @@ def test_irrelevant_handlers_with_annotations_not_satisfied(
 def test_irrelevant_handlers_with_when_callback_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                when=_always)
     def some_fn(**_): ...
 
@@ -651,7 +651,7 @@ def test_irrelevant_handlers_with_when_callback_satisfied(
 def test_irrelevant_handlers_with_when_callback_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                when=_never)
     def some_fn(**_): ...
 
@@ -668,7 +668,7 @@ def test_irrelevant_handlers_with_when_callback_not_satisfied(
 @matching_reason_and_decorator_with_field
 def test_field_same_as_diff(cause_with_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field='level1.level2')
     def some_fn(**_): ...
 
@@ -684,7 +684,7 @@ def test_field_same_as_diff(cause_with_diff, registry, resource, reason, decorat
 @matching_reason_and_decorator_with_field
 def test_field_shorter_than_diff(cause_with_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field='level1')
     def some_fn(**_): ...
 
@@ -700,7 +700,7 @@ def test_field_shorter_than_diff(cause_with_diff, registry, resource, reason, de
 @matching_reason_and_decorator_with_field
 def test_field_longer_than_diff_for_wrong_field(cause_with_diff, registry, resource, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field='level1.level2.level3')
     def some_fn(**_): ...
 
@@ -725,7 +725,7 @@ def test_field_longer_than_diff_for_wrong_field(cause_with_diff, registry, resou
 @matching_reason_and_decorator_with_field
 def test_field_longer_than_diff_for_right_field(cause_with_diff, registry, resource, old, new, reason, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field='level1.level2.level3')
     def some_fn(**_): ...
 
@@ -745,19 +745,19 @@ def test_field_longer_than_diff_for_right_field(cause_with_diff, registry, resou
 
 def test_order_persisted_a(cause_with_diff, registry, resource):
 
-    @kopf.on.create(resource.group, resource.version, resource.plural, registry=registry)
+    @kopf.on.create(resource.group, resource.version, resource.plural)
     def some_fn_1(**_): ...  # used
 
-    @kopf.on.update(resource.group, resource.version, resource.plural, registry=registry)
+    @kopf.on.update(resource.group, resource.version, resource.plural)
     def some_fn_2(**_): ...  # filtered out
 
-    @kopf.on.create(resource.group, resource.version, resource.plural, registry=registry)
+    @kopf.on.create(resource.group, resource.version, resource.plural)
     def some_fn_3(**_): ...  # used
 
-    @kopf.on.field(resource.group, resource.version, resource.plural, registry=registry, field='filtered-out-field')
+    @kopf.on.field(resource.group, resource.version, resource.plural, field='filtered-out-field')
     def some_fn_4(**_): ...  # filtered out
 
-    @kopf.on.field(resource.group, resource.version, resource.plural, registry=registry, field='some-field')
+    @kopf.on.field(resource.group, resource.version, resource.plural, field='some-field')
     def some_fn_5(**_): ...  # used
 
     cause = cause_with_diff
@@ -776,19 +776,19 @@ def test_order_persisted_b(cause_with_diff, registry, resource):
     # TODO: add registering by just `resource` or `resource.name`
     # TODO: remake it to `registry.on.field(...)`, and make `kopf.on` decorators as aliases for a default registry.
     # @registry.on.field(resource.group, resource.version, resource.plural, field='some-field')
-    @kopf.on.field(resource.group, resource.version, resource.plural, registry=registry, field='some-field')
+    @kopf.on.field(resource.group, resource.version, resource.plural, field='some-field')
     def some_fn_1(**_): ...  # used
 
-    @kopf.on.field(resource.group, resource.version, resource.plural, registry=registry, field='filtered-out-field')
+    @kopf.on.field(resource.group, resource.version, resource.plural, field='filtered-out-field')
     def some_fn_2(**_): ...  # filtered out
 
-    @kopf.on.create(resource.group, resource.version, resource.plural, registry=registry)
+    @kopf.on.create(resource.group, resource.version, resource.plural)
     def some_fn_3(**_): ...  # used
 
-    @kopf.on.update(resource.group, resource.version, resource.plural, registry=registry)
+    @kopf.on.update(resource.group, resource.version, resource.plural)
     def some_fn_4(**_): ...  # filtered out
 
-    @kopf.on.create(resource.group, resource.version, resource.plural, registry=registry)
+    @kopf.on.create(resource.group, resource.version, resource.plural)
     def some_fn_5(**_): ...  # used
 
     cause = cause_with_diff
@@ -811,8 +811,8 @@ def test_deduplicated(
         cause_with_diff, registry, resource, reason, decorator):
 
     # Note: the decorators are applied bottom-up -- hence, the order of ids:
-    @decorator(resource.group, resource.version, resource.plural, registry=registry, id='b')
-    @decorator(resource.group, resource.version, resource.plural, registry=registry, id='a')
+    @decorator(resource.group, resource.version, resource.plural, id='b')
+    @decorator(resource.group, resource.version, resource.plural, id='a')
     def some_fn(**_): ...
 
     cause = cause_with_diff

--- a/tests/registries/test_matching_for_changing.py
+++ b/tests/registries/test_matching_for_changing.py
@@ -5,7 +5,7 @@ import pytest
 import kopf
 from kopf.structs.bodies import Body
 from kopf.structs.dicts import parse_field
-from kopf.structs.filters import MetaFilterToken
+from kopf.structs.filters import ABSENT, PRESENT
 from kopf.structs.handlers import ALL_REASONS, Reason, ResourceChangingHandler
 
 
@@ -165,7 +165,7 @@ def test_catchall_handlers_with_exact_labels_not_satisfied(
 def test_catchall_handlers_with_desired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(reason=None, labels={'somelabel': MetaFilterToken.PRESENT})
+    handler_factory(reason=None, labels={'somelabel': PRESENT})
     handlers = registry._resource_changing.get_handlers(cause)
     assert handlers
 
@@ -177,7 +177,7 @@ def test_catchall_handlers_with_desired_labels_present(
 def test_catchall_handlers_with_desired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(reason=None, labels={'somelabel': MetaFilterToken.PRESENT})
+    handler_factory(reason=None, labels={'somelabel': PRESENT})
     handlers = registry._resource_changing.get_handlers(cause)
     assert not handlers
 
@@ -189,7 +189,7 @@ def test_catchall_handlers_with_desired_labels_absent(
 def test_catchall_handlers_with_undesired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(reason=None, labels={'somelabel': MetaFilterToken.ABSENT})
+    handler_factory(reason=None, labels={'somelabel': ABSENT})
     handlers = registry._resource_changing.get_handlers(cause)
     assert not handlers
 
@@ -201,7 +201,7 @@ def test_catchall_handlers_with_undesired_labels_present(
 def test_catchall_handlers_with_undesired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(reason=None, labels={'somelabel': MetaFilterToken.ABSENT})
+    handler_factory(reason=None, labels={'somelabel': ABSENT})
     handlers = registry._resource_changing.get_handlers(cause)
     assert handlers
 
@@ -279,7 +279,7 @@ def test_catchall_handlers_with_exact_annotations_not_satisfied(
 def test_catchall_handlers_with_desired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(reason=None, annotations={'someannotation': MetaFilterToken.PRESENT})
+    handler_factory(reason=None, annotations={'someannotation': PRESENT})
     handlers = registry._resource_changing.get_handlers(cause)
     assert handlers
 
@@ -291,7 +291,7 @@ def test_catchall_handlers_with_desired_annotations_present(
 def test_catchall_handlers_with_desired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(reason=None, annotations={'someannotation': MetaFilterToken.PRESENT})
+    handler_factory(reason=None, annotations={'someannotation': PRESENT})
     handlers = registry._resource_changing.get_handlers(cause)
     assert not handlers
 
@@ -303,7 +303,7 @@ def test_catchall_handlers_with_desired_annotations_absent(
 def test_catchall_handlers_with_undesired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(reason=None, annotations={'someannotation': MetaFilterToken.ABSENT})
+    handler_factory(reason=None, annotations={'someannotation': ABSENT})
     handlers = registry._resource_changing.get_handlers(cause)
     assert not handlers
 
@@ -315,7 +315,7 @@ def test_catchall_handlers_with_undesired_annotations_present(
 def test_catchall_handlers_with_undesired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(reason=None, annotations={'someannotation': MetaFilterToken.ABSENT})
+    handler_factory(reason=None, annotations={'someannotation': ABSENT})
     handlers = registry._resource_changing.get_handlers(cause)
     assert handlers
 
@@ -471,7 +471,7 @@ def test_relevant_handlers_with_labels_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               labels={'somelabel': MetaFilterToken.PRESENT})
+               labels={'somelabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -485,7 +485,7 @@ def test_relevant_handlers_with_labels_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               labels={'otherlabel': MetaFilterToken.PRESENT})
+               labels={'otherlabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -499,7 +499,7 @@ def test_relevant_handlers_with_annotations_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               annotations={'someannotation': MetaFilterToken.PRESENT})
+               annotations={'someannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -513,7 +513,7 @@ def test_relevant_handlers_with_annotations_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               annotations={'otherannotation': MetaFilterToken.PRESENT})
+               annotations={'otherannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -582,7 +582,7 @@ def test_irrelevant_handlers_with_labels_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               labels={'somelabel': MetaFilterToken.PRESENT})
+               labels={'somelabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -596,7 +596,7 @@ def test_irrelevant_handlers_with_labels_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               labels={'otherlabel': MetaFilterToken.PRESENT})
+               labels={'otherlabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -610,7 +610,7 @@ def test_irrelevant_handlers_with_annotations_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               annotations={'someannotation': MetaFilterToken.PRESENT})
+               annotations={'someannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff
@@ -624,7 +624,7 @@ def test_irrelevant_handlers_with_annotations_not_satisfied(
         cause_any_diff, registry, resource, reason, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               annotations={'otherannotation': MetaFilterToken.PRESENT})
+               annotations={'otherannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_diff

--- a/tests/registries/test_matching_for_spawning.py
+++ b/tests/registries/test_matching_for_spawning.py
@@ -7,7 +7,6 @@ from kopf.reactor.causation import ResourceSpawningCause
 from kopf.structs.dicts import parse_field
 from kopf.structs.filters import MetaFilterToken
 from kopf.structs.handlers import ResourceSpawningHandler
-from kopf.structs.references import Selector
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.

--- a/tests/registries/test_matching_for_spawning.py
+++ b/tests/registries/test_matching_for_spawning.py
@@ -392,8 +392,7 @@ def test_catchall_handlers_with_when_callback_mismatching(
 def test_decorator_without_field_found(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field=None)
+    @decorator(*resource, field=None)
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -405,8 +404,7 @@ def test_decorator_without_field_found(
 def test_decorator_with_field_found(
         cause_with_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field='some-field')
+    @decorator(*resource, field='some-field')
     def some_fn(**_): ...
 
     cause = cause_with_field
@@ -418,8 +416,7 @@ def test_decorator_with_field_found(
 def test_decorator_with_field_ignored(
         cause_no_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               field='some-field')
+    @decorator(*resource, field='some-field')
     def some_fn(**_): ...
 
     cause = cause_no_field
@@ -431,8 +428,7 @@ def test_decorator_with_field_ignored(
 def test_decorator_with_labels_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               labels={'somelabel': PRESENT})
+    @decorator(*resource, labels={'somelabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -444,8 +440,7 @@ def test_decorator_with_labels_satisfied(
 def test_decorator_with_labels_not_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               labels={'otherlabel': PRESENT})
+    @decorator(*resource, labels={'otherlabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -457,8 +452,7 @@ def test_decorator_with_labels_not_satisfied(
 def test_decorator_with_annotations_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               annotations={'someannotation': PRESENT})
+    @decorator(*resource, annotations={'someannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -470,8 +464,7 @@ def test_decorator_with_annotations_satisfied(
 def test_decorator_with_annotations_not_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               annotations={'otherannotation': PRESENT})
+    @decorator(*resource, annotations={'otherannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -483,8 +476,7 @@ def test_decorator_with_annotations_not_satisfied(
 def test_decorator_with_filter_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               when=_always)
+    @decorator(*resource, when=_always)
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -496,8 +488,7 @@ def test_decorator_with_filter_satisfied(
 def test_decorator_with_filter_not_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural,
-               when=_never)
+    @decorator(*resource, when=_never)
     def some_fn(**_): ...
 
     cause = cause_any_field

--- a/tests/registries/test_matching_for_spawning.py
+++ b/tests/registries/test_matching_for_spawning.py
@@ -5,7 +5,7 @@ import pytest
 import kopf
 from kopf.reactor.causation import ResourceSpawningCause
 from kopf.structs.dicts import parse_field
-from kopf.structs.filters import MetaFilterToken
+from kopf.structs.filters import ABSENT, PRESENT
 from kopf.structs.handlers import ResourceSpawningHandler
 
 
@@ -138,7 +138,7 @@ def test_catchall_handlers_with_exact_labels_not_satisfied(
 def test_catchall_handlers_with_desired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': MetaFilterToken.PRESENT})
+    handler_factory(labels={'somelabel': PRESENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
@@ -150,7 +150,7 @@ def test_catchall_handlers_with_desired_labels_present(
 def test_catchall_handlers_with_desired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': MetaFilterToken.PRESENT})
+    handler_factory(labels={'somelabel': PRESENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
@@ -162,7 +162,7 @@ def test_catchall_handlers_with_desired_labels_absent(
 def test_catchall_handlers_with_undesired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': MetaFilterToken.ABSENT})
+    handler_factory(labels={'somelabel': ABSENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
@@ -174,7 +174,7 @@ def test_catchall_handlers_with_undesired_labels_present(
 def test_catchall_handlers_with_undesired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': MetaFilterToken.ABSENT})
+    handler_factory(labels={'somelabel': ABSENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
@@ -252,7 +252,7 @@ def test_catchall_handlers_with_exact_annotations_not_satisfied(
 def test_catchall_handlers_with_desired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': MetaFilterToken.PRESENT})
+    handler_factory(annotations={'someannotation': PRESENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
@@ -264,7 +264,7 @@ def test_catchall_handlers_with_desired_annotations_present(
 def test_catchall_handlers_with_desired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': MetaFilterToken.PRESENT})
+    handler_factory(annotations={'someannotation': PRESENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
@@ -276,7 +276,7 @@ def test_catchall_handlers_with_desired_annotations_absent(
 def test_catchall_handlers_with_undesired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': MetaFilterToken.ABSENT})
+    handler_factory(annotations={'someannotation': ABSENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
@@ -288,7 +288,7 @@ def test_catchall_handlers_with_undesired_annotations_present(
 def test_catchall_handlers_with_undesired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': MetaFilterToken.ABSENT})
+    handler_factory(annotations={'someannotation': ABSENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
@@ -432,7 +432,7 @@ def test_decorator_with_labels_satisfied(
         cause_any_field, registry, resource, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               labels={'somelabel': MetaFilterToken.PRESENT})
+               labels={'somelabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -445,7 +445,7 @@ def test_decorator_with_labels_not_satisfied(
         cause_any_field, registry, resource, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               labels={'otherlabel': MetaFilterToken.PRESENT})
+               labels={'otherlabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -458,7 +458,7 @@ def test_decorator_with_annotations_satisfied(
         cause_any_field, registry, resource, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               annotations={'someannotation': MetaFilterToken.PRESENT})
+               annotations={'someannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -471,7 +471,7 @@ def test_decorator_with_annotations_not_satisfied(
         cause_any_field, registry, resource, decorator):
 
     @decorator(resource.group, resource.version, resource.plural,
-               annotations={'otherannotation': MetaFilterToken.PRESENT})
+               annotations={'otherannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field

--- a/tests/registries/test_matching_for_spawning.py
+++ b/tests/registries/test_matching_for_spawning.py
@@ -48,19 +48,19 @@ def handler_factory(registry, selector):
 ])
 def cause_no_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
-                                        'annotations': {'someannotation': 'somevalue'}}})
+    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
+                                        'annotations': {'known': 'value'}}})
     cause = cause_factory(cls=ResourceSpawningCause, **kwargs)
     return cause
 
 
 @pytest.fixture(params=[
-    pytest.param(dict(body={'some-field': 'new'}), id='with-field'),
+    pytest.param(dict(body={'known-field': 'new'}), id='with-field'),
 ])
 def cause_with_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
-                                        'annotations': {'someannotation': 'somevalue'}}})
+    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
+                                        'annotations': {'known': 'value'}}})
     cause = cause_factory(cls=ResourceSpawningCause, **kwargs)
     return cause
 
@@ -68,12 +68,12 @@ def cause_with_field(request, cause_factory):
 @pytest.fixture(params=[
     # The original no-diff was equivalent to no-field until body/old/new were added to the check.
     pytest.param(dict(body={}, diff=[]), id='no-field'),
-    pytest.param(dict(body={'some-field': 'new'}), id='with-field'),
+    pytest.param(dict(body={'known-field': 'new'}), id='with-field'),
 ])
 def cause_any_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
-                                        'annotations': {'someannotation': 'somevalue'}}})
+    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
+                                        'annotations': {'known': 'value'}}})
     cause = cause_factory(cls=ResourceSpawningCause, **kwargs)
     return cause
 
@@ -93,7 +93,7 @@ def test_catchall_handlers_without_field_found(
 def test_catchall_handlers_with_field_found(
         cause_with_field, registry, handler_factory):
     cause = cause_with_field
-    handler_factory(field=parse_field('some-field'))
+    handler_factory(field=parse_field('known-field'))
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
@@ -101,116 +101,116 @@ def test_catchall_handlers_with_field_found(
 def test_catchall_handlers_with_field_ignored(
         cause_no_field, registry, handler_factory):
     cause = cause_no_field
-    handler_factory(field=parse_field('some-field'))
+    handler_factory(field=parse_field('known-field'))
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('labels', [
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_exact_labels_satisfied(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': 'somevalue'})
+    handler_factory(labels={'known': 'value'})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
-    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_exact_labels_not_satisfied(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': 'somevalue'})
+    handler_factory(labels={'known': 'value'})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('labels', [
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_desired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': PRESENT})
+    handler_factory(labels={'known': PRESENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_desired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': PRESENT})
+    handler_factory(labels={'known': PRESENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('labels', [
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_undesired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': ABSENT})
+    handler_factory(labels={'known': ABSENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_undesired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': ABSENT})
+    handler_factory(labels={'known': ABSENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_labels_callback_says_true(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': _always})
+    handler_factory(labels={'known': _always})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_labels_callback_says_false(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': _never})
+    handler_factory(labels={'known': _never})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
-    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
-    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_without_labels(
         cause_factory, registry, handler_factory, labels):
@@ -221,110 +221,110 @@ def test_catchall_handlers_without_labels(
 
 
 @pytest.mark.parametrize('annotations', [
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_with_exact_annotations_satisfied(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': 'somevalue'})
+    handler_factory(annotations={'known': 'value'})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
-    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_exact_annotations_not_satisfied(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': 'somevalue'})
+    handler_factory(annotations={'known': 'value'})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('annotations', [
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_desired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': PRESENT})
+    handler_factory(annotations={'known': PRESENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_desired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': PRESENT})
+    handler_factory(annotations={'known': PRESENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('annotations', [
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_undesired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': ABSENT})
+    handler_factory(annotations={'known': ABSENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_undesired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': ABSENT})
+    handler_factory(annotations={'known': ABSENT})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_annotations_callback_says_true(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': _always})
+    handler_factory(annotations={'known': _always})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_annotations_callback_says_false(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': _never})
+    handler_factory(annotations={'known': _never})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
-    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
-    pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_without_annotations(
         cause_factory, registry, handler_factory, annotations):
@@ -335,30 +335,30 @@ def test_catchall_handlers_without_annotations(
 
 
 @pytest.mark.parametrize('labels, annotations', [
-    pytest.param({'somelabel': 'somevalue'}, {'someannotation': 'somevalue'}, id='with-label-annotation'),
-    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue'}, id='with-extra-label-annotation'),
-    pytest.param({'somelabel': 'somevalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-label-extra-annotation'),
-    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-label-extra-annotation'),
+    pytest.param({'known': 'value'}, {'known': 'value'}, id='with-label-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, {'known': 'value'}, id='with-extra-label-annotation'),
+    pytest.param({'known': 'value'}, {'known': 'value', 'extra': 'other'}, id='with-label-extra-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, {'known': 'value', 'extra': 'other'}, id='with-extra-label-extra-annotation'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_satisfied(
         cause_factory, registry, handler_factory, labels, annotations):
     cause = cause_factory(body={'metadata': {'labels': labels, 'annotations': annotations}})
-    handler_factory(labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    handler_factory(labels={'known': 'value'}, annotations={'known': 'value'})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
-    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
-    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    handler_factory(labels={'known': 'value'}, annotations={'known': 'value'})
     handlers = registry._resource_spawning.get_handlers(cause)
     assert not handlers
 
@@ -404,7 +404,7 @@ def test_decorator_without_field_found(
 def test_decorator_with_field_found(
         cause_with_field, registry, resource, decorator):
 
-    @decorator(*resource, field='some-field')
+    @decorator(*resource, field='known-field')
     def some_fn(**_): ...
 
     cause = cause_with_field
@@ -416,7 +416,7 @@ def test_decorator_with_field_found(
 def test_decorator_with_field_ignored(
         cause_no_field, registry, resource, decorator):
 
-    @decorator(*resource, field='some-field')
+    @decorator(*resource, field='known-field')
     def some_fn(**_): ...
 
     cause = cause_no_field
@@ -428,7 +428,7 @@ def test_decorator_with_field_ignored(
 def test_decorator_with_labels_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(*resource, labels={'somelabel': PRESENT})
+    @decorator(*resource, labels={'known': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -440,7 +440,7 @@ def test_decorator_with_labels_satisfied(
 def test_decorator_with_labels_not_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(*resource, labels={'otherlabel': PRESENT})
+    @decorator(*resource, labels={'extra': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -452,7 +452,7 @@ def test_decorator_with_labels_not_satisfied(
 def test_decorator_with_annotations_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(*resource, annotations={'someannotation': PRESENT})
+    @decorator(*resource, annotations={'known': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -464,7 +464,7 @@ def test_decorator_with_annotations_satisfied(
 def test_decorator_with_annotations_not_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(*resource, annotations={'otherannotation': PRESENT})
+    @decorator(*resource, annotations={'extra': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field

--- a/tests/registries/test_matching_for_spawning.py
+++ b/tests/registries/test_matching_for_spawning.py
@@ -392,7 +392,7 @@ def test_catchall_handlers_with_when_callback_mismatching(
 def test_decorator_without_field_found(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field=None)
     def some_fn(**_): ...
 
@@ -405,7 +405,7 @@ def test_decorator_without_field_found(
 def test_decorator_with_field_found(
         cause_with_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field='some-field')
     def some_fn(**_): ...
 
@@ -418,7 +418,7 @@ def test_decorator_with_field_found(
 def test_decorator_with_field_ignored(
         cause_no_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                field='some-field')
     def some_fn(**_): ...
 
@@ -431,7 +431,7 @@ def test_decorator_with_field_ignored(
 def test_decorator_with_labels_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                labels={'somelabel': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -444,7 +444,7 @@ def test_decorator_with_labels_satisfied(
 def test_decorator_with_labels_not_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                labels={'otherlabel': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -457,7 +457,7 @@ def test_decorator_with_labels_not_satisfied(
 def test_decorator_with_annotations_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                annotations={'someannotation': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -470,7 +470,7 @@ def test_decorator_with_annotations_satisfied(
 def test_decorator_with_annotations_not_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                annotations={'otherannotation': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -483,7 +483,7 @@ def test_decorator_with_annotations_not_satisfied(
 def test_decorator_with_filter_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                when=_always)
     def some_fn(**_): ...
 
@@ -496,7 +496,7 @@ def test_decorator_with_filter_satisfied(
 def test_decorator_with_filter_not_satisfied(
         cause_any_field, registry, resource, decorator):
 
-    @decorator(resource.group, resource.version, resource.plural, registry=registry,
+    @decorator(resource.group, resource.version, resource.plural,
                when=_never)
     def some_fn(**_): ...
 

--- a/tests/registries/test_matching_for_watching.py
+++ b/tests/registries/test_matching_for_watching.py
@@ -384,8 +384,7 @@ def test_catchall_handlers_with_when_callback_mismatching(
 def test_decorator_without_field_found(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural,
-                   field=None)
+    @kopf.on.event(*resource, field=None)
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -396,8 +395,7 @@ def test_decorator_without_field_found(
 def test_decorator_with_field_found(
         cause_with_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural,
-                   field='some-field')
+    @kopf.on.event(*resource, field='some-field')
     def some_fn(**_): ...
 
     cause = cause_with_field
@@ -408,8 +406,7 @@ def test_decorator_with_field_found(
 def test_decorator_with_field_ignored(
         cause_no_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural,
-                   field='some-field')
+    @kopf.on.event(*resource, field='some-field')
     def some_fn(**_): ...
 
     cause = cause_no_field
@@ -420,8 +417,7 @@ def test_decorator_with_field_ignored(
 def test_decorator_with_labels_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural,
-                   labels={'somelabel': PRESENT})
+    @kopf.on.event(*resource, labels={'somelabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -432,8 +428,7 @@ def test_decorator_with_labels_satisfied(
 def test_decorator_with_labels_not_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural,
-                   labels={'otherlabel': PRESENT})
+    @kopf.on.event(*resource, labels={'otherlabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -444,8 +439,7 @@ def test_decorator_with_labels_not_satisfied(
 def test_decorator_with_annotations_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural,
-                   annotations={'someannotation': PRESENT})
+    @kopf.on.event(*resource, annotations={'someannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -456,8 +450,7 @@ def test_decorator_with_annotations_satisfied(
 def test_decorator_with_annotations_not_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural,
-                   annotations={'otherannotation': PRESENT})
+    @kopf.on.event(*resource, annotations={'otherannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -468,8 +461,7 @@ def test_decorator_with_annotations_not_satisfied(
 def test_decorator_with_filter_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural,
-                   when=_always)
+    @kopf.on.event(*resource, when=_always)
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -480,8 +472,7 @@ def test_decorator_with_filter_satisfied(
 def test_decorator_with_filter_not_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural,
-                   when=_never)
+    @kopf.on.event(*resource, when=_never)
     def some_fn(**_): ...
 
     cause = cause_any_field

--- a/tests/registries/test_matching_for_watching.py
+++ b/tests/registries/test_matching_for_watching.py
@@ -384,7 +384,7 @@ def test_catchall_handlers_with_when_callback_mismatching(
 def test_decorator_without_field_found(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+    @kopf.on.event(resource.group, resource.version, resource.plural,
                    field=None)
     def some_fn(**_): ...
 
@@ -396,7 +396,7 @@ def test_decorator_without_field_found(
 def test_decorator_with_field_found(
         cause_with_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+    @kopf.on.event(resource.group, resource.version, resource.plural,
                    field='some-field')
     def some_fn(**_): ...
 
@@ -408,7 +408,7 @@ def test_decorator_with_field_found(
 def test_decorator_with_field_ignored(
         cause_no_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+    @kopf.on.event(resource.group, resource.version, resource.plural,
                    field='some-field')
     def some_fn(**_): ...
 
@@ -420,7 +420,7 @@ def test_decorator_with_field_ignored(
 def test_decorator_with_labels_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+    @kopf.on.event(resource.group, resource.version, resource.plural,
                    labels={'somelabel': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -432,7 +432,7 @@ def test_decorator_with_labels_satisfied(
 def test_decorator_with_labels_not_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+    @kopf.on.event(resource.group, resource.version, resource.plural,
                    labels={'otherlabel': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -444,7 +444,7 @@ def test_decorator_with_labels_not_satisfied(
 def test_decorator_with_annotations_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+    @kopf.on.event(resource.group, resource.version, resource.plural,
                    annotations={'someannotation': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -456,7 +456,7 @@ def test_decorator_with_annotations_satisfied(
 def test_decorator_with_annotations_not_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+    @kopf.on.event(resource.group, resource.version, resource.plural,
                    annotations={'otherannotation': MetaFilterToken.PRESENT})
     def some_fn(**_): ...
 
@@ -468,7 +468,7 @@ def test_decorator_with_annotations_not_satisfied(
 def test_decorator_with_filter_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+    @kopf.on.event(resource.group, resource.version, resource.plural,
                    when=_always)
     def some_fn(**_): ...
 
@@ -480,7 +480,7 @@ def test_decorator_with_filter_satisfied(
 def test_decorator_with_filter_not_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(resource.group, resource.version, resource.plural, registry=registry,
+    @kopf.on.event(resource.group, resource.version, resource.plural,
                    when=_never)
     def some_fn(**_): ...
 

--- a/tests/registries/test_matching_for_watching.py
+++ b/tests/registries/test_matching_for_watching.py
@@ -5,7 +5,7 @@ import pytest
 import kopf
 from kopf.reactor.causation import ResourceWatchingCause
 from kopf.structs.dicts import parse_field
-from kopf.structs.filters import MetaFilterToken
+from kopf.structs.filters import ABSENT, PRESENT
 from kopf.structs.handlers import ResourceWatchingHandler
 
 
@@ -131,7 +131,7 @@ def test_catchall_handlers_with_exact_labels_not_satisfied(
 def test_catchall_handlers_with_desired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': MetaFilterToken.PRESENT})
+    handler_factory(labels={'somelabel': PRESENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
@@ -143,7 +143,7 @@ def test_catchall_handlers_with_desired_labels_present(
 def test_catchall_handlers_with_desired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': MetaFilterToken.PRESENT})
+    handler_factory(labels={'somelabel': PRESENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
@@ -155,7 +155,7 @@ def test_catchall_handlers_with_desired_labels_absent(
 def test_catchall_handlers_with_undesired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': MetaFilterToken.ABSENT})
+    handler_factory(labels={'somelabel': ABSENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
@@ -167,7 +167,7 @@ def test_catchall_handlers_with_undesired_labels_present(
 def test_catchall_handlers_with_undesired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': MetaFilterToken.ABSENT})
+    handler_factory(labels={'somelabel': ABSENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
@@ -245,7 +245,7 @@ def test_catchall_handlers_with_exact_annotations_not_satisfied(
 def test_catchall_handlers_with_desired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': MetaFilterToken.PRESENT})
+    handler_factory(annotations={'someannotation': PRESENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
@@ -257,7 +257,7 @@ def test_catchall_handlers_with_desired_annotations_present(
 def test_catchall_handlers_with_desired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': MetaFilterToken.PRESENT})
+    handler_factory(annotations={'someannotation': PRESENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
@@ -269,7 +269,7 @@ def test_catchall_handlers_with_desired_annotations_absent(
 def test_catchall_handlers_with_undesired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': MetaFilterToken.ABSENT})
+    handler_factory(annotations={'someannotation': ABSENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
@@ -281,7 +281,7 @@ def test_catchall_handlers_with_undesired_annotations_present(
 def test_catchall_handlers_with_undesired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': MetaFilterToken.ABSENT})
+    handler_factory(annotations={'someannotation': ABSENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
@@ -421,7 +421,7 @@ def test_decorator_with_labels_satisfied(
         cause_any_field, registry, resource):
 
     @kopf.on.event(resource.group, resource.version, resource.plural,
-                   labels={'somelabel': MetaFilterToken.PRESENT})
+                   labels={'somelabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -433,7 +433,7 @@ def test_decorator_with_labels_not_satisfied(
         cause_any_field, registry, resource):
 
     @kopf.on.event(resource.group, resource.version, resource.plural,
-                   labels={'otherlabel': MetaFilterToken.PRESENT})
+                   labels={'otherlabel': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -445,7 +445,7 @@ def test_decorator_with_annotations_satisfied(
         cause_any_field, registry, resource):
 
     @kopf.on.event(resource.group, resource.version, resource.plural,
-                   annotations={'someannotation': MetaFilterToken.PRESENT})
+                   annotations={'someannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -457,7 +457,7 @@ def test_decorator_with_annotations_not_satisfied(
         cause_any_field, registry, resource):
 
     @kopf.on.event(resource.group, resource.version, resource.plural,
-                   annotations={'otherannotation': MetaFilterToken.PRESENT})
+                   annotations={'otherannotation': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field

--- a/tests/registries/test_matching_for_watching.py
+++ b/tests/registries/test_matching_for_watching.py
@@ -41,19 +41,19 @@ def handler_factory(registry, selector):
 ])
 def cause_no_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
-                                        'annotations': {'someannotation': 'somevalue'}}})
+    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
+                                        'annotations': {'known': 'value'}}})
     cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
     return cause
 
 
 @pytest.fixture(params=[
-    pytest.param(dict(body={'some-field': 'new'}), id='with-field'),
+    pytest.param(dict(body={'known-field': 'new'}), id='with-field'),
 ])
 def cause_with_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
-                                        'annotations': {'someannotation': 'somevalue'}}})
+    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
+                                        'annotations': {'known': 'value'}}})
     cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
     return cause
 
@@ -61,12 +61,12 @@ def cause_with_field(request, cause_factory):
 @pytest.fixture(params=[
     # The original no-diff was equivalent to no-field until body/old/new were added to the check.
     pytest.param(dict(body={}, diff=[]), id='no-field'),
-    pytest.param(dict(body={'some-field': 'new'}), id='with-field'),
+    pytest.param(dict(body={'known-field': 'new'}), id='with-field'),
 ])
 def cause_any_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'somelabel': 'somevalue'},
-                                        'annotations': {'someannotation': 'somevalue'}}})
+    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
+                                        'annotations': {'known': 'value'}}})
     cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
     return cause
 
@@ -86,7 +86,7 @@ def test_catchall_handlers_without_field_found(
 def test_catchall_handlers_with_field_found(
         cause_with_field, registry, handler_factory):
     cause = cause_with_field
-    handler_factory(field=parse_field('some-field'))
+    handler_factory(field=parse_field('known-field'))
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
@@ -94,116 +94,116 @@ def test_catchall_handlers_with_field_found(
 def test_catchall_handlers_with_field_ignored(
         cause_no_field, registry, handler_factory):
     cause = cause_no_field
-    handler_factory(field=parse_field('some-field'))
+    handler_factory(field=parse_field('known-field'))
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('labels', [
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_exact_labels_satisfied(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': 'somevalue'})
+    handler_factory(labels={'known': 'value'})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
-    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_exact_labels_not_satisfied(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': 'somevalue'})
+    handler_factory(labels={'known': 'value'})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('labels', [
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_desired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': PRESENT})
+    handler_factory(labels={'known': PRESENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_desired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': PRESENT})
+    handler_factory(labels={'known': PRESENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('labels', [
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_undesired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': ABSENT})
+    handler_factory(labels={'known': ABSENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
 ])
 def test_catchall_handlers_with_undesired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': ABSENT})
+    handler_factory(labels={'known': ABSENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_labels_callback_says_true(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': _always})
+    handler_factory(labels={'known': _always})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_labels_callback_says_false(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': _never})
+    handler_factory(labels={'known': _never})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
-    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
-    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_without_labels(
         cause_factory, registry, handler_factory, labels):
@@ -214,110 +214,110 @@ def test_catchall_handlers_without_labels(
 
 
 @pytest.mark.parametrize('annotations', [
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_with_exact_annotations_satisfied(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': 'somevalue'})
+    handler_factory(annotations={'known': 'value'})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
-    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_exact_annotations_not_satisfied(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': 'somevalue'})
+    handler_factory(annotations={'known': 'value'})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('annotations', [
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_desired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': PRESENT})
+    handler_factory(annotations={'known': PRESENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_desired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': PRESENT})
+    handler_factory(annotations={'known': PRESENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('annotations', [
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_undesired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': ABSENT})
+    handler_factory(annotations={'known': ABSENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
 ])
 def test_catchall_handlers_with_undesired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': ABSENT})
+    handler_factory(annotations={'known': ABSENT})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_annotations_callback_says_true(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': _always})
+    handler_factory(annotations={'known': _always})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
 ])
 def test_catchall_handlers_with_annotations_callback_says_false(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
-    handler_factory(annotations={'someannotation': _never})
+    handler_factory(annotations={'known': _never})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
 
 @pytest.mark.parametrize('annotations', [
     pytest.param({}, id='without-annotation'),
-    pytest.param({'someannotation': 'somevalue'}, id='with-annotation'),
-    pytest.param({'someannotation': 'othervalue'}, id='with-other-value'),
-    pytest.param({'otherannotation': 'othervalue'}, id='with-other-annotation'),
-    pytest.param({'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-annotation'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-annotation'),
 ])
 def test_catchall_handlers_without_annotations(
         cause_factory, registry, handler_factory, annotations):
@@ -328,30 +328,30 @@ def test_catchall_handlers_without_annotations(
 
 
 @pytest.mark.parametrize('labels, annotations', [
-    pytest.param({'somelabel': 'somevalue'}, {'someannotation': 'somevalue'}, id='with-label-annotation'),
-    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue'}, id='with-extra-label-annotation'),
-    pytest.param({'somelabel': 'somevalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-label-extra-annotation'),
-    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, {'someannotation': 'somevalue', 'otherannotation': 'othervalue'}, id='with-extra-label-extra-annotation'),
+    pytest.param({'known': 'value'}, {'known': 'value'}, id='with-label-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, {'known': 'value'}, id='with-extra-label-annotation'),
+    pytest.param({'known': 'value'}, {'known': 'value', 'extra': 'other'}, id='with-label-extra-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, {'known': 'value', 'extra': 'other'}, id='with-extra-label-extra-annotation'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_satisfied(
         cause_factory, registry, handler_factory, labels, annotations):
     cause = cause_factory(body={'metadata': {'labels': labels, 'annotations': annotations}})
-    handler_factory(labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    handler_factory(labels={'known': 'value'}, annotations={'known': 'value'})
     handlers = registry._resource_watching.get_handlers(cause)
     assert handlers
 
 
 @pytest.mark.parametrize('labels', [
     pytest.param({}, id='without-label'),
-    pytest.param({'somelabel': 'somevalue'}, id='with-label'),
-    pytest.param({'somelabel': 'othervalue'}, id='with-other-value'),
-    pytest.param({'otherlabel': 'othervalue'}, id='with-other-label'),
-    pytest.param({'somelabel': 'somevalue', 'otherlabel': 'othervalue'}, id='with-extra-label'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-label'),
 ])
 def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
-    handler_factory(labels={'somelabel': 'somevalue'}, annotations={'someannotation': 'somevalue'})
+    handler_factory(labels={'known': 'value'}, annotations={'known': 'value'})
     handlers = registry._resource_watching.get_handlers(cause)
     assert not handlers
 
@@ -395,7 +395,7 @@ def test_decorator_without_field_found(
 def test_decorator_with_field_found(
         cause_with_field, registry, resource):
 
-    @kopf.on.event(*resource, field='some-field')
+    @kopf.on.event(*resource, field='known-field')
     def some_fn(**_): ...
 
     cause = cause_with_field
@@ -406,7 +406,7 @@ def test_decorator_with_field_found(
 def test_decorator_with_field_ignored(
         cause_no_field, registry, resource):
 
-    @kopf.on.event(*resource, field='some-field')
+    @kopf.on.event(*resource, field='known-field')
     def some_fn(**_): ...
 
     cause = cause_no_field
@@ -417,7 +417,7 @@ def test_decorator_with_field_ignored(
 def test_decorator_with_labels_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(*resource, labels={'somelabel': PRESENT})
+    @kopf.on.event(*resource, labels={'known': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -428,7 +428,7 @@ def test_decorator_with_labels_satisfied(
 def test_decorator_with_labels_not_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(*resource, labels={'otherlabel': PRESENT})
+    @kopf.on.event(*resource, labels={'extra': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -439,7 +439,7 @@ def test_decorator_with_labels_not_satisfied(
 def test_decorator_with_annotations_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(*resource, annotations={'someannotation': PRESENT})
+    @kopf.on.event(*resource, annotations={'known': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field
@@ -450,7 +450,7 @@ def test_decorator_with_annotations_satisfied(
 def test_decorator_with_annotations_not_satisfied(
         cause_any_field, registry, resource):
 
-    @kopf.on.event(*resource, annotations={'otherannotation': PRESENT})
+    @kopf.on.event(*resource, annotations={'extra': PRESENT})
     def some_fn(**_): ...
 
     cause = cause_any_field

--- a/tests/registries/test_matching_for_watching.py
+++ b/tests/registries/test_matching_for_watching.py
@@ -7,7 +7,6 @@ from kopf.reactor.causation import ResourceWatchingCause
 from kopf.structs.dicts import parse_field
 from kopf.structs.filters import MetaFilterToken
 from kopf.structs.handlers import ResourceWatchingHandler
-from kopf.structs.references import Selector
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.

--- a/tests/registries/test_requires_finalizer.py
+++ b/tests/registries/test_requires_finalizer.py
@@ -26,7 +26,7 @@ def test_requires_finalizer_deletion_handler(
         optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural, optional=optional)
+    @kopf.on.delete(*resource, optional=optional)
     def fn(**_):
         pass
 
@@ -42,11 +42,11 @@ def test_requires_finalizer_multiple_handlers(
         optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.create(resource.group, resource.version, resource.plural)
+    @kopf.on.create(*resource)
     def fn1(**_):
         pass
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural, optional=optional)
+    @kopf.on.delete(*resource, optional=optional)
     def fn2(**_):
         pass
 
@@ -58,7 +58,7 @@ def test_requires_finalizer_no_deletion_handler(
         cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.create(resource.group, resource.version, resource.plural)
+    @kopf.on.create(*resource)
     def fn1(**_):
         pass
 
@@ -78,7 +78,7 @@ def test_requires_finalizer_deletion_handler_matches_labels(
         labels, optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural, labels=labels, optional=optional)
+    @kopf.on.delete(*resource, labels=labels, optional=optional)
     def fn(**_):
         pass
 
@@ -98,7 +98,7 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(
         labels, optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural, labels=labels, optional=optional)
+    @kopf.on.delete(*resource, labels=labels, optional=optional)
     def fn(**_):
         pass
 
@@ -118,7 +118,7 @@ def test_requires_finalizer_deletion_handler_matches_annotations(
         annotations, optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural, annotations=annotations, optional=optional)
+    @kopf.on.delete(*resource, annotations=annotations, optional=optional)
     def fn(**_):
         pass
 
@@ -138,7 +138,7 @@ def test_requires_finalizer_deletion_handler_mismatches_annotations(
         annotations, optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural, annotations=annotations, optional=optional)
+    @kopf.on.delete(*resource, annotations=annotations, optional=optional)
     def fn(**_):
         pass
 

--- a/tests/registries/test_requires_finalizer.py
+++ b/tests/registries/test_requires_finalizer.py
@@ -1,7 +1,6 @@
 import pytest
 
 import kopf
-from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.filters import MetaFilterToken
 
 OBJECT_BODY = {
@@ -24,13 +23,10 @@ OBJECT_BODY = {
     pytest.param(False, True, id='mandatory'),
 ])
 def test_requires_finalizer_deletion_handler(
-        optional, expected, cause_factory, resource):
-
-    registry = OperatorRegistry()
+        optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural,
-                    registry=registry, optional=optional)
+    @kopf.on.delete(resource.group, resource.version, resource.plural, optional=optional)
     def fn(**_):
         pass
 
@@ -43,18 +39,14 @@ def test_requires_finalizer_deletion_handler(
     pytest.param(False, True, id='mandatory'),
 ])
 def test_requires_finalizer_multiple_handlers(
-        optional, expected, cause_factory, resource):
-
-    registry = OperatorRegistry()
+        optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.create(resource.group, resource.version, resource.plural,
-                    registry=registry)
+    @kopf.on.create(resource.group, resource.version, resource.plural)
     def fn1(**_):
         pass
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural,
-                    registry=registry, optional=optional)
+    @kopf.on.delete(resource.group, resource.version, resource.plural, optional=optional)
     def fn2(**_):
         pass
 
@@ -63,13 +55,10 @@ def test_requires_finalizer_multiple_handlers(
 
 
 def test_requires_finalizer_no_deletion_handler(
-        cause_factory, resource):
-
-    registry = OperatorRegistry()
+        cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.create(resource.group, resource.version, resource.plural,
-                    registry=registry)
+    @kopf.on.create(resource.group, resource.version, resource.plural)
     def fn1(**_):
         pass
 
@@ -86,14 +75,10 @@ def test_requires_finalizer_no_deletion_handler(
     pytest.param({'key': MetaFilterToken.PRESENT}, id='key-exists'),
 ])
 def test_requires_finalizer_deletion_handler_matches_labels(
-        labels, optional, expected, cause_factory, resource):
-
-    registry = OperatorRegistry()
+        labels, optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural,
-                    labels=labels,
-                    registry=registry, optional=optional)
+    @kopf.on.delete(resource.group, resource.version, resource.plural, labels=labels, optional=optional)
     def fn(**_):
         pass
 
@@ -110,14 +95,10 @@ def test_requires_finalizer_deletion_handler_matches_labels(
     pytest.param({'otherkey': MetaFilterToken.PRESENT}, id='key-doesnt-exist'),
 ])
 def test_requires_finalizer_deletion_handler_mismatches_labels(
-        labels, optional, expected, cause_factory, resource):
-
-    registry = OperatorRegistry()
+        labels, optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural,
-                    labels=labels,
-                    registry=registry, optional=optional)
+    @kopf.on.delete(resource.group, resource.version, resource.plural, labels=labels, optional=optional)
     def fn(**_):
         pass
 
@@ -134,14 +115,10 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(
     pytest.param({'key': MetaFilterToken.PRESENT}, id='key-exists'),
 ])
 def test_requires_finalizer_deletion_handler_matches_annotations(
-        annotations, optional, expected, cause_factory, resource):
-
-    registry = OperatorRegistry()
+        annotations, optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural,
-                    annotations=annotations,
-                    registry=registry, optional=optional)
+    @kopf.on.delete(resource.group, resource.version, resource.plural, annotations=annotations, optional=optional)
     def fn(**_):
         pass
 
@@ -158,14 +135,10 @@ def test_requires_finalizer_deletion_handler_matches_annotations(
     pytest.param({'otherkey': MetaFilterToken.PRESENT}, id='key-doesnt-exist'),
 ])
 def test_requires_finalizer_deletion_handler_mismatches_annotations(
-        annotations, optional, expected, cause_factory, resource):
-
-    registry = OperatorRegistry()
+        annotations, optional, expected, cause_factory, resource, registry):
     cause = cause_factory(resource=resource, body=OBJECT_BODY)
 
-    @kopf.on.delete(resource.group, resource.version, resource.plural,
-                    annotations=annotations,
-                    registry=registry, optional=optional)
+    @kopf.on.delete(resource.group, resource.version, resource.plural, annotations=annotations, optional=optional)
     def fn(**_):
         pass
 

--- a/tests/registries/test_requires_finalizer.py
+++ b/tests/registries/test_requires_finalizer.py
@@ -1,7 +1,7 @@
 import pytest
 
 import kopf
-from kopf.structs.filters import MetaFilterToken
+from kopf.structs.filters import PRESENT
 
 OBJECT_BODY = {
     'apiVersion': 'group/version',
@@ -72,7 +72,7 @@ def test_requires_finalizer_no_deletion_handler(
 ])
 @pytest.mark.parametrize('labels', [
     pytest.param({'key': 'value'}, id='value-matches'),
-    pytest.param({'key': MetaFilterToken.PRESENT}, id='key-exists'),
+    pytest.param({'key': PRESENT}, id='key-exists'),
 ])
 def test_requires_finalizer_deletion_handler_matches_labels(
         labels, optional, expected, cause_factory, resource, registry):
@@ -92,7 +92,7 @@ def test_requires_finalizer_deletion_handler_matches_labels(
 ])
 @pytest.mark.parametrize('labels', [
     pytest.param({'key': 'othervalue'}, id='value-mismatch'),
-    pytest.param({'otherkey': MetaFilterToken.PRESENT}, id='key-doesnt-exist'),
+    pytest.param({'otherkey': PRESENT}, id='key-doesnt-exist'),
 ])
 def test_requires_finalizer_deletion_handler_mismatches_labels(
         labels, optional, expected, cause_factory, resource, registry):
@@ -112,7 +112,7 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(
 ])
 @pytest.mark.parametrize('annotations', [
     pytest.param({'key': 'value'}, id='value-matches'),
-    pytest.param({'key': MetaFilterToken.PRESENT}, id='key-exists'),
+    pytest.param({'key': PRESENT}, id='key-exists'),
 ])
 def test_requires_finalizer_deletion_handler_matches_annotations(
         annotations, optional, expected, cause_factory, resource, registry):
@@ -132,7 +132,7 @@ def test_requires_finalizer_deletion_handler_matches_annotations(
 ])
 @pytest.mark.parametrize('annotations', [
     pytest.param({'key': 'othervalue'}, id='value-mismatch'),
-    pytest.param({'otherkey': MetaFilterToken.PRESENT}, id='key-doesnt-exist'),
+    pytest.param({'otherkey': PRESENT}, id='key-doesnt-exist'),
 ])
 def test_requires_finalizer_deletion_handler_mismatches_annotations(
         annotations, optional, expected, cause_factory, resource, registry):

--- a/tests/registries/test_resumes_mixed_in.py
+++ b/tests/registries/test_resumes_mixed_in.py
@@ -13,7 +13,7 @@ def test_resumes_ignored_for_non_initial_causes(
     cause = cause_factory(resource=resource, reason=reason, initial=False,
                           body={'metadata': {'deletionTimestamp': '...'} if deleted else {}})
 
-    @kopf.on.resume(resource.group, resource.version, resource.plural)
+    @kopf.on.resume(*resource)
     def fn(**_):
         pass
 
@@ -28,7 +28,7 @@ def test_resumes_selected_for_initial_non_deletions(
     registry = kopf.get_default_registry()
     cause = cause_factory(resource=resource, reason=reason, initial=True)
 
-    @kopf.on.resume(resource.group, resource.version, resource.plural)
+    @kopf.on.resume(*resource)
     def fn(**_):
         pass
 
@@ -45,7 +45,7 @@ def test_resumes_ignored_for_initial_deletions_by_default(
     cause = cause_factory(resource=resource, reason=reason, initial=True,
                           body={'metadata': {'deletionTimestamp': '...'}})
 
-    @kopf.on.resume(resource.group, resource.version, resource.plural)
+    @kopf.on.resume(*resource)
     def fn(**_):
         pass
 
@@ -61,7 +61,7 @@ def test_resumes_selected_for_initial_deletions_when_explicitly_marked(
     cause = cause_factory(resource=resource, reason=reason, initial=True,
                           body={'metadata': {'deletionTimestamp': '...'}})
 
-    @kopf.on.resume(resource.group, resource.version, resource.plural, deleted=True)
+    @kopf.on.resume(*resource, deleted=True)
     def fn(**_):
         pass
 


### PR DESCRIPTION
No essential changes in either the framework behaviour or even in test coverage.

Only some test refactorings to make those tests visually shorter, using the newer selector syntax.

Plus some cleanups here & there.