### PR TITLE
Expose the resource being handled in kwargs

### DIFF
--- a/docs/kwargs.rst
+++ b/docs/kwargs.rst
@@ -57,6 +57,7 @@ See also: :doc:`configuration`.
 Resource-related kwargs
 =======================
 
+.. kwarg:: resource
 .. kwarg:: body
 .. kwarg:: spec
 .. kwarg:: meta
@@ -69,6 +70,11 @@ Resource-related kwargs
 
 Body parts
 ----------
+
+``resource`` (:class:`kopf.Resource`) is the actual resource being served
+as retrieved from the cluster during the initial discovery.
+Please note that it is not necessary the same selector as used in the decorator,
+as one selector can match multiple actual resources.
 
 ``body`` is the handled object's body, a read-only mapping (dict).
 

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -60,6 +60,7 @@ def build_kwargs(
         )
     if isinstance(cause, causation.ResourceCause):
         new_kwargs.update(
+            resource=cause.resource,
             patch=cause.patch,
             memo=cause.memo,
             body=cause.body,

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Collection, Coroutine, NewType, Optional, Type
 
 from typing_extensions import Protocol
 
-from kopf.structs import bodies, diffs, patches, primitives
+from kopf.structs import bodies, diffs, patches, primitives, references
 
 # A specialised type to highlight the purpose or origin of the data of type Any,
 # to not be mixed with other arbitrary Any values, where it is indeed "any".
@@ -49,6 +49,7 @@ class ResourceWatchingFn(Protocol):
             namespace: Optional[str],
             patch: patches.Patch,
             logger: Union[logging.Logger, logging.LoggerAdapter],
+            resource: references.Resource,
             **kwargs: Any,
     ) -> _SyncOrAsyncResult: ...
 
@@ -69,6 +70,7 @@ class ResourceChangingFn(Protocol):
             diff: diffs.Diff,
             old: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
             new: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
+            resource: references.Resource,
             **kwargs: Any,
     ) -> _SyncOrAsyncResult: ...
 
@@ -86,6 +88,7 @@ class ResourceDaemonSyncFn(Protocol):
             namespace: Optional[str],
             logger: Union[logging.Logger, logging.LoggerAdapter],
             stopped: primitives.SyncDaemonStopperChecker,  # << different type
+            resource: references.Resource,
             **kwargs: Any,
     ) -> Optional[Result]: ...
 
@@ -103,6 +106,7 @@ class ResourceDaemonAsyncFn(Protocol):
             namespace: Optional[str],
             logger: Union[logging.Logger, logging.LoggerAdapter],
             stopped: primitives.AsyncDaemonStopperChecker,  # << different type
+            resource: references.Resource,
             **kwargs: Any,
     ) -> Optional[Result]: ...
 
@@ -122,6 +126,7 @@ class ResourceTimerFn(Protocol):
             name: Optional[str],
             namespace: Optional[str],
             logger: Union[logging.Logger, logging.LoggerAdapter],
+            resource: references.Resource,
             **kwargs: Any,
     ) -> _SyncOrAsyncResult: ...
 
@@ -147,6 +152,7 @@ class WhenFilterFn(Protocol):
             diff: diffs.Diff,
             old: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
             new: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
+            resource: references.Resource,
             **kwargs: Any,
     ) -> bool: ...
 
@@ -165,6 +171,7 @@ class MetaFilterFn(Protocol):
             namespace: Optional[str],
             patch: patches.Patch,
             logger: Union[logging.Logger, logging.LoggerAdapter],
+            resource: references.Resource,
             **kwargs: Any,
     ) -> bool: ...
 

--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -4,7 +4,7 @@ import enum
 import fnmatch
 import re
 import urllib.parse
-from typing import Collection, Iterable, Iterator, List, Mapping, \
+from typing import Collection, FrozenSet, Iterable, Iterator, List, Mapping, \
                    MutableMapping, NewType, Optional, Pattern, Set, Union
 
 # A namespace specification with globs, negations, and some minimal syntax; see `match_namespace()`.
@@ -117,12 +117,12 @@ class Resource:
 
     kind: Optional[str] = None
     singular: Optional[str] = None
-    shortcuts: Collection[str] = ()
-    categories: Collection[str] = ()
-    subresources: Collection[str] = ()
+    shortcuts: FrozenSet[str] = frozenset()
+    categories: FrozenSet[str] = frozenset()
+    subresources: FrozenSet[str] = frozenset()
     namespaced: Optional[bool] = None
     preferred: bool = True  # against conventions, but makes versionless selectors match by default.
-    verbs: Collection[str] = ()
+    verbs: FrozenSet[str] = frozenset()
 
     def __hash__(self) -> int:
         return hash((self.group, self.version, self.plural))

--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -112,17 +112,64 @@ class Resource:
     """
 
     group: str
+    """
+    The resource's API group; e.g. ``"kopf.dev"``, ``"apps"``, ``"batch"``.
+    For Core v1 API resources, an empty string: ``""``.
+    """
+
     version: str
+    """
+    The resource's API version; e.g. ``"v1"``, ``"v1beta1"``, etc.
+    """
+
     plural: str
+    """
+    The resource's plural name; e.g. ``"pods"``, ``"kopfexamples"``.
+    It is used as an API endpoint, together with API group & version.
+    """
 
     kind: Optional[str] = None
+    """
+    The resource's kind (as in YAML files); e.g. ``"Pod"``, ``"KopfExample"``.
+    """
+
     singular: Optional[str] = None
+    """
+    The resource's singular name; e.g. ``"pod"``, ``"kopfexample"``.
+    """
+
     shortcuts: FrozenSet[str] = frozenset()
+    """
+    The resource's short names; e.g. ``{"po"}``, ``{"kex", "kexes"}``.
+    """
+
     categories: FrozenSet[str] = frozenset()
+    """
+    The resource's categories, to which the resource belongs; e.g. ``{"all"}``.
+    """
+
     subresources: FrozenSet[str] = frozenset()
+    """
+    The resource's subresources, if defined; e.g. ``{"status", "scale"}``.
+    """
+
     namespaced: Optional[bool] = None
+    """
+    Whether the resource is namespaced (``True``) or cluster-scoped (``False``).
+    """
+
     preferred: bool = True  # against conventions, but makes versionless selectors match by default.
+    """
+    Whether the resource belong to a "preferred" API version.
+    Only "preferred" resources are served when the version is not specified.
+    """
+
     verbs: FrozenSet[str] = frozenset()
+    """
+    All available verbs for the resource, as supported by K8s API;
+    e.g., ``{"list", "watch", "create", "update", "delete", "patch"}``.
+    Note that it is not the same as all verbs permitted by RBAC.
+    """
 
     def __hash__(self) -> int:
         return hash((self.group, self.version, self.plural))
@@ -154,6 +201,20 @@ class Resource:
             subresource: Optional[str] = None,
             params: Optional[Mapping[str, str]] = None,
     ) -> str:
+        """
+        Build a URL to be used with K8s API.
+
+        If the namespace is not set, a cluster-wide URL is returned.
+        For cluster-scoped resources, the namespace is ignored.
+
+        If the name is not set, the URL for the resource list is returned.
+        Otherwise (if set), the URL for the individual resource is returned.
+
+        If subresource is set, that subresource's URL is returned,
+        regardless of whether such a subresource is known or not.
+
+        Params go to the query parameters (``?param1=value1&param2=value2...``).
+        """
         if subresource is not None and name is None:
             raise ValueError("Subresources can be used only with specific resources by their name.")
         if not self.namespaced and namespace is not None:

--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -145,15 +145,6 @@ class Resource:
     def __iter__(self) -> Iterator[str]:
         return iter((self.group, self.version, self.plural))
 
-    @property
-    def name(self) -> str:
-        return f'{self.plural}.{self.group}'.strip('.')
-
-    @property
-    def api_version(self) -> str:
-        # Strip heading/trailing slashes if group is absent (e.g. for pods).
-        return f'{self.group}/{self.version}'.strip('/')
-
     def get_url(
             self,
             *,
@@ -170,7 +161,7 @@ class Resource:
         if self.namespaced and namespace is None and name is not None:
             raise ValueError("Specific namespaces are required for specific namespaced resources.")
 
-        return self._build_url(server, params, [
+        parts: List[Optional[str]] = [
             '/api' if self.group == '' and self.version == 'v1' else '/apis',
             self.group,
             self.version,
@@ -179,26 +170,8 @@ class Resource:
             self.plural,
             name,
             subresource,
-        ])
+        ]
 
-    def get_version_url(
-            self,
-            *,
-            server: Optional[str] = None,
-            params: Optional[Mapping[str, str]] = None,
-    ) -> str:
-        return self._build_url(server, params, [
-            '/api' if self.group == '' and self.version == 'v1' else '/apis',
-            self.group,
-            self.version,
-        ])
-
-    def _build_url(
-            self,
-            server: Optional[str],
-            params: Optional[Mapping[str, str]],
-            parts: List[Optional[str]],
-    ) -> str:
         query = urllib.parse.urlencode(params, encoding='utf-8') if params else ''
         path = '/'.join([part for part in parts if part])
         url = path + ('?' if query else '') + query

--- a/tests/basic-structs/test_resource.py
+++ b/tests/basic-structs/test_resource.py
@@ -35,30 +35,6 @@ def test_creation_with_all_kwargs():
     assert resource.verbs == ['verb1', 'verb2']
 
 
-def test_api_version_of_custom_resource():
-    resource = Resource('group', 'version', 'plural')
-    api_version = resource.api_version
-    assert api_version == 'group/version'
-
-
-def test_api_version_of_corev1_resource():
-    resource = Resource('', 'v1', 'plural')
-    api_version = resource.api_version
-    assert api_version == 'v1'
-
-
-def test_name_of_custom_resource():
-    resource = Resource('group', 'version', 'plural')
-    name = resource.name
-    assert name == 'plural.group'
-
-
-def test_name_of_corev1_resource():
-    resource = Resource('', 'v1', 'plural')
-    name = resource.name
-    assert name == 'plural'
-
-
 def test_url_for_a_list_of_clusterscoped_custom_resources_clusterwide():
     resource = Resource('group', 'version', 'plural', namespaced=False)
     url = resource.get_url(namespace=None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,8 +274,9 @@ def version_api(resp_mocker, aresponses, hostname, resource):
         'name': resource.plural,
         'namespaced': True,
     }]}
+    version_url = resource.get_url().rsplit('/', 1)[0]  # except the plural name
     list_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
-    aresponses.add(hostname, resource.get_version_url(), 'get', list_mock)
+    aresponses.add(hostname, version_url, 'get', list_mock)
 
 
 @pytest.fixture()

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -188,17 +188,6 @@ async def test_special_kwargs_added(fn, resource):
     assert fn.called
     assert fn.call_count == 1
 
-    assert len(fn.call_args[1]) >= 2
-    assert fn.call_args[1]['reason'] is cause.reason
-    assert fn.call_args[1]['body'] is cause.body
-    assert fn.call_args[1]['spec'] == cause.body['spec']
-    assert fn.call_args[1]['meta'] == cause.body['metadata']
-    assert fn.call_args[1]['status'] == cause.body['status']
-    assert fn.call_args[1]['diff'] is cause.diff
-    assert fn.call_args[1]['old'] is cause.old
-    assert fn.call_args[1]['new'] is cause.new
-    assert fn.call_args[1]['patch'] is cause.patch
-    assert fn.call_args[1]['logger'] is cause.logger
-    assert fn.call_args[1]['uid'] == cause.body['metadata']['uid']
-    assert fn.call_args[1]['name'] == cause.body['metadata']['name']
-    assert fn.call_args[1]['namespace'] == cause.body['metadata']['namespace']
+    # Only check that kwargs are passed at all. The exact kwargs per cause are tested separately.
+    assert 'logger' in fn.call_args[1]
+    assert 'resource' in fn.call_args[1]

--- a/tests/invocations/test_kwargs.py
+++ b/tests/invocations/test_kwargs.py
@@ -58,10 +58,11 @@ def test_resource_watching_kwargs(resource):
         raw={'type': 'ADDED', 'object': {}},
     )
     kwargs = build_kwargs(cause=cause, extrakwarg=123)
-    assert set(kwargs) == {'extrakwarg', 'logger', 'patch', 'event', 'type', 'memo',
+    assert set(kwargs) == {'extrakwarg', 'logger', 'resource', 'patch', 'event', 'type', 'memo',
                            'body', 'spec', 'status', 'meta', 'uid', 'name', 'namespace',
                            'labels', 'annotations'}
     assert kwargs['extrakwarg'] == 123
+    assert kwargs['resource'] is cause.resource
     assert kwargs['logger'] is cause.logger
     assert kwargs['patch'] is cause.patch
     assert kwargs['event'] is cause.raw
@@ -96,10 +97,11 @@ def test_resource_changing_kwargs(resource):
         new=BodyEssence(),
     )
     kwargs = build_kwargs(cause=cause, extrakwarg=123)
-    assert set(kwargs) == {'extrakwarg', 'logger', 'patch', 'reason', 'memo',
+    assert set(kwargs) == {'extrakwarg', 'logger', 'resource', 'patch', 'reason', 'memo',
                            'body', 'spec', 'status', 'meta', 'uid', 'name', 'namespace',
                            'labels', 'annotations', 'diff', 'old', 'new'}
     assert kwargs['extrakwarg'] == 123
+    assert kwargs['resource'] is cause.resource
     assert kwargs['reason'] is cause.reason
     assert kwargs['logger'] is cause.logger
     assert kwargs['patch'] is cause.patch
@@ -132,10 +134,11 @@ def test_resource_spawning_kwargs(resource):
         reset=False,
     )
     kwargs = build_kwargs(cause=cause, extrakwarg=123)
-    assert set(kwargs) == {'extrakwarg', 'logger', 'patch', 'memo',
+    assert set(kwargs) == {'extrakwarg', 'logger', 'resource', 'patch', 'memo',
                            'body', 'spec', 'status', 'meta', 'uid', 'name', 'namespace',
                            'labels', 'annotations'}
     assert kwargs['extrakwarg'] == 123
+    assert kwargs['resource'] is cause.resource
     assert kwargs['logger'] is cause.logger
     assert kwargs['patch'] is cause.patch
     assert kwargs['memo'] is cause.memo
@@ -164,10 +167,11 @@ def test_daemon_kwargs(resource):
         stopper=DaemonStopper(),
     )
     kwargs = build_kwargs(cause=cause, extrakwarg=123)
-    assert set(kwargs) == {'extrakwarg', 'logger', 'patch', 'memo',
+    assert set(kwargs) == {'extrakwarg', 'logger', 'resource', 'patch', 'memo',
                            'body', 'spec', 'status', 'meta', 'uid', 'name', 'namespace',
                            'labels', 'annotations'}
     assert kwargs['extrakwarg'] == 123
+    assert kwargs['resource'] is cause.resource
     assert kwargs['logger'] is cause.logger
     assert kwargs['patch'] is cause.patch
     assert kwargs['memo'] is cause.memo

--- a/tests/invocations/test_kwargs.py
+++ b/tests/invocations/test_kwargs.py
@@ -1,0 +1,209 @@
+import logging
+
+import pytest
+
+from kopf.reactor.causation import ActivityCause, DaemonCause, ResourceChangingCause, \
+                                   ResourceSpawningCause, ResourceWatchingCause
+from kopf.reactor.invocation import build_kwargs
+from kopf.structs.bodies import Body, BodyEssence
+from kopf.structs.configuration import OperatorSettings
+from kopf.structs.containers import Memo
+from kopf.structs.diffs import Diff
+from kopf.structs.handlers import Activity, Reason
+from kopf.structs.patches import Patch
+from kopf.structs.primitives import DaemonStopper
+
+
+@pytest.mark.parametrize('activity', set(Activity) - {Activity.STARTUP})
+def test_activity_kwargs(resource, activity):
+    cause = ActivityCause(
+        logger=logging.getLogger('kopf.test.fake.logger'),
+        activity=activity,
+        settings=OperatorSettings(),
+    )
+    kwargs = build_kwargs(cause=cause, extrakwarg=123)
+    assert set(kwargs) == {'extrakwarg', 'logger', 'activity'}
+    assert kwargs['extrakwarg'] == 123
+    assert kwargs['logger'] is cause.logger
+    assert kwargs['activity'] is activity
+
+
+@pytest.mark.parametrize('activity', {Activity.STARTUP})
+def test_startup_kwargs(resource, activity):
+    cause = ActivityCause(
+        logger=logging.getLogger('kopf.test.fake.logger'),
+        activity=activity,
+        settings=OperatorSettings(),
+    )
+    kwargs = build_kwargs(cause=cause, extrakwarg=123)
+    assert set(kwargs) == {'extrakwarg', 'logger', 'activity', 'settings'}
+    assert kwargs['extrakwarg'] == 123
+    assert kwargs['logger'] is cause.logger
+    assert kwargs['activity'] is activity
+    assert kwargs['settings'] is cause.settings
+
+
+def test_resource_watching_kwargs(resource):
+    body = {'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1',
+                         'labels': {'l1': 'v1'}, 'annotations': {'a1': 'v1'}},
+            'spec': {'field': 'value'},
+            'status': {'info': 'payload'}}
+    cause = ResourceWatchingCause(
+        logger=logging.getLogger('kopf.test.fake.logger'),
+        resource=resource,
+        patch=Patch(),
+        memo=Memo(),
+        body=Body(body),
+        type='ADDED',
+        raw={'type': 'ADDED', 'object': {}},
+    )
+    kwargs = build_kwargs(cause=cause, extrakwarg=123)
+    assert set(kwargs) == {'extrakwarg', 'logger', 'patch', 'event', 'type', 'memo',
+                           'body', 'spec', 'status', 'meta', 'uid', 'name', 'namespace',
+                           'labels', 'annotations'}
+    assert kwargs['extrakwarg'] == 123
+    assert kwargs['logger'] is cause.logger
+    assert kwargs['patch'] is cause.patch
+    assert kwargs['event'] is cause.raw
+    assert kwargs['memo'] is cause.memo
+    assert kwargs['type'] is cause.type
+    assert kwargs['body'] is cause.body
+    assert kwargs['spec'] is cause.body.spec
+    assert kwargs['meta'] is cause.body.metadata
+    assert kwargs['status'] is cause.body.status
+    assert kwargs['labels'] is cause.body.metadata.labels
+    assert kwargs['annotations'] is cause.body.metadata.annotations
+    assert kwargs['uid'] == cause.body.metadata.uid
+    assert kwargs['name'] == cause.body.metadata.name
+    assert kwargs['namespace'] == cause.body.metadata.namespace
+
+
+def test_resource_changing_kwargs(resource):
+    body = {'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1',
+                         'labels': {'l1': 'v1'}, 'annotations': {'a1': 'v1'}},
+            'spec': {'field': 'value'},
+            'status': {'info': 'payload'}}
+    cause = ResourceChangingCause(
+        logger=logging.getLogger('kopf.test.fake.logger'),
+        resource=resource,
+        patch=Patch(),
+        initial=False,
+        reason=Reason.NOOP,
+        memo=Memo(),
+        body=Body(body),
+        diff=Diff([]),
+        old=BodyEssence(),
+        new=BodyEssence(),
+    )
+    kwargs = build_kwargs(cause=cause, extrakwarg=123)
+    assert set(kwargs) == {'extrakwarg', 'logger', 'patch', 'reason', 'memo',
+                           'body', 'spec', 'status', 'meta', 'uid', 'name', 'namespace',
+                           'labels', 'annotations', 'diff', 'old', 'new'}
+    assert kwargs['extrakwarg'] == 123
+    assert kwargs['reason'] is cause.reason
+    assert kwargs['logger'] is cause.logger
+    assert kwargs['patch'] is cause.patch
+    assert kwargs['memo'] is cause.memo
+    assert kwargs['diff'] is cause.diff
+    assert kwargs['old'] is cause.old
+    assert kwargs['new'] is cause.new
+    assert kwargs['body'] is cause.body
+    assert kwargs['spec'] is cause.body.spec
+    assert kwargs['meta'] is cause.body.metadata
+    assert kwargs['status'] is cause.body.status
+    assert kwargs['labels'] is cause.body.metadata.labels
+    assert kwargs['annotations'] is cause.body.metadata.annotations
+    assert kwargs['uid'] == cause.body.metadata.uid
+    assert kwargs['name'] == cause.body.metadata.name
+    assert kwargs['namespace'] == cause.body.metadata.namespace
+
+
+def test_resource_spawning_kwargs(resource):
+    body = {'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1',
+                         'labels': {'l1': 'v1'}, 'annotations': {'a1': 'v1'}},
+            'spec': {'field': 'value'},
+            'status': {'info': 'payload'}}
+    cause = ResourceSpawningCause(
+        logger=logging.getLogger('kopf.test.fake.logger'),
+        resource=resource,
+        patch=Patch(),
+        memo=Memo(),
+        body=Body(body),
+        reset=False,
+    )
+    kwargs = build_kwargs(cause=cause, extrakwarg=123)
+    assert set(kwargs) == {'extrakwarg', 'logger', 'patch', 'memo',
+                           'body', 'spec', 'status', 'meta', 'uid', 'name', 'namespace',
+                           'labels', 'annotations'}
+    assert kwargs['extrakwarg'] == 123
+    assert kwargs['logger'] is cause.logger
+    assert kwargs['patch'] is cause.patch
+    assert kwargs['memo'] is cause.memo
+    assert kwargs['body'] is cause.body
+    assert kwargs['spec'] is cause.body.spec
+    assert kwargs['meta'] is cause.body.metadata
+    assert kwargs['status'] is cause.body.status
+    assert kwargs['labels'] is cause.body.metadata.labels
+    assert kwargs['annotations'] is cause.body.metadata.annotations
+    assert kwargs['uid'] == cause.body.metadata.uid
+    assert kwargs['name'] == cause.body.metadata.name
+    assert kwargs['namespace'] == cause.body.metadata.namespace
+
+
+def test_daemon_kwargs(resource):
+    body = {'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1',
+                         'labels': {'l1': 'v1'}, 'annotations': {'a1': 'v1'}},
+            'spec': {'field': 'value'},
+            'status': {'info': 'payload'}}
+    cause = DaemonCause(
+        logger=logging.getLogger('kopf.test.fake.logger'),
+        resource=resource,
+        patch=Patch(),
+        memo=Memo(),
+        body=Body(body),
+        stopper=DaemonStopper(),
+    )
+    kwargs = build_kwargs(cause=cause, extrakwarg=123)
+    assert set(kwargs) == {'extrakwarg', 'logger', 'patch', 'memo',
+                           'body', 'spec', 'status', 'meta', 'uid', 'name', 'namespace',
+                           'labels', 'annotations'}
+    assert kwargs['extrakwarg'] == 123
+    assert kwargs['logger'] is cause.logger
+    assert kwargs['patch'] is cause.patch
+    assert kwargs['memo'] is cause.memo
+    assert kwargs['body'] is cause.body
+    assert kwargs['spec'] is cause.body.spec
+    assert kwargs['meta'] is cause.body.metadata
+    assert kwargs['status'] is cause.body.status
+    assert kwargs['labels'] is cause.body.metadata.labels
+    assert kwargs['annotations'] is cause.body.metadata.annotations
+    assert kwargs['uid'] == cause.body.metadata.uid
+    assert kwargs['name'] == cause.body.metadata.name
+    assert kwargs['namespace'] == cause.body.metadata.namespace
+    assert 'stopped' not in kwargs
+
+
+def test_daemon_sync_stopper(resource):
+    cause = DaemonCause(
+        logger=logging.getLogger('kopf.test.fake.logger'),
+        resource=resource,
+        patch=Patch(),
+        memo=Memo(),
+        body=Body({}),
+        stopper=DaemonStopper(),
+    )
+    kwargs = build_kwargs(cause=cause, _sync=True)
+    assert kwargs['stopped'] is cause.stopper.sync_checker
+
+
+def test_daemon_async_stopper(resource):
+    cause = DaemonCause(
+        logger=logging.getLogger('kopf.test.fake.logger'),
+        resource=resource,
+        patch=Patch(),
+        memo=Memo(),
+        body=Body({}),
+        stopper=DaemonStopper(),
+    )
+    kwargs = build_kwargs(cause=cause, _sync=False)
+    assert kwargs['stopped'] is cause.stopper.async_checker


### PR DESCRIPTION
Expose the `resource` kwarg instead of removed `cause.resource`.

The `cause` kwarg was deprecated long time ago and removed in #511. The replacement was to use all kwargs directly. However, one of them — the `cause.resource` — was never exposed properly as a kwarg (by mistake). This PR adds the `resource` kwarg to the full list of other kwargs available, so that the set is complete and reflects the original `cause` object properly.

In addition, it is better documented in the docs now, including better (more precise) typing of the fields.

---

Some public properties and methods that are not used by the framework are dropped to reduce the public interface of the class. The class was exposed before this change, but it had no direct use-cases, so presumably was not used, so it is safe to drop these fields/methods now. These properties/methods can be reconstructed from the available fields anyway — they are just formatted strings.

Instead, more fields with more information about the resource are added — as discovered from the cluster (as a result of #600; [diff](https://github.com/nolar/kopf/pull/600/files#diff-68531b553d8a20a1885b82de4b33127bc2b57b6b51988f3c5160aa6bc8cca197R118-R125)): all names (singular, kind, short — in addition to plural), all categories, the resource's scope & supported verbs.

Issues: #657