### PR TITLE
Replace zalando.org → kopf.dev for peering

### DIFF
--- a/docs/continuity.rst
+++ b/docs/continuity.rst
@@ -12,7 +12,8 @@ All information is retrieved and stored via Kubernetes API.
 Specifically:
 
 * The cross-operator exchange is performed via peering objects of type
-  ``KopfPeering`` or ``ClusterKopfPeering`` (API version: ``zalando.org/v1``).
+  ``KopfPeering`` or ``ClusterKopfPeering``
+  (API versions: either ``kopf.dev/v1`` or ``zalando.org/v1``).
   See :doc:`peering` for more info.
 * The last handled state of the object is stored in ``metadata.annotations``
   (the ``kopf.zalando.org/last-handled-configuration`` annotation).

--- a/docs/deployment-rbac.yaml
+++ b/docs/deployment-rbac.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
 
   # Framework: knowing which other operators are running (i.e. peering).
-  - apiGroups: [zalando.org]
+  - apiGroups: [kopf.dev]
     resources: [clusterkopfpeerings]
     verbs: [list, watch, patch, get]
 
@@ -37,7 +37,7 @@ metadata:
 rules:
 
   # Framework: knowing which other operators are running (i.e. peering).
-  - apiGroups: [zalando.org]
+  - apiGroups: [kopf.dev]
     resources: [kopfpeerings]
     verbs: [list, watch, patch, get]
 

--- a/docs/peering.rst
+++ b/docs/peering.rst
@@ -53,14 +53,14 @@ Create the peering objects as needed with one of:
 
 .. code-block:: yaml
 
-    apiVersion: zalando.org/v1
+    apiVersion: kopf.dev/v1
     kind: ClusterKopfPeering
     metadata:
       name: example
 
 .. code-block:: yaml
 
-    apiVersion: zalando.org/v1
+    apiVersion: kopf.dev/v1
     kind: KopfPeering
     metadata:
       namespace: default
@@ -69,10 +69,20 @@ Create the peering objects as needed with one of:
 .. note::
 
     In ``kopf<0.11`` (until May'2019), ``KopfPeering`` was the only CRD,
-    and it was cluster-scoped. In ``kopf>=0.11,<0.29`` (until Oct'2020),
+    and it was cluster-scoped. In ``kopf>=0.11,<1.29`` (until Dec'2020),
     this mode was deprecated but supported if the old CRD existed.
-    Since ``kopf>=0.29`` (Nov'2020), it is not supported anymore.
+    Since ``kopf>=1.29`` (Jan'2021), it is not supported anymore.
     To upgrade, delete and re-create the peering CRDs to the new ones.
+
+.. note::
+
+    In ``kopf<1.29``, all peering CRDs used the API group ``kopf.zalando.org``.
+    Since ``kopf>=1.29`` (Jan'2021), they belong to the API group ``kopf.dev``.
+
+    At runtime, both API groups are supported. However, these resources
+    of different API groups are mutually exclusive and cannot co-exist
+    in the same cluster since they use the same names. Whenever possible,
+    re-create them with the new API group after the operator/framework upgrade.
 
 
 Custom peering

--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -355,12 +355,14 @@ class Selector:
 # Some predefined API endpoints that we use in the framework itself (not exposed to the operators).
 # Note: the CRDs are versionless: we do not look into its ``spec`` stanza, we only watch for
 # the fact of changes, so the schema does not matter, any cluster-preferred API version would work.
+# Note: the peering resources are either zalando.org/v1 or kopf.dev/v1; both cannot co-exist because
+# they would share the names, so K8s will not let this. It is done for domain name transitioning.
 CRDS = Selector('apiextensions.k8s.io', 'customresourcedefinitions')
 EVENTS = Selector('v1', 'events')
 EVENTS_K8S = Selector('events.k8s.io', 'events')  # only for exclusion from EVERYTHING
 NAMESPACES = Selector('v1', 'namespaces')
-CLUSTER_PEERINGS = Selector('zalando.org/v1', 'clusterkopfpeerings')
-NAMESPACED_PEERINGS = Selector('zalando.org/v1', 'kopfpeerings')
+CLUSTER_PEERINGS = Selector('clusterkopfpeerings')
+NAMESPACED_PEERINGS = Selector('kopfpeerings')
 
 
 class Backbone(Mapping[Selector, Resource]):

--- a/peering-v1beta1.yaml
+++ b/peering-v1beta1.yaml
@@ -4,10 +4,10 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterkopfpeerings.zalando.org
+  name: clusterkopfpeerings.kopf.dev
 spec:
   scope: Cluster
-  group: zalando.org
+  group: kopf.dev
   names:
     kind: ClusterKopfPeering
     plural: clusterkopfpeerings
@@ -20,10 +20,10 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: kopfpeerings.zalando.org
+  name: kopfpeerings.kopf.dev
 spec:
   scope: Namespaced
-  group: zalando.org
+  group: kopf.dev
   names:
     kind: KopfPeering
     plural: kopfpeerings
@@ -33,12 +33,12 @@ spec:
       served: true
       storage: true
 ---
-apiVersion: zalando.org/v1
+apiVersion: kopf.dev/v1
 kind: ClusterKopfPeering
 metadata:
   name: default
 ---
-apiVersion: zalando.org/v1
+apiVersion: kopf.dev/v1
 kind: KopfPeering
 metadata:
   namespace: default

--- a/peering.yaml
+++ b/peering.yaml
@@ -4,10 +4,10 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterkopfpeerings.zalando.org
+  name: clusterkopfpeerings.kopf.dev
 spec:
   scope: Cluster
-  group: zalando.org
+  group: kopf.dev
   names:
     kind: ClusterKopfPeering
     plural: clusterkopfpeerings
@@ -27,10 +27,10 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: kopfpeerings.zalando.org
+  name: kopfpeerings.kopf.dev
 spec:
   scope: Namespaced
-  group: zalando.org
+  group: kopf.dev
   names:
     kind: KopfPeering
     plural: kopfpeerings
@@ -47,12 +47,12 @@ spec:
               type: object
               x-kubernetes-preserve-unknown-fields: true
 ---
-apiVersion: zalando.org/v1
+apiVersion: kopf.dev/v1
 kind: ClusterKopfPeering
 metadata:
   name: default
 ---
-apiVersion: zalando.org/v1
+apiVersion: kopf.dev/v1
 kind: KopfPeering
 metadata:
   namespace: default

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,32 @@ def enforce_asyncio_mocker(pytestconfig):
     assert fixture.mock_module is asynctest, "Mock replacement failed!"
 
 
+@pytest.fixture(params=[
+    ('kopf.dev', 'v1', 'clusterkopfpeerings'),
+    ('zalando.org', 'v1', 'clusterkopfpeerings'),
+], ids=['kopf-dev-namespaced', 'zalando-org-namespaced'])
+def namespaced_peering_resource(request):
+    return Resource(*request.param[:3], namespaced=True)
+
+
+@pytest.fixture(params=[
+    ('kopf.dev', 'v1', 'kopfpeerings'),
+    ('zalando.org', 'v1', 'kopfpeerings'),
+], ids=['kopf-dev-cluster', 'zalando-org-cluster'])
+def cluster_peering_resource(request):
+    return Resource(*request.param[:3], namespaced=False)
+
+
+@pytest.fixture(params=[
+    ('kopf.dev', 'v1', 'clusterkopfpeerings', False),
+    ('zalando.org', 'v1', 'clusterkopfpeerings', False),
+    ('kopf.dev', 'v1', 'kopfpeerings', True),
+    ('zalando.org', 'v1', 'kopfpeerings', True),
+], ids=['kopf-dev-cluster', 'zalando-org-cluster', 'kopf-dev-namespaced', 'zalando-org-namespaced'])
+def peering_resource(request):
+    return Resource(*request.param[:3], namespaced=request.param[3])
+
+
 @pytest.fixture()
 def namespaced_resource():
     """ The resource used in the tests. Usually mocked, so it does not matter. """
@@ -113,6 +139,11 @@ def resource(request):
 def selector(resource):
     """ The selector used in the tests. Usually mocked, so it does not matter. """
     return Selector(group=resource.group, version=resource.version, plural=resource.plural)
+
+
+@pytest.fixture()
+def peering_namespace(peering_resource):
+    return 'ns' if peering_resource.namespaced else None
 
 
 @pytest.fixture()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -59,5 +59,5 @@ def no_crd():
 
 @pytest.fixture()
 def no_peering():
-    subprocess.run("kubectl delete customresourcedefinition kopfpeerings.zalando.org",
+    subprocess.run("kubectl delete customresourcedefinition kopfpeerings.kopf.dev",
                    shell=True, check=True, timeout=10, capture_output=True)

--- a/tests/peering/conftest.py
+++ b/tests/peering/conftest.py
@@ -1,56 +1,6 @@
 import pytest
 
-from kopf.structs.references import Resource
-
-NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', namespaced=True)
-CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings', namespaced=False)
-
 
 @pytest.fixture(autouse=True)
 def _autouse_fake_vault(fake_vault):
     pass
-
-
-@pytest.fixture()
-def with_cluster_crd(hostname, aresponses):
-    result = {'resources': [{
-        'group': CLUSTER_PEERING_RESOURCE.group,
-        'version': CLUSTER_PEERING_RESOURCE.version,
-        'name': CLUSTER_PEERING_RESOURCE.plural,
-        'namespaced': False,
-    }]}
-    url = CLUSTER_PEERING_RESOURCE.get_version_url()
-    aresponses.add(hostname, url, 'get', result)
-
-
-@pytest.fixture()
-def with_namespaced_crd(hostname, aresponses):
-    result = {'resources': [{
-        'group': NAMESPACED_PEERING_RESOURCE.group,
-        'version': NAMESPACED_PEERING_RESOURCE.version,
-        'name': NAMESPACED_PEERING_RESOURCE.plural,
-        'namespaced': True,
-    }]}
-    url = NAMESPACED_PEERING_RESOURCE.get_version_url()
-    aresponses.add(hostname, url, 'get', result)
-
-
-@pytest.fixture()
-def with_both_crds(hostname, aresponses):
-    result = {'resources': [{
-        'group': CLUSTER_PEERING_RESOURCE.group,
-        'version': CLUSTER_PEERING_RESOURCE.version,
-        'name': CLUSTER_PEERING_RESOURCE.plural,
-        'namespaced': False,
-    }, {
-        'group': NAMESPACED_PEERING_RESOURCE.group,
-        'version': NAMESPACED_PEERING_RESOURCE.version,
-        'name': NAMESPACED_PEERING_RESOURCE.plural,
-        'namespaced': True,
-    }]}
-    urls = {
-        CLUSTER_PEERING_RESOURCE.get_version_url(),
-        NAMESPACED_PEERING_RESOURCE.get_version_url(),
-    }
-    for url in urls:
-        aresponses.add(hostname, url, 'get', result)

--- a/tests/peering/test_freeze_mode.py
+++ b/tests/peering/test_freeze_mode.py
@@ -7,9 +7,6 @@ import pytest
 
 from kopf.engines.peering import process_peering_event
 from kopf.structs import bodies, primitives
-from kopf.structs.references import Resource
-
-NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', namespaced=True)
 
 
 @dataclasses.dataclass(frozen=True, eq=False)
@@ -35,7 +32,8 @@ async def replenished(mocker):
 
 
 async def test_other_peering_objects_are_ignored(
-        mocker, k8s_mocked, settings, replenished):
+        mocker, k8s_mocked, settings, replenished,
+        peering_resource, peering_namespace):
 
     status = mocker.Mock()
     status.items.side_effect = Exception("This should not be called.")
@@ -56,8 +54,8 @@ async def test_other_peering_objects_are_ignored(
         autoclean=False,
         identity='id',
         settings=settings,
-        namespace='namespace',
-        resource=NAMESPACED_PEERING_RESOURCE,
+        namespace=peering_namespace,
+        resource=peering_resource,
     )
     assert not status.items.called
     assert not k8s_mocked.patch_obj.called
@@ -66,12 +64,13 @@ async def test_other_peering_objects_are_ignored(
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 async def test_toggled_on_for_higher_priority_peer_when_initially_off(
-        mocker, k8s_mocked, replenished, caplog, assert_logs, settings):
+        mocker, k8s_mocked, replenished, caplog, assert_logs, settings,
+        peering_resource, peering_namespace):
 
     event = bodies.RawEvent(
         type='ADDED',  # irrelevant
         object={
-            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'metadata': {'name': 'name', 'namespace': peering_namespace},  # for matching
             'status': {
                 'higher-prio': {
                     'priority': 101,
@@ -93,8 +92,8 @@ async def test_toggled_on_for_higher_priority_peer_when_initially_off(
         freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
-        namespace='namespace',
-        resource=NAMESPACED_PEERING_RESOURCE,
+        namespace=peering_namespace,
+        resource=peering_resource,
         identity='id',
         settings=settings,
     )
@@ -111,12 +110,13 @@ async def test_toggled_on_for_higher_priority_peer_when_initially_off(
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 async def test_ignored_for_higher_priority_peer_when_already_on(
-        mocker, k8s_mocked, replenished, caplog, assert_logs, settings):
+        mocker, k8s_mocked, replenished, caplog, assert_logs, settings,
+        peering_resource, peering_namespace):
 
     event = bodies.RawEvent(
         type='ADDED',  # irrelevant
         object={
-            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'metadata': {'name': 'name', 'namespace': peering_namespace},  # for matching
             'status': {
                 'higher-prio': {
                     'priority': 101,
@@ -138,8 +138,8 @@ async def test_ignored_for_higher_priority_peer_when_already_on(
         freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
-        namespace='namespace',
-        resource=NAMESPACED_PEERING_RESOURCE,
+        namespace=peering_namespace,
+        resource=peering_resource,
         identity='id',
         settings=settings,
     )
@@ -157,12 +157,13 @@ async def test_ignored_for_higher_priority_peer_when_already_on(
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 async def test_toggled_off_for_lower_priority_peer_when_initially_on(
-        mocker, k8s_mocked, replenished, caplog, assert_logs, settings):
+        mocker, k8s_mocked, replenished, caplog, assert_logs, settings,
+        peering_resource, peering_namespace):
 
     event = bodies.RawEvent(
         type='ADDED',  # irrelevant
         object={
-            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'metadata': {'name': 'name', 'namespace': peering_namespace},  # for matching
             'status': {
                 'higher-prio': {
                     'priority': 99,
@@ -184,8 +185,8 @@ async def test_toggled_off_for_lower_priority_peer_when_initially_on(
         freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
-        namespace='namespace',
-        resource=NAMESPACED_PEERING_RESOURCE,
+        namespace=peering_namespace,
+        resource=peering_resource,
         identity='id',
         settings=settings,
     )
@@ -201,12 +202,13 @@ async def test_toggled_off_for_lower_priority_peer_when_initially_on(
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 async def test_ignored_for_lower_priority_peer_when_already_off(
-        mocker, k8s_mocked, replenished, caplog, assert_logs, settings):
+        mocker, k8s_mocked, replenished, caplog, assert_logs, settings,
+        peering_resource, peering_namespace):
 
     event = bodies.RawEvent(
         type='ADDED',  # irrelevant
         object={
-            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'metadata': {'name': 'name', 'namespace': peering_namespace},  # for matching
             'status': {
                 'higher-prio': {
                     'priority': 99,
@@ -228,8 +230,8 @@ async def test_ignored_for_lower_priority_peer_when_already_off(
         freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
-        namespace='namespace',
-        resource=NAMESPACED_PEERING_RESOURCE,
+        namespace=peering_namespace,
+        resource=peering_resource,
         identity='id',
         settings=settings,
     )
@@ -246,12 +248,13 @@ async def test_ignored_for_lower_priority_peer_when_already_off(
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 async def test_toggled_on_for_same_priority_peer_when_initially_off(
-        mocker, k8s_mocked, replenished, caplog, assert_logs, settings):
+        mocker, k8s_mocked, replenished, caplog, assert_logs, settings,
+        peering_resource, peering_namespace):
 
     event = bodies.RawEvent(
         type='ADDED',  # irrelevant
         object={
-            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'metadata': {'name': 'name', 'namespace': peering_namespace},  # for matching
             'status': {
                 'higher-prio': {
                     'priority': 100,
@@ -273,8 +276,8 @@ async def test_toggled_on_for_same_priority_peer_when_initially_off(
         freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
-        namespace='namespace',
-        resource=NAMESPACED_PEERING_RESOURCE,
+        namespace=peering_namespace,
+        resource=peering_resource,
         identity='id',
         settings=settings,
     )
@@ -293,12 +296,13 @@ async def test_toggled_on_for_same_priority_peer_when_initially_off(
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 async def test_ignored_for_same_priority_peer_when_already_on(
-        mocker, k8s_mocked, replenished, caplog, assert_logs, settings):
+        mocker, k8s_mocked, replenished, caplog, assert_logs, settings,
+        peering_resource, peering_namespace):
 
     event = bodies.RawEvent(
         type='ADDED',  # irrelevant
         object={
-            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'metadata': {'name': 'name', 'namespace': peering_namespace},  # for matching
             'status': {
                 'higher-prio': {
                     'priority': 100,
@@ -320,8 +324,8 @@ async def test_ignored_for_same_priority_peer_when_already_on(
         freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
-        namespace='namespace',
-        resource=NAMESPACED_PEERING_RESOURCE,
+        namespace=peering_namespace,
+        resource=peering_resource,
         identity='id',
         settings=settings,
     )
@@ -341,12 +345,13 @@ async def test_ignored_for_same_priority_peer_when_already_on(
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 @pytest.mark.parametrize('priority', [100, 101])
 async def test_resumes_immediately_on_expiration_of_blocking_peers(
-        mocker, k8s_mocked, replenished, caplog, assert_logs, settings, priority):
+        mocker, k8s_mocked, replenished, caplog, assert_logs, settings, priority,
+        peering_resource, peering_namespace):
 
     event = bodies.RawEvent(
         type='ADDED',  # irrelevant
         object={
-            'metadata': {'name': 'name', 'namespace': 'namespace'},  # for matching
+            'metadata': {'name': 'name', 'namespace': peering_namespace},  # for matching
             'status': {
                 'higher-prio': {
                     'priority': priority,
@@ -368,8 +373,8 @@ async def test_resumes_immediately_on_expiration_of_blocking_peers(
         freeze_toggle=freeze_toggle,
         replenished=replenished,
         autoclean=False,
-        namespace='namespace',
-        resource=NAMESPACED_PEERING_RESOURCE,
+        namespace=peering_namespace,
+        resource=peering_resource,
         identity='id',
         settings=settings,
     )

--- a/tests/peering/test_keepalive.py
+++ b/tests/peering/test_keepalive.py
@@ -1,16 +1,13 @@
 import pytest
 
-from kopf.engines.peering import Peer, keepalive
-from kopf.structs.references import Resource
-
-NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', namespaced=True)
+from kopf.engines.peering import keepalive
 
 
 class StopInfiniteCycleException(Exception):
     pass
 
 
-async def test_background_task_runs(mocker, settings):
+async def test_background_task_runs(mocker, settings, namespaced_peering_resource):
     touch_mock = mocker.patch('kopf.engines.peering.touch')
 
     sleep_mock = mocker.patch('asyncio.sleep')
@@ -22,7 +19,7 @@ async def test_background_task_runs(mocker, settings):
     settings.peering.lifetime = 33
     with pytest.raises(StopInfiniteCycleException):
         await keepalive(settings=settings, identity='id',
-                        resource=NAMESPACED_PEERING_RESOURCE, namespace='namespace')
+                        resource=namespaced_peering_resource, namespace='namespace')
 
     assert randint_mock.call_count == 3  # only to be sure that we test the right thing
     assert sleep_mock.call_count == 3

--- a/tests/peering/test_peer_patching.py
+++ b/tests/peering/test_peer_patching.py
@@ -9,7 +9,6 @@ NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', name
 CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings', namespaced=False)
 
 
-@pytest.mark.usefixtures('with_both_crds')
 @pytest.mark.parametrize('namespace, peering_resource', [
     pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
     pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
@@ -36,7 +35,6 @@ async def test_cleaning_peers_purges_them(
     assert patch['status']['id1'] is None
 
 
-@pytest.mark.usefixtures('with_both_crds')
 @pytest.mark.parametrize('namespace, peering_resource', [
     pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
     pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
@@ -60,7 +58,6 @@ async def test_touching_a_peer_stores_it(
     assert patch['status']['id1']['lifetime'] == 60
 
 
-@pytest.mark.usefixtures('with_both_crds')
 @pytest.mark.parametrize('namespace, peering_resource', [
     pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
     pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
@@ -82,7 +79,6 @@ async def test_expiring_a_peer_purges_it(
     assert patch['status']['id1'] is None
 
 
-@pytest.mark.usefixtures('with_both_crds')
 @pytest.mark.parametrize('namespace, peering_resource', [
     pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
     pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
@@ -106,7 +102,6 @@ async def test_logs_are_skipped_in_stealth_mode(
     ])
 
 
-@pytest.mark.usefixtures('with_both_crds')
 @pytest.mark.parametrize('namespace, peering_resource', [
     pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
     pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
@@ -129,7 +124,6 @@ async def test_logs_are_logged_in_exposed_mode(
     ])
 
 
-@pytest.mark.usefixtures('with_both_crds')
 @pytest.mark.parametrize('stealth', [True, False], ids=['stealth', 'exposed'])
 @pytest.mark.parametrize('namespace, peering_resource', [
     pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),

--- a/tests/peering/test_peer_patching.py
+++ b/tests/peering/test_peer_patching.py
@@ -3,31 +3,25 @@ import freezegun
 import pytest
 
 from kopf.engines.peering import Peer, clean, touch
-from kopf.structs.references import Resource
-
-NAMESPACED_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'kopfpeerings', namespaced=True)
-CLUSTER_PEERING_RESOURCE = Resource('zalando.org', 'v1', 'clusterkopfpeerings', namespaced=False)
 
 
-@pytest.mark.parametrize('namespace, peering_resource', [
-    pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
-    pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
-])
 @pytest.mark.parametrize('lastseen', [
     pytest.param('2020-01-01T00:00:00', id='when-dead'),
     pytest.param('2020-12-31T23:59:59', id='when-alive'),
 ])
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 async def test_cleaning_peers_purges_them(
-        hostname, aresponses, resp_mocker, namespace, peering_resource, settings, lastseen):
+        hostname, aresponses, resp_mocker, settings, lastseen,
+        peering_resource, peering_namespace):
 
     settings.peering.name = 'name0'
     patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    url = peering_resource.get_url(name='name0', namespace=namespace)
+    url = peering_resource.get_url(name='name0', namespace=peering_namespace)
     aresponses.add(hostname, url, 'patch', patch_mock)
 
     peer = Peer(identity='id1', lastseen=lastseen)
-    await clean(peers=[peer], resource=peering_resource, settings=settings, namespace=namespace)
+    await clean(peers=[peer], resource=peering_resource, settings=settings,
+                namespace=peering_namespace)
 
     assert patch_mock.called
     patch = await patch_mock.call_args_list[0][0][0].json()
@@ -35,20 +29,18 @@ async def test_cleaning_peers_purges_them(
     assert patch['status']['id1'] is None
 
 
-@pytest.mark.parametrize('namespace, peering_resource', [
-    pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
-    pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
-])
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 async def test_touching_a_peer_stores_it(
-        hostname, aresponses, resp_mocker, namespace, peering_resource, settings):
+        hostname, aresponses, resp_mocker, settings,
+        peering_resource, peering_namespace):
 
     settings.peering.name = 'name0'
     patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    url = peering_resource.get_url(name='name0', namespace=namespace)
+    url = peering_resource.get_url(name='name0', namespace=peering_namespace)
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    await touch(identity='id1', resource=peering_resource, settings=settings, namespace=namespace)
+    await touch(identity='id1', resource=peering_resource, settings=settings,
+                namespace=peering_namespace)
 
     assert patch_mock.called
     patch = await patch_mock.call_args_list[0][0][0].json()
@@ -58,20 +50,18 @@ async def test_touching_a_peer_stores_it(
     assert patch['status']['id1']['lifetime'] == 60
 
 
-@pytest.mark.parametrize('namespace, peering_resource', [
-    pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
-    pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
-])
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 async def test_expiring_a_peer_purges_it(
-        hostname, aresponses, resp_mocker, namespace, peering_resource, settings):
+        hostname, aresponses, resp_mocker, settings,
+        peering_resource, peering_namespace):
 
     settings.peering.name = 'name0'
     patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    url = peering_resource.get_url(name='name0', namespace=namespace)
+    url = peering_resource.get_url(name='name0', namespace=peering_namespace)
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    await touch(identity='id1', resource=peering_resource, settings=settings, namespace=namespace, lifetime=0)
+    await touch(identity='id1', resource=peering_resource, settings=settings,
+                namespace=peering_namespace, lifetime=0)
 
     assert patch_mock.called
     patch = await patch_mock.call_args_list[0][0][0].json()
@@ -79,45 +69,39 @@ async def test_expiring_a_peer_purges_it(
     assert patch['status']['id1'] is None
 
 
-@pytest.mark.parametrize('namespace, peering_resource', [
-    pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
-    pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
-])
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 async def test_logs_are_skipped_in_stealth_mode(
-        hostname, aresponses, resp_mocker, namespace, peering_resource, settings,
-        assert_logs, caplog):
+        hostname, aresponses, resp_mocker, settings, assert_logs, caplog,
+        peering_resource, peering_namespace):
 
     caplog.set_level(0)
     settings.peering.stealth = True
     settings.peering.name = 'name0'
     patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    url = peering_resource.get_url(name='name0', namespace=namespace)
+    url = peering_resource.get_url(name='name0', namespace=peering_namespace)
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    await touch(identity='id1', resource=peering_resource, settings=settings, namespace=namespace)
+    await touch(identity='id1', resource=peering_resource, settings=settings,
+                namespace=peering_namespace)
 
     assert_logs([], prohibited=[
         "Keep-alive in",
     ])
 
 
-@pytest.mark.parametrize('namespace, peering_resource', [
-    pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
-    pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
-])
 async def test_logs_are_logged_in_exposed_mode(
-        hostname, aresponses, resp_mocker, namespace, peering_resource, settings,
-        assert_logs, caplog):
+        hostname, aresponses, resp_mocker, settings, assert_logs, caplog,
+        peering_resource, peering_namespace):
 
     caplog.set_level(0)
     settings.peering.stealth = False
     settings.peering.name = 'name0'
     patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    url = peering_resource.get_url(name='name0', namespace=namespace)
+    url = peering_resource.get_url(name='name0', namespace=peering_namespace)
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    await touch(identity='id1', resource=peering_resource, settings=settings, namespace=namespace)
+    await touch(identity='id1', resource=peering_resource, settings=settings,
+                namespace=peering_namespace)
 
     assert_logs([
         r"Keep-alive in 'name0' (in 'ns'|cluster-wide): ok",
@@ -125,22 +109,19 @@ async def test_logs_are_logged_in_exposed_mode(
 
 
 @pytest.mark.parametrize('stealth', [True, False], ids=['stealth', 'exposed'])
-@pytest.mark.parametrize('namespace, peering_resource', [
-    pytest.param('ns', NAMESPACED_PEERING_RESOURCE, id='namespace-scoped'),
-    pytest.param(None, CLUSTER_PEERING_RESOURCE, id='cluster-scoped'),
-])
 async def test_logs_are_logged_when_absent(
-        hostname, aresponses, resp_mocker, namespace, peering_resource, stealth, settings,
-        assert_logs, caplog):
+        hostname, aresponses, resp_mocker, stealth, settings, assert_logs, caplog,
+        peering_resource, peering_namespace):
 
     caplog.set_level(0)
     settings.peering.stealth = stealth
     settings.peering.name = 'name0'
     patch_mock = resp_mocker(return_value=aresponses.Response(status=404))
-    url = peering_resource.get_url(name='name0', namespace=namespace)
+    url = peering_resource.get_url(name='name0', namespace=peering_namespace)
     aresponses.add(hostname, url, 'patch', patch_mock)
 
-    await touch(identity='id1', resource=peering_resource, settings=settings, namespace=namespace)
+    await touch(identity='id1', resource=peering_resource, settings=settings,
+                namespace=peering_namespace)
 
     assert_logs([
         r"Keep-alive in 'name0' (in 'ns'|cluster-wide): not found",

--- a/tests/references/test_backbone.py
+++ b/tests/references/test_backbone.py
@@ -24,6 +24,8 @@ def test_empty_backbone(selector: Selector):
     (CRDS, Resource('apiextensions.k8s.io', 'vX', 'customresourcedefinitions')),
     (EVENTS, Resource('', 'v1', 'events')),
     (NAMESPACES, Resource('', 'v1', 'namespaces')),
+    (CLUSTER_PEERINGS, Resource('kopf.dev', 'v1', 'clusterkopfpeerings')),
+    (NAMESPACED_PEERINGS, Resource('kopf.dev', 'v1', 'kopfpeerings')),
     (CLUSTER_PEERINGS, Resource('zalando.org', 'v1', 'clusterkopfpeerings')),
     (NAMESPACED_PEERINGS, Resource('zalando.org', 'v1', 'kopfpeerings')),
 ])


### PR DESCRIPTION
Since we are going to release the next major version, it is time to also make somewhat incompatible changes: use the framework's own identity.

In this part, only the peering is changed. It does affect the runtime. (Related: #643 for docs & examples.)

The peering selectors are modified so that they only select by name (plural name in this case), ignoring the group. As such, both `zalando.org` and `kopf.dev` peerings will be supported (so as any other domains, actually; but the resource name itself implies Kopf, not some other frameworks).

This relies on an assumption that *either* `zalando.org` *or* `kopf.dev` peering resources are installed in the cluster, *not both*. It is assumed that both resources cannot co-exist because they share the same names and would cause a conflict anyway.

*Compatibility*: The newly configured clusters will use `kopf.dev`, and all is fine. The existing cluster can continue using `zalando.org`, and it will work too (unless reconfigured).

*For transitioning*, the old CRD must be removed, and a new CRD must be created. This will wipe all existing peering CRs too, so they must be re-created with the new domain (`kopf.dev`). Applying them with the old domain will fail, as after such a transition, those resources will not exist.
