### PR TITLE
Add missing `memo` kwargs to callback protocols

### DIFF
--- a/examples/12-embedded/example.py
+++ b/examples/12-embedded/example.py
@@ -61,7 +61,7 @@ def main(steps=3):
 
 
 class KopfExample(pykube.objects.NamespacedAPIObject):
-    version = "v1"
+    version = "kopf.dev/v1"
     endpoint = "kopfexamples"
     kind = "KopfExample"
 

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -90,9 +90,6 @@ from kopf.structs.callbacks import (
 from kopf.structs.configuration import (
     OperatorSettings,
 )
-from kopf.structs.containers import (
-    Memo,
-)
 from kopf.structs.credentials import (
     LoginError,
     ConnectionInfo,
@@ -114,6 +111,9 @@ from kopf.structs.handlers import (
     HandlerId,
     ErrorsMode,
     Reason,
+)
+from kopf.structs.memos import (
+    Memo,
 )
 from kopf.structs.patches import (
     Patch,

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -24,8 +24,8 @@ import logging
 from typing import Any, Optional, TypeVar, Union
 
 from kopf.storage import finalizers
-from kopf.structs import bodies, configuration, containers, diffs, \
-                         handlers, patches, primitives, references
+from kopf.structs import bodies, configuration, diffs, handlers, \
+                         memos, patches, primitives, references
 
 
 @dataclasses.dataclass
@@ -44,7 +44,7 @@ class ResourceCause(BaseCause):
     resource: references.Resource
     patch: patches.Patch
     body: bodies.Body
-    memo: containers.Memo
+    memo: memos.Memo
 
 
 @dataclasses.dataclass

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Collection, Coroutine, NewType, Optional, Type
 
 from typing_extensions import Protocol
 
-from kopf.structs import bodies, diffs, patches, primitives, references
+from kopf.structs import bodies, diffs, memos, patches, primitives, references
 
 # A specialised type to highlight the purpose or origin of the data of type Any,
 # to not be mixed with other arbitrary Any values, where it is indeed "any".
@@ -50,6 +50,7 @@ class ResourceWatchingFn(Protocol):
             patch: patches.Patch,
             logger: Union[logging.Logger, logging.LoggerAdapter],
             resource: references.Resource,
+            memo: memos.Memo,
             **kwargs: Any,
     ) -> _SyncOrAsyncResult: ...
 
@@ -71,6 +72,7 @@ class ResourceChangingFn(Protocol):
             old: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
             new: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
             resource: references.Resource,
+            memo: memos.Memo,
             **kwargs: Any,
     ) -> _SyncOrAsyncResult: ...
 
@@ -89,6 +91,7 @@ class ResourceDaemonSyncFn(Protocol):
             logger: Union[logging.Logger, logging.LoggerAdapter],
             stopped: primitives.SyncDaemonStopperChecker,  # << different type
             resource: references.Resource,
+            memo: memos.Memo,
             **kwargs: Any,
     ) -> Optional[Result]: ...
 
@@ -107,6 +110,7 @@ class ResourceDaemonAsyncFn(Protocol):
             logger: Union[logging.Logger, logging.LoggerAdapter],
             stopped: primitives.AsyncDaemonStopperChecker,  # << different type
             resource: references.Resource,
+            memo: memos.Memo,
             **kwargs: Any,
     ) -> Optional[Result]: ...
 
@@ -127,6 +131,7 @@ class ResourceTimerFn(Protocol):
             namespace: Optional[str],
             logger: Union[logging.Logger, logging.LoggerAdapter],
             resource: references.Resource,
+            memo: memos.Memo,
             **kwargs: Any,
     ) -> _SyncOrAsyncResult: ...
 
@@ -153,6 +158,7 @@ class WhenFilterFn(Protocol):
             old: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
             new: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
             resource: references.Resource,
+            memo: memos.Memo,
             **kwargs: Any,
     ) -> bool: ...
 
@@ -172,6 +178,7 @@ class MetaFilterFn(Protocol):
             patch: patches.Patch,
             logger: Union[logging.Logger, logging.LoggerAdapter],
             resource: references.Resource,
+            memo: memos.Memo,
             **kwargs: Any,
     ) -> bool: ...
 

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -10,9 +10,9 @@ object, even if that object does not show up in the event streams for long time.
 import dataclasses
 import logging
 import time
-from typing import Any, Dict, Iterator, MutableMapping, Optional, Set, Union
+from typing import Dict, Iterator, MutableMapping, Optional, Set, Union
 
-from kopf.structs import bodies, handlers, primitives
+from kopf.structs import bodies, handlers, memos, primitives
 from kopf.utilities import aiotasks
 
 
@@ -32,31 +32,12 @@ class Throttler:
     active_until: Optional[float] = None  # internal clock
 
 
-class Memo(Dict[Any, Any]):
-    """ A container to hold arbitrary keys-fields assigned by the users. """
-
-    def __setattr__(self, key: str, value: Any) -> None:
-        self[key] = value
-
-    def __delattr__(self, key: str) -> None:
-        try:
-            del self[key]
-        except KeyError as e:
-            raise AttributeError(str(e))
-
-    def __getattr__(self, key: str) -> Any:
-        try:
-            return self[key]
-        except KeyError as e:
-            raise AttributeError(str(e))
-
-
 @dataclasses.dataclass(frozen=False)
 class ResourceMemory:
     """ A system memo about a single resource/object. Usually stored in `Memories`. """
 
     # For arbitrary user data to be stored in memory, passed as `memo` to all the handlers.
-    memo: Memo = dataclasses.field(default_factory=Memo)
+    memo: memos.Memo = dataclasses.field(default_factory=memos.Memo)
 
     # For resuming handlers tracking and deciding on should they be called or not.
     noticed_by_listing: bool = False

--- a/kopf/structs/memos.py
+++ b/kopf/structs/memos.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict
+
+
+class Memo(Dict[Any, Any]):
+    """ A container to hold arbitrary keys-fields assigned by the users. """
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        self[key] = value
+
+    def __delattr__(self, key: str) -> None:
+        try:
+            del self[key]
+        except KeyError as e:
+            raise AttributeError(str(e))
+
+    def __getattr__(self, key: str) -> Any:
+        try:
+            return self[key]
+        except KeyError as e:
+            raise AttributeError(str(e))

--- a/kopf/structs/memos.py
+++ b/kopf/structs/memos.py
@@ -2,7 +2,28 @@ from typing import Any, Dict
 
 
 class Memo(Dict[Any, Any]):
-    """ A container to hold arbitrary keys-fields assigned by the users. """
+    """
+    A container to hold arbitrary keys-values assigned by operator developers.
+
+    It is used in the :kwarg:`memo` kwarg to all resource handlers, isolated
+    per individual resource object (not the resource kind).
+
+    The values can be accessed either as dictionary keys (the memo is a ``dict``
+    under the hood) or as object attributes (except for methods of ``dict``).
+
+    >>> memo = Memo()
+
+    >>> memo.f1 = 100
+    >>> memo['f1']
+    ... 100
+
+    >>> memo['f2'] = 200
+    >>> memo.f2
+    ... 200
+
+    >>> set(memo.keys())
+    ... {'f1', 'f2'}
+    """
 
     def __setattr__(self, key: str, value: Any) -> None:
         self[key] = value

--- a/tests/basic-structs/test_containers.py
+++ b/tests/basic-structs/test_containers.py
@@ -1,6 +1,3 @@
-import collections.abc
-
-import pytest
 
 from kopf.structs.bodies import Body
 from kopf.structs.containers import ResourceMemories, ResourceMemory
@@ -43,58 +40,3 @@ async def test_forgetting_deletes_when_present():
 async def test_forgetting_ignores_when_absent():
     memories = ResourceMemories()
     await memories.forget(BODY)
-
-
-def test_object_dict_creation():
-    obj = Memo()
-    assert isinstance(obj, collections.abc.MutableMapping)
-
-
-def test_object_dict_fields_are_keys():
-    obj = Memo()
-    obj.xyz = 100
-    assert obj['xyz'] == 100
-
-
-def test_object_dict_keys_are_fields():
-    obj = Memo()
-    obj['xyz'] = 100
-    assert obj.xyz == 100
-
-
-def test_object_dict_keys_deleted():
-    obj = Memo()
-    obj['xyz'] = 100
-    del obj['xyz']
-    assert obj == {}
-
-
-def test_object_dict_fields_deleted():
-    obj = Memo()
-    obj.xyz = 100
-    del obj.xyz
-    assert obj == {}
-
-
-def test_object_dict_raises_key_errors_on_get():
-    obj = Memo()
-    with pytest.raises(KeyError):
-        obj['unexistent']
-
-
-def test_object_dict_raises_attribute_errors_on_get():
-    obj = Memo()
-    with pytest.raises(AttributeError):
-        obj.unexistent
-
-
-def test_object_dict_raises_key_errors_on_del():
-    obj = Memo()
-    with pytest.raises(KeyError):
-        del obj['unexistent']
-
-
-def test_object_dict_raises_attribute_errors_on_del():
-    obj = Memo()
-    with pytest.raises(AttributeError):
-        del obj.unexistent

--- a/tests/basic-structs/test_containers.py
+++ b/tests/basic-structs/test_containers.py
@@ -3,7 +3,8 @@ import collections.abc
 import pytest
 
 from kopf.structs.bodies import Body
-from kopf.structs.containers import Memo, ResourceMemories, ResourceMemory
+from kopf.structs.containers import ResourceMemories, ResourceMemory
+from kopf.structs.memos import Memo
 
 BODY: Body = {
     'metadata': {

--- a/tests/basic-structs/test_memos.py
+++ b/tests/basic-structs/test_memos.py
@@ -1,0 +1,93 @@
+import collections.abc
+
+import pytest
+
+from kopf.structs.memos import Memo
+
+
+def test_creation_with_defaults():
+    obj = Memo()
+    assert isinstance(obj, collections.abc.MutableMapping)
+    assert not set(obj)
+
+
+def test_creation_with_dict():
+    obj = Memo({'xyz': 100})
+    assert isinstance(obj, collections.abc.MutableMapping)
+    assert set(obj) == {'xyz'}
+
+
+def test_creation_with_list():
+    obj = Memo([('xyz', 100)])
+    assert isinstance(obj, collections.abc.MutableMapping)
+    assert set(obj) == {'xyz'}
+
+
+def test_creation_with_memo():
+    obj = Memo(Memo({'xyz': 100}))
+    assert isinstance(obj, collections.abc.MutableMapping)
+    assert set(obj) == {'xyz'}
+
+
+def test_fields_are_keys():
+    obj = Memo()
+    obj.xyz = 100
+    assert obj['xyz'] == 100
+
+
+def test_keys_are_fields():
+    obj = Memo()
+    obj['xyz'] = 100
+    assert obj.xyz == 100
+
+
+def test_keys_deleted():
+    obj = Memo()
+    obj['xyz'] = 100
+    del obj['xyz']
+    assert obj == {}
+
+
+def test_fields_deleted():
+    obj = Memo()
+    obj.xyz = 100
+    del obj.xyz
+    assert obj == {}
+
+
+def test_raises_key_errors_on_get():
+    obj = Memo()
+    with pytest.raises(KeyError):
+        obj['unexistent']
+
+
+def test_raises_attribute_errors_on_get():
+    obj = Memo()
+    with pytest.raises(AttributeError):
+        obj.unexistent
+
+
+def test_raises_key_errors_on_del():
+    obj = Memo()
+    with pytest.raises(KeyError):
+        del obj['unexistent']
+
+
+def test_raises_attribute_errors_on_del():
+    obj = Memo()
+    with pytest.raises(AttributeError):
+        del obj.unexistent
+
+
+def test_shallow_copied_keys():
+    obj1 = Memo({'xyz': 100})
+    obj2 = Memo(obj1)
+    obj1['xyz'] = 200
+    assert obj2['xyz'] == 100
+
+
+def test_shallow_copied_values():
+    obj1 = Memo({'xyz': 100})
+    obj2 = Memo(dat=obj1)
+    obj1['xyz'] = 200
+    assert obj2['dat']['xyz'] == 200

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -7,8 +7,8 @@ from kopf.reactor.causation import ResourceChangingCause, ResourceWatchingCause
 from kopf.reactor.handling import cause_var
 from kopf.reactor.invocation import context
 from kopf.structs.bodies import Body, RawBody, RawEvent, RawMeta
-from kopf.structs.containers import Memo
 from kopf.structs.handlers import Reason
+from kopf.structs.memos import Memo
 from kopf.structs.patches import Patch
 
 OWNER_API_VERSION = 'owner-api-version'

--- a/tests/invocations/test_kwargs.py
+++ b/tests/invocations/test_kwargs.py
@@ -7,9 +7,9 @@ from kopf.reactor.causation import ActivityCause, DaemonCause, ResourceChangingC
 from kopf.reactor.invocation import build_kwargs
 from kopf.structs.bodies import Body, BodyEssence
 from kopf.structs.configuration import OperatorSettings
-from kopf.structs.containers import Memo
 from kopf.structs.diffs import Diff
 from kopf.structs.handlers import Activity, Reason
+from kopf.structs.memos import Memo
 from kopf.structs.patches import Patch
 from kopf.structs.primitives import DaemonStopper
 

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -7,8 +7,8 @@ from kopf.reactor.causation import ResourceChangingCause
 from kopf.reactor.invocation import invoke
 from kopf.storage.states import State
 from kopf.structs.bodies import Body
-from kopf.structs.containers import Memo
 from kopf.structs.handlers import Reason
+from kopf.structs.memos import Memo
 from kopf.structs.patches import Patch
 
 

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -8,9 +8,9 @@ from kopf.reactor.registries import ActivityRegistry, OperatorRegistry, Resource
                                     ResourceRegistry, ResourceSpawningRegistry, \
                                     ResourceWatchingRegistry
 from kopf.structs.bodies import Body
-from kopf.structs.containers import Memo
 from kopf.structs.diffs import Diff, DiffItem
 from kopf.structs.handlers import HandlerId, ResourceChangingHandler
+from kopf.structs.memos import Memo
 from kopf.structs.patches import Patch
 
 


### PR DESCRIPTION
Add missing `memo` kwargs to callback protocols and make them part of the public interface (docs, tests).

In addition, resolve circular imports:

* `callbacks` require `containers` (now: `memos`) for the kwarg `memo`.
* `containers` require `handlers` for `HandlerId` & daemon handler.
* `handlers` require `callbacks` for callback protocols.

Previously, it was not a problem because `callbacks` did not declare `memo` kwargs by mistake, and therefore did not import `containers`. 

The chain is broken at the `callbacks`→`containers` import: it is now `callbacks`→`memos`.
