### PR TITLE
Re-adjust pytest-mock to asynctest as a mocking module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,7 @@ jobs:
         run: coveralls  # NB: Coveralls GitHub Action does not work: it wants an LCOV file.
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
+        continue-on-error: true
       - name: Publish coverage to CodeCov.io
         uses: codecov/codecov-action@v1
         if: ${{ success() }}
@@ -54,6 +55,7 @@ jobs:
         with:
           flags: unit
           env_vars: PYTHON
+        continue-on-error: true
 
   functional:
     strategy:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,9 +84,11 @@ def pytest_collection_modifyitems(config, items):
 
 # Substitute the regular mock with the async-aware mock in the `mocker` fixture.
 @pytest.fixture(scope='session', autouse=True)
-def enforce_asyncio_mocker():
-    pytest_mock.plugin._get_mock_module = lambda config: asynctest
-    pytest_mock._get_mock_module = pytest_mock.plugin._get_mock_module
+def enforce_asyncio_mocker(pytestconfig):
+    pytest_mock.plugin.get_mock_module = lambda config: asynctest
+    pytest_mock.get_mock_module = pytest_mock.plugin.get_mock_module
+    fixture = pytest_mock.MockerFixture(pytestconfig)
+    assert fixture.mock_module is asynctest, "Mock replacement failed!"
 
 
 @pytest.fixture()


### PR DESCRIPTION
It was changed in https://github.com/pytest-dev/pytest-mock/commit/379b6239f54de77752ffc1031017ecad2099ca6c on 10.01.2021.

Additionally, verify that the replacement worked as expected — for future changes (since we hack the internal unpublished interface).