### PR TITLE
Drop pykube-ng & kubernetes from dependencies (unused)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
         with:
           version: ${{ matrix.k3s }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt -r examples/requirements.txt
       - run: pytest --color=yes --only-e2e
 
   coveralls-finish:

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -86,7 +86,7 @@ jobs:
         with:
           version: ${{ matrix.k3s }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt -r examples/requirements.txt
       - run: pytest --color=yes --only-e2e
 
   full-scale-crd-v1:
@@ -107,7 +107,7 @@ jobs:
         with:
           python-version: "3.9"
       - run: tools/install-minikube.sh
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt -r examples/requirements.txt
       - run: pytest --color=yes --only-e2e
 
   full-scale-crd-v1beta1:
@@ -128,7 +128,7 @@ jobs:
         with:
           python-version: "3.9"
       - run: tools/install-minikube.sh
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt -r examples/requirements.txt
       - run: pytest --color=yes --only-e2e
 
   coveralls-finish:

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -69,6 +69,7 @@ Multiple handlers can be declared to retrieve different credentials,
 or the same credentials via different libraries. All of the retrieved
 credentials will be used in random order with no specific priority.
 
+.. _auth-piggybacking:
 
 Piggybacking
 ============
@@ -80,6 +81,12 @@ In the future, more libraries can be added for authentication piggybacking.
 
 .. _pykube-ng: https://github.com/hjacobs/pykube
 .. _kubernetes: https://github.com/kubernetes-client/python
+
+.. note::
+
+    Since ``kopf>=1.29``, ``pykube-ng`` is not pre-installed implicitly.
+    If needed, install it explicitly as a dependency of the operator,
+    or via ``kopf[full-auth]`` (see :doc:`install`).
 
 *Piggybacking* means that the config parsing and authentication methods of these
 libraries are used, and only the information needed for API calls is extracted.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,6 +8,12 @@ To install Kopf::
 
     pip install kopf
 
+If you use some of the managed Kubernetes services which require a sophisticated
+authentication beyond username+password, fixed tokens, or client ssl certs
+(also see :ref:`authentication piggy-backing <auth-piggybacking>`)::
+
+    pip install kopf[full-auth]
+
 Unless you use the standalone mode,
 create few Kopf-specific custom resources in the cluster::
 

--- a/examples/10-builtins/test_example_10.py
+++ b/examples/10-builtins/test_example_10.py
@@ -2,7 +2,6 @@ import os.path
 import time
 
 import kopf.testing
-import pykube
 
 
 def test_pods_reacted():
@@ -27,6 +26,7 @@ def test_pods_reacted():
 
 
 def _create_pod():
+    import pykube
     api = pykube.HTTPClient(pykube.KubeConfig.from_file())
     with api.session:
         pod = pykube.Pod(api, {
@@ -45,6 +45,7 @@ def _create_pod():
 
 
 def _delete_pod(name):
+    import pykube
     api = pykube.HTTPClient(pykube.KubeConfig.from_file())
     with api.session:
         pod = pykube.Pod.objects(api, namespace='default').get_by_name(name)

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,4 +1,3 @@
 kopf
-kubernetes
 pykube-ng
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,5 @@ setup(
         'iso8601',
         'aiohttp<4.0.0',
         'aiojobs',
-        'pykube-ng>=0.27',  # used only for config parsing
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,7 @@ setup(
         'aiohttp<4.0.0',
         'aiojobs',
     ],
+    extras_require={
+        'full-auth': ['pykube-ng', 'kubernetes'],
+    },
 )


### PR DESCRIPTION
`pykube-ng` was an underlying client library once, but later replaced with the raw `aiohttp`. The dependency was not removed since then.

Now, if an operator uses `pykube-ng`, it should be declared as a dependency of that operator explicitly, not relied on pre-existing due to Kopf.

For authentication, rudimentary methods (username+password, tokens, client ssl certs) are supported by Kopf directly. More complex authentication schemas (e.g. for GKE with token rotation) should pre-install `pykube-ng` or `kubernetes` explicitly.
