### PR TITLE
Evade collision of annotations in Deployments & ReplicaSets

### DIFF
--- a/kopf/storage/diffbase.py
+++ b/kopf/storage/diffbase.py
@@ -128,7 +128,7 @@ class AnnotationsDiffBaseStorage(conventions.StorageKeyFormingConvention, DiffBa
     ) -> bodies.BodyEssence:
         essence = super().build(body=body, extra_fields=extra_fields)
         annotations = essence.get('metadata', {}).get('annotations', {})
-        for full_key in self.make_keys(self.key):
+        for full_key in self.make_keys(self.key, body=body):
             if full_key in annotations:
                 del annotations[full_key]
         return essence
@@ -138,7 +138,7 @@ class AnnotationsDiffBaseStorage(conventions.StorageKeyFormingConvention, DiffBa
             *,
             body: bodies.Body,
     ) -> Optional[bodies.BodyEssence]:
-        for full_key in self.make_keys(self.key):
+        for full_key in self.make_keys(self.key, body=body):
             encoded = body.metadata.annotations.get(full_key, None)
             decoded = json.loads(encoded) if encoded is not None else None
             if decoded is not None:
@@ -154,7 +154,7 @@ class AnnotationsDiffBaseStorage(conventions.StorageKeyFormingConvention, DiffBa
     ) -> None:
         encoded: str = json.dumps(essence, separators=(',', ':'))  # NB: no spaces
         encoded += '\n'  # for better kubectl presentation without wrapping (same as kubectl's one)
-        for full_key in self.make_keys(self.key):
+        for full_key in self.make_keys(self.key, body=body):
             patch.metadata.annotations[full_key] = encoded
         self._store_marker(prefix=self.prefix, patch=patch, body=body)
 

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -180,7 +180,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
             key: handlers.HandlerId,
             body: bodies.Body,
     ) -> Optional[ProgressRecord]:
-        for full_key in self.make_keys(key):
+        for full_key in self.make_keys(key, body=body):
             key_field = ['metadata', 'annotations', full_key]
             encoded = dicts.resolve(body, key_field, None)
             decoded = json.loads(encoded) if encoded is not None else None
@@ -198,7 +198,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
     ) -> None:
         decoded = {key: val for key, val in record.items() if self.verbose or val is not None}
         encoded = json.dumps(decoded, separators=(',', ':'))  # NB: no spaces
-        for full_key in self.make_keys(key):
+        for full_key in self.make_keys(key, body=body):
             key_field = ['metadata', 'annotations', full_key]
             dicts.ensure(patch, key_field, encoded)
         self._store_marker(prefix=self.prefix, patch=patch, body=body)
@@ -211,7 +211,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
             patch: patches.Patch,
     ) -> None:
         absent = object()
-        for full_key in self.make_keys(key):
+        for full_key in self.make_keys(key, body=body):
             key_field = ['metadata', 'annotations', full_key]
             body_value = dicts.resolve(body, key_field, absent)
             patch_value = dicts.resolve(patch, key_field, absent)
@@ -227,7 +227,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
             patch: patches.Patch,
             value: Optional[str],
     ) -> None:
-        for full_key in self.make_keys(self.touch_key):
+        for full_key in self.make_keys(self.touch_key, body=body):
             key_field = ['metadata', 'annotations', full_key]
             body_value = dicts.resolve(body, key_field, None)
             if body_value != value:  # also covers absent-vs-None cases.

--- a/tests/persistence/test_annotations_hashing.py
+++ b/tests/persistence/test_annotations_hashing.py
@@ -89,6 +89,19 @@ def test_keys_deduplication(cls):
     assert v2_key in keys
 
 
+@pytest.mark.parametrize('kind, owners, expected', [
+    pytest.param('ReplicaSet', [{'kind': 'Deployment'}], 'kopf.dev/xyz-ofDRS', id='DRS'),
+    pytest.param('ReplicaSet', [{'kind': 'OtherOwner'}], 'kopf.dev/xyz', id='not-deployment'),
+    pytest.param('OtherKind', [{'kind': 'Deployment'}], 'kopf.dev/xyz', id='not-replicaset'),
+])
+@pytest.mark.parametrize('cls', STORAGE_KEY_FORMING_CLASSES)
+def test_keys_of_replicaset_owned_by_deployment(cls, kind, owners, expected):
+    storage = cls(v1=True, prefix='kopf.dev')
+    body = Body({'kind': kind, 'metadata': {'ownerReferences': owners}})
+    keys = storage.make_keys('xyz', body=body)
+    assert set(keys) == {expected}
+
+
 @pytest.mark.parametrize('prefix, provided_key, expected_key', COMMON_KEYS + V1_KEYS)
 @pytest.mark.parametrize('cls', STORAGE_KEY_FORMING_CLASSES)
 def test_key_hashing_v1(cls, prefix, provided_key, expected_key):


### PR DESCRIPTION
For ReplicaSets owned by Deployments, annotations are implicitly propagated down from the owner to the resource on every change of the owner:

* https://github.com/kubernetes/kubernetes/blob/v1.20.2/pkg/controller/deployment/util/deployment_util.go#L230-L234
* https://github.com/kubernetes/kubernetes/blob/v1.20.2/pkg/controller/deployment/util/deployment_util.go#L310-L341

Since Kopf stores its intermediate state in annotations, this causes all kinds of chaos possible: the diff-base of ReplicaSets is taken from its parent Deployment and is falsely identified as an update of everything; the progress of same-named handlers can be mixed, so some handlers can be skipped or mistakenly retried; etc.

This only happens if both of ReplicaSets & Deployments are served by Kopf-based operators with the same or default identity. E.g.:

```python
import kopf

@kopf.on.create('deployments')
@kopf.on.create('replicasets')
@kopf.on.update('deployments')
@kopf.on.update('replicasets')
@kopf.on.resume('deployments')
@kopf.on.resume('replicasets')
def fn(spec, **kwargs):
    pass
```

This is especially visible in "operators of everything" (worth nothing: an artificial case), where they start processing the ReplicaSets in non-stop and forever instead of stopping at some moment:

```python
import kopf

@kopf.on.update(kopf.EVERYTHING)
def fn(spec, **kwargs):
    pass
```

Even in the stable state, the cascade of events can be triggered by a simple change in a Deployment which usually causes a re-creation of ReplicaSets, e.g. in K3d/K3s:

```
$ kubectl patch deploy -n kube-system traefik --type merge -p '{"spec":{"template":{"metadata":{"labels":{"xxx":"yyy"}}}}}'
```

This fix adds a special mark to such ReplicaSets to prevent collisions. They will now look like:

```
$ kubectl get -n kube-system replicaset traefik-b677ccbf4 -o yaml
apiVersion: apps/v1
kind: ReplicaSet
metadata:
  annotations:
    deployment.kubernetes.io/desired-replicas: "1"
    deployment.kubernetes.io/max-replicas: "2"
    deployment.kubernetes.io/revision: "2"
    kopf.zalando.org/fn: '{"started":"2021-01-24T21:44:24.840647","stopped":"2021-01-24T21:44:24.844691","purpose":"update","retries":1,"success":true,"failure":false}'
    kopf.zalando.org/last-handled-configuration: |
      {"spec":{"replicas":1,"selector":{"matchLabels":{"app":"traefik","release":"traefik"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"traefik","chart":"traefik-1.81.0","heritage":"Helm","release":"traefik","xxx":"yyy"},"annotations":{"checksum/config":"160e687e8146d38bb3af5be4fd2fc17a2f4bddb909238f10a72b8755675478de"}},"spec":{"volumes":[{"name":"config","configMap":{"name":"traefik","defaultMode":420}},{"name":"ssl","secret":{"secretName":"traefik-default-cert","defaultMode":420}}],"containers":[{"name":"traefik","image":"rancher/library-traefik:1.7.19","args":["--configfile=/config/traefik.toml"],"ports":[{"name":"http","containerPort":80,"protocol":"TCP"},{"name":"httpn","containerPort":8880,"protocol":"TCP"},{"name":"https","containerPort":443,"protocol":"TCP"},{"name":"dash","containerPort":8080,"protocol":"TCP"},{"name":"metrics","containerPort":9100,"protocol":"TCP"}],"resources":{},"volumeMounts":[{"name":"config","mountPath":"/config"},{"name":"ssl","mountPath":"/ssl"}],"livenessProbe":{"httpGet":{"path":"/ping","port":"http","scheme":"HTTP"},"initialDelaySeconds":10,"timeoutSeconds":2,"periodSeconds":10,"successThreshold":1,"failureThreshold":3},"readinessProbe":{"httpGet":{"path":"/ping","port":"http","scheme":"HTTP"},"initialDelaySeconds":10,"timeoutSeconds":2,"periodSeconds":10,"successThreshold":1,"failureThreshold":1},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":60,"dnsPolicy":"ClusterFirst","serviceAccountName":"traefik","serviceAccount":"traefik","securityContext":{},"schedulerName":"default-scheduler","tolerations":[{"key":"CriticalAddonsOnly","operator":"Exists"},{"key":"node-role.kubernetes.io/master","operator":"Exists","effect":"NoSchedule"}]}},"strategy":{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":"25%","maxSurge":"25%"}},"revisionHistoryLimit":10,"progressDeadlineSeconds":600},"metadata":{"labels":{"app":"traefik","chart":"traefik-1.81.0","heritage":"Helm","release":"traefik"},"annotations":{"deployment.kubernetes.io/revision":"2"}}}
    kopf.zalando.org/last-handled-configuration-ofDRS: |
      {"spec":{"replicas":1,"selector":{"matchLabels":{"app":"traefik","pod-template-hash":"b677ccbf4","release":"traefik"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"traefik","chart":"traefik-1.81.0","heritage":"Helm","pod-template-hash":"b677ccbf4","release":"traefik","xxx":"yyy"},"annotations":{"checksum/config":"160e687e8146d38bb3af5be4fd2fc17a2f4bddb909238f10a72b8755675478de"}},"spec":{"volumes":[{"name":"config","configMap":{"name":"traefik","defaultMode":420}},{"name":"ssl","secret":{"secretName":"traefik-default-cert","defaultMode":420}}],"containers":[{"name":"traefik","image":"rancher/library-traefik:1.7.19","args":["--configfile=/config/traefik.toml"],"ports":[{"name":"http","containerPort":80,"protocol":"TCP"},{"name":"httpn","containerPort":8880,"protocol":"TCP"},{"name":"https","containerPort":443,"protocol":"TCP"},{"name":"dash","containerPort":8080,"protocol":"TCP"},{"name":"metrics","containerPort":9100,"protocol":"TCP"}],"resources":{},"volumeMounts":[{"name":"config","mountPath":"/config"},{"name":"ssl","mountPath":"/ssl"}],"livenessProbe":{"httpGet":{"path":"/ping","port":"http","scheme":"HTTP"},"initialDelaySeconds":10,"timeoutSeconds":2,"periodSeconds":10,"successThreshold":1,"failureThreshold":3},"readinessProbe":{"httpGet":{"path":"/ping","port":"http","scheme":"HTTP"},"initialDelaySeconds":10,"timeoutSeconds":2,"periodSeconds":10,"successThreshold":1,"failureThreshold":1},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"IfNotPresent"}],"restartPolicy":"Always","terminationGracePeriodSeconds":60,"dnsPolicy":"ClusterFirst","serviceAccountName":"traefik","serviceAccount":"traefik","securityContext":{},"schedulerName":"default-scheduler","tolerations":[{"key":"CriticalAddonsOnly","operator":"Exists"},{"key":"node-role.kubernetes.io/master","operator":"Exists","effect":"NoSchedule"}]}}},"metadata":{"labels":{"app":"traefik","chart":"traefik-1.81.0","heritage":"Helm","pod-template-hash":"b677ccbf4","release":"traefik","xxx":"yyy"},"annotations":{"deployment.kubernetes.io/desired-replicas":"1","deployment.kubernetes.io/max-replicas":"2","deployment.kubernetes.io/revision":"2"}}}
  creationTimestamp: "2021-01-24T21:44:24Z"
```

Note: `kopf.zalando.org/last-handled-configuration` and `kopf.zalando.org/fn` are propagated from the Deployment, and only `kopf.zalando.org/last-handled-configuration-ofDRS` truly belongs to the ReplicaSet. The garbage annotations cannot even be deleted, as they are interpreted as annotations belonging to some other operator; though, they are still ignored in diff-detection.

We assume that this problem exists only for ReplicaSets-owned-by-Deployments, and not any other resources, and not owned by any other resources — unless it is proven otherwise (then, more criteria and marks can be added).

There is intentionally no backwards compatibility: such a case — Deployments & their ReplicaSets served by the same operator — simply did not work before, so there is no need to ensure the transitioning of annotations. This fix enables this case, not modifies it.

fixes #635 