### PR TITLE
Fix Coveralls.io in CI, time-limit the tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
   linters:
     name: Linting and static analysis
     runs-on: ubuntu-20.04
+    timeout-minutes: 2  # usually 0.5-1 mins
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -31,6 +32,7 @@ jobs:
         python-version: [ "3.7", "3.8", "3.9" ]
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-20.04
+    timeout-minutes: 5  # usually 2-3 mins
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -70,6 +72,7 @@ jobs:
             crdapi: v1beta1
     name: K3s ${{matrix.k3s}} ${{matrix.crdapi && format('CRD={0}', matrix.crdapi) || ''}}
     runs-on: ubuntu-20.04
+    timeout-minutes: 10  # usually 4-5 mins
     env:
       CRDAPI: ${{ matrix.crdapi || '' }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Publish coverage to Coveralls.io
         if: ${{ success() }}
-        run: coveralls  # NB: Coveralls GitHub Action does not work: it wants an LCOV file.
+        run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
         continue-on-error: true
@@ -91,6 +91,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v2
       - run: pip install coveralls
-      - run: coveralls --finish
+      - run: coveralls --service=github --finish
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
+        continue-on-error: true

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Publish coverage to Coveralls.io
         if: success()
-        run: coveralls  # NB: Coveralls GitHub Action does not work: it wants an LCOV file.
+        run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
       - name: Publish coverage to CodeCov.io
@@ -133,6 +133,6 @@ jobs:
     steps:
       - uses: actions/setup-python@v2
       - run: pip install coveralls
-      - run: coveralls --finish
+      - run: coveralls --service=github --finish
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -17,6 +17,7 @@ jobs:
   linters:
     name: Linting and static analysis
     runs-on: ubuntu-20.04
+    timeout-minutes: 2  # usually 0.5-1 mins
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -35,6 +36,7 @@ jobs:
         python-version: [ "3.7", "3.8", "3.9" ]
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-20.04
+    timeout-minutes: 5  # usually 2-3 mins
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -72,6 +74,7 @@ jobs:
             crdapi: v1beta1
     name: K3s ${{matrix.k3s}} ${{matrix.crdapi && format('CRD={0}', matrix.crdapi) || ''}}
     runs-on: ubuntu-20.04
+    timeout-minutes: 10  # usually 4-5 mins
     env:
       CRDAPI: ${{ matrix.crdapi || '' }}
     steps:
@@ -94,6 +97,7 @@ jobs:
         crdapi: [""]
     name: K8s ${{matrix.k8s}} ${{matrix.crdapi && format('CRD={0}', matrix.crdapi) || ''}}
     runs-on: ubuntu-20.04
+    timeout-minutes: 10  # usually 4-5 mins
     env:
       K8S: ${{ matrix.k8s }}
       CRDAPI: ${{ matrix.crdapi || '' }}
@@ -114,6 +118,7 @@ jobs:
         crdapi: [v1beta1]
     name: K8s ${{matrix.k8s}} ${{matrix.crdapi && format('CRD={0}', matrix.crdapi) || ''}}
     runs-on: ubuntu-20.04
+    timeout-minutes: 10  # usually 4-5 mins
     env:
       K8S: ${{ matrix.k8s }}
       CRDAPI: ${{ matrix.crdapi || '' }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Operator Pythonic Framework (Kopf)
 
-[![CI](https://github.com/nolar/kopf/workflows/CI/badge.svg)](https://github.com/nolar/kopf/actions)
+[![CI](https://github.com/nolar/kopf/workflows/Thorough%20tests/badge.svg)](https://github.com/nolar/kopf/actions)
 [![codecov](https://codecov.io/gh/nolar/kopf/branch/master/graph/badge.svg)](https://codecov.io/gh/nolar/kopf)
 [![Coverage Status](https://coveralls.io/repos/github/nolar/kopf/badge.svg?branch=master)](https://coveralls.io/github/nolar/kopf?branch=master)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/nolar/kopf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nolar/kopf/alerts/)


### PR DESCRIPTION
See: https://github.com/TheKevJames/coveralls-python/issues/252

For timeouts, the default is 6 hours per job. That would be an overkill and can waste assigned resources. With these timeouts, it is already 2x more than usually needed. If it becomes slower, it should be treated as a bug (unless more tests are added).

_**PS:** The branch name is accidentally wrong._