### PR TITLE
fix liveness probe parameter in docs

### DIFF
--- a/docs/probing.rst
+++ b/docs/probing.rst
@@ -13,7 +13,7 @@ To specify an endpoint to listen for probes, use :option:`--liveness`:
 
 .. code-block:: bash
 
-    kopf run --liveness=http://:8080/healthz --verbose handlers.py
+    kopf run --liveness=http://0.0.0.0:8080/healthz --verbose handlers.py
 
 Currently, only HTTP is supported.
 Other protocols (TCP, HTTPS) can be added in the future.


### PR DESCRIPTION
## What do these changes do?

Fixing the liveness probe parameter in the documentation


## Description

The current parameter only exposes the liveness endpoint on localhost which Kubernetes cannot reach. Adding 0.0.0.0 will also expose it on the cluster internal IP which Kubernetes can reach.

## Type of changes

- Mostly documentation and examples (no code changes)

## Checklist

- [ ] The code addresses only the mentioned problem, and this problem only
- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`