### PR TITLE
Keep a live in-memory "view" of all matching resources in the cluster

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,8 +36,9 @@ Kopf: Kubernetes Operators Framework
    filters
    results
    errors
-   memos
    scopes
+   memos
+   indexing
 
 .. toctree::
    :maxdepth: 2

--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -1,0 +1,532 @@
+==================
+In-memory indexing
+==================
+
+Indexers automatically maintain in-memory overviews of resources (indices),
+grouped by keys that are usually calculated based on these resources.
+
+The indices can be used for cross-resource awareness:
+e.g., when a resource of kind X is changed, it can get all the information
+about all resources of kind Y without talking to the Kubernetes API.
+Under the hood, the centralised watch-streams ---one per resource kind--- are
+more efficient in gathering the information than individual listing requests.
+
+
+Index declaration
+=================
+
+Indices are declared with a ``@kopf.index`` decorator on an indexing function
+(all standard filters are supported --- see :doc:`filters`):
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods')
+    def my_idx(**_):
+        ...
+
+The name of the function or its ``id=`` option is the index's name.
+
+The indices are then available to all resource- and operator-level handlers
+as the direct kwargs named the same as the index (type hints are optional):
+
+.. code-block:: python
+
+    import kopf
+
+    # ... continued from previous examples:
+    @kopf.timer('KopfExample', interval=5)
+    def tick(my_idx: kopf.Index, **_):
+        ...
+
+    @kopf.on.probe()
+    def metric(my_idx: kopf.Index, **_):
+        ...
+
+When a resource is created or starts matching the filters, it is processed
+by all relevant indexing functions, and the result is put into the indices.
+
+When a previously indexed resource is deleted or stops matching the filters,
+all associated values are removed (so are all empty collections after this
+--- to keep the indices clean).
+
+.. seealso::
+    :doc:`/probing` for probing handlers in the example above.
+
+
+Index structure
+===============
+
+An index is always a read-only *mapping* (dictionary-like) of type `kopf.Index`
+with arbitrary keys leading to *collections* of arbitrary values (`kopf.Store`).
+The index is initially empty. The collections are never empty
+(empty collections are removed when the last item in them is removed).
+
+For example, if several individual resources return the following results
+from the same indexing function, then the index gets the following structure
+(shown in the comment below the code):
+
+.. code-block:: python
+
+    return {'key1': 'valueA'}  # 1st
+    return {'key1': 'valueB'}  # 2nd
+    return {'key2': 'valueC'}  # 3rd
+    # {'key1': ['valueA', 'valueB'],
+    #  'key2': ['valueC']}
+
+The indices are not nested. The 2nd-level mapping in the result
+is stored as a regular value:
+
+.. code-block:: python
+
+    return {'key1': 'valueA'}  # 1st
+    return {'key1': 'valueB'}  # 2nd
+    return {'key2': {'key3': 'valueC'}}  # 3rd
+    # {'key1': ['valueA', 'valueB'],
+    #  'key2': [{'key3': 'valueC'}]}
+
+
+Index content
+=============
+
+When an indexing function returns a ``dict`` (strictly ``dict``!
+not a generic mapping, not even a descendant of ``dict``, such as `kopf.Memo`),
+it is merged into the index under the key taken from the result:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods')
+    def string_keys(namespace, name, **_):
+        return {namespace: name}
+        # {'namespace1': ['pod1a', 'pod1b', ...],
+        #  'namespace2': ['pod2a', 'pod2b', ...],
+        #   ...]
+
+Multi-value keys are possible with e.g. tuples or other hashable types:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods')
+    def tuple_keys(namespace, name, **_):
+        return {(namespace, name): 'hello'}
+        # {('namespace1', 'pod1a'): ['hello'],
+        #  ('namespace1', 'pod1b'): ['hello'],
+        #  ('namespace2': 'pod2a'): ['hello'],
+        #  ('namespace2', 'pod2b'): ['hello'],
+        #   ...}
+
+Multiple keys can be returned at once for a single resource.
+They are all merged into their relevant places in the index:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods')
+    def by_label(labels, name, **_):
+        return {(label, value): name for label, value in labels.items()}
+        # {('label1', 'value1a'): ['pod1', 'pod2', ...],
+        #  ('label1', 'value1b'): ['pod3', 'pod4', ...],
+        #  ('label2', 'value2a'): ['pod5', 'pod6', ...],
+        #  ('label2', 'value2b'): ['pod1', 'pod3', ...],
+        #   ...}
+
+    @kopf.timer('kex', interval=5)
+    def tick(by_label: kopf.Index, **_):
+        print(list(by_label.get(('label2', 'value2b'), [])))
+        # ['pod1', 'pod3']
+        for podname in by_label.get(('label2', 'value2b'), []):
+            print(f"==> {podname}")
+        # ==> pod1
+        # ==> pod3
+
+Note the multiple occurrences of some pods because they have two or more labels.
+But they never repeat within the same label --- labels can have only one value.
+
+
+Recipes
+=======
+
+Unindexed collections
+---------------------
+
+When an indexing function returns a non-``dict`` --- i.e. strings, numbers,
+tuples, lists, sets, memos, arbitrary objects except ``dict`` --- then the key
+is assumed to be ``None`` and a flat index with only one key is constructed.
+The resources are not indexed, but rather collected under the same key
+(which is still considered as indexing):
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods')
+    def pod_names(name: str, **_):
+        return name
+        # {None: ['pod1', 'pod2', ...]}
+
+Other types and complex objects returned from the indexing function are stored
+"as is" (i.e. with no special treatment):
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods')
+    def container_names(spec: kopf.Spec, **_):
+        return {container['name'] for container in spec.get('containers', [])}
+        # {None: [{'main1', 'sidecar2'}, {'main2'}, ...]}
+
+
+Enumerating resources
+---------------------
+
+If the goal is not to store any payload but to only list the existing resources,
+then index the resources' identities (usually, their namespaces and names).
+
+One way is to only collect their identities in a flat collection -- in case
+you need mostly to iterate over all of them without key lookups:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods')
+    def pods_list(namespace, name, **_):
+        return namespace, name
+        # {None: [('namespace1', 'pod1a'),
+        #         ('namespace1', 'pod1b'),
+        #         ('namespace2', 'pod2a'),
+        #         ('namespace2', 'pod2b'),
+        #           ...]}
+
+    @kopf.timer('kopfexamples', interval=5)
+    def tick_list(pods_list: kopf.Index, **_):
+        for ns, name in pods_list.get(None, []):
+            print(f"{ns}::{name}")
+
+Another way is to index them by keys --- when index lookups are going to happen
+more often than index iterations:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods')
+    def pods_dict(namespace, name, **_):
+        return {(namespace, name): None}
+        # {('namespace1', 'pod1a'): [None],
+        #  ('namespace1', 'pod1b'): [None],
+        #  ('namespace2', 'pod2a'): [None],
+        #  ('namespace2', 'pod2b'): [None],
+        #   ...}
+
+    @kopf.timer('kopfexamples', interval=5)
+    def tick_dict(pods_dict: kopf.Index, spec: kopf.Spec, namespace: str, **_):
+        monitored_namespace = spec.get('monitoredNamespace', namespace)
+        for ns, name in pods_dict:
+            if ns == monitored_namespace:
+                print(f"in {ns}: {name}")
+
+
+Mirroring resources
+-------------------
+
+To store the whole resource or its essential parts, return them explicitly:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('deployments')
+    def whole_deployments(name: str, namespace: str, body: kopf.Body, **_):
+        return {(namespace, name): body}
+
+    @kopf.timer('kopfexamples', interval=5)
+    def tick(whole_deployments: kopf.Index, **_):
+        deployment, *_ = whole_deployments[('kube-system', 'coredns')]
+        actual = deployment.status.get('replicas')
+        desired = deployment.spec.get('replicas')
+        print(f"{deployment.meta.name}: {actual}/{desired}")
+
+.. note::
+
+    Mind the memory consumption on large clusters and/or overly verbose objects.
+    Especially mind the memory consumption for "managed fields"
+    (see `kubernetes/kubernetes#90066`__).
+
+    __ https://github.com/kubernetes/kubernetes/issues/90066
+
+
+Indices of indices
+------------------
+
+Iterating over all keys of the index can be slow (especially if there are many
+keys: e.g. with thousands of pods). For that case, an index of an index
+can be built: with one primary indexing containing the real values to be used,
+while the other secondary index only contains the keys of the primary index
+(full or partial).
+
+By looking up a single key in the secondary index, the operator can directly
+get or indirectly reconstruct all the necessary keys in the primary index
+instead of iterating over the primary index with filtering.
+
+For example, we want to get all container names of all pods in a namespace.
+In that case, the primary index will index containers by pods' namespaces+names,
+while the secondary index will index pods' names by namespaces only:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods')
+    def primary(namespace, name, spec, **_):
+        container_names = {container['name'] for container in spec['containers']}
+        return {(namespace, name): container_names}
+        # {('namespace1', 'pod1a'): [{'main'}],
+        #  ('namespace1', 'pod1b'): [{'main', 'sidecar'}],
+        #  ('namespace2', 'pod2a'): [{'main'}],
+        #  ('namespace2', 'pod2b'): [{'the-only-one'}],
+        #   ...}
+
+    @kopf.index('pods')
+    def secondary(namespace, name, **_):
+        return {namespace: name}
+        # {'namespace1': ['pod1a', 'pod1b'],
+        #  'namespace2': ['pod2a', 'pod2b'],
+        #   ...}
+
+    @kopf.timer('kopfexamples', interval=5)
+    def tick(primary: kopf.Index, secondary: kopf.Index, spec: kopf.Spec, **_):
+        namespace_containers = set()
+        monitored_namespace = spec.get('monitoredNamespace', 'default')
+        for pod_name in secondary.get(monitored_namespace, []):
+            reconstructed_key = (monitored_namespace, pod_name)
+            pod_containers, *_ = primary[reconstructed_key]
+            namespace_containers |= pod_containers
+        print(f"containers in {monitored_namespace}: {namespace_containers}")
+        # containers in namespace1: {'main', 'sidecar'}
+        # containers in namespace2: {'main', 'the-only-one'}
+
+However, such complicated structures and such performance requirements are rare.
+For simplicity and performance, nested indices are not directly provided by
+the framework as a feature, only as this tip based on other official features.
+
+
+Conditional indexing
+====================
+
+Besides the usual filters (see :doc:`/filters`), the resources can be skipped
+from indexing by returning ``None`` (Python's default for no-result functions).
+
+If the indexing function returns ``None`` or does not return anything,
+its result is ignored and not indexed. The existing values in the index
+are preserved as they are (this is also the case when unexpected errors
+happen in the indexing function with the errors mode set to ``IGNORED``):
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods')
+    def empty_index(**_):
+        pass
+        # {}
+
+However, if the indexing function returns a dict with ``None`` as values,
+such values are indexed as usually (they are not ignored). ``None`` values
+can be used as placeholders when only the keys are sufficient; otherwise,
+indices and collections with no values left in them are removed from the index:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods')
+    def index_of_nones(**_):
+        return {'key': None}
+        # {'key': [None, None, ...]}
+
+
+Errors in indexing
+==================
+
+The indexing functions are supposed to be fast and non-blocking,
+as they are capable of delaying the operator startup and resource processing.
+For this reason, in case of errors in handlers, the handlers are never retried.
+
+Arbitrary exceptions with ``errors=IGNORED`` (the default) make the framework
+to ignore the error and keep the existing indexed values (which are now stale).
+It means that the new values are expected to appear soon, but the old values
+are good enough meanwhile (which is usually highly probable). This is the same
+as returning ``None``, except that the exception's stack trace is logged too:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods', errors=kopf.ErrorsMode.IGNORED)  # the default
+    def fn1(**_):
+        raise Exception("Keep the stale values, if any.")
+
+`kopf.PermanentError` and arbitrary exceptions with ``errors=PERMANENT``
+remove any existing indexed values and the resource's keys from the index,
+and exclude the failed resource from indexing by this index in the future
+(so that even the indexing function is not invoked for them):
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods', errors=kopf.ErrorsMode.PERMANENT)
+    def fn1(**_):
+        raise Exception("Excluded forever.")
+
+    @kopf.index('pods')
+    def fn2(**_):
+        raise kopf.PermamentError("Excluded forever.")
+
+`kopf.TemporaryError` and arbitrary exceptions with ``errors=TEMPORARY``
+remove any existing indexed values and the resource's keys from the index,
+and exclude the failed resource from indexing for the specified duration
+(via the error's ``delay`` option; set to ``0`` or ``None`` for no delay).
+It is expected that the resource could be reindexed in the future,
+but right now, problems are preventing this from happening:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.index('pods', errors=kopf.ErrorsMode.TEMPORARY)
+    def fn1(**_):
+        raise Exception("Excluded for 60s.")
+
+    @kopf.index('pods')
+    def fn2(**_):
+        raise kopf.TemporaryError("Excluded for 30s.", delay=30)
+
+In the "temporary" mode, the decorator's options for error handling are used:
+the ``backoff=`` is a default delay before the resource can be re-indexed
+(the default is 60 seconds; for no delay, use ``0`` explicitly);
+the ``retries=`` and ``timeout=`` are the limit of retries and the overall
+duration since the first failure until the resource will be marked
+as permanently excluded from indexing (unless it succeeds at some point).
+
+The handler's kwargs :kwarg:`retry`, :kwarg:`started`, :kwarg:`runtime`
+report the retrying attempts since the first indexing failure.
+Successful indexing resets all the counters/timeouts and the retrying state
+is not stored (to save memory).
+
+The same as with regular handlers (:doc:`errors`),
+Kopf's error classes (expected errors) only log a short message,
+while arbitrary exceptions (unexpected errors) also dump their stack traces.
+
+This matches the semantics of regular handlers but with in-memory specifics.
+
+.. warning::
+
+    **There is no good out-of-the-box default mode for error handling:**
+    any kind of errors in the indexing functions means that the index becomes
+    inconsistent with the actual state of the cluster and its resources:
+    the entries for matching resources are either "lost" (permanent or temporary
+    errors), or contain possibly outdated/stale values (ignored errors) ---
+    all of these cases are misinformation about the actual state of the cluster.
+
+    The default mode is chosen to reduce the index changes and reindexing
+    in case of frequent errors --- by not making any changes to the index.
+    Besides, the stale values can still be relevant and useful to some extent.
+
+    For two other cases, the operator developers have to explicitly accept the
+    risks by setting ``errors=`` if the operator can afford to lose the keys.
+
+
+Kwargs safety
+=============
+
+Indices that are injected into kwargs, overwrite any kwargs of the framework,
+existing and those to be added later. This guarantees that the new framework
+versions will not break an operator if new kwargs are added with the same name
+as the existing indices.
+
+In this case, the trade-off is that the handlers cannot use the new features
+until their indices are renamed to something else. Since the new features are
+new, the old operator's code does not use them, so it is backwards compatible.
+
+To reduce the probability of name collisions, keep these conventions in mind
+when naming indices (they are fully optional and for convenience only):
+
+* System kwargs are usually one-word; name your indices with 2+ words.
+* System kwargs are usually singular (not always); name the indices as plurals.
+* System kwargs are usually nouns; using abbreviations or prefixes/suffixes
+  (e.g. ``cnames``, ``rpods``) would reduce the probability of collisions.
+
+
+Performance
+===========
+
+Indexing can be a CPU- & RAM-consuming operation.
+The data structures behind indices are chosen to be as efficient as possible:
+
+* The index's lookups are O(1) --- as in Python's ``dict``.
+* The store's updates/deletions are O(1) -- a ``dict`` is used internally.
+* The overall updates/deletions are O(k), where "k" is the number of keys
+  per object (not of all keys!), which is fixed in most cases, so it is O(1).
+
+Neither the number of values stored in the index nor the overall amount of keys
+affect its performance (in theory).
+
+Some performance can be lost on additional method calls of the user-facing
+mappings/collections made to hide the internal ``dict`` structures.
+It is assumed to be negligible compared to the overall code overhead.
+
+
+Guarantees
+==========
+
+If an index is declared, there is no need to additionally pre-check for its
+existence --- the index exists immediately even if it contains no resources.
+
+The indices are guaranteed to be fully pre-populated before any other
+resource-related handlers are invoked in the operator.
+As such, even the on-creation handlers or raw event handlers are guaranteed
+to have the complete indexed overview of the cluster,
+not just partially populated to the moment when they happened to be triggered.
+
+There is no such guarantee for the operator handlers, such as startup/cleanup,
+authentication, health probing, and for the indexing functions themselves:
+the indices are available in kwargs but can be empty or partially populated
+in the operator's startup and index pre-population stage. This can affect
+the cleanup/login/probe handlers if they are invoked at that stage.
+
+Though, the indices are safe to be passed to threads/tasks for later processing
+if such threads/tasks are started from the before-mentioned startup handlers.
+
+
+Limitations
+===========
+
+All in-memory values are lost on operator restarts; there is no persistence.
+In particular, the indices are fully recalculated on operator restarts during
+the initial listing of the resources (equivalent to ``@kopf.on.event``).
+
+On large clusters with thousands of resources, the initial index population
+can take time, so the operator's processing will be delayed regardless of
+whether the handlers do use the indices or they do not (the framework cannot
+know this for sure).
+
+.. seealso::
+
+    :doc:`/memos` --- other in-memory structures with similar limitations.
+
+.. seealso::
+
+    Indexers and indices are conceptually similar to `client-go's indexers`__
+    -- with all the underlying components implemented inside of the framework
+    ("batteries included").
+
+    __ https://github.com/kubernetes/sample-controller/blob/master/docs/controller-client-go.md

--- a/docs/kwargs.rst
+++ b/docs/kwargs.rst
@@ -172,8 +172,27 @@ and later used to populate the resources' ``memo`` containers.
 
 .. seealso::
     :doc:`memos` and :class:`kopf.Memo`.
+
+
+.. kwarg:: indices
+.. kwarg:: indexes
+
+In-memory indices
+-----------------
+
+Indices are in-memory overviews of matching resources in the cluster.
+They are populated according to ``@kopf.index`` handlers and their filters.
+
+Each individual index is exposed in kwargs under its own name (function name)
+or id (if overridden with ``id=``). There is no global structure to access
+all indices at once. If needed, use ``**kwargs`` itself.
+
+Indices are available for all operator-level and all resource-level handlers.
+For resource handlers, they are guaranteed to be populated before any handlers
+are invoked. For operator handlers, there is no such guarantee.
+
 .. seealso::
-    :doc:`memories` and :class:`kopf.Memo`.
+    :doc:`indices`.
 
 
 Resource-watching kwargs

--- a/docs/memos.rst
+++ b/docs/memos.rst
@@ -160,3 +160,7 @@ For persistent values, use the status stanza or annotations of the resources.
 Essentially, the operator's memo is not much different from global variables
 (unless there are 2+ embedded operator tasks running) or asyncio contextvars,
 except that it provides the same interface as for per-resource memos.
+
+.. seealso::
+
+    :doc:`/indexing` --- other in-memory structures with similar limitations.

--- a/examples/16-indexing/example.py
+++ b/examples/16-indexing/example.py
@@ -1,0 +1,41 @@
+import pprint
+
+import kopf
+
+
+@kopf.index('pods')
+def is_running(namespace, name, status, **_):
+    return {(namespace, name): status.get('phase') == 'Running'}
+    # {('kube-system', 'traefik-...-...'): True,
+    #  ('kube-system', 'helm-install-traefik-...'): False,
+    #    ...}
+
+
+@kopf.index('pods')
+def by_label(labels, name, **_):
+    return {(label, value): name for label, value in labels.items()}
+    # {('app', 'traefik'): ['traefik-...-...'],
+    #  ('job-name', 'helm-install-traefik'): ['helm-install-traefik-...'],
+    #  ('helmcharts.helm.cattle.io/chart', 'traefik'): ['helm-install-traefik-...'],
+    #    ...}
+
+
+@kopf.on.probe()
+def pod_count(is_running: kopf.Index, **_):
+    return len(is_running)
+
+
+@kopf.on.probe()
+def pod_names(is_running: kopf.Index, **_):
+    return [name for _, name in is_running]
+
+
+@kopf.timer('kex', interval=5)
+def intervalled(is_running: kopf.Index, by_label: kopf.Index, patch: kopf.Patch, **_):
+    pprint.pprint(dict(by_label))
+    patch.status['running-pods'] = [
+        f"{ns}::{name}"
+        for (ns, name), is_running in is_running.items()
+        if ns in ['kube-system', 'default']
+        if is_running
+    ]

--- a/examples/16-indexing/example.py
+++ b/examples/16-indexing/example.py
@@ -39,3 +39,7 @@ def intervalled(is_running: kopf.Index, by_label: kopf.Index, patch: kopf.Patch,
         if ns in ['kube-system', 'default']
         if is_running
     ]
+
+
+# Marks for the e2e tests (see tests/e2e/test_examples.py):
+E2E_SUCCESS_COUNTS = {}  # we do not care: pods can have 6-10 updates here.

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -106,6 +106,8 @@ from kopf.structs.diffs import (
 )
 from kopf.structs.ephemera import (
     Memo,
+    Index,
+    Store,
 )
 from kopf.structs.filters import (
     ABSENT,
@@ -186,7 +188,7 @@ __all__ = [
     'BodyEssence',
     'ObjectReference',
     'OwnerReference',
-    'Memo',
+    'Memo', 'Index', 'Store',
     'ObjectLogger',
     'LocalObjectLogger',
     'FieldSpec',

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -27,6 +27,7 @@ from kopf.on import (
     register,
     daemon,
     timer,
+    index,
 )
 from kopf.reactor import (
     lifecycles,  # as a separate name on the public namespace
@@ -141,7 +142,7 @@ from kopf.utilities.piggybacking import (
 )
 
 __all__ = [
-    'on', 'lifecycles', 'register', 'execute', 'daemon', 'timer',
+    'on', 'lifecycles', 'register', 'execute', 'daemon', 'timer', 'index',
     'configure', 'LogFormat',
     'login_via_pykube', 'login_via_client', 'LoginError', 'ConnectionInfo',
     'event', 'info', 'warn', 'exception',

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -21,6 +21,7 @@ async def health_reporter(
         endpoint: str,
         *,
         memo: ephemera.AnyMemo,
+        indices: ephemera.Indices,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         ready_flag: Optional[asyncio.Event] = None,  # used for testing
@@ -55,6 +56,7 @@ async def health_reporter(
                         registry=registry,
                         settings=settings,
                         activity=handlers.Activity.PROBE,
+                        indices=indices,
                         memo=memo,
                     )
                     probing_container.clear()

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -44,6 +44,7 @@ async def authenticator(
         *,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
+        indices: ephemera.Indices,
         vault: credentials.Vault,
         memo: ephemera.AnyMemo,
 ) -> NoReturn:
@@ -53,6 +54,7 @@ async def authenticator(
         await authenticate(
             registry=registry,
             settings=settings,
+            indices=indices,
             vault=vault,
             memo=memo,
             _activity_title="Re-authentication" if counter else "Initial authentication",
@@ -64,6 +66,7 @@ async def authenticate(
         *,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
+        indices: ephemera.Indices,
         vault: credentials.Vault,
         memo: ephemera.AnyMemo,
         _activity_title: str = "Authentication",
@@ -81,6 +84,7 @@ async def authenticate(
         registry=registry,
         settings=settings,
         activity=handlers_.Activity.AUTHENTICATION,
+        indices=indices,
         memo=memo,
     )
 
@@ -100,6 +104,7 @@ async def run_activity(
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         activity: handlers_.Activity,
+        indices: ephemera.Indices,
         memo: ephemera.AnyMemo,
 ) -> Mapping[handlers_.HandlerId, callbacks.Result]:
     logger = logging.getLogger(f'kopf.activities.{activity.value}')
@@ -109,6 +114,7 @@ async def run_activity(
         logger=logger,
         activity=activity,
         settings=settings,
+        indices=indices,
         memo=memo,
     )
     handlers = registry._activities.get_handlers(activity=activity)

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -48,6 +48,14 @@ class ResourceCause(BaseCause):
 
 
 @dataclasses.dataclass
+class ResourceIndexingCause(ResourceCause):
+    """
+    The raw event received from the API.
+    """
+    pass
+
+
+@dataclasses.dataclass
 class ResourceWatchingCause(ResourceCause):
     """
     The raw event received from the API.

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -30,6 +30,7 @@ from kopf.structs import bodies, configuration, diffs, ephemera, \
 
 @dataclasses.dataclass
 class BaseCause:
+    indices: ephemera.Indices
     logger: Union[logging.Logger, logging.LoggerAdapter]
     memo: ephemera.AnyMemo
 

--- a/kopf/reactor/daemons.py
+++ b/kopf/reactor/daemons.py
@@ -56,6 +56,7 @@ async def spawn_resource_daemons(
             stopper = primitives.DaemonStopper()
             daemon_cause = causation.DaemonCause(
                 resource=cause.resource,
+                indices=cause.indices,
                 logger=cause.logger,
                 body=memory.live_fresh_body,
                 memo=memory.memo,

--- a/kopf/reactor/indexing.py
+++ b/kopf/reactor/indexing.py
@@ -1,0 +1,143 @@
+from typing import Any, Dict, Generic, Iterable, Iterator, Optional, Tuple, TypeVar
+
+from kopf.structs import ephemera, handlers, references
+
+Key = Tuple[references.Namespace, Optional[str], Optional[str]]
+_K = TypeVar('_K')
+_V = TypeVar('_V')
+
+
+class Store(ephemera.Store[_V], Generic[_V]):
+    """
+    A specific implementation of `.ephemera.Store` usable by inxeders.
+
+    The resources-to-values association is internal and is not exposed
+    to handlers or operators. Currently, it is a dictionary
+    with the keys of form ``(namespace, name, uid)`` of type `Key`,
+    but the implementation can later change without notice.
+    """
+    __items: Dict[Key, _V]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.__items = {}
+
+    def __repr__(self) -> str:
+        return repr(list(self.__items.values()))
+
+    def __bool__(self) -> bool:
+        return bool(self.__items)
+
+    def __len__(self) -> int:
+        return len(self.__items)
+
+    def __iter__(self) -> Iterator[_V]:
+        return iter(self.__items.values())
+
+    def __contains__(self, obj: object) -> bool:
+        return any(val == obj for val in self.__items.values())
+
+
+class Index(ephemera.Index[_K, _V], Generic[_K, _V]):
+    """
+    A specific implementation of `.ephemera.Index` usable by inxeders.
+
+    The indexers and all writing interfaces for indices are not exposed
+    to handlers or operators or developers, they remain strictly internal.
+    Only the read-only indices and stores are exposed.
+    """
+    __items: Dict[_K, Store[_V]]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.__items = {}
+
+    def __repr__(self) -> str:
+        return repr(self.__items)
+
+    def __bool__(self) -> bool:
+        return bool(self.__items)
+
+    def __len__(self) -> int:
+        return len(self.__items)
+
+    def __iter__(self) -> Iterator[_K]:
+        return iter(self.__items)
+
+    def __getitem__(self, item: _K) -> Store[_V]:
+        return self.__items[item]
+
+    def __contains__(self, item: object) -> bool:  # for performant lookups!
+        return item in self.__items
+
+
+class OperatorIndexer:
+    """
+    Indexers are read-write managers of read-only and minimalistic indices.
+
+    .. note::
+        Indexers are internal to the framework, they are not exposed
+        to the operator developers (except for embedded operators).
+    """
+    index: Index[Any, Any]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.index = Index()
+
+    def __repr__(self) -> str:
+        return repr(self.index)
+
+
+class OperatorIndexers(Dict[handlers.HandlerId, OperatorIndexer]):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.indices = OperatorIndices(self)
+
+    def ensure(self, __handlers: Iterable[handlers.ResourceIndexingHandler]) -> None:
+        """
+        Pre-create indices/indexers to match the existing handlers.
+
+        Any other indices will cause a KeyError at runtime.
+        This is done to control the consistency of in-memory structures.
+        """
+        for handler in __handlers:
+            self[handler.id] = OperatorIndexer()
+
+
+class OperatorIndices(ephemera.Indices):
+    """
+    A read-only view of indices of the operator.
+
+    This view is carried through the whole call stack of the operator
+    in a cause object, and later unfolded into the kwargs of the handlers.
+
+    Why? First, carrying the indexers creates a circular import chain:
+
+    * "causation" requires "OperatorIndexers" from "indexing".
+    * "indexing" requires "ResourceIndexingCause" from "causation".
+
+    The chain is broken by having a separate interface: `~ephemera.Indices`,
+    while the implementation remains here.
+
+    Second, read-write indexers create a temptation to modify them
+    in modules and components that should not do this.
+    Only "indexing" (this module) should modify the indices via indexers.
+    """
+
+    def __init__(self, indexers: "OperatorIndexers") -> None:
+        super().__init__()
+        self.__indexers = indexers
+
+    def __len__(self) -> int:
+        return len(self.__indexers)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.__indexers)
+
+    def __getitem__(self, id: str) -> Index[Any, Any]:
+        return self.__indexers[handlers.HandlerId(id)].index
+
+    def __contains__(self, id: object) -> bool:
+        return id in self.__indexers

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -89,6 +89,15 @@ def build_kwargs(
         new_kwargs.update(
             stopped=cause.stopper.sync_checker if _sync else cause.stopper.async_checker,
         )
+
+    # Inject indices in the end, so that they overwrite regular kwargs.
+    # Why? For backwards compatibility: if an operator's handlers use an index e.g. "children",
+    # and Kopf introduces a new kwarg "children", the code could break on the new version upgrade.
+    # To prevent this, overwrite it and let the developers rename it when they want the new kwarg.
+    # Naming new indices after the known kwargs harms only these developers. This is fine.
+    if isinstance(cause, causation.BaseCause):
+        new_kwargs.update(cause.indices)
+
     return new_kwargs
 
 

--- a/kopf/reactor/observation.py
+++ b/kopf/reactor/observation.py
@@ -91,6 +91,7 @@ async def resource_observer(
 
     # Scan only the resource-related handlers, ignore activies & co.
     all_handlers: List[handlers.ResourceHandler] = []
+    all_handlers.extend(registry._resource_indexing.get_all_handlers())
     all_handlers.extend(registry._resource_watching.get_all_handlers())
     all_handlers.extend(registry._resource_spawning.get_all_handlers())
     all_handlers.extend(registry._resource_changing.get_all_handlers())
@@ -199,6 +200,7 @@ def revise_resources(
 
     # Scan only the resource-related handlers, ignore activies & co.
     all_handlers: List[handlers.ResourceHandler] = []
+    all_handlers.extend(registry._resource_indexing.get_all_handlers())
     all_handlers.extend(registry._resource_watching.get_all_handlers())
     all_handlers.extend(registry._resource_spawning.get_all_handlers())
     all_handlers.extend(registry._resource_changing.get_all_handlers())

--- a/kopf/reactor/observation.py
+++ b/kopf/reactor/observation.py
@@ -27,7 +27,7 @@ from typing import Collection, List, Optional
 
 from kopf.clients import errors, fetching, scanning
 from kopf.reactor import queueing, registries
-from kopf.structs import bodies, configuration, handlers, references
+from kopf.structs import bodies, configuration, handlers, primitives, references
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +138,8 @@ async def process_discovered_namespace_event(
         insights: references.Insights,
         # Must be accepted whether used or not -- as passed by watcher()/worker().
         stream_pressure: Optional[asyncio.Event] = None,  # None for tests
+        resource_indexed: Optional[primitives.Toggle] = None,  # None for tests & observation
+        operator_indexed: Optional[primitives.ToggleSet] = None,  # None for tests & observation
 ) -> None:
     if raw_event['type'] is None:
         return
@@ -154,6 +156,8 @@ async def process_discovered_resource_event(
         insights: references.Insights,
         # Must be accepted whether used or not -- as passed by watcher()/worker().
         stream_pressure: Optional[asyncio.Event] = None,  # None for tests
+        resource_indexed: Optional[primitives.Toggle] = None,  # None for tests & observation
+        operator_indexed: Optional[primitives.ToggleSet] = None,  # None for tests & observation
 ) -> None:
     # Ignore the initial listing, as all custom resources were already noticed by API listing.
     # This prevents numerous unneccessary API requests at the the start of the operator.

--- a/kopf/reactor/orchestration.py
+++ b/kopf/reactor/orchestration.py
@@ -27,7 +27,7 @@ import dataclasses
 import functools
 import itertools
 import logging
-from typing import Any, Collection, Container, Dict, MutableMapping, NamedTuple
+from typing import Any, Collection, Container, Dict, MutableMapping, NamedTuple, Optional
 
 from kopf.engines import peering
 from kopf.reactor import queueing
@@ -148,6 +148,7 @@ async def adjust_tasks(
     await spawn_missing_watchers(ensemble=ensemble,
                                  settings=settings,
                                  processor=processor,
+                                 indexable=insights.indexable,
                                  resources=insights.resources,
                                  namespaces=insights.namespaces)
 
@@ -214,23 +215,37 @@ async def spawn_missing_watchers(
         processor: queueing.WatchStreamProcessor,
         settings: configuration.OperatorSettings,
         resources: Collection[references.Resource],
+        indexable: Collection[references.Resource],
         namespaces: Collection[references.Namespace],
         ensemble: Ensemble,
 ) -> None:
+
+    # Block the operator globally until specialised per-resource-kind blockers are created.
+    # NB: Must be created before the point of parallelisation!
+    operator_blocked = await ensemble.operator_indexed.make_toggle(name="orchestration blocker")
+
+    # Spawn watchers and create the specialised per-resource-kind blockers.
     for resource, namespace in itertools.product(resources, namespaces):
         namespace = namespace if resource.namespaced else None
         dkey = EnsembleKey(resource=resource, namespace=namespace)
         if dkey not in ensemble.watcher_tasks:
             what = f"{resource}@{namespace}"
+            resource_indexed: Optional[primitives.Toggle] = None
+            if resource in indexable:
+                resource_indexed = await ensemble.operator_indexed.make_toggle(name=what)
             ensemble.watcher_tasks[dkey] = aiotasks.create_guarded_task(
                 name=f"watcher for {what}", logger=logger, cancellable=True,
                 coro=queueing.watcher(
                     operator_paused=ensemble.operator_paused,
                     operator_indexed=ensemble.operator_indexed,
+                    resource_indexed=resource_indexed,
                     settings=settings,
                     resource=resource,
                     namespace=namespace,
                     processor=functools.partial(processor, resource=resource)))
+
+    # Unblock globally, let the specialised per-resource-kind blockers hold the readiness.
+    await ensemble.operator_indexed.drop_toggle(operator_blocked)
 
     # Ensure that all guarded tasks got control for a moment to enter the guard.
     await asyncio.sleep(0)

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -85,7 +85,7 @@ async def process_resource_event(
                 resource=resource,
                 raw_event=raw_event,
                 body=body,
-                memo=memory.memo,
+                memory=memory,
                 logger=loggers.TerseObjectLogger(body=body, settings=settings),
             )
 

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -18,7 +18,7 @@ import time
 from typing import Collection, Optional, Tuple
 
 from kopf.engines import loggers, posting
-from kopf.reactor import causation, daemons, effects, handling, lifecycles, registries
+from kopf.reactor import causation, daemons, effects, handling, indexing, lifecycles, registries
 from kopf.storage import finalizers, states
 from kopf.structs import bodies, configuration, containers, diffs, ephemera, \
                          handlers as handlers_, patches, references
@@ -26,6 +26,7 @@ from kopf.structs import bodies, configuration, containers, diffs, ephemera, \
 
 async def process_resource_event(
         lifecycle: lifecycles.LifeCycleFn,
+        indexers: indexing.OperatorIndexers,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         memories: containers.ResourceMemories,
@@ -79,6 +80,7 @@ async def process_resource_event(
             # Do the magic -- do the job.
             delays, matched = await process_resource_causes(
                 lifecycle=lifecycle,
+                indexers=indexers,
                 registry=registry,
                 settings=settings,
                 resource=resource,
@@ -108,6 +110,7 @@ async def process_resource_event(
 
 async def process_resource_causes(
         lifecycle: lifecycles.LifeCycleFn,
+        indexers: indexing.OperatorIndexers,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         resource: references.Resource,
@@ -133,6 +136,7 @@ async def process_resource_causes(
     resource_watching_cause = causation.detect_resource_watching_cause(
         raw_event=raw_event,
         resource=resource,
+        indices=indexers.indices,
         logger=logger,
         patch=patch,
         body=body,
@@ -141,6 +145,7 @@ async def process_resource_causes(
 
     resource_spawning_cause = causation.detect_resource_spawning_cause(
         resource=resource,
+        indices=indexers.indices,
         logger=logger,
         patch=patch,
         body=body,
@@ -152,6 +157,7 @@ async def process_resource_causes(
         finalizer=finalizer,
         raw_event=raw_event,
         resource=resource,
+        indices=indexers.indices,
         logger=logger,
         patch=patch,
         body=body,

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -177,7 +177,7 @@ async def spawn_tasks(
     event_queue: posting.K8sEventQueue = asyncio.Queue()
     signal_flag: aiotasks.Future = asyncio.Future()
     started_flag: asyncio.Event = asyncio.Event()
-    operator_paused = primitives.ToggleSet()
+    operator_paused = primitives.ToggleSet(any)
     tasks: MutableSequence[aiotasks.Task] = []
 
     # Map kwargs into the settings object.

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -8,8 +8,8 @@ from typing import Collection, Coroutine, MutableSequence, Optional, Sequence
 
 from kopf.clients import auth
 from kopf.engines import peering, posting, probing
-from kopf.reactor import activities, daemons, lifecycles, observation, \
-                         orchestration, processing, registries
+from kopf.reactor import activities, daemons, indexing, lifecycles, \
+                         observation, orchestration, processing, registries
 from kopf.structs import configuration, containers, credentials, \
                          ephemera, handlers, primitives, references
 from kopf.utilities import aiotasks
@@ -21,6 +21,7 @@ def run(
         *,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         lifecycle: Optional[lifecycles.LifeCycleFn] = None,
+        indexers: Optional[indexing.OperatorIndexers] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         settings: Optional[configuration.OperatorSettings] = None,
         memories: Optional[containers.ResourceMemories] = None,
@@ -48,6 +49,7 @@ def run(
     try:
         loop.run_until_complete(operator(
             lifecycle=lifecycle,
+            indexers=indexers,
             registry=registry,
             settings=settings,
             memories=memories,
@@ -73,6 +75,7 @@ def run(
 async def operator(
         *,
         lifecycle: Optional[lifecycles.LifeCycleFn] = None,
+        indexers: Optional[indexing.OperatorIndexers] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         settings: Optional[configuration.OperatorSettings] = None,
         memories: Optional[containers.ResourceMemories] = None,
@@ -102,6 +105,7 @@ async def operator(
     existing_tasks = await aiotasks.all_tasks()
     operator_tasks = await spawn_tasks(
         lifecycle=lifecycle,
+        indexers=indexers,
         registry=registry,
         settings=settings,
         memories=memories,
@@ -126,6 +130,7 @@ async def operator(
 async def spawn_tasks(
         *,
         lifecycle: Optional[lifecycles.LifeCycleFn] = None,
+        indexers: Optional[indexing.OperatorIndexers] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         settings: Optional[configuration.OperatorSettings] = None,
         memories: Optional[containers.ResourceMemories] = None,
@@ -170,6 +175,7 @@ async def spawn_tasks(
     registry = registry if registry is not None else registries.get_default_registry()
     settings = settings if settings is not None else configuration.OperatorSettings()
     memories = memories if memories is not None else containers.ResourceMemories()
+    indexers = indexers if indexers is not None else indexing.OperatorIndexers()
     insights = insights if insights is not None else references.Insights()
     identity = identity if identity is not None else peering.detect_own_id(manual=False)
     vault = vault if vault is not None else credentials.Vault()
@@ -189,6 +195,9 @@ async def spawn_tasks(
         settings.peering.standalone = standalone
     if priority is not None:
         settings.peering.priority = priority
+
+    # Prepopulate indexers with empty indices -- to be available startup handlers.
+    indexers.ensure(registry._resource_indexing.get_all_handlers())
 
     # Global credentials store for this operator, also for CRD-reading & peering mode detection.
     auth.vault_var.set(vault)
@@ -216,6 +225,7 @@ async def spawn_tasks(
             started_flag=started_flag,
             registry=registry,
             settings=settings,
+            indices=indexers.indices,
             vault=vault,
             memo=memo)))  # to purge & finalize the caches in the end.
 
@@ -233,6 +243,7 @@ async def spawn_tasks(
         coro=activities.authenticator(
             registry=registry,
             settings=settings,
+            indices=indexers.indices,
             vault=vault,
             memo=memo)))
 
@@ -252,6 +263,7 @@ async def spawn_tasks(
                 registry=registry,
                 settings=settings,
                 endpoint=liveness_endpoint,
+                indices=indexers.indices,
                 memo=memo)))
 
     # Permanent observation of what resource kinds and namespaces are available in the cluster.
@@ -288,6 +300,7 @@ async def spawn_tasks(
                                             lifecycle=lifecycle,
                                             registry=registry,
                                             settings=settings,
+                                            indexers=indexers,
                                             memories=memories,
                                             memobase=memo,
                                             event_queue=event_queue))))
@@ -433,6 +446,7 @@ async def _startup_cleanup_activities(
         started_flag: asyncio.Event,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
+        indices: ephemera.Indices,
         vault: credentials.Vault,
         memo: ephemera.AnyMemo,
 ) -> None:
@@ -456,6 +470,7 @@ async def _startup_cleanup_activities(
             registry=registry,
             settings=settings,
             activity=handlers.Activity.STARTUP,
+            indices=indices,
             memo=memo,
         )
     except asyncio.CancelledError:
@@ -489,6 +504,7 @@ async def _startup_cleanup_activities(
             registry=registry,
             settings=settings,
             activity=handlers.Activity.CLEANUP,
+            indices=indices,
             memo=memo,
         )
         await vault.close()

--- a/kopf/storage/states.py
+++ b/kopf/storage/states.py
@@ -231,6 +231,14 @@ class State(Mapping[handlers_.HandlerId, HandlerState]):
             for handler_id, handler_state in self.items()
         }, purpose=self.purpose)
 
+    def without_successes(self) -> "State":
+        cls = type(self)
+        return cls({
+            handler_id: handler_state
+            for handler_id, handler_state in self.items()
+            if not handler_state.success # i.e. failures & in-progress/retrying
+        })
+
     def store(
             self,
             body: bodies.Body,

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -89,6 +89,7 @@ class ResourceDaemonSyncFn(Protocol):
             uid: Optional[str],
             name: Optional[str],
             namespace: Optional[str],
+            patch: patches.Patch,
             logger: Union[logging.Logger, logging.LoggerAdapter],
             stopped: primitives.SyncDaemonStopperChecker,  # << different type
             resource: references.Resource,
@@ -108,6 +109,7 @@ class ResourceDaemonAsyncFn(Protocol):
             uid: Optional[str],
             name: Optional[str],
             namespace: Optional[str],
+            patch: patches.Patch,
             logger: Union[logging.Logger, logging.LoggerAdapter],
             stopped: primitives.AsyncDaemonStopperChecker,  # << different type
             resource: references.Resource,
@@ -130,6 +132,7 @@ class ResourceTimerFn(Protocol):
             uid: Optional[str],
             name: Optional[str],
             namespace: Optional[str],
+            patch: patches.Patch,
             logger: Union[logging.Logger, logging.LoggerAdapter],
             resource: references.Resource,
             memo: ephemera.AnyMemo,

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -35,6 +35,25 @@ class ActivityFn(Protocol):
     ) -> _SyncOrAsyncResult: ...
 
 
+class ResourceIndexingFn(Protocol):
+    def __call__(  # lgtm[py/similar-function]
+            self,
+            *args: Any,
+            body: bodies.Body,
+            meta: bodies.Meta,
+            spec: bodies.Spec,
+            status: bodies.Status,
+            uid: Optional[str],
+            name: Optional[str],
+            namespace: Optional[str],
+            patch: patches.Patch,
+            logger: Union[logging.Logger, logging.LoggerAdapter],
+            resource: references.Resource,
+            memo: ephemera.AnyMemo,
+            **kwargs: Any,
+    ) -> _SyncOrAsyncResult: ...
+
+
 class ResourceWatchingFn(Protocol):
     def __call__(  # lgtm[py/similar-function]
             self,

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -13,6 +13,7 @@ import logging
 import time
 from typing import Dict, Iterator, MutableMapping, Optional, Set, Union
 
+from kopf.storage import states
 from kopf.structs import bodies, ephemera, handlers, primitives
 from kopf.utilities import aiotasks
 
@@ -52,6 +53,9 @@ class ResourceMemory:
     idle_reset_time: float = dataclasses.field(default_factory=time.monotonic)
     forever_stopped: Set[handlers.HandlerId] = dataclasses.field(default_factory=set)
     running_daemons: Dict[handlers.HandlerId, Daemon] = dataclasses.field(default_factory=dict)
+
+    # For indexing errors backoffs/retries/timeouts. It is None when successfully indexed.
+    indexing_state: Optional[states.State] = None
 
 
 class ResourceMemories:

--- a/kopf/structs/ephemera.py
+++ b/kopf/structs/ephemera.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union
+from typing import Any, Collection, Dict, Generic, Mapping, TypeVar, Union
 
 # Used for type-checking of embedded operators, where it can have any type.
 # It is usually of type `Memo` -- but the framework must not rely on that.
@@ -46,3 +46,49 @@ class Memo(Dict[Any, Any]):
             return self[key]
         except KeyError as e:
             raise AttributeError(str(e))
+
+
+_K = TypeVar('_K')
+_V = TypeVar('_V')
+
+
+class Store(Collection[_V], Generic[_V]):
+    """
+    A collection of all values under a single unique index key.
+
+    Multiple objects can yield the same keys, so all their values
+    are accumulated into collections. When an object is deleted
+    or stops matching the filters, all associated values are discarded.
+
+    The order of values is not guaranteed.
+
+    The values are not deduplicated, so duplicates are possible if multiple
+    objects return the same values from their indexing functions.
+
+    .. note::
+        This class is only an abstract interface of an indexed store.
+        The actual implementation is in `.indexing.Store`.
+
+    .. seealso:
+        :doc:`/indexing`.
+    """
+
+
+class Index(Mapping[_K, Store[_V]], Generic[_K, _V]):
+    """
+    A mapping of index keys to collections of values indexed under those keys.
+
+    A single index is identified by a handler id and is populated by values
+    usually from a single indexing function (the ``@kopf.index()`` decorator).
+
+    .. note::
+        This class is only an abstract interface of an index.
+        The actual implementation is in `.indexing.Index`.
+
+    .. seealso:
+        :doc:`/indexing`.
+    """
+
+
+# Only an abstract interface. Implementated in `~indexing.Indices`.
+Indices = Mapping[str, Index[Any, Any]]

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -106,6 +106,18 @@ class ResourceHandler(BaseHandler):
 
 
 @dataclasses.dataclass
+class ResourceIndexingHandler(ResourceHandler):
+    fn: callbacks.ResourceIndexingFn  # type clarification
+
+    def __str__(self) -> str:
+        return f"Indexer {self.id!r}"
+
+    @property
+    def requires_patching(self) -> bool:
+        return False
+
+
+@dataclasses.dataclass
 class ResourceWatchingHandler(ResourceHandler):
     fn: callbacks.ResourceWatchingFn  # type clarification
 

--- a/kopf/structs/references.py
+++ b/kopf/structs/references.py
@@ -479,3 +479,6 @@ class Insights:
     # The flags that are set after the initial listing is finished. Not cleared afterwards.
     ready_namespaces: asyncio.Event = dataclasses.field(default_factory=asyncio.Event)
     ready_resources: asyncio.Event = dataclasses.field(default_factory=asyncio.Event)
+
+    # The resources that are part of indices and can block the operator readiness on start.
+    indexable: Set[Resource] = dataclasses.field(default_factory=set)

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -1,6 +1,7 @@
 import pytest
 
 from kopf.reactor.activities import authenticate
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.credentials import ConnectionInfo, LoginError, Vault
 from kopf.structs.ephemera import Memo
@@ -16,6 +17,7 @@ async def test_empty_registry_produces_no_credentials(settings):
         settings=settings,
         vault=vault,
         memo=Memo(),
+        indices=OperatorIndexers().indices,
     )
 
     assert not vault
@@ -42,6 +44,7 @@ async def test_noreturn_handler_produces_no_credentials(settings):
         settings=settings,
         vault=vault,
         memo=Memo(),
+        indices=OperatorIndexers().indices,
     )
 
     assert not vault
@@ -69,6 +72,7 @@ async def test_single_credentials_provided_to_vault(settings):
         settings=settings,
         vault=vault,
         memo=Memo(),
+        indices=OperatorIndexers().indices,
     )
 
     assert vault

--- a/tests/basic-structs/test_causes.py
+++ b/tests/basic-structs/test_causes.py
@@ -12,22 +12,26 @@ def test_cause_with_no_args(cls):
 def test_activity_cause(mocker):
     memo = mocker.Mock()
     logger = mocker.Mock()
+    indices = mocker.Mock()
     activity = mocker.Mock()
     settings = mocker.Mock()
     cause = ActivityCause(
         activity=activity,
         settings=settings,
+        indices=indices,
         logger=logger,
         memo=memo,
     )
     assert cause.activity is activity
     assert cause.settings is settings
+    assert cause.indices is indices
     assert cause.logger is logger
     assert cause.memo is memo
 
 
 def test_resource_watching_cause(mocker):
     logger = mocker.Mock()
+    indices = mocker.Mock()
     resource = mocker.Mock()
     body = mocker.Mock()
     patch = mocker.Mock()
@@ -36,6 +40,7 @@ def test_resource_watching_cause(mocker):
     raw = mocker.Mock()
     cause = ResourceWatchingCause(
         resource=resource,
+        indices=indices,
         logger=logger,
         body=body,
         patch=patch,
@@ -44,6 +49,7 @@ def test_resource_watching_cause(mocker):
         raw=raw,
     )
     assert cause.resource is resource
+    assert cause.indices is indices
     assert cause.logger is logger
     assert cause.body is body
     assert cause.patch is patch
@@ -54,6 +60,7 @@ def test_resource_watching_cause(mocker):
 
 def test_resource_changing_cause_with_all_args(mocker):
     logger = mocker.Mock()
+    indices = mocker.Mock()
     resource = mocker.Mock()
     reason = mocker.Mock()
     initial = mocker.Mock()
@@ -65,6 +72,7 @@ def test_resource_changing_cause_with_all_args(mocker):
     new = mocker.Mock()
     cause = ResourceChangingCause(
         resource=resource,
+        indices=indices,
         logger=logger,
         reason=reason,
         initial=initial,
@@ -76,6 +84,7 @@ def test_resource_changing_cause_with_all_args(mocker):
         new=new,
     )
     assert cause.resource is resource
+    assert cause.indices is indices
     assert cause.logger is logger
     assert cause.reason is reason
     assert cause.initial is initial
@@ -89,6 +98,7 @@ def test_resource_changing_cause_with_all_args(mocker):
 
 def test_resource_changing_cause_with_only_required_args(mocker):
     logger = mocker.Mock()
+    indices = mocker.Mock()
     resource = mocker.Mock()
     reason = mocker.Mock()
     initial = mocker.Mock()
@@ -97,6 +107,7 @@ def test_resource_changing_cause_with_only_required_args(mocker):
     memo = mocker.Mock()
     cause = ResourceChangingCause(
         resource=resource,
+        indices=indices,
         logger=logger,
         reason=reason,
         initial=initial,
@@ -105,6 +116,7 @@ def test_resource_changing_cause_with_only_required_args(mocker):
         memo=memo,
     )
     assert cause.resource is resource
+    assert cause.indices is indices
     assert cause.logger is logger
     assert cause.reason is reason
     assert cause.initial is initial

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -118,6 +118,7 @@ def kwargs():
     return dict(
         finalizer=FINALIZER,
         resource=object(),
+        indices=object(),
         logger=object(),
         patch=object(),
         memo=object(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from kopf.engines.loggers import ObjectPrefixingTextFormatter, configure
 from kopf.engines.posting import settings_var
 from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.configuration import OperatorSettings
+from kopf.structs.containers import ResourceMemories
 from kopf.structs.credentials import ConnectionInfo, Vault, VaultKey
 from kopf.structs.references import Resource, Selector
 
@@ -154,6 +155,11 @@ def namespace(resource):
 @pytest.fixture()
 def settings():
     return OperatorSettings()
+
+
+@pytest.fixture()
+def memories():
+    return ResourceMemories()
 
 
 @pytest.fixture()

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -62,6 +62,7 @@ def k8s_mocked(mocker, resp_mocker):
 
 @dataclasses.dataclass(frozen=True, eq=False, order=False)
 class HandlersContainer:
+    index_mock: Mock
     event_mock: Mock
     create_mock: Mock
     update_mock: Mock
@@ -76,11 +77,16 @@ class HandlersContainer:
 
 @pytest.fixture()
 def handlers(registry):
+    index_mock = Mock(return_value=None)
     event_mock = Mock(return_value=None)
     create_mock = Mock(return_value=None)
     update_mock = Mock(return_value=None)
     delete_mock = Mock(return_value=None)
     resume_mock = Mock(return_value=None)
+
+    @kopf.index('kopfexamples', id='index_fn')
+    async def index_fn(**kwargs):
+        return index_mock(**kwargs)
 
     @kopf.on.event('kopfexamples', id='event_fn')
     async def event_fn(**kwargs):
@@ -105,6 +111,7 @@ def handlers(registry):
         return delete_mock(**kwargs)
 
     return HandlersContainer(
+        index_mock=index_mock,
         event_mock=event_mock,
         create_mock=create_mock,
         update_mock=update_mock,
@@ -120,11 +127,16 @@ def handlers(registry):
 
 @pytest.fixture()
 def extrahandlers(registry, handlers):
+    index_mock = Mock(return_value=None)
     event_mock = Mock(return_value=None)
     create_mock = Mock(return_value=None)
     update_mock = Mock(return_value=None)
     delete_mock = Mock(return_value=None)
     resume_mock = Mock(return_value=None)
+
+    @kopf.index('kopfexamples', id='index_fn2')
+    async def index_fn2(**kwargs):
+        return index_mock(**kwargs)
 
     @kopf.on.event('kopfexamples', id='event_fn2')
     async def event_fn2(**kwargs):
@@ -149,6 +161,7 @@ def extrahandlers(registry, handlers):
         return delete_mock(**kwargs)
 
     return HandlersContainer(
+        index_mock=index_mock,
         event_mock=event_mock,
         create_mock=create_mock,
         update_mock=update_mock,

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -40,11 +40,6 @@ def dummy():
 
 
 @pytest.fixture()
-def memories():
-    return ResourceMemories()
-
-
-@pytest.fixture()
 def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
     """
     Simulate K8s behaviour locally in memory (some meaningful approximation).

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 import kopf
 from kopf.reactor.daemons import daemon_killer
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.bodies import RawBody
 from kopf.structs.containers import ResourceMemories
@@ -66,6 +67,7 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
             resource=resource,
             memories=memories,
             memobase=Memo(),
+            indexers=OperatorIndexers(),
             raw_event={'type': 'irrelevant', 'object': event_object},
             event_queue=asyncio.Queue(),
         )

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -79,7 +79,7 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
 
 @pytest.fixture()
 async def operator_paused():
-    return ToggleSet()
+    return ToggleSet(any)
 
 
 @pytest.fixture()

--- a/tests/handling/indexing/conftest.py
+++ b/tests/handling/indexing/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+
+from kopf.reactor.indexing import OperatorIndexer, OperatorIndexers
+from kopf.structs.bodies import Body
+
+
+@pytest.fixture()
+def indexers():
+    return OperatorIndexers()
+
+
+@pytest.fixture()
+def index(indexers):
+    indexer = OperatorIndexer()
+    indexers['index_fn'] = indexer
+    return indexer.index
+
+
+@pytest.fixture()
+async def indexed_123(indexers, index):
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    key = indexers.make_key(Body(body))
+    indexers['index_fn'].replace(key, 123)
+    assert set(index) == {None}
+    assert set(index[None]) == {123}

--- a/tests/handling/indexing/test_blocking_until_indexed.py
+++ b/tests/handling/indexing/test_blocking_until_indexed.py
@@ -1,0 +1,107 @@
+import asyncio
+import logging
+
+import async_timeout
+import pytest
+
+from kopf.reactor.lifecycles import all_at_once
+from kopf.reactor.processing import process_resource_event
+from kopf.structs.containers import ResourceMemories
+from kopf.structs.ephemera import Memo
+from kopf.structs.primitives import ToggleSet
+
+EVENT_TYPES_WHEN_EXISTS = [None, 'ADDED', 'MODIFIED']
+EVENT_TYPES_WHEN_GONE = ['DELETED']
+EVENT_TYPES = EVENT_TYPES_WHEN_EXISTS + EVENT_TYPES_WHEN_GONE
+
+
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_reporting_on_resource_readiness(
+        resource, settings, registry, indexers, caplog, event_type, handlers, timer):
+    caplog.set_level(logging.DEBUG)
+
+    operator_indexed = ToggleSet(all)
+    resource_indexed = await operator_indexed.make_toggle()
+    async with timer, async_timeout.timeout(0.5) as timeout:
+        await process_resource_event(
+            lifecycle=all_at_once,
+            registry=registry,
+            settings=settings,
+            resource=resource,
+            indexers=indexers,
+            memories=ResourceMemories(),
+            memobase=Memo(),
+            raw_event={'type': event_type, 'object': {}},
+            event_queue=asyncio.Queue(),
+            operator_indexed=operator_indexed,
+            resource_indexed=resource_indexed,
+        )
+    assert not timeout.expired
+    assert timer.seconds < 0.2  # asap, nowait
+    assert operator_indexed.is_on()
+    assert set(operator_indexed) == set()  # save RAM
+    assert handlers.event_mock.called
+
+
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_blocking_when_operator_is_not_ready(
+        resource, settings, registry, indexers, caplog, event_type, handlers, timer):
+    caplog.set_level(logging.DEBUG)
+
+    operator_indexed = ToggleSet(all)
+    resource_listed = await operator_indexed.make_toggle()
+    resource_indexed = await operator_indexed.make_toggle()
+    with pytest.raises(asyncio.TimeoutError):
+        async with timer, async_timeout.timeout(0.2) as timeout:
+            await process_resource_event(
+                lifecycle=all_at_once,
+                registry=registry,
+                settings=settings,
+                resource=resource,
+                indexers=indexers,
+                memories=ResourceMemories(),
+                memobase=Memo(),
+                raw_event={'type': event_type, 'object': {}},
+                event_queue=asyncio.Queue(),
+                operator_indexed=operator_indexed,
+                resource_indexed=resource_indexed,
+            )
+    assert timeout.expired
+    assert 0.2 < timer.seconds < 0.4
+    assert operator_indexed.is_off()
+    assert set(operator_indexed) == {resource_listed}
+    assert not handlers.event_mock.called
+
+
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_unblocking_once_operator_is_ready(
+        resource, settings, registry, indexers, caplog, event_type, handlers, timer):
+    caplog.set_level(logging.DEBUG)
+
+    async def delayed_readiness(delay: float):
+        await asyncio.sleep(delay)
+        await resource_listed.turn_to(True)
+
+    operator_indexed = ToggleSet(all)
+    resource_listed = await operator_indexed.make_toggle()
+    resource_indexed = await operator_indexed.make_toggle()
+    async with timer, async_timeout.timeout(1.0) as timeout:
+        asyncio.create_task(delayed_readiness(0.2))
+        await process_resource_event(
+            lifecycle=all_at_once,
+            registry=registry,
+            settings=settings,
+            resource=resource,
+            indexers=indexers,
+            memories=ResourceMemories(),
+            memobase=Memo(),
+            raw_event={'type': event_type, 'object': {}},
+            event_queue=asyncio.Queue(),
+            operator_indexed=operator_indexed,
+            resource_indexed=resource_indexed,
+        )
+    assert not timeout.expired
+    assert 0.2 < timer.seconds < 0.4
+    assert operator_indexed.is_on()
+    assert set(operator_indexed) == {resource_listed}
+    assert handlers.event_mock.called

--- a/tests/handling/indexing/test_index_exclusion.py
+++ b/tests/handling/indexing/test_index_exclusion.py
@@ -1,0 +1,204 @@
+import asyncio
+import datetime
+import logging
+
+import freezegun
+import pytest
+
+from kopf.reactor.handling import PermanentError, TemporaryError
+from kopf.reactor.lifecycles import all_at_once
+from kopf.reactor.processing import process_resource_event
+from kopf.storage.states import HandlerState, State
+from kopf.structs.ephemera import Memo
+
+EVENT_TYPES_WHEN_EXISTS = [None, 'ADDED', 'MODIFIED']
+EVENT_TYPES_WHEN_GONE = ['DELETED']
+EVENT_TYPES = EVENT_TYPES_WHEN_EXISTS + EVENT_TYPES_WHEN_GONE
+
+
+#
+# PART 1/2:
+# First, test that the initial indexing state is interpreted properly
+# and that it affects the indexing decision (to do or not to do).
+#
+
+
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_successes_are_removed_from_the_indexing_state(
+        resource, settings, registry, memories, indexers, caplog, event_type, handlers):
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    memory = await memories.recall(raw_body=body)
+    memory.indexing_state = State({'unrelated': HandlerState(success=True)})
+    handlers.index_mock.side_effect = 123
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=memories,
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert handlers.index_mock.call_count == 1
+    assert memory.indexing_state is None
+
+
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_temporary_failures_with_no_delays_are_reindexed(
+        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers):
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    memory = await memories.recall(raw_body=body)
+    memory.indexing_state = State({'index_fn': HandlerState(delayed=None)})
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=memories,
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert handlers.index_mock.call_count == 1
+
+
+@freezegun.freeze_time('2020-12-31T23:59:59.123456')
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_temporary_failures_with_expired_delays_are_reindexed(
+        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers):
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    delayed = datetime.datetime(2020, 12, 31, 23, 59, 59, 0)
+    memory = await memories.recall(raw_body=body)
+    memory.indexing_state = State({'index_fn': HandlerState(delayed=delayed)})
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=memories,
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert handlers.index_mock.call_count == 1
+
+
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_permanent_failures_are_not_reindexed(
+        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers):
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    memory = await memories.recall(raw_body=body)
+    memory.indexing_state = State({'index_fn': HandlerState(failure=True)})
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=memories,
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert handlers.index_mock.call_count == 0
+
+
+#
+# PART 2/2:
+# Once the resulting indexing state's and its effect on reindexing is tested,
+# we can assert that some specific state is reached without actually reindexing.
+#
+
+
+@pytest.mark.usefixtures('indexed_123')
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_removed_and_remembered_on_permanent_errors(
+        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers):
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    memory = await memories.recall(raw_body=body)
+    handlers.index_mock.side_effect = PermanentError("boo!")
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=memories,
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert set(index) == set()
+    assert memory.indexing_state['index_fn'].finished == True
+    assert memory.indexing_state['index_fn'].failure == True
+    assert memory.indexing_state['index_fn'].success == False
+    assert memory.indexing_state['index_fn'].message == 'boo!'
+    assert memory.indexing_state['index_fn'].delayed == None
+
+
+@freezegun.freeze_time('2020-12-31T00:00:00')
+@pytest.mark.parametrize('delay_kwargs, expected_delayed', [
+    (dict(), datetime.datetime(2020, 12, 31, 0, 1, 0)),
+    (dict(delay=0), datetime.datetime(2020, 12, 31, 0, 0, 0)),
+    (dict(delay=9), datetime.datetime(2020, 12, 31, 0, 0, 9)),
+    (dict(delay=None), None),
+])
+@pytest.mark.usefixtures('indexed_123')
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_removed_and_remembered_on_temporary_errors(
+        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers,
+        delay_kwargs, expected_delayed):
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    memory = await memories.recall(raw_body=body)
+    handlers.index_mock.side_effect = TemporaryError("boo!", **delay_kwargs)
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=memories,
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert set(index) == set()
+    assert memory.indexing_state['index_fn'].finished == False
+    assert memory.indexing_state['index_fn'].failure == False
+    assert memory.indexing_state['index_fn'].success == False
+    assert memory.indexing_state['index_fn'].message == 'boo!'
+    assert memory.indexing_state['index_fn'].delayed == expected_delayed
+
+
+@pytest.mark.usefixtures('indexed_123')
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_preserved_on_ignored_errors(
+        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers):
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    memory = await memories.recall(raw_body=body)
+    handlers.index_mock.side_effect = Exception("boo!")
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=memories,
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert set(index) == {None}
+    assert set(index[None]) == {123}
+    assert memory.indexing_state is None

--- a/tests/handling/indexing/test_index_exclusion.py
+++ b/tests/handling/indexing/test_index_exclusion.py
@@ -10,6 +10,7 @@ from kopf.reactor.lifecycles import all_at_once
 from kopf.reactor.processing import process_resource_event
 from kopf.storage.states import HandlerState, State
 from kopf.structs.ephemera import Memo
+from kopf.structs.primitives import Toggle
 
 EVENT_TYPES_WHEN_EXISTS = [None, 'ADDED', 'MODIFIED']
 EVENT_TYPES_WHEN_GONE = ['DELETED']
@@ -41,6 +42,7 @@ async def test_successes_are_removed_from_the_indexing_state(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert handlers.index_mock.call_count == 1
     assert memory.indexing_state is None
@@ -63,6 +65,7 @@ async def test_temporary_failures_with_no_delays_are_reindexed(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert handlers.index_mock.call_count == 1
 
@@ -86,6 +89,7 @@ async def test_temporary_failures_with_expired_delays_are_reindexed(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert handlers.index_mock.call_count == 1
 
@@ -107,6 +111,7 @@ async def test_permanent_failures_are_not_reindexed(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert handlers.index_mock.call_count == 0
 
@@ -136,6 +141,7 @@ async def test_removed_and_remembered_on_permanent_errors(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert set(index) == set()
     assert memory.indexing_state['index_fn'].finished == True
@@ -171,6 +177,7 @@ async def test_removed_and_remembered_on_temporary_errors(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert set(index) == set()
     assert memory.indexing_state['index_fn'].finished == False
@@ -198,6 +205,7 @@ async def test_preserved_on_ignored_errors(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert set(index) == {None}
     assert set(index[None]) == {123}

--- a/tests/handling/indexing/test_index_population.py
+++ b/tests/handling/indexing/test_index_population.py
@@ -7,6 +7,7 @@ from kopf.reactor.lifecycles import all_at_once
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
+from kopf.structs.primitives import Toggle
 
 EVENT_TYPES_WHEN_EXISTS = [None, 'ADDED', 'MODIFIED']
 EVENT_TYPES_WHEN_GONE = ['DELETED']
@@ -29,6 +30,7 @@ async def test_initially_stored(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert set(index) == {None}
     assert set(index[None]) == {123}
@@ -51,6 +53,7 @@ async def test_overwritten(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert set(index) == {None}
     assert set(index[None]) == {456}
@@ -74,6 +77,7 @@ async def test_preserved_on_logical_deletion(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert set(index) == {None}
     assert set(index[None]) == {456}
@@ -96,6 +100,7 @@ async def test_removed_on_physical_deletion(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert set(index) == set()
 
@@ -121,5 +126,6 @@ async def test_removed_on_filters_mismatch(
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         event_queue=asyncio.Queue(),
+        resource_indexed=Toggle(),  # used! only to enable indexing.
     )
     assert set(index) == set()

--- a/tests/handling/indexing/test_index_population.py
+++ b/tests/handling/indexing/test_index_population.py
@@ -1,0 +1,125 @@
+import asyncio
+import logging
+
+import pytest
+
+from kopf.reactor.lifecycles import all_at_once
+from kopf.reactor.processing import process_resource_event
+from kopf.structs.containers import ResourceMemories
+from kopf.structs.ephemera import Memo
+
+EVENT_TYPES_WHEN_EXISTS = [None, 'ADDED', 'MODIFIED']
+EVENT_TYPES_WHEN_GONE = ['DELETED']
+EVENT_TYPES = EVENT_TYPES_WHEN_EXISTS + EVENT_TYPES_WHEN_GONE
+
+
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_initially_stored(
+        resource, settings, registry, indexers, index, caplog, event_type, handlers):
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    handlers.index_mock.return_value = 123
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=ResourceMemories(),
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert set(index) == {None}
+    assert set(index[None]) == {123}
+
+
+@pytest.mark.usefixtures('indexed_123')
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_overwritten(
+        resource, settings, registry, indexers, index, caplog, event_type, handlers):
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    handlers.index_mock.return_value = 456
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=ResourceMemories(),
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert set(index) == {None}
+    assert set(index[None]) == {456}
+
+
+@pytest.mark.usefixtures('indexed_123')
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_preserved_on_logical_deletion(
+        resource, settings, registry, indexers, index, caplog, event_type, handlers):
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1',
+                         'deletionTimestamp': '...'}}
+    handlers.index_mock.return_value = 456
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=ResourceMemories(),
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert set(index) == {None}
+    assert set(index[None]) == {456}
+
+
+@pytest.mark.usefixtures('indexed_123')
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_GONE)
+async def test_removed_on_physical_deletion(
+        resource, settings, registry, indexers, index, caplog, event_type, handlers):
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    handlers.index_mock.return_value = 456
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=ResourceMemories(),
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert set(index) == set()
+
+
+@pytest.mark.usefixtures('indexed_123')
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_removed_on_filters_mismatch(
+        resource, settings, registry, indexers, index, caplog, event_type, handlers, mocker):
+
+    # Simulate the indexing handler is gone out of scope (this is only one of the ways to do it):
+    mocker.patch.object(registry._resource_indexing, 'get_handlers', return_value=[])
+
+    caplog.set_level(logging.DEBUG)
+    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    handlers.index_mock.return_value = 123
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=ResourceMemories(),
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': body},
+        event_queue=asyncio.Queue(),
+    )
+    assert set(index) == set()

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -5,6 +5,7 @@ import pytest
 
 from kopf.reactor.activities import ActivityError, run_activity
 from kopf.reactor.handling import PermanentError, TemporaryError
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.lifecycles import all_at_once
 from kopf.reactor.registries import OperatorRegistry
 from kopf.storage.states import HandlerOutcome
@@ -45,6 +46,7 @@ async def test_results_are_returned_on_success(settings, activity):
         settings=settings,
         activity=activity,
         lifecycle=all_at_once,
+        indices=OperatorIndexers().indices,
         memo=Memo(),
     )
 
@@ -78,6 +80,7 @@ async def test_errors_are_raised_aggregated(settings, activity):
             settings=settings,
             activity=activity,
             lifecycle=all_at_once,
+            indices=OperatorIndexers().indices,
             memo=Memo(),
         )
 
@@ -112,6 +115,7 @@ async def test_errors_are_cascaded_from_one_of_the_originals(settings, activity)
             settings=settings,
             activity=activity,
             lifecycle=all_at_once,
+            indices=OperatorIndexers().indices,
             memo=Memo(),
         )
 
@@ -140,6 +144,7 @@ async def test_retries_are_simulated(settings, activity, mocker):
             settings=settings,
             activity=activity,
             lifecycle=all_at_once,
+            indices=OperatorIndexers().indices,
             memo=Memo(),
         )
 
@@ -173,6 +178,7 @@ async def test_delays_are_simulated(settings, activity, mocker):
                 settings=settings,
                 activity=activity,
                 lifecycle=all_at_once,
+                indices=OperatorIndexers().indices,
                 memo=Memo(),
             )
 

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -4,6 +4,7 @@ import logging
 import pytest
 
 import kopf
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
@@ -27,6 +28,7 @@ async def test_create(registry, settings, handlers, resource, cause_mock, event_
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
@@ -67,6 +69,7 @@ async def test_update(registry, settings, handlers, resource, cause_mock, event_
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
@@ -109,6 +112,7 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
@@ -149,6 +153,7 @@ async def test_gone(registry, settings, handlers, resource, cause_mock, event_ty
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
@@ -179,6 +184,7 @@ async def test_free(registry, settings, handlers, resource, cause_mock, event_ty
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
@@ -210,6 +216,7 @@ async def test_noop(registry, settings, handlers, resource, cause_mock, event_ty
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -6,6 +6,7 @@ import freezegun
 import pytest
 
 import kopf
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.storage.progress import StatusProgressStorage
 from kopf.structs.containers import ResourceMemories
@@ -25,6 +26,7 @@ async def test_all_logs_are_prefixed(registry, settings, resource, handlers,
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
@@ -55,6 +57,7 @@ async def test_diffs_logged_if_present(registry, settings, resource, handlers,
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
@@ -85,6 +88,7 @@ async def test_diffs_not_logged_if_absent(registry, settings, resource, handlers
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
@@ -128,6 +132,7 @@ async def test_supersession_is_logged(
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -8,6 +8,7 @@ import pytest
 import kopf
 from kopf.reactor.effects import WAITING_KEEPALIVE_INTERVAL
 from kopf.reactor.handling import TemporaryError
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.storage.states import HandlerState
 from kopf.structs.containers import ResourceMemories
@@ -38,6 +39,7 @@ async def test_delayed_handlers_progress(
             registry=registry,
             settings=settings,
             resource=resource,
+            indexers=OperatorIndexers(),
             memories=ResourceMemories(),
             memobase=Memo(),
             raw_event={'type': event_type, 'object': {}},
@@ -94,6 +96,7 @@ async def test_delayed_handlers_sleep(
             registry=registry,
             settings=settings,
             resource=resource,
+            indexers=OperatorIndexers(),
             memories=ResourceMemories(),
             memobase=Memo(),
             raw_event={'type': event_type, 'object': event_body},

--- a/tests/handling/test_error_handling.py
+++ b/tests/handling/test_error_handling.py
@@ -5,6 +5,7 @@ import pytest
 
 import kopf
 from kopf.reactor.handling import PermanentError, TemporaryError
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
@@ -31,6 +32,7 @@ async def test_fatal_error_stops_handler(
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
@@ -75,6 +77,7 @@ async def test_retry_error_delays_handler(
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
@@ -120,6 +123,7 @@ async def test_arbitrary_error_delays_handler(
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -4,6 +4,7 @@ import logging
 import pytest
 
 import kopf
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
@@ -22,6 +23,7 @@ async def test_handlers_called_always(
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': 'ev-type', 'object': {'field': 'value'}},
@@ -57,6 +59,7 @@ async def test_errors_are_ignored(
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': 'ev-type', 'object': {}},

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 import kopf
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
@@ -33,6 +34,7 @@ async def test_1st_step_stores_progress_by_patching(
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
@@ -92,6 +94,7 @@ async def test_2nd_step_finishes_the_handlers(caplog,
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -4,6 +4,7 @@ import logging
 import pytest
 
 import kopf
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
@@ -37,6 +38,7 @@ async def test_skipped_with_no_handlers(
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
@@ -92,6 +94,7 @@ async def test_stealth_mode_with_mismatching_handlers(
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},

--- a/tests/handling/test_parametrization.py
+++ b/tests/handling/test_parametrization.py
@@ -2,6 +2,7 @@ import asyncio
 from unittest.mock import Mock
 
 import kopf
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
@@ -22,6 +23,7 @@ async def test_parameter_is_passed_when_specified(resource, cause_mock, registry
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': None, 'object': {}},
@@ -47,6 +49,7 @@ async def test_parameter_is_passed_even_if_not_specified(resource, cause_mock, r
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': None, 'object': {}},

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -5,6 +5,7 @@ import freezegun
 import pytest
 
 import kopf
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
@@ -40,6 +41,7 @@ async def test_timed_out_handler_fails(
             registry=registry,
             settings=settings,
             resource=resource,
+            indexers=OperatorIndexers(),
             memories=ResourceMemories(),
             memobase=Memo(),
             raw_event={'type': event_type, 'object': event_body},
@@ -89,6 +91,7 @@ async def test_retries_limited_handler_fails(
         registry=registry,
         settings=settings,
         resource=resource,
+        indexers=OperatorIndexers(),
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},

--- a/tests/handling/test_timing_consistency.py
+++ b/tests/handling/test_timing_consistency.py
@@ -4,6 +4,7 @@ import datetime
 import freezegun
 
 import kopf
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
@@ -61,6 +62,7 @@ async def test_consistent_awakening(registry, settings, resource, k8s_mocked, mo
             registry=registry,
             settings=settings,
             resource=resource,
+            indexers=OperatorIndexers(),
             memories=ResourceMemories(),
             memobase=Memo(),
             raw_event={'type': 'ADDED', 'object': body},

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -6,6 +6,7 @@ import pytest
 import kopf
 from kopf.reactor.causation import ResourceChangingCause, ResourceWatchingCause
 from kopf.reactor.handling import cause_var
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.invocation import context
 from kopf.structs.bodies import Body, RawBody, RawEvent, RawMeta
 from kopf.structs.ephemera import Memo
@@ -36,6 +37,7 @@ def owner(request, resource):
     if request.param == 'state-changing-cause':
         cause = ResourceChangingCause(
             logger=logging.getLogger('kopf.test.fake.logger'),
+            indices=OperatorIndexers().indices,
             resource=resource,
             patch=Patch(),
             memo=Memo(),
@@ -48,6 +50,7 @@ def owner(request, resource):
     elif request.param == 'event-watching-cause':
         cause = ResourceWatchingCause(
             logger=logging.getLogger('kopf.test.fake.logger'),
+            indices=OperatorIndexers().indices,
             resource=resource,
             patch=Patch(),
             memo=Memo(),

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -6,6 +6,7 @@ import pytest
 from asynctest import MagicMock
 
 from kopf.reactor.causation import ResourceChangingCause
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.invocation import invoke, is_async_fn
 from kopf.structs.bodies import Body
 from kopf.structs.handlers import Reason
@@ -171,6 +172,7 @@ async def test_special_kwargs_added(fn, resource):
     # Values can be any.
     cause = ResourceChangingCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
+        indices=OperatorIndexers().indices,
         resource=resource,
         patch=Patch(),
         initial=False,

--- a/tests/k8s/test_watching_bookmarks.py
+++ b/tests/k8s/test_watching_bookmarks.py
@@ -1,0 +1,48 @@
+import asyncio
+import json
+import logging
+
+import aiohttp.web
+import pytest
+
+from kopf.clients.watching import Bookmark, continuous_watch
+
+
+async def test_listed_is_inbetween(
+        settings, resource, namespace, hostname, aresponses):
+
+    # Resource version is used as a continutation for the watch-queries.
+    list_data = {'metadata': {'resourceVersion': '123'}, 'items': [
+        {'spec': 'a'},
+        {'spec': 'b'},
+    ]}
+    list_resp = aiohttp.web.json_response(list_data)
+    list_url = resource.get_url(namespace=namespace)
+
+    # The same as in the `stream` fixture. But here, we also mock lists.
+    stream_data = [
+        {'type': 'ADDED', 'object': {'spec': 'c'}},  # stream.feed()
+        {'type': 'ADDED', 'object': {'spec': 'd'}},  # stream.feed()
+        {'type': 'ERROR', 'object': {'code': 410}},  # stream.close()
+    ]
+    stream_text = '\n'.join(json.dumps(event) for event in stream_data)
+    stream_resp = aresponses.Response(text=stream_text)
+    stream_query = {'watch': 'true', 'resourceVersion': '123'}
+    stream_url = resource.get_url(namespace=namespace, params=stream_query)
+
+    aresponses.add(hostname, list_url, 'get', list_resp, match_querystring=True)
+    aresponses.add(hostname, stream_url, 'get', stream_resp, match_querystring=True)
+
+    events = []
+    async for event in continuous_watch(settings=settings,
+                                        resource=resource,
+                                        namespace=namespace,
+                                        operator_pause_waiter=asyncio.Future()):
+        events.append(event)
+
+    assert len(events) == 5
+    assert events[0]['object']['spec'] == 'a'
+    assert events[1]['object']['spec'] == 'b'
+    assert events[2] == Bookmark.LISTED
+    assert events[3]['object']['spec'] == 'c'
+    assert events[4]['object']['spec'] == 'd'

--- a/tests/k8s/test_watching_infinitely.py
+++ b/tests/k8s/test_watching_infinitely.py
@@ -1,7 +1,7 @@
 import pytest
 
 from kopf.clients.errors import APIError
-from kopf.clients.watching import infinite_watch
+from kopf.clients.watching import Bookmark, infinite_watch
 
 STREAM_WITH_UNKNOWN_EVENT = [
     {'type': 'ADDED', 'object': {'spec': 'a'}},
@@ -57,7 +57,9 @@ async def test_infinite_watch_never_exits_normally(
 
     assert e.value.status == 555
 
-    assert len(events) == 3
-    assert events[0]['object']['spec'] == 'a'
+    assert len(events) == 5
+    assert events[0] == Bookmark.LISTED
     assert events[1]['object']['spec'] == 'a'
-    assert events[2]['object']['spec'] == 'b'
+    assert events[2] == Bookmark.LISTED
+    assert events[3]['object']['spec'] == 'a'
+    assert events[4]['object']['spec'] == 'b'

--- a/tests/k8s/test_watching_with_freezes.py
+++ b/tests/k8s/test_watching_with_freezes.py
@@ -12,7 +12,7 @@ async def test_pausing_is_ignored_if_turned_off(
         resource, namespace, timer, caplog, assert_logs):
     caplog.set_level(logging.DEBUG)
 
-    operator_paused = ToggleSet()
+    operator_paused = ToggleSet(any)
     await operator_paused.make_toggle(False)
 
     async with timer, async_timeout.timeout(0.5) as timeout:
@@ -35,7 +35,7 @@ async def test_pausing_waits_forever_if_not_resumed(
         resource, namespace, timer, caplog, assert_logs):
     caplog.set_level(logging.DEBUG)
 
-    operator_paused = ToggleSet()
+    operator_paused = ToggleSet(any)
     await operator_paused.make_toggle(True)
 
     with pytest.raises(asyncio.TimeoutError):
@@ -60,7 +60,7 @@ async def test_pausing_waits_until_resumed(
         resource, namespace, timer, caplog, assert_logs):
     caplog.set_level(logging.DEBUG)
 
-    operator_paused = ToggleSet()
+    operator_paused = ToggleSet(any)
     conflicts_found = await operator_paused.make_toggle(True)
 
     async def delayed_resuming(delay: float):

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -4,6 +4,7 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import ResourceChangingCause
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.invocation import invoke
 from kopf.storage.states import State
 from kopf.structs.bodies import Body
@@ -28,6 +29,7 @@ async def test_protocol_invocation(lifecycle, resource):
     state = State.from_scratch()
     cause = ResourceChangingCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
+        indices=OperatorIndexers().indices,
         resource=resource,
         patch=Patch(),
         memo=Memo(),

--- a/tests/observation/test_processing_of_resources.py
+++ b/tests/observation/test_processing_of_resources.py
@@ -84,7 +84,7 @@ def group1_404mock(resp_mocker, aresponses, hostname, apis_mock):
 
 
 @pytest.fixture(params=[
-    kopf.on.event, kopf.daemon, kopf.timer,
+    kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def handlers(request, registry):

--- a/tests/observation/test_revision_of_resources.py
+++ b/tests/observation/test_revision_of_resources.py
@@ -8,7 +8,7 @@ VERBS = ['list', 'watch', 'patch']
 
 
 @pytest.fixture(params=[
-    kopf.on.event, kopf.daemon, kopf.timer,
+    kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def handlers(request, registry):
@@ -56,7 +56,7 @@ def test_replacing_a_new_group(registry):
 
 
 @pytest.mark.parametrize('decorator', [
-    kopf.on.event, kopf.daemon, kopf.timer,
+    kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_ambiguity_in_specific_selectors(registry, decorator, caplog, assert_logs):
@@ -73,7 +73,7 @@ def test_ambiguity_in_specific_selectors(registry, decorator, caplog, assert_log
 
 
 @pytest.mark.parametrize('decorator', [
-    kopf.on.event, kopf.daemon, kopf.timer,
+    kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_corev1_overrides_ambuigity(registry, decorator, caplog, assert_logs):
@@ -90,7 +90,7 @@ def test_corev1_overrides_ambuigity(registry, decorator, caplog, assert_logs):
 
 
 @pytest.mark.parametrize('decorator', [
-    kopf.on.event, kopf.daemon, kopf.timer,
+    kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_no_ambiguity_in_generic_selector(registry, decorator, caplog, assert_logs):
@@ -107,7 +107,7 @@ def test_no_ambiguity_in_generic_selector(registry, decorator, caplog, assert_lo
 
 
 @pytest.mark.parametrize('decorator', [
-    kopf.on.event, kopf.daemon, kopf.timer,
+    kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
 ])
 def test_selectors_with_no_resources(registry, decorator, caplog, assert_logs):

--- a/tests/orchestration/test_task_adjustments.py
+++ b/tests/orchestration/test_task_adjustments.py
@@ -39,9 +39,14 @@ async def insights(settings, peering_resource):
 
 @pytest.fixture()
 async def ensemble(_no_asyncio_pending_tasks):
+    operator_indexed = primitives.ToggleSet(all)
     operator_paused = primitives.ToggleSet(any)
     peering_missing = await operator_paused.make_toggle()
-    ensemble = Ensemble(operator_paused=operator_paused, peering_missing=peering_missing)
+    ensemble = Ensemble(
+        operator_indexed=operator_indexed,
+        operator_paused=operator_paused,
+        peering_missing=peering_missing,
+    )
 
     try:
         yield ensemble

--- a/tests/orchestration/test_task_adjustments.py
+++ b/tests/orchestration/test_task_adjustments.py
@@ -39,7 +39,7 @@ async def insights(settings, peering_resource):
 
 @pytest.fixture()
 async def ensemble(_no_asyncio_pending_tasks):
-    operator_paused = primitives.ToggleSet()
+    operator_paused = primitives.ToggleSet(any)
     peering_missing = await operator_paused.make_toggle()
     ensemble = Ensemble(operator_paused=operator_paused, peering_missing=peering_missing)
 

--- a/tests/primitives/test_togglesets.py
+++ b/tests/primitives/test_togglesets.py
@@ -5,84 +5,92 @@ import pytest
 from kopf.structs.primitives import Toggle, ToggleSet
 
 
-async def test_created_as_off():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn, expected', [(all, True), (any, False)])
+async def test_created_empty(fn, expected):
+    toggleset = ToggleSet(fn)
     assert len(toggleset) == 0
     assert set(toggleset) == set()
     assert Toggle() not in toggleset
-    assert not toggleset.is_on()
-    assert toggleset.is_off()
+    assert toggleset.is_on() == expected
+    assert toggleset.is_off() == (not expected)
 
 
-async def test_making_a_default_toggle():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_making_a_default_toggle(fn):
+    toggleset = ToggleSet(fn)
     toggle = await toggleset.make_toggle()
     assert len(toggleset) == 1
     assert set(toggleset) == {toggle}
     assert toggle in toggleset
     assert Toggle() not in toggleset
-    assert not toggleset.is_on()
-    assert toggleset.is_off()
+    assert toggleset.is_on() == False
+    assert toggleset.is_off() == True
 
 
-async def test_making_a_turned_off_toggle():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_making_a_turned_off_toggle(fn):
+    toggleset = ToggleSet(fn)
     toggle = await toggleset.make_toggle(False)
     assert len(toggleset) == 1
     assert set(toggleset) == {toggle}
     assert toggle in toggleset
     assert Toggle() not in toggleset
-    assert not toggleset.is_on()
-    assert toggleset.is_off()
+    assert toggleset.is_on() == False
+    assert toggleset.is_off() == True
 
 
-async def test_making_a_turned_on_toggle():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_making_a_turned_on_toggle(fn):
+    toggleset = ToggleSet(fn)
     toggle = await toggleset.make_toggle(True)
     assert len(toggleset) == 1
     assert set(toggleset) == {toggle}
     assert toggle in toggleset
     assert Toggle() not in toggleset
-    assert toggleset.is_on()
-    assert not toggleset.is_off()
+    assert toggleset.is_on() == True
+    assert toggleset.is_off() == False
 
 
-async def test_dropping_a_turned_off_toggle():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn, expected', [(all, True), (any, False)])
+async def test_dropping_a_turned_off_toggle(fn, expected):
+    toggleset = ToggleSet(fn)
     toggle = await toggleset.make_toggle(False)
     await toggle.turn_to(True)
     await toggleset.drop_toggle(toggle)
     assert len(toggleset) == 0
     assert set(toggleset) == set()
     assert toggle not in toggleset
-    assert not toggleset.is_on()
-    assert toggleset.is_off()
+    assert toggleset.is_on() == expected
+    assert toggleset.is_off() == (not expected)
 
 
-async def test_dropping_a_turned_on_toggle():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn, expected', [(all, True), (any, False)])
+async def test_dropping_a_turned_on_toggle(fn, expected):
+    toggleset = ToggleSet(fn)
     toggle = await toggleset.make_toggle(True)
     await toggleset.drop_toggle(toggle)
     assert len(toggleset) == 0
     assert set(toggleset) == set()
     assert toggle not in toggleset
-    assert not toggleset.is_on()
-    assert toggleset.is_off()
+    assert toggleset.is_on() == expected
+    assert toggleset.is_off() == (not expected)
 
 
-async def test_dropping_an_unexistent_toggle():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn, expected', [(all, True), (any, False)])
+async def test_dropping_an_unexistent_toggle(fn, expected):
+    toggleset = ToggleSet(fn)
     toggle = Toggle()
     await toggleset.drop_toggle(toggle)
     assert len(toggleset) == 0
     assert set(toggleset) == set()
     assert toggle not in toggleset
-    assert not toggleset.is_on()
-    assert toggleset.is_off()
+    assert toggleset.is_on() == expected
+    assert toggleset.is_off() == (not expected)
 
 
-async def test_dropping_multiple_toggles():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn, expected', [(all, True), (any, False)])
+async def test_dropping_multiple_toggles(fn, expected):
+    toggleset = ToggleSet(fn)
     toggle1 = await toggleset.make_toggle(True)
     toggle2 = Toggle()
     await toggleset.drop_toggles([toggle1, toggle2])
@@ -90,82 +98,123 @@ async def test_dropping_multiple_toggles():
     assert set(toggleset) == set()
     assert toggle1 not in toggleset
     assert toggle2 not in toggleset
-    assert not toggleset.is_on()
-    assert toggleset.is_off()
+    assert toggleset.is_on() == expected
+    assert toggleset.is_off() == (not expected)
 
 
-async def test_turning_a_toggle_on_turns_the_toggleset_on():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_turning_a_toggle_on_turns_the_toggleset_on(fn):
+    toggleset = ToggleSet(fn)
     toggle = await toggleset.make_toggle(False)
-    assert not toggleset.is_on()
-    assert toggleset.is_off()
+    assert toggleset.is_on() == False
+    assert toggleset.is_off() == True
 
     await toggle.turn_to(True)
-    assert toggleset.is_on()
-    assert not toggleset.is_off()
+    assert toggleset.is_on() == True
+    assert toggleset.is_off() == False
 
 
-async def test_turning_a_toggle_off_turns_the_toggleset_off():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_turning_a_toggle_off_turns_the_toggleset_off(fn):
+    toggleset = ToggleSet(fn)
     toggle = await toggleset.make_toggle(True)
-    assert toggleset.is_on()
-    assert not toggleset.is_off()
+    assert toggleset.is_on() == True
+    assert toggleset.is_off() == False
 
     await toggle.turn_to(False)
-    assert not toggleset.is_on()
-    assert toggleset.is_off()
+    assert toggleset.is_on() == False
+    assert toggleset.is_off() == True
 
 
-async def test_any_toggle_must_be_on_for_toggleset_to_be_on():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all])
+async def test_all_toggles_must_be_on_for_alltoggleset_to_be_on(fn):
+    toggleset = ToggleSet(fn)
     toggle1 = await toggleset.make_toggle(False)
     toggle2 = await toggleset.make_toggle(False)
-    assert not toggleset.is_on()
-    assert toggleset.is_off()
+    assert toggleset.is_on() == False
+    assert toggleset.is_off() == True
 
     await toggle1.turn_to(True)
-    assert toggleset.is_on()
-    assert not toggleset.is_off()
+    assert toggleset.is_on() == False
+    assert toggleset.is_off() == True
 
     await toggle2.turn_to(True)
-    assert toggleset.is_on()
-    assert not toggleset.is_off()
+    assert toggleset.is_on() == True
+    assert toggleset.is_off() == False
 
 
-async def test_all_toggles_must_be_off_for_toggleset_to_be_off():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all])
+async def test_any_toggle_must_be_off_for_alltoggleset_to_be_off(fn):
+    toggleset = ToggleSet(fn)
     toggle1 = await toggleset.make_toggle(True)
     toggle2 = await toggleset.make_toggle(True)
-    assert toggleset.is_on()
-    assert not toggleset.is_off()
+    assert toggleset.is_on() == True
+    assert toggleset.is_off() == False
 
     await toggle1.turn_to(False)
-    assert toggleset.is_on()
-    assert not toggleset.is_off()
+    assert toggleset.is_on() == False
+    assert toggleset.is_off() == True
 
     await toggle2.turn_to(False)
-    assert not toggleset.is_on()
-    assert toggleset.is_off()
+    assert toggleset.is_on() == False
+    assert toggleset.is_off() == True
 
 
-async def test_waiting_until_on_fails_when_not_turned_on():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [any])
+async def test_any_toggle_must_be_on_for_anytoggleset_to_be_on(fn):
+    toggleset = ToggleSet(fn)
+    toggle1 = await toggleset.make_toggle(False)
+    toggle2 = await toggleset.make_toggle(False)
+    assert toggleset.is_on() == False
+    assert toggleset.is_off() == True
+
+    await toggle1.turn_to(True)
+    assert toggleset.is_on() == True
+    assert toggleset.is_off() == False
+
+    await toggle2.turn_to(True)
+    assert toggleset.is_on() == True
+    assert toggleset.is_off() == False
+
+
+@pytest.mark.parametrize('fn', [any])
+async def test_all_toggles_must_be_off_for_anytoggleset_to_be_off(fn):
+    toggleset = ToggleSet(fn)
+    toggle1 = await toggleset.make_toggle(True)
+    toggle2 = await toggleset.make_toggle(True)
+    assert toggleset.is_on() == True
+    assert toggleset.is_off() == False
+
+    await toggle1.turn_to(False)
+    assert toggleset.is_on() == True
+    assert toggleset.is_off() == False
+
+    await toggle2.turn_to(False)
+    assert toggleset.is_on() == False
+    assert toggleset.is_off() == True
+
+
+@pytest.mark.parametrize('fn', [all, any])
+async def test_waiting_until_on_fails_when_not_turned_on(fn):
+    toggleset = ToggleSet(fn)
     await toggleset.make_toggle(False)
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(toggleset.wait_for(True), timeout=0.1)
     assert toggleset.is_off()
 
 
-async def test_waiting_until_off_fails_when_not_turned_off():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_waiting_until_off_fails_when_not_turned_off(fn):
+    toggleset = ToggleSet(fn)
     await toggleset.make_toggle(True)
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(toggleset.wait_for(False), timeout=0.1)
     assert toggleset.is_on()
 
 
-async def test_waiting_until_on_wakes_when_turned_on(timer):
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_waiting_until_on_wakes_when_turned_on(fn, timer):
+    toggleset = ToggleSet(fn)
     toggle = await toggleset.make_toggle(False)
 
     async def delayed_turning_on(delay: float):
@@ -180,8 +229,9 @@ async def test_waiting_until_on_wakes_when_turned_on(timer):
     assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead
 
 
-async def test_waiting_until_off_wakes_when_turned_off(timer):
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_waiting_until_off_wakes_when_turned_off(fn, timer):
+    toggleset = ToggleSet(fn)
     toggle = await toggleset.make_toggle(True)
 
     async def delayed_turning_off(delay: float):
@@ -196,36 +246,42 @@ async def test_waiting_until_off_wakes_when_turned_off(timer):
     assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead
 
 
-async def test_secures_against_usage_as_a_boolean():
-    toggle = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_secures_against_usage_as_a_boolean(fn):
+    toggle = ToggleSet(fn)
     with pytest.raises(NotImplementedError):
         bool(toggle)
 
 
-async def test_repr_when_empty():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_repr_when_empty(fn):
+    toggleset = ToggleSet(fn)
     assert repr(toggleset) == "set()"
 
 
-async def test_repr_when_unnamed_and_off():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_repr_when_unnamed_and_off(fn):
+    toggleset = ToggleSet(fn)
     await toggleset.make_toggle(False)
     assert repr(toggleset) == "{<Toggle: off>}"
 
 
-async def test_repr_when_unnamed_and_on():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_repr_when_unnamed_and_on(fn):
+    toggleset = ToggleSet(fn)
     await toggleset.make_toggle(True)
     assert repr(toggleset) == "{<Toggle: on>}"
 
 
-async def test_repr_when_named_and_off():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_repr_when_named_and_off(fn):
+    toggleset = ToggleSet(fn)
     await toggleset.make_toggle(False, name='xyz')
     assert repr(toggleset) == "{<Toggle: xyz: off>}"
 
 
-async def test_repr_when_named_and_on():
-    toggleset = ToggleSet()
+@pytest.mark.parametrize('fn', [all, any])
+async def test_repr_when_named_and_on(fn):
+    toggleset = ToggleSet(fn)
     await toggleset.make_toggle(True, name='xyz')
     assert repr(toggleset) == "{<Toggle: xyz: on>}"

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -10,6 +10,9 @@ Excluded: the causation and handling routines
 Used for internal control that the event queueing works are intended.
 If the intentions change, the tests should be rewritten.
 They are NOT part of the public interface of the framework.
+
+NOTE: These tests also check that the bookmarks are ignored
+by checking that they are not multiplexed into workers.
 """
 import asyncio
 import contextlib

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 from kopf.reactor.causation import ActivityCause, ResourceCause, ResourceChangingCause, \
                                    ResourceSpawningCause, ResourceWatchingCause
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.registries import ActivityRegistry, OperatorRegistry, ResourceChangingRegistry, \
                                     ResourceRegistry, ResourceSpawningRegistry, \
                                     ResourceWatchingRegistry
@@ -98,12 +99,14 @@ def cause_factory(resource):
             return ActivityCause(
                 memo=Memo(),
                 logger=logging.getLogger('kopf.test.fake.logger'),
+                indices=OperatorIndexers().indices,
                 activity=activity,
                 settings=settings,
             )
         if cls is ResourceCause or cls is ResourceRegistry:
             return ResourceCause(
                 logger=logging.getLogger('kopf.test.fake.logger'),
+                indices=OperatorIndexers().indices,
                 resource=resource,
                 patch=Patch(),
                 memo=Memo(),
@@ -112,6 +115,7 @@ def cause_factory(resource):
         if cls is ResourceWatchingCause or cls is ResourceWatchingRegistry:
             return ResourceWatchingCause(
                 logger=logging.getLogger('kopf.test.fake.logger'),
+                indices=OperatorIndexers().indices,
                 resource=resource,
                 patch=Patch(),
                 memo=Memo(),
@@ -122,6 +126,7 @@ def cause_factory(resource):
         if cls is ResourceChangingCause or cls is ResourceChangingRegistry:
             return ResourceChangingCause(
                 logger=logging.getLogger('kopf.test.fake.logger'),
+                indices=OperatorIndexers().indices,
                 resource=resource,
                 patch=Patch(),
                 memo=Memo(),
@@ -135,6 +140,7 @@ def cause_factory(resource):
         if cls is ResourceSpawningCause or cls is ResourceSpawningRegistry:
             return ResourceSpawningCause(
                 logger=logging.getLogger('kopf.test.fake.logger'),
+                indices=OperatorIndexers().indices,
                 resource=resource,
                 patch=Patch(),
                 memo=Memo(),

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -490,6 +490,7 @@ def test_subhandler_imperatively(parent_handler, cause_factory):
 
 
 @pytest.mark.parametrize('decorator, kwargs', [
+    (kopf.index, {}),
     (kopf.on.event, {}),
     (kopf.on.resume, {}),
     (kopf.on.create, {}),
@@ -506,6 +507,7 @@ def test_labels_filter_with_nones(resource, decorator, kwargs):
 
 
 @pytest.mark.parametrize('decorator, kwargs', [
+    (kopf.index, {}),
     (kopf.on.event, {}),
     (kopf.on.resume, {}),
     (kopf.on.create, {}),
@@ -522,6 +524,7 @@ def test_annotations_filter_with_nones(resource, decorator, kwargs):
 
 
 @pytest.mark.parametrize('decorator, causeargs, handlers_prop', [
+    pytest.param(kopf.index, dict(), '_resource_indexing', id='on-index'),
     pytest.param(kopf.on.event, dict(), '_resource_watching', id='on-event'),
     pytest.param(kopf.on.resume, dict(reason=None, initial=True), '_resource_changing', id='on-resume'),
     pytest.param(kopf.on.create, dict(reason=Reason.CREATE), '_resource_changing', id='on-create'),
@@ -570,6 +573,7 @@ def test_field_with_oldnew(mocker, cause_factory, decorator, causeargs, handlers
 
 
 @pytest.mark.parametrize('decorator', [
+    pytest.param(kopf.index, id='on-index'),
     pytest.param(kopf.on.event, id='on-event'),
     pytest.param(kopf.on.resume, id='on-resume'),
     pytest.param(kopf.on.create, id='on-create'),

--- a/tests/registries/test_matching_for_indexing.py
+++ b/tests/registries/test_matching_for_indexing.py
@@ -1,0 +1,480 @@
+import copy
+
+import pytest
+
+import kopf
+from kopf.reactor.causation import ResourceWatchingCause
+from kopf.structs.dicts import parse_field
+from kopf.structs.filters import ABSENT, PRESENT
+from kopf.structs.handlers import ResourceIndexingHandler
+
+
+# Used in the tests. Must be global-scoped, or its qualname will be affected.
+def some_fn(x=None):
+    pass
+
+
+def _never(*_, **__):
+    return False
+
+
+def _always(*_, **__):
+    return True
+
+
+@pytest.fixture()
+def handler_factory(registry, selector):
+    def factory(**kwargs):
+        handler = ResourceIndexingHandler(**dict(dict(
+            fn=some_fn, id='a', param=None,
+            errors=None, timeout=None, retries=None, backoff=None,
+            selector=selector, annotations=None, labels=None, when=None,
+            field=None, value=None,
+        ), **kwargs))
+        registry._resource_indexing.append(handler)
+        return handler
+    return factory
+
+
+@pytest.fixture(params=[
+    pytest.param(dict(body={}), id='no-field'),
+])
+def cause_no_field(request, cause_factory):
+    kwargs = copy.deepcopy(request.param)
+    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
+                                        'annotations': {'known': 'value'}}})
+    cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
+    return cause
+
+
+@pytest.fixture(params=[
+    pytest.param(dict(body={'known-field': 'new'}), id='with-field'),
+])
+def cause_with_field(request, cause_factory):
+    kwargs = copy.deepcopy(request.param)
+    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
+                                        'annotations': {'known': 'value'}}})
+    cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
+    return cause
+
+
+@pytest.fixture(params=[
+    # The original no-diff was equivalent to no-field until body/old/new were added to the check.
+    pytest.param(dict(body={}, diff=[]), id='no-field'),
+    pytest.param(dict(body={'known-field': 'new'}), id='with-field'),
+])
+def cause_any_field(request, cause_factory):
+    kwargs = copy.deepcopy(request.param)
+    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
+                                        'annotations': {'known': 'value'}}})
+    cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
+    return cause
+
+
+#
+# "Catch-all" handlers.
+#
+
+def test_catchall_handlers_without_field_found(
+        cause_any_field, registry, handler_factory):
+    cause = cause_any_field
+    handler_factory(field=None)
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+def test_catchall_handlers_with_field_found(
+        cause_with_field, registry, handler_factory):
+    cause = cause_with_field
+    handler_factory(field=parse_field('known-field'))
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+def test_catchall_handlers_with_field_ignored(
+        cause_no_field, registry, handler_factory):
+    cause = cause_no_field
+    handler_factory(field=parse_field('known-field'))
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-label'),
+])
+def test_catchall_handlers_with_exact_labels_satisfied(
+        cause_factory, registry, handler_factory, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'known': 'value'})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
+])
+def test_catchall_handlers_with_exact_labels_not_satisfied(
+        cause_factory, registry, handler_factory, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'known': 'value'})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_desired_labels_present(
+        cause_factory, registry, handler_factory, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'known': PRESENT})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
+])
+def test_catchall_handlers_with_desired_labels_absent(
+        cause_factory, registry, handler_factory, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'known': PRESENT})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_undesired_labels_present(
+        cause_factory, registry, handler_factory, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'known': ABSENT})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
+])
+def test_catchall_handlers_with_undesired_labels_absent(
+        cause_factory, registry, handler_factory, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'known': ABSENT})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_labels_callback_says_true(
+        cause_factory, registry, handler_factory, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'known': _always})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_labels_callback_says_false(
+        cause_factory, registry, handler_factory, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'known': _never})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-label'),
+])
+def test_catchall_handlers_without_labels(
+        cause_factory, registry, handler_factory, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels=None)
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-annotation'),
+])
+def test_catchall_handlers_with_exact_annotations_satisfied(
+        cause_factory, registry, handler_factory, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'known': 'value'})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
+])
+def test_catchall_handlers_with_exact_annotations_not_satisfied(
+        cause_factory, registry, handler_factory, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'known': 'value'})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_desired_annotations_present(
+        cause_factory, registry, handler_factory, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'known': PRESENT})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
+])
+def test_catchall_handlers_with_desired_annotations_absent(
+        cause_factory, registry, handler_factory, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'known': PRESENT})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_undesired_annotations_present(
+        cause_factory, registry, handler_factory, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'known': ABSENT})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
+])
+def test_catchall_handlers_with_undesired_annotations_absent(
+        cause_factory, registry, handler_factory, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'known': ABSENT})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_annotations_callback_says_true(
+        cause_factory, registry, handler_factory, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'known': _always})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+])
+def test_catchall_handlers_with_annotations_callback_says_false(
+        cause_factory, registry, handler_factory, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory(annotations={'known': _never})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('annotations', [
+    pytest.param({}, id='without-annotation'),
+    pytest.param({'known': 'value'}, id='with-annotation'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-annotation'),
+])
+def test_catchall_handlers_without_annotations(
+        cause_factory, registry, handler_factory, annotations):
+    cause = cause_factory(body={'metadata': {'annotations': annotations}})
+    handler_factory()
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels, annotations', [
+    pytest.param({'known': 'value'}, {'known': 'value'}, id='with-label-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, {'known': 'value'}, id='with-extra-label-annotation'),
+    pytest.param({'known': 'value'}, {'known': 'value', 'extra': 'other'}, id='with-label-extra-annotation'),
+    pytest.param({'known': 'value', 'extra': 'other'}, {'known': 'value', 'extra': 'other'}, id='with-extra-label-extra-annotation'),
+])
+def test_catchall_handlers_with_labels_and_annotations_satisfied(
+        cause_factory, registry, handler_factory, labels, annotations):
+    cause = cause_factory(body={'metadata': {'labels': labels, 'annotations': annotations}})
+    handler_factory(labels={'known': 'value'}, annotations={'known': 'value'})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('labels', [
+    pytest.param({}, id='without-label'),
+    pytest.param({'known': 'value'}, id='with-label'),
+    pytest.param({'known': 'other'}, id='with-other-value'),
+    pytest.param({'extra': 'other'}, id='with-other-label'),
+    pytest.param({'known': 'value', 'extra': 'other'}, id='with-extra-label'),
+])
+def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
+        cause_factory, registry, handler_factory, labels):
+    cause = cause_factory(body={'metadata': {'labels': labels}})
+    handler_factory(labels={'known': 'value'}, annotations={'known': 'value'})
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+@pytest.mark.parametrize('when', [
+    pytest.param(None, id='without-when'),
+    pytest.param(lambda body=None, **_: body['spec']['name'] == 'test', id='with-when'),
+    pytest.param(lambda **_: True, id='with-other-when'),
+])
+def test_catchall_handlers_with_when_callback_matching(
+        cause_factory, registry, handler_factory, when):
+    cause = cause_factory(body={'spec': {'name': 'test'}})
+    handler_factory(when=when)
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+@pytest.mark.parametrize('when', [
+    pytest.param(lambda body=None, **_: body['spec']['name'] != "test", id='with-when'),
+    pytest.param(lambda **_: False, id='with-other-when'),
+])
+def test_catchall_handlers_with_when_callback_mismatching(
+        cause_factory, registry, handler_factory, when):
+    cause = cause_factory(body={'spec': {'name': 'test'}})
+    handler_factory(when=when)
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+def test_decorator_without_field_found(
+        cause_any_field, registry, resource):
+
+    @kopf.index(*resource, field=None)
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+def test_decorator_with_field_found(
+        cause_with_field, registry, resource):
+
+    @kopf.index(*resource, field='known-field')
+    def some_fn(**_): ...
+
+    cause = cause_with_field
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+def test_decorator_with_field_ignored(
+        cause_no_field, registry, resource):
+
+    @kopf.index(*resource, field='known-field')
+    def some_fn(**_): ...
+
+    cause = cause_no_field
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+def test_decorator_with_labels_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.index(*resource, labels={'known': PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+def test_decorator_with_labels_not_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.index(*resource, labels={'extra': PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+def test_decorator_with_annotations_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.index(*resource, annotations={'known': PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+def test_decorator_with_annotations_not_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.index(*resource, annotations={'extra': PRESENT})
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers
+
+
+def test_decorator_with_filter_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.index(*resource, when=_always)
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert handlers
+
+
+def test_decorator_with_filter_not_satisfied(
+        cause_any_field, registry, resource):
+
+    @kopf.index(*resource, when=_never)
+    def some_fn(**_): ...
+
+    cause = cause_any_field
+    handlers = registry._resource_indexing.get_handlers(cause)
+    assert not handlers

--- a/tests/test_liveness.py
+++ b/tests/test_liveness.py
@@ -4,6 +4,7 @@ import aiohttp
 import pytest
 
 from kopf.engines.probing import health_reporter
+from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.ephemera import Memo
 from kopf.structs.handlers import Activity, ActivityHandler
@@ -27,6 +28,7 @@ async def liveness_url(settings, liveness_registry, aiohttp_unused_port):
             registry=liveness_registry,
             settings=settings,
             ready_flag=ready_flag,
+            indices=OperatorIndexers().indices,
             memo=Memo(),
         )
     )


### PR DESCRIPTION
Indexers automatically maintain in-memory overviews of resources (indices), grouped by keys that are usually calculated based on these resources.

See the detailed description and several recipes in the .rst file in the PR's changes. The essence:

```python
import kopf

@kopf.index('pods', labels={'excluded': kopf.ABSENT})
def pod_phases(namespace, name, status, **_):
    return {(namespace, name): status.get('phase')}

@kopf.timer('kex', interval=5)
def tick(patch, pod_phases: kopf.Index, **_):
    patch.status['children'] = [
        f"{pod_namespace}/{pod_name}"
        for (pod_namespace, pod_name), pod_phase in pod_phases.items()
        if pod_phase == 'Running'
    ]
    print(patch.status['children'])
```

The indices can be used for cross-resource awareness: e.g., when a resource of kind X is changed, it can get all the information about all resources of kind Y without talking to the Kubernetes API.

The indices are optimized for lookups by keys (O(1) — the same as Python's dicts), though iterating over them is also an option. The updates & deletions are O(k), where "k" is the number of keys per object (not of the overall keys!).

**A side-note:** The in-memory indices are a step further towards cross-resource handlers (an example: when a child pod is changed, the cross-resource handler should be invoked in the context of its parent, not of the child itself, with all other pods' information at hand). In that case, only one resource is known due to the arrived event, while another resource should be either remembered in-memory or fake-patched with the full info of each child to trigger the handling. The latter way looks stressful to K8s & K8s API, so the in-memory way seems the only viable solution.

---
Things left to do (can take time):

* [x] Decide: do we need a `key=` callback or the key structure must be frozen (mapping to K8s API uniqueness: resource, namespace, name). What if 2+ handlers for the same function have different key structures?
  * No. Custom keys complicate things and give no benefits. A minimalistic `(namespace, name)` key is enough. Resources are not needed as a part of the key, as they can be replaced by a cache name/id.
* [x] Decide: are views retriable? What do the TemporaryErrors/PermanentErrors mean? Backoffs? Timeouts?
  * No, not retriable. However, the interpretation of errors has to be decided: do they remove the cache entry on permanent error? Mark it as out-of-date on a temporary error?
* [x] Decide: can we implement the same with the existing handlers/causes/registries (watching-changing-spawning), or do we need a new type?
  * A new type and a new registry is needed. The cache handlers are executed separately from all other handlers — to ensure that the caches are pre-populated before doing regular handlers. Besides, they might have their own properties: e.g. `ttl`.
* [x] Decide: Naming: cacheing (rare), caching (common), indexing, or something else. Formally, it is not caching as a faster memoisation technique.
  * Indexing. Also: indices (the user-facing structures), indexers (internal managers of indices).
* [x] Implement: proper Cache/Caches classes; currently: `defaultdict`. Separate read-only (operator) and read-write (framework) modes accessors.
* [x] Implement: filtering in and filtering out (i.e., not just deletion, but changing labels/annotations/fields/values to become included/excluded).
* EXCLUDED: Implement: a condition (sync/async) to wait for changes in the daemon — for immediate reaction in another resource, not just time-intervalled. (maybe as a separate enhancement).
* EXCLUDED: TTL for cache entries — to save memory on long runs. (questionable! no resync is possible!).
* EXCLUDED: Up-to-date/out-of-sync/stale read-only flags. (see errors interpretation above).
* [x] Clean up the code.
* [x] Write the tests.
* [x] Write the docs.
* [ ] Manually test that all docs examples do actually work.
