### PR TITLE
Parametrize handlers

### DIFF
--- a/kopf/on.py
+++ b/kopf/on.py
@@ -25,11 +25,14 @@ ResourceTimerDecorator = Callable[[callbacks.ResourceTimerFn], callbacks.Resourc
 
 def startup(  # lgtm[py/similar-function]
         *,
+        # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
+        # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityDecorator:
     def decorator(  # lgtm[py/similar-function]
@@ -38,7 +41,7 @@ def startup(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             activity=handlers.Activity.STARTUP,
         )
@@ -49,11 +52,14 @@ def startup(  # lgtm[py/similar-function]
 
 def cleanup(  # lgtm[py/similar-function]
         *,
+        # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
+        # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityDecorator:
     def decorator(  # lgtm[py/similar-function]
@@ -62,7 +68,7 @@ def cleanup(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             activity=handlers.Activity.CLEANUP,
         )
@@ -73,11 +79,14 @@ def cleanup(  # lgtm[py/similar-function]
 
 def login(  # lgtm[py/similar-function]
         *,
+        # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
+        # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityDecorator:
     """ ``@kopf.on.login()`` handler for custom (re-)authentication. """
@@ -87,7 +96,7 @@ def login(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             activity=handlers.Activity.AUTHENTICATION,
         )
@@ -98,11 +107,14 @@ def login(  # lgtm[py/similar-function]
 
 def probe(  # lgtm[py/similar-function]
         *,
+        # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
+        # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityDecorator:
     """ ``@kopf.on.probe()`` handler for arbitrary liveness metrics. """
@@ -112,7 +124,7 @@ def probe(  # lgtm[py/similar-function]
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             activity=handlers.Activity.PROBE,
         )
@@ -136,17 +148,20 @@ def resume(  # lgtm[py/similar-function]
         category: Optional[str] = None,
         # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
-        registry: Optional[registries.OperatorRegistry] = None,
         deleted: Optional[bool] = None,
+        # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
         field: Optional[dicts.FieldSpec] = None,
         value: Optional[filters.ValueFilter] = None,
+        # Operator specification:
+        registry: Optional[registries.OperatorRegistry] = None,
 ) -> ResourceChangingDecorator:
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
     def decorator(  # lgtm[py/similar-function]
@@ -163,7 +178,7 @@ def resume(  # lgtm[py/similar-function]
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
         handler = handlers.ResourceChangingHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=None, new=None, field_needs_change=False,
@@ -190,6 +205,7 @@ def create(  # lgtm[py/similar-function]
         category: Optional[str] = None,
         # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
@@ -218,7 +234,7 @@ def create(  # lgtm[py/similar-function]
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
         handler = handlers.ResourceChangingHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=None, new=None, field_needs_change=False,
@@ -245,6 +261,7 @@ def update(  # lgtm[py/similar-function]
         category: Optional[str] = None,
         # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
@@ -275,7 +292,7 @@ def update(  # lgtm[py/similar-function]
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
         handler = handlers.ResourceChangingHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=old, new=new, field_needs_change=True,
@@ -302,6 +319,7 @@ def delete(  # lgtm[py/similar-function]
         category: Optional[str] = None,
         # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
@@ -331,7 +349,7 @@ def delete(  # lgtm[py/similar-function]
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
         handler = handlers.ResourceChangingHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=None, new=None, field_needs_change=False,
@@ -358,6 +376,7 @@ def field(  # lgtm[py/similar-function]
         category: Optional[str] = None,
         # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
@@ -388,7 +407,7 @@ def field(  # lgtm[py/similar-function]
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
         handler = handlers.ResourceChangingHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=old, new=new, field_needs_change=True,
@@ -415,6 +434,7 @@ def event(  # lgtm[py/similar-function]
         category: Optional[str] = None,
         # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
@@ -439,7 +459,7 @@ def event(  # lgtm[py/similar-function]
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
         handler = handlers.ResourceWatchingHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=None, timeout=None, retries=None, backoff=None,
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value,
@@ -464,6 +484,7 @@ def daemon(  # lgtm[py/similar-function]
         category: Optional[str] = None,
         # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
@@ -496,7 +517,7 @@ def daemon(  # lgtm[py/similar-function]
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
         handler = handlers.ResourceDaemonHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value,
@@ -525,6 +546,7 @@ def timer(  # lgtm[py/similar-function]
         category: Optional[str] = None,
         # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
@@ -557,7 +579,7 @@ def timer(  # lgtm[py/similar-function]
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
         handler = handlers.ResourceTimerHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value,
@@ -573,6 +595,7 @@ def subhandler(  # lgtm[py/similar-function]
         *,
         # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
@@ -628,7 +651,7 @@ def subhandler(  # lgtm[py/similar-function]
         real_id = registries.generate_id(fn=fn, id=id,
                                          prefix=parent_handler.id if parent_handler else None)
         handler = handlers.ResourceChangingHandler(
-            fn=fn, id=real_id,
+            fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=None, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=old, new=new,
@@ -646,6 +669,7 @@ def register(  # lgtm[py/similar-function]
         *,
         # Handler's behaviour specification:
         id: Optional[str] = None,
+        param: Optional[Any] = None,
         errors: Optional[handlers.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
@@ -680,7 +704,7 @@ def register(  # lgtm[py/similar-function]
                     pass
     """
     decorator = subhandler(
-        id=id,
+        id=id, param=param,
         errors=errors, timeout=timeout, retries=retries, backoff=backoff,
         labels=labels, annotations=annotations, when=when,
     )

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -100,7 +100,7 @@ async def execute(
         for id, fn in fns.items():
             real_id = registries.generate_id(fn=fn, id=id, prefix=parent_prefix)
             handler = handlers_.ResourceChangingHandler(
-                fn=fn, id=real_id,
+                fn=fn, id=real_id, param=None,
                 errors=None, timeout=None, retries=None, backoff=None,
                 selector=None, labels=None, annotations=None, when=None,
                 initial=None, deleted=None, requires_finalizer=None,
@@ -114,7 +114,7 @@ async def execute(
         for fn in fns:
             real_id = registries.generate_id(fn=fn, id=None, prefix=parent_prefix)
             handler = handlers_.ResourceChangingHandler(
-                fn=fn, id=real_id,
+                fn=fn, id=real_id, param=None,
                 errors=None, timeout=None, retries=None, backoff=None,
                 selector=None, labels=None, annotations=None, when=None,
                 initial=None, deleted=None, requires_finalizer=None,
@@ -370,6 +370,7 @@ async def invoke_handler(
             *args,
             settings=settings,
             cause=cause,
+            param=handler.param,
             **kwargs,
         )
 

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -37,7 +37,7 @@ def context(
 def build_kwargs(
         cause: Optional[causation.BaseCause] = None,
         _sync: Optional[bool] = None,
-        **kwargs: Any
+        **kwargs: Any,  # includes param, retry, started, runtime, etc.
 ) -> Dict[str, Any]:
     """
     Expand kwargs dict with fields from the causation.
@@ -96,7 +96,7 @@ async def invoke(
         *args: Any,
         settings: Optional[configuration.OperatorSettings] = None,
         cause: Optional[causation.BaseCause] = None,
-        **kwargs: Any,
+        **kwargs: Any,  # includes param, retry, started, runtime, etc.
 ) -> Any:
     """
     Invoke a single function, but safely for the main asyncio process.

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -251,7 +251,7 @@ class SmartOperatorRegistry(OperatorRegistry):
                 fn=cast(callbacks.ActivityFn, piggybacking.login_via_pykube),
                 activity=handlers.Activity.AUTHENTICATION,
                 errors=handlers.ErrorsMode.IGNORED,
-                timeout=None, retries=None, backoff=None,
+                param=None, timeout=None, retries=None, backoff=None,
                 _fallback=True,
             ))
         try:
@@ -264,7 +264,7 @@ class SmartOperatorRegistry(OperatorRegistry):
                 fn=cast(callbacks.ActivityFn, piggybacking.login_via_client),
                 activity=handlers.Activity.AUTHENTICATION,
                 errors=handlers.ErrorsMode.IGNORED,
-                timeout=None, retries=None, backoff=None,
+                param=None, timeout=None, retries=None, backoff=None,
                 _fallback=True,
             ))
 

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -1,6 +1,6 @@
 import dataclasses
 import enum
-from typing import NewType, Optional
+from typing import Any, NewType, Optional
 
 from kopf.structs import callbacks, dicts, filters, references
 
@@ -70,6 +70,7 @@ TITLES = {
 class BaseHandler:
     id: HandlerId
     fn: callbacks.BaseFn
+    param: Optional[Any]
     errors: Optional[ErrorsMode]
     timeout: Optional[float]
     retries: Optional[int]

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -32,7 +32,7 @@ async def test_noreturn_handler_produces_no_credentials(settings):
     # NB: id auto-detection does not work, as it is local to the test function.
     registry._activities.append(ActivityHandler(
         fn=login_fn, id='login_fn', activity=Activity.AUTHENTICATION,
-        errors=None, timeout=None, retries=None, backoff=None,
+        param=None, errors=None, timeout=None, retries=None, backoff=None,
     ))
 
     await authenticate(
@@ -58,7 +58,7 @@ async def test_single_credentials_provided_to_vault(settings):
     # NB: id auto-detection does not work, as it is local to the test function.
     registry._activities.append(ActivityHandler(
         fn=login_fn, id='login_fn', activity=Activity.AUTHENTICATION,
-        errors=None, timeout=None, retries=None, backoff=None,
+        param=None, errors=None, timeout=None, retries=None, backoff=None,
     ))
 
     await authenticate(

--- a/tests/basic-structs/test_handlers.py
+++ b/tests/basic-structs/test_handlers.py
@@ -12,6 +12,7 @@ def test_handler_with_no_args(cls):
 def test_activity_handler_with_all_args(mocker):
     fn = mocker.Mock()
     id = mocker.Mock()
+    param = mocker.Mock()
     errors = mocker.Mock()
     timeout = mocker.Mock()
     retries = mocker.Mock()
@@ -20,6 +21,7 @@ def test_activity_handler_with_all_args(mocker):
     handler = ActivityHandler(
         fn=fn,
         id=id,
+        param=param,
         errors=errors,
         timeout=timeout,
         retries=retries,
@@ -28,6 +30,7 @@ def test_activity_handler_with_all_args(mocker):
     )
     assert handler.fn is fn
     assert handler.id is id
+    assert handler.param is param
     assert handler.errors is errors
     assert handler.timeout is timeout
     assert handler.retries is retries
@@ -38,6 +41,7 @@ def test_activity_handler_with_all_args(mocker):
 def test_resource_handler_with_all_args(mocker):
     fn = mocker.Mock()
     id = mocker.Mock()
+    param = mocker.Mock()
     selector = mocker.Mock()
     reason = mocker.Mock()
     errors = mocker.Mock()
@@ -58,6 +62,7 @@ def test_resource_handler_with_all_args(mocker):
     handler = ResourceChangingHandler(
         fn=fn,
         id=id,
+        param=param,
         selector=selector,
         reason=reason,
         errors=errors,
@@ -78,6 +83,7 @@ def test_resource_handler_with_all_args(mocker):
     )
     assert handler.fn is fn
     assert handler.id is id
+    assert handler.param is param
     assert handler.selector is selector
     assert handler.reason is reason
     assert handler.errors is errors

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -32,11 +32,11 @@ async def test_results_are_returned_on_success(settings, activity):
     registry = OperatorRegistry()
     registry._activities.append(ActivityHandler(
         fn=sample_fn1, id='id1', activity=activity,
-        errors=None, timeout=None, retries=None, backoff=None,
+        param=None, errors=None, timeout=None, retries=None, backoff=None,
     ))
     registry._activities.append(ActivityHandler(
         fn=sample_fn2, id='id2', activity=activity,
-        errors=None, timeout=None, retries=None, backoff=None,
+        param=None, errors=None, timeout=None, retries=None, backoff=None,
     ))
 
     results = await run_activity(
@@ -63,11 +63,11 @@ async def test_errors_are_raised_aggregated(settings, activity):
     registry = OperatorRegistry()
     registry._activities.append(ActivityHandler(
         fn=sample_fn1, id='id1', activity=activity,
-        errors=None, timeout=None, retries=None, backoff=None,
+        param=None, errors=None, timeout=None, retries=None, backoff=None,
     ))
     registry._activities.append(ActivityHandler(
         fn=sample_fn2, id='id2', activity=activity,
-        errors=None, timeout=None, retries=None, backoff=None,
+        param=None, errors=None, timeout=None, retries=None, backoff=None,
     ))
 
     with pytest.raises(ActivityError) as e:
@@ -100,7 +100,7 @@ async def test_errors_are_cascaded_from_one_of_the_originals(settings, activity)
     registry = OperatorRegistry()
     registry._activities.append(ActivityHandler(
         fn=sample_fn, id='id', activity=activity,
-        errors=None, timeout=None, retries=None, backoff=None,
+        param=None, errors=None, timeout=None, retries=None, backoff=None,
     ))
 
     with pytest.raises(ActivityError) as e:
@@ -127,7 +127,7 @@ async def test_retries_are_simulated(settings, activity, mocker):
     registry = OperatorRegistry()
     registry._activities.append(ActivityHandler(
         fn=sample_fn, id='id', activity=activity,
-        errors=None, timeout=None, retries=3, backoff=None,
+        param=None, errors=None, timeout=None, retries=3, backoff=None,
     ))
 
     with pytest.raises(ActivityError) as e:
@@ -151,7 +151,7 @@ async def test_delays_are_simulated(settings, activity, mocker):
     registry = OperatorRegistry()
     registry._activities.append(ActivityHandler(
         fn=sample_fn, id='id', activity=activity,
-        errors=None, timeout=None, retries=3, backoff=None,
+        param=None, errors=None, timeout=None, retries=3, backoff=None,
     ))
 
     with freezegun.freeze_time() as frozen:

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -24,7 +24,7 @@ async def test_skipped_with_no_handlers(
     assert not registry._resource_changing.has_handlers(resource=resource)  # prerequisite
     registry._resource_changing.append(ResourceChangingHandler(
         reason='a-non-existent-cause-type',
-        fn=lambda **_: None, id='id',
+        fn=lambda **_: None, id='id', param=None,
         errors=None, timeout=None, retries=None, backoff=None,
         selector=selector, annotations=None, labels=None, when=None,
         field=None, value=None, old=None, new=None, field_needs_change=None,
@@ -79,7 +79,7 @@ async def test_stealth_mode_with_mismatching_handlers(
     assert not registry._resource_changing.has_handlers(resource=resource)  # prerequisite
     registry._resource_changing.append(ResourceChangingHandler(
         reason=None,
-        fn=lambda **_: None, id='id',
+        fn=lambda **_: None, id='id', param=None,
         errors=None, timeout=None, retries=None, backoff=None,
         selector=selector, annotations=annotations, labels=labels, when=when,
         field=None, value=None, old=None, new=None, field_needs_change=None,

--- a/tests/handling/test_parametrization.py
+++ b/tests/handling/test_parametrization.py
@@ -1,0 +1,56 @@
+import asyncio
+from unittest.mock import Mock
+
+import kopf
+from kopf.reactor.processing import process_resource_event
+from kopf.structs.containers import ResourceMemories
+
+
+async def test_parameter_is_passed_when_specified(resource, cause_mock, registry, settings):
+    mock = Mock()
+
+    # If it works for this handler, we assume it works for all of them.
+    # Otherwise, it is too difficult to trigger the actual invocation.
+    @kopf.on.event(*resource, param=123)
+    def fn(**kwargs):
+        mock(**kwargs)
+
+    event_queue = asyncio.Queue()
+    await process_resource_event(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        memories=ResourceMemories(),
+        raw_event={'type': None, 'object': {}},
+        replenished=asyncio.Event(),
+        event_queue=event_queue,
+    )
+
+    assert mock.called
+    assert mock.call_args_list[0][1]['param'] == 123
+
+
+async def test_parameter_is_passed_even_if_not_specified(resource, cause_mock, registry, settings):
+    mock = Mock()
+
+    # If it works for this handler, we assume it works for all of them.
+    # Otherwise, it is too difficult to trigger the actual invocation.
+    @kopf.on.event(*resource)
+    def fn(**kwargs):
+        mock(**kwargs)
+
+    event_queue = asyncio.Queue()
+    await process_resource_event(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        memories=ResourceMemories(),
+        raw_event={'type': None, 'object': {}},
+        replenished=asyncio.Event(),
+        event_queue=event_queue,
+    )
+
+    assert mock.called
+    assert mock.call_args_list[0][1]['param'] is None

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -52,7 +52,7 @@ def parent_handler(selector):
         pass
 
     return ResourceChangingHandler(
-        fn=parent_fn, id=HandlerId('parent_fn'),
+        fn=parent_fn, id=HandlerId('parent_fn'), param=None,
         errors=None, retries=None, timeout=None, backoff=None,
         selector=selector, labels=None, annotations=None, when=None,
         field=None, value=None, old=None, new=None, field_needs_change=None,

--- a/tests/registries/test_matching_for_changing.py
+++ b/tests/registries/test_matching_for_changing.py
@@ -51,7 +51,7 @@ mismatching_reason_and_decorator = pytest.mark.parametrize('reason, decorator', 
 def handler_factory(registry, selector):
     def factory(**kwargs):
         handler = ResourceChangingHandler(**dict(dict(
-            fn=some_fn, id='a',
+            fn=some_fn, id='a', param=None,
             errors=None, timeout=None, retries=None, backoff=None,
             initial=None, deleted=None, requires_finalizer=None,
             selector=selector, annotations=None, labels=None, when=None,

--- a/tests/registries/test_matching_for_spawning.py
+++ b/tests/registries/test_matching_for_spawning.py
@@ -32,7 +32,7 @@ spawning_decorators = pytest.mark.parametrize('decorator', [
 def handler_factory(registry, selector):
     def factory(**kwargs):
         handler = ResourceSpawningHandler(**dict(dict(
-            fn=some_fn, id='a',
+            fn=some_fn, id='a', param=None,
             errors=None, timeout=None, retries=None, backoff=None,
             selector=selector, annotations=None, labels=None, when=None,
             field=None, value=None,

--- a/tests/registries/test_matching_for_watching.py
+++ b/tests/registries/test_matching_for_watching.py
@@ -26,7 +26,7 @@ def _always(*_, **__):
 def handler_factory(registry, selector):
     def factory(**kwargs):
         handler = ResourceWatchingHandler(**dict(dict(
-            fn=some_fn, id='a',
+            fn=some_fn, id='a', param=None,
             errors=None, timeout=None, retries=None, backoff=None,
             selector=selector, annotations=None, labels=None, when=None,
             field=None, value=None,

--- a/tests/registries/test_matching_of_callbacks.py
+++ b/tests/registries/test_matching_of_callbacks.py
@@ -32,7 +32,7 @@ def handler(request, callback, selector):
         field=parse_field('spec.field'),
         value='value',
         when=None,
-        fn=some_fn, id='a', errors=None, timeout=None, retries=None, backoff=None,  # irrelevant
+        fn=some_fn, id='a', param=None, errors=None, timeout=None, retries=None, backoff=None,
     )
     if request.param in ['annotations', 'labels']:
         handler = dataclasses.replace(handler, **{request.param: {'known': callback}})

--- a/tests/test_liveness.py
+++ b/tests/test_liveness.py
@@ -57,11 +57,11 @@ async def test_liveness_with_reporting(liveness_url, liveness_registry):
 
     liveness_registry._activities.append(ActivityHandler(
         fn=fn1, id='id1', activity=Activity.PROBE,
-        errors=None, timeout=None, retries=None, backoff=None,
+        param=None, errors=None, timeout=None, retries=None, backoff=None,
     ))
     liveness_registry._activities.append(ActivityHandler(
         fn=fn2, id='id2', activity=Activity.PROBE,
-        errors=None, timeout=None, retries=None, backoff=None,
+        param=None, errors=None, timeout=None, retries=None, backoff=None,
     ))
 
     async with aiohttp.ClientSession() as session:
@@ -81,7 +81,7 @@ async def test_liveness_data_is_cached(liveness_url, liveness_registry):
 
     liveness_registry._activities.append(ActivityHandler(
         fn=fn1, id='id1', activity=Activity.PROBE,
-        errors=None, timeout=None, retries=None, backoff=None,
+        param=None, errors=None, timeout=None, retries=None, backoff=None,
     ))
 
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
Add an optional parameter (`param=` option) to all handlers — for a rudimentary parametrization to distinguish several non-overlapping handlers pointing to the same function. This can be applied to parametrize several causes & filters of the same resource, so as for handlers for different resources (still pointing to the same function, e.g. `children_updated`).

Example 1 (same resource, different occasions):

```python
import kopf

@kopf.on.create('KopfExample', param=1000)
@kopf.on.resume('KopfExample', param=100)
@kopf.on.update('KopfExample', param=10, field='spec.field')
@kopf.on.update('KopfExample', param=1, field='spec.items')
def count_updates(param, patch, **_):
    patch.status['counter'] = body.status.get('counter', 0) + param
```

Example 2 (different resources, similar occasions):

```python
import kopf

@kopf.on.update('Child1', param='first', field='status.done', new=True)
@kopf.on.update('Child2', param='second', field='status.done', new=True)
def child_updated(param, patch, **_):
    patch_parent({'status': {param: {'done': True}}})
```

Issue: #657 