### PR TITLE
Operator-level memos, optionally passed into embedded operators

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Kopf: Kubernetes Operators Framework
    filters
    results
    errors
+   memories
    scopes
 
 .. toctree::

--- a/docs/kwargs.rst
+++ b/docs/kwargs.rst
@@ -139,7 +139,6 @@ as empty dicts.
 Logging
 -------
 
-
 ``logger`` is a per-object logger, with the messages prefixed with the object's
 namespace/name.
 
@@ -163,13 +162,16 @@ in the framework, why make separate API calls for patching?)_.
 In-memory container
 -------------------
 
-``memo`` is an in-memory container for arbitrary runtime-only keys/fields
-and values stored during the operator lifetime.
-The values are shared by all the handlers for the same object.
+``memo`` is an in-memory container for arbitrary runtime-only keys-values.
+The values can be accessed as either object attributes or dictionary keys.
 
-The in-memory values are lost on operator restarts.
-If the resource is deleted and re-created with the same name,
-the in-memory values are also lost (technically, it is a new object).
+For resource handlers, ``memo`` is shared by all handlers of the same
+individual resource (not of the resource kind, but of the resource object).
+For operator handlers, ``memo`` is shared by all handlers of the same operator,
+and later used to populate the resources' ``memo`` containers.
+
+.. seealso::
+    :doc:`memories` and :class:`kopf.Memo`.
 
 
 Resource-watching kwargs

--- a/docs/memories.rst
+++ b/docs/memories.rst
@@ -1,0 +1,110 @@
+====================
+In-memory containers
+====================
+
+Kopf prodives several ways of storing and exchanging the data in-memory
+between handlers and operators.
+
+
+Resource memo
+=============
+
+Every resource handler gets a :kwarg:`memo` kwarg of type :class:`kopf.Memo`.
+It is an in-memory container for arbitrary runtime-only keys-values.
+The values can be accessed as either object attributes or dictionary keys.
+
+The memo is shared by all handlers of the same individual resource
+(not of the resource kind, but of a resource object).
+If the resource is deleted and re-created with the same name,
+the memo is also re-created (technically, it is a new resource).
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.event('KopfExample')
+    def pinged(memo: kopf.Memo, **_):
+        memo.counter = memo.get('counter', 0) + 1
+
+    @kopf.timer('KopfExample', interval=10)
+    def tick(memo: kopf.Memo, logger, **_):
+        logger.info(f"{memo.counter} events have been received in 10 seconds.")
+        memo.counter = 0
+
+
+Operator memo
+=============
+
+In the operator handlers, such as the operator startup/cleanup, liveness probes,
+credentials retrieval, and everything else not specific to resources,
+:kwarg:`memo` points to the operator's global container for arbitrary values.
+
+The per-operator container can be either populated in the startup handlers,
+or passed from outside of the operator when :doc:`embedding` is used, or both:
+
+.. code-block:: python
+
+    import kopf
+    import queue
+    import threading
+
+    @kopf.on.startup()
+    def start_background_worker(memo: kopf.Memo, **_):
+        memo.my_queue = queue.Queue()
+        memo.my_thread = threading.Thread(target=background, args=(memo.my_queue,))
+        memo.my_thread.start()
+
+    @kopf.on.cleanup()
+    def stop_background_worker(memo: kopf.Memo, **_):
+        memo['my_queue'].put(None)
+        memo['my_thread'].join()
+
+    def background(queue: queue.Queue):
+        while True:
+            item = queue.get()
+            if item is None:
+                break
+            else:
+                print(item)
+
+.. note::
+
+    For code quality and style consistency, it is recommended to use
+    the same approach when accessing the stored values.
+    The mixed style here is for demonstration purposes only.
+
+The operator's memo is later used to populate the per-resource memos.
+All keys & values are shallow-copied into each individual resource's memo,
+where they can be mixed with the per-resource values:
+
+.. code-block:: python
+
+    # ... continued from the previous example.
+    @kopf.on.event('KopfExample')
+    def pinged(memo: kopf.Memo, namespace: str, name: str, **_):
+        if not memo.get('is_seen'):
+            memo.my_queue.put(f"{namespace}/{name}")
+            memo.is_seen = True
+
+Any changes to the operator's container since the first appearence
+of the resource are **not** replicated to the existing resources' containers,
+and are not guaranteed to be seen by the new resources (even if they are now).
+
+However, due to shallow copying, the mutable objects (lists, dicts, and even
+custom instances of :class:`kopf.Memo` itself) in the operator's container
+can be modified from outside, and these changes will be seen in all individual
+resource handlers & daemons which use their own per-resource containers.
+
+
+Limitations
+===========
+
+All in-memory values are lost on operator restarts; there is no persistence.
+
+The in-memory containers are recommended only for ephemeral objects scoped
+to the process lifetime, such as concurrency primitives: locks, tasks, threads…
+For persistent values, use the status stanza or annotations of the resources.
+
+Essentially, the operator's memo is not much different from global variables
+(unless there are 2+ embedded operator tasks running) or asyncio contextvars,
+except that it provides the same interface as for per-resource memos.

--- a/examples/12-embedded/example.py
+++ b/examples/12-embedded/example.py
@@ -8,13 +8,13 @@ import pykube
 
 
 @kopf.on.create('kopfexamples')
-def create_fn(**_):
-    pass
+def create_fn(memo: kopf.Memo, **kwargs):
+    print(memo.create_tpl.format(**kwargs))
 
 
 @kopf.on.delete('kopfexamples')
-def delete_fn(**_):
-    pass
+def delete_fn(memo: kopf.Memo, **kwargs):
+    print(memo.delete_tpl.format(**kwargs))
 
 
 def kopf_thread(
@@ -30,6 +30,10 @@ def kopf_thread(
         loop.run_until_complete(kopf.operator(
             ready_flag=ready_flag,
             stop_flag=stop_flag,
+            memo=kopf.Memo(
+                create_tpl="Hello, {name}!",
+                delete_tpl="Good bye, {name}!",
+            ),
         ))
 
 

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -20,7 +20,7 @@ _Key = Tuple[str, int]  # hostname, port
 async def health_reporter(
         endpoint: str,
         *,
-        memo: memos.Memo,
+        memo: memos.AnyMemo,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         ready_flag: Optional[asyncio.Event] = None,  # used for testing

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -7,7 +7,7 @@ from typing import MutableMapping, Optional, Tuple
 import aiohttp.web
 
 from kopf.reactor import activities, lifecycles, registries
-from kopf.structs import callbacks, configuration, handlers
+from kopf.structs import callbacks, configuration, handlers, memos
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +20,7 @@ _Key = Tuple[str, int]  # hostname, port
 async def health_reporter(
         endpoint: str,
         *,
+        memo: memos.Memo,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         ready_flag: Optional[asyncio.Event] = None,  # used for testing
@@ -54,6 +55,7 @@ async def health_reporter(
                         registry=registry,
                         settings=settings,
                         activity=handlers.Activity.PROBE,
+                        memo=memo,
                     )
                     probing_container.clear()
                     probing_container.update(activity_results)

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -44,7 +44,7 @@ async def authenticator(
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         vault: credentials.Vault,
-        memo: memos.Memo,
+        memo: memos.AnyMemo,
 ) -> NoReturn:
     """ Keep the credentials forever up to date. """
     counter: int = 1 if vault else 0
@@ -64,7 +64,7 @@ async def authenticate(
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         vault: credentials.Vault,
-        memo: memos.Memo,
+        memo: memos.AnyMemo,
         _activity_title: str = "Authentication",
 ) -> None:
     """ Retrieve the credentials once, successfully or not, and exit. """
@@ -99,7 +99,7 @@ async def run_activity(
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         activity: handlers_.Activity,
-        memo: memos.Memo,
+        memo: memos.AnyMemo,
 ) -> Mapping[handlers_.HandlerId, callbacks.Result]:
     logger = logging.getLogger(f'kopf.activities.{activity.value}')
 

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -21,7 +21,7 @@ from typing import Mapping, MutableMapping, NoReturn
 
 from kopf.reactor import causation, effects, handling, lifecycles, registries
 from kopf.storage import states
-from kopf.structs import callbacks, configuration, credentials, handlers as handlers_
+from kopf.structs import callbacks, configuration, credentials, handlers as handlers_, memos
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +44,7 @@ async def authenticator(
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         vault: credentials.Vault,
+        memo: memos.Memo,
 ) -> NoReturn:
     """ Keep the credentials forever up to date. """
     counter: int = 1 if vault else 0
@@ -52,6 +53,7 @@ async def authenticator(
             registry=registry,
             settings=settings,
             vault=vault,
+            memo=memo,
             _activity_title="Re-authentication" if counter else "Initial authentication",
         )
         counter += 1
@@ -62,6 +64,7 @@ async def authenticate(
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         vault: credentials.Vault,
+        memo: memos.Memo,
         _activity_title: str = "Authentication",
 ) -> None:
     """ Retrieve the credentials once, successfully or not, and exit. """
@@ -77,6 +80,7 @@ async def authenticate(
         registry=registry,
         settings=settings,
         activity=handlers_.Activity.AUTHENTICATION,
+        memo=memo,
     )
 
     if activity_results:
@@ -95,11 +99,17 @@ async def run_activity(
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         activity: handlers_.Activity,
+        memo: memos.Memo,
 ) -> Mapping[handlers_.HandlerId, callbacks.Result]:
     logger = logging.getLogger(f'kopf.activities.{activity.value}')
 
     # For the activity handlers, we have neither bodies, nor patches, just the state.
-    cause = causation.ActivityCause(logger=logger, activity=activity, settings=settings)
+    cause = causation.ActivityCause(
+        logger=logger,
+        activity=activity,
+        settings=settings,
+        memo=memo,
+    )
     handlers = registry._activities.get_handlers(activity=activity)
     state = states.State.from_scratch().with_handlers(handlers)
     outcomes: MutableMapping[handlers_.HandlerId, states.HandlerOutcome] = {}

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -31,7 +31,7 @@ from kopf.structs import bodies, configuration, diffs, handlers, \
 @dataclasses.dataclass
 class BaseCause:
     logger: Union[logging.Logger, logging.LoggerAdapter]
-    memo: memos.Memo
+    memo: memos.AnyMemo
 
 
 @dataclasses.dataclass

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -31,6 +31,7 @@ from kopf.structs import bodies, configuration, diffs, handlers, \
 @dataclasses.dataclass
 class BaseCause:
     logger: Union[logging.Logger, logging.LoggerAdapter]
+    memo: memos.Memo
 
 
 @dataclasses.dataclass
@@ -44,7 +45,6 @@ class ResourceCause(BaseCause):
     resource: references.Resource
     patch: patches.Patch
     body: bodies.Body
-    memo: memos.Memo
 
 
 @dataclasses.dataclass

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -49,6 +49,7 @@ def build_kwargs(
     if isinstance(cause, causation.BaseCause):
         new_kwargs.update(
             logger=cause.logger,
+            memo=cause.memo,
         )
     if isinstance(cause, causation.ActivityCause):
         new_kwargs.update(
@@ -62,7 +63,6 @@ def build_kwargs(
         new_kwargs.update(
             resource=cause.resource,
             patch=cause.patch,
-            memo=cause.memo,
             body=cause.body,
             spec=cause.body.spec,
             meta=cause.body.metadata,

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -21,7 +21,7 @@ from kopf.engines import loggers, posting
 from kopf.reactor import causation, daemons, effects, handling, lifecycles, registries
 from kopf.storage import finalizers, states
 from kopf.structs import bodies, configuration, containers, diffs, \
-                         handlers as handlers_, patches, references
+                         handlers as handlers_, memos, patches, references
 
 
 async def process_resource_event(
@@ -29,6 +29,7 @@ async def process_resource_event(
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         memories: containers.ResourceMemories,
+        memobase: memos.Memo,
         resource: references.Resource,
         raw_event: bodies.RawEvent,
         replenished: asyncio.Event,
@@ -44,7 +45,7 @@ async def process_resource_event(
     # Recall what is stored about that object. Share it in little portions with the consumers.
     # And immediately forget it if the object is deleted from the cluster (but keep in memory).
     raw_type, raw_body = raw_event['type'], raw_event['object']
-    memory = await memories.recall(raw_body, noticed_by_listing=raw_type is None)
+    memory = await memories.recall(raw_body, noticed_by_listing=raw_type is None, memo=memobase)
     if memory.live_fresh_body is not None:
         memory.live_fresh_body._replace_with(raw_body)
     if raw_type == 'DELETED':

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -29,7 +29,7 @@ async def process_resource_event(
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         memories: containers.ResourceMemories,
-        memobase: memos.Memo,
+        memobase: memos.AnyMemo,
         resource: references.Resource,
         raw_event: bodies.RawEvent,
         replenished: asyncio.Event,

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -281,6 +281,7 @@ async def spawn_tasks(
                                             registry=registry,
                                             settings=settings,
                                             memories=memories,
+                                            memobase=memo,
                                             event_queue=event_queue))))
 
     # Ensure that all guarded tasks got control for a moment to enter the guard.

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -10,7 +10,8 @@ from kopf.clients import auth
 from kopf.engines import peering, posting, probing
 from kopf.reactor import activities, daemons, lifecycles, observation, \
                          orchestration, processing, registries
-from kopf.structs import configuration, containers, credentials, handlers, primitives, references
+from kopf.structs import configuration, containers, credentials, \
+                         handlers, memos, primitives, references
 from kopf.utilities import aiotasks
 
 logger = logging.getLogger(__name__)
@@ -167,6 +168,7 @@ async def spawn_tasks(
     insights = insights if insights is not None else references.Insights()
     identity = identity if identity is not None else peering.detect_own_id(manual=False)
     vault = vault if vault is not None else credentials.Vault()
+    memo = memos.Memo()
     event_queue: posting.K8sEventQueue = asyncio.Queue()
     signal_flag: aiotasks.Future = asyncio.Future()
     started_flag: asyncio.Event = asyncio.Event()
@@ -208,7 +210,8 @@ async def spawn_tasks(
             started_flag=started_flag,
             registry=registry,
             settings=settings,
-            vault=vault)))  # to purge & finalize the caches in the end.
+            vault=vault,
+            memo=memo)))  # to purge & finalize the caches in the end.
 
     # Kill all the daemons gracefully when the operator exits (so that they are not "hung").
     tasks.append(aiotasks.create_guarded_task(
@@ -223,7 +226,8 @@ async def spawn_tasks(
         coro=activities.authenticator(
             registry=registry,
             settings=settings,
-            vault=vault)))
+            vault=vault,
+            memo=memo)))
 
     # K8s-event posting. Events are queued in-memory and posted in the background.
     # NB: currently, it is a global task, but can be made per-resource or per-object.
@@ -240,7 +244,8 @@ async def spawn_tasks(
             coro=probing.health_reporter(
                 registry=registry,
                 settings=settings,
-                endpoint=liveness_endpoint)))
+                endpoint=liveness_endpoint,
+                memo=memo)))
 
     # Permanent observation of what resource kinds and namespaces are available in the cluster.
     # Spawn and cancel dimensional tasks as they come and go; dimensions = resources x namespaces.
@@ -420,6 +425,7 @@ async def _startup_cleanup_activities(
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         vault: credentials.Vault,
+        memo: memos.Memo,
 ) -> None:
     """
     Startup and cleanup activities.
@@ -441,6 +447,7 @@ async def _startup_cleanup_activities(
             registry=registry,
             settings=settings,
             activity=handlers.Activity.STARTUP,
+            memo=memo,
         )
     except asyncio.CancelledError:
         logger.warning("Startup activity is only partially executed due to cancellation.")
@@ -473,6 +480,7 @@ async def _startup_cleanup_activities(
             registry=registry,
             settings=settings,
             activity=handlers.Activity.CLEANUP,
+            memo=memo,
         )
         await vault.close()
     except asyncio.CancelledError:

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -36,7 +36,7 @@ def run(
         stop_flag: Optional[primitives.Flag] = None,
         ready_flag: Optional[primitives.Flag] = None,
         vault: Optional[credentials.Vault] = None,
-        memo: Optional[memos.Memo] = None,
+        memo: Optional[memos.AnyMemo] = None,
         _command: Optional[Coroutine[None, None, None]] = None,
 ) -> None:
     """
@@ -88,7 +88,7 @@ async def operator(
         stop_flag: Optional[primitives.Flag] = None,
         ready_flag: Optional[primitives.Flag] = None,
         vault: Optional[credentials.Vault] = None,
-        memo: Optional[memos.Memo] = None,
+        memo: Optional[memos.AnyMemo] = None,
         _command: Optional[Coroutine[None, None, None]] = None,
 ) -> None:
     """
@@ -141,7 +141,7 @@ async def spawn_tasks(
         stop_flag: Optional[primitives.Flag] = None,
         ready_flag: Optional[primitives.Flag] = None,
         vault: Optional[credentials.Vault] = None,
-        memo: Optional[memos.Memo] = None,
+        memo: Optional[memos.AnyMemo] = None,
         _command: Optional[Coroutine[None, None, None]] = None,
 ) -> Collection[aiotasks.Task]:
     """
@@ -431,7 +431,7 @@ async def _startup_cleanup_activities(
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         vault: credentials.Vault,
-        memo: memos.Memo,
+        memo: memos.AnyMemo,
 ) -> None:
     """
     Startup and cleanup activities.

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -36,6 +36,7 @@ def run(
         stop_flag: Optional[primitives.Flag] = None,
         ready_flag: Optional[primitives.Flag] = None,
         vault: Optional[credentials.Vault] = None,
+        memo: Optional[memos.Memo] = None,
         _command: Optional[Coroutine[None, None, None]] = None,
 ) -> None:
     """
@@ -62,6 +63,7 @@ def run(
             stop_flag=stop_flag,
             ready_flag=ready_flag,
             vault=vault,
+            memo=memo,
             _command=_command,
         ))
     except asyncio.CancelledError:
@@ -86,6 +88,7 @@ async def operator(
         stop_flag: Optional[primitives.Flag] = None,
         ready_flag: Optional[primitives.Flag] = None,
         vault: Optional[credentials.Vault] = None,
+        memo: Optional[memos.Memo] = None,
         _command: Optional[Coroutine[None, None, None]] = None,
 ) -> None:
     """
@@ -114,6 +117,7 @@ async def operator(
         stop_flag=stop_flag,
         ready_flag=ready_flag,
         vault=vault,
+        memo=memo,
         _command=_command,
     )
     await run_tasks(operator_tasks, ignored=existing_tasks)
@@ -137,6 +141,7 @@ async def spawn_tasks(
         stop_flag: Optional[primitives.Flag] = None,
         ready_flag: Optional[primitives.Flag] = None,
         vault: Optional[credentials.Vault] = None,
+        memo: Optional[memos.Memo] = None,
         _command: Optional[Coroutine[None, None, None]] = None,
 ) -> Collection[aiotasks.Task]:
     """
@@ -168,7 +173,7 @@ async def spawn_tasks(
     insights = insights if insights is not None else references.Insights()
     identity = identity if identity is not None else peering.detect_own_id(manual=False)
     vault = vault if vault is not None else credentials.Vault()
-    memo = memos.Memo()
+    memo = memo if memo is not None else memos.Memo()
     event_queue: posting.K8sEventQueue = asyncio.Queue()
     signal_flag: aiotasks.Future = asyncio.Future()
     started_flag: asyncio.Event = asyncio.Event()

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -30,6 +30,7 @@ class ActivityFn(Protocol):
             self,
             *args: Any,
             logger: Union[logging.Logger, logging.LoggerAdapter],
+            memo: memos.Memo,
             **kwargs: Any,
     ) -> _SyncOrAsyncResult: ...
 

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -30,7 +30,7 @@ class ActivityFn(Protocol):
             self,
             *args: Any,
             logger: Union[logging.Logger, logging.LoggerAdapter],
-            memo: memos.Memo,
+            memo: memos.AnyMemo,
             **kwargs: Any,
     ) -> _SyncOrAsyncResult: ...
 
@@ -51,7 +51,7 @@ class ResourceWatchingFn(Protocol):
             patch: patches.Patch,
             logger: Union[logging.Logger, logging.LoggerAdapter],
             resource: references.Resource,
-            memo: memos.Memo,
+            memo: memos.AnyMemo,
             **kwargs: Any,
     ) -> _SyncOrAsyncResult: ...
 
@@ -73,7 +73,7 @@ class ResourceChangingFn(Protocol):
             old: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
             new: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
             resource: references.Resource,
-            memo: memos.Memo,
+            memo: memos.AnyMemo,
             **kwargs: Any,
     ) -> _SyncOrAsyncResult: ...
 
@@ -92,7 +92,7 @@ class ResourceDaemonSyncFn(Protocol):
             logger: Union[logging.Logger, logging.LoggerAdapter],
             stopped: primitives.SyncDaemonStopperChecker,  # << different type
             resource: references.Resource,
-            memo: memos.Memo,
+            memo: memos.AnyMemo,
             **kwargs: Any,
     ) -> Optional[Result]: ...
 
@@ -111,7 +111,7 @@ class ResourceDaemonAsyncFn(Protocol):
             logger: Union[logging.Logger, logging.LoggerAdapter],
             stopped: primitives.AsyncDaemonStopperChecker,  # << different type
             resource: references.Resource,
-            memo: memos.Memo,
+            memo: memos.AnyMemo,
             **kwargs: Any,
     ) -> Optional[Result]: ...
 
@@ -132,7 +132,7 @@ class ResourceTimerFn(Protocol):
             namespace: Optional[str],
             logger: Union[logging.Logger, logging.LoggerAdapter],
             resource: references.Resource,
-            memo: memos.Memo,
+            memo: memos.AnyMemo,
             **kwargs: Any,
     ) -> _SyncOrAsyncResult: ...
 
@@ -159,7 +159,7 @@ class WhenFilterFn(Protocol):
             old: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
             new: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
             resource: references.Resource,
-            memo: memos.Memo,
+            memo: memos.AnyMemo,
             **kwargs: Any,
     ) -> bool: ...
 
@@ -179,7 +179,7 @@ class MetaFilterFn(Protocol):
             patch: patches.Patch,
             logger: Union[logging.Logger, logging.LoggerAdapter],
             resource: references.Resource,
-            memo: memos.Memo,
+            memo: memos.AnyMemo,
             **kwargs: Any,
     ) -> bool: ...
 

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -38,7 +38,7 @@ class ResourceMemory:
     """ A system memo about a single resource/object. Usually stored in `Memories`. """
 
     # For arbitrary user data to be stored in memory, passed as `memo` to all the handlers.
-    memo: memos.Memo = dataclasses.field(default_factory=memos.Memo)
+    memo: memos.AnyMemo = dataclasses.field(default_factory=memos.Memo)
 
     # For resuming handlers tracking and deciding on should they be called or not.
     noticed_by_listing: bool = False
@@ -86,7 +86,7 @@ class ResourceMemories:
             self,
             raw_body: bodies.RawBody,
             *,
-            memo: Optional[memos.Memo] = None,
+            memo: Optional[memos.AnyMemo] = None,
             noticed_by_listing: bool = False,
     ) -> ResourceMemory:
         """

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -7,6 +7,7 @@ On the operator restart, all the memories are lost.
 It is used internally to track allocated system resources for each Kubernetes
 object, even if that object does not show up in the event streams for long time.
 """
+import copy
 import dataclasses
 import logging
 import time
@@ -85,6 +86,7 @@ class ResourceMemories:
             self,
             raw_body: bodies.RawBody,
             *,
+            memo: Optional[memos.Memo] = None,
             noticed_by_listing: bool = False,
     ) -> ResourceMemory:
         """
@@ -94,7 +96,10 @@ class ResourceMemories:
         """
         key = self._build_key(raw_body)
         if key not in self._items:
-            memory = ResourceMemory(noticed_by_listing=noticed_by_listing)
+            if memo is None:
+                memory = ResourceMemory(noticed_by_listing=noticed_by_listing)
+            else:
+                memory = ResourceMemory(noticed_by_listing=noticed_by_listing, memo=copy.copy(memo))
             self._items[key] = memory
         return self._items[key]
 

--- a/kopf/structs/memos.py
+++ b/kopf/structs/memos.py
@@ -1,4 +1,9 @@
-from typing import Any, Dict
+from typing import Any, Dict, Union
+
+# Used for type-checking of embedded operators, where it can have any type.
+# It is usually of type `Memo` -- but the framework must not rely on that.
+# `Memo`, despite inheritance from `object`, is added to enable IDE completions.
+AnyMemo = Union["Memo", object]
 
 
 class Memo(Dict[Any, Any]):

--- a/kopf/structs/memos.py
+++ b/kopf/structs/memos.py
@@ -11,6 +11,8 @@ class Memo(Dict[Any, Any]):
     The values can be accessed either as dictionary keys (the memo is a ``dict``
     under the hood) or as object attributes (except for methods of ``dict``).
 
+    See more in :doc:`/memories`.
+
     >>> memo = Memo()
 
     >>> memo.f1 = 100

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -4,6 +4,7 @@ from kopf.reactor.activities import authenticate
 from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.credentials import ConnectionInfo, LoginError, Vault
 from kopf.structs.handlers import Activity, ActivityHandler
+from kopf.structs.memos import Memo
 
 
 async def test_empty_registry_produces_no_credentials(settings):
@@ -14,6 +15,7 @@ async def test_empty_registry_produces_no_credentials(settings):
         registry=registry,
         settings=settings,
         vault=vault,
+        memo=Memo(),
     )
 
     assert not vault
@@ -39,6 +41,7 @@ async def test_noreturn_handler_produces_no_credentials(settings):
         registry=registry,
         settings=settings,
         vault=vault,
+        memo=Memo(),
     )
 
     assert not vault
@@ -65,6 +68,7 @@ async def test_single_credentials_provided_to_vault(settings):
         registry=registry,
         settings=settings,
         vault=vault,
+        memo=Memo(),
     )
 
     assert vault

--- a/tests/basic-structs/test_causes.py
+++ b/tests/basic-structs/test_causes.py
@@ -10,6 +10,7 @@ def test_cause_with_no_args(cls):
 
 
 def test_activity_cause(mocker):
+    memo = mocker.Mock()
     logger = mocker.Mock()
     activity = mocker.Mock()
     settings = mocker.Mock()
@@ -17,10 +18,12 @@ def test_activity_cause(mocker):
         activity=activity,
         settings=settings,
         logger=logger,
+        memo=memo,
     )
     assert cause.activity is activity
     assert cause.settings is settings
     assert cause.logger is logger
+    assert cause.memo is memo
 
 
 def test_resource_watching_cause(mocker):

--- a/tests/basic-structs/test_containers.py
+++ b/tests/basic-structs/test_containers.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock
 
 from kopf.structs.bodies import Body
 from kopf.structs.containers import ResourceMemories, ResourceMemory
@@ -40,3 +41,18 @@ async def test_forgetting_deletes_when_present():
 async def test_forgetting_ignores_when_absent():
     memories = ResourceMemories()
     await memories.forget(BODY)
+
+
+async def test_memo_is_shallow_copied():
+
+    class MyMemo(Memo):
+        def __copy__(self):
+            mock()
+            return MyMemo()
+
+    mock = Mock()
+    memo = MyMemo()
+    memories = ResourceMemories()
+    memory = await memories.recall(BODY, memo=memo)
+    assert mock.call_count == 1
+    assert memory.memo is not memo

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -9,6 +9,7 @@ import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.bodies import RawBody
 from kopf.structs.containers import ResourceMemories
+from kopf.structs.memos import Memo
 
 
 class DaemonDummy:
@@ -62,6 +63,7 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
             settings=settings,
             resource=resource,
             memories=memories,
+            memobase=Memo(),
             raw_event={'type': 'irrelevant', 'object': event_object},
             replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -9,6 +9,7 @@ from kopf.reactor.lifecycles import all_at_once
 from kopf.reactor.registries import OperatorRegistry
 from kopf.storage.states import HandlerOutcome
 from kopf.structs.handlers import Activity, ActivityHandler, HandlerId
+from kopf.structs.memos import Memo
 
 
 def test_activity_error_exception():
@@ -44,6 +45,7 @@ async def test_results_are_returned_on_success(settings, activity):
         settings=settings,
         activity=activity,
         lifecycle=all_at_once,
+        memo=Memo(),
     )
 
     assert set(results.keys()) == {'id1', 'id2'}
@@ -76,6 +78,7 @@ async def test_errors_are_raised_aggregated(settings, activity):
             settings=settings,
             activity=activity,
             lifecycle=all_at_once,
+            memo=Memo(),
         )
 
     assert set(e.value.outcomes.keys()) == {'id1', 'id2'}
@@ -109,6 +112,7 @@ async def test_errors_are_cascaded_from_one_of_the_originals(settings, activity)
             settings=settings,
             activity=activity,
             lifecycle=all_at_once,
+            memo=Memo(),
         )
 
     assert e.value.__cause__
@@ -136,6 +140,7 @@ async def test_retries_are_simulated(settings, activity, mocker):
             settings=settings,
             activity=activity,
             lifecycle=all_at_once,
+            memo=Memo(),
         )
 
     assert isinstance(e.value.outcomes['id'].exception, PermanentError)
@@ -168,6 +173,7 @@ async def test_delays_are_simulated(settings, activity, mocker):
                 settings=settings,
                 activity=activity,
                 lifecycle=all_at_once,
+                memo=Memo(),
             )
 
     assert sleep_or_wait.call_count >= 3  # 3 retries, 1 sleep each

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -7,6 +7,7 @@ import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import Reason
+from kopf.structs.memos import Memo
 
 LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 
@@ -27,6 +28,7 @@ async def test_create(registry, settings, handlers, resource, cause_mock, event_
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=event_queue,
@@ -67,6 +69,7 @@ async def test_update(registry, settings, handlers, resource, cause_mock, event_
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=event_queue,
@@ -109,6 +112,7 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
         replenished=asyncio.Event(),
         event_queue=event_queue,
@@ -149,6 +153,7 @@ async def test_gone(registry, settings, handlers, resource, cause_mock, event_ty
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=event_queue,
@@ -179,6 +184,7 @@ async def test_free(registry, settings, handlers, resource, cause_mock, event_ty
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=event_queue,
@@ -210,6 +216,7 @@ async def test_noop(registry, settings, handlers, resource, cause_mock, event_ty
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=event_queue,

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -10,6 +10,7 @@ from kopf.reactor.processing import process_resource_event
 from kopf.storage.progress import StatusProgressStorage
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import ALL_REASONS, HANDLER_REASONS, Reason
+from kopf.structs.memos import Memo
 
 
 @pytest.mark.parametrize('cause_type', ALL_REASONS)
@@ -25,6 +26,7 @@ async def test_all_logs_are_prefixed(registry, settings, resource, handlers,
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
@@ -55,6 +57,7 @@ async def test_diffs_logged_if_present(registry, settings, resource, handlers,
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
@@ -85,6 +88,7 @@ async def test_diffs_not_logged_if_absent(registry, settings, resource, handlers
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
@@ -128,6 +132,7 @@ async def test_supersession_is_logged(
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -12,6 +12,7 @@ from kopf.reactor.processing import process_resource_event
 from kopf.storage.states import HandlerState
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import HANDLER_REASONS, Reason
+from kopf.structs.memos import Memo
 
 
 @pytest.mark.parametrize('cause_reason', HANDLER_REASONS)
@@ -38,6 +39,7 @@ async def test_delayed_handlers_progress(
             settings=settings,
             resource=resource,
             memories=ResourceMemories(),
+            memobase=Memo(),
             raw_event={'type': event_type, 'object': {}},
             replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
@@ -94,6 +96,7 @@ async def test_delayed_handlers_sleep(
             settings=settings,
             resource=resource,
             memories=ResourceMemories(),
+            memobase=Memo(),
             raw_event={'type': event_type, 'object': event_body},
             replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),

--- a/tests/handling/test_error_handling.py
+++ b/tests/handling/test_error_handling.py
@@ -8,6 +8,7 @@ from kopf.reactor.handling import PermanentError, TemporaryError
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import HANDLER_REASONS, Reason
+from kopf.structs.memos import Memo
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.
@@ -31,6 +32,7 @@ async def test_fatal_error_stops_handler(
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
@@ -75,6 +77,7 @@ async def test_retry_error_delays_handler(
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
@@ -120,6 +123,7 @@ async def test_arbitrary_error_delays_handler(
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -7,6 +7,7 @@ import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import ALL_REASONS
+from kopf.structs.memos import Memo
 
 
 @pytest.mark.parametrize('cause_type', ALL_REASONS)
@@ -22,6 +23,7 @@ async def test_handlers_called_always(
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': 'ev-type', 'object': {'field': 'value'}},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
@@ -57,6 +59,7 @@ async def test_errors_are_ignored(
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': 'ev-type', 'object': {}},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -6,6 +6,7 @@ import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import HANDLER_REASONS, Reason
+from kopf.structs.memos import Memo
 
 
 @pytest.mark.parametrize('deletion_ts', [
@@ -33,6 +34,7 @@ async def test_1st_step_stores_progress_by_patching(
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
@@ -92,6 +94,7 @@ async def test_2nd_step_finishes_the_handlers(caplog,
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -7,6 +7,7 @@ import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import HANDLER_REASONS, ResourceChangingHandler
+from kopf.structs.memos import Memo
 
 LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 
@@ -37,6 +38,7 @@ async def test_skipped_with_no_handlers(
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
@@ -92,6 +94,7 @@ async def test_stealth_mode_with_mismatching_handlers(
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),

--- a/tests/handling/test_parametrization.py
+++ b/tests/handling/test_parametrization.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
+from kopf.structs.memos import Memo
 
 
 async def test_parameter_is_passed_when_specified(resource, cause_mock, registry, settings):
@@ -22,6 +23,7 @@ async def test_parameter_is_passed_when_specified(resource, cause_mock, registry
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': None, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=event_queue,
@@ -47,6 +49,7 @@ async def test_parameter_is_passed_even_if_not_specified(resource, cause_mock, r
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': None, 'object': {}},
         replenished=asyncio.Event(),
         event_queue=event_queue,

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -8,6 +8,7 @@ import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.handlers import HANDLER_REASONS, Reason
+from kopf.structs.memos import Memo
 
 
 # The timeout is hard-coded in conftest.py:handlers().
@@ -40,6 +41,7 @@ async def test_timed_out_handler_fails(
             settings=settings,
             resource=resource,
             memories=ResourceMemories(),
+            memobase=Memo(),
             raw_event={'type': event_type, 'object': event_body},
             replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
@@ -89,6 +91,7 @@ async def test_retries_limited_handler_fails(
         settings=settings,
         resource=resource,
         memories=ResourceMemories(),
+        memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
         replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),

--- a/tests/handling/test_timing_consistency.py
+++ b/tests/handling/test_timing_consistency.py
@@ -6,6 +6,7 @@ import freezegun
 import kopf
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
+from kopf.structs.memos import Memo
 
 
 async def test_consistent_awakening(registry, settings, resource, k8s_mocked, mocker):
@@ -61,6 +62,7 @@ async def test_consistent_awakening(registry, settings, resource, k8s_mocked, mo
             settings=settings,
             resource=resource,
             memories=ResourceMemories(),
+            memobase=Memo(),
             raw_event={'type': 'ADDED', 'object': body},
             replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),

--- a/tests/invocations/test_kwargs.py
+++ b/tests/invocations/test_kwargs.py
@@ -17,12 +17,13 @@ from kopf.structs.primitives import DaemonStopper
 @pytest.mark.parametrize('activity', set(Activity) - {Activity.STARTUP})
 def test_activity_kwargs(resource, activity):
     cause = ActivityCause(
+        memo=Memo(),
         logger=logging.getLogger('kopf.test.fake.logger'),
         activity=activity,
         settings=OperatorSettings(),
     )
     kwargs = build_kwargs(cause=cause, extrakwarg=123)
-    assert set(kwargs) == {'extrakwarg', 'logger', 'activity'}
+    assert set(kwargs) == {'extrakwarg', 'memo', 'logger', 'activity'}
     assert kwargs['extrakwarg'] == 123
     assert kwargs['logger'] is cause.logger
     assert kwargs['activity'] is activity
@@ -31,12 +32,13 @@ def test_activity_kwargs(resource, activity):
 @pytest.mark.parametrize('activity', {Activity.STARTUP})
 def test_startup_kwargs(resource, activity):
     cause = ActivityCause(
+        memo=Memo(),
         logger=logging.getLogger('kopf.test.fake.logger'),
         activity=activity,
         settings=OperatorSettings(),
     )
     kwargs = build_kwargs(cause=cause, extrakwarg=123)
-    assert set(kwargs) == {'extrakwarg', 'logger', 'activity', 'settings'}
+    assert set(kwargs) == {'extrakwarg', 'memo', 'logger', 'activity', 'settings'}
     assert kwargs['extrakwarg'] == 123
     assert kwargs['logger'] is cause.logger
     assert kwargs['activity'] is activity

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -96,6 +96,7 @@ def cause_factory(resource):
     ):
         if cls is ActivityCause or cls is ActivityRegistry:
             return ActivityCause(
+                memo=Memo(),
                 logger=logging.getLogger('kopf.test.fake.logger'),
                 activity=activity,
                 settings=settings,

--- a/tests/test_liveness.py
+++ b/tests/test_liveness.py
@@ -6,6 +6,7 @@ import pytest
 from kopf.engines.probing import health_reporter
 from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.handlers import Activity, ActivityHandler
+from kopf.structs.memos import Memo
 
 
 @pytest.fixture()
@@ -26,6 +27,7 @@ async def liveness_url(settings, liveness_registry, aiohttp_unused_port):
             registry=liveness_registry,
             settings=settings,
             ready_flag=ready_flag,
+            memo=Memo(),
         )
     )
 


### PR DESCRIPTION
Extend the existing `memo` kwarg to operators' handlers and embedded operators' options, and connect global memos to per-resource memos.

Now, an external memo can be passed into an embedded operator via `memo=` option, and all the keys will be seen both in operator-level and resource-level handlers. An object of any arbitrary class can be passed as the operator's memo, as long as all handlers understand it and use it accordingly, and it is capable of shallow-copying.

```python
import asyncio
import dataclasses
import kopf

@dataclasses.dataclass()
class CustomContext:
    create_tpl: str
    delete_tpl: str

@kopf.on.startup()
def startup(memo: CustomContext, **_):
    memo.some_field = 0

@kopf.on.create('kopfexamples')
def create_fn(memo: CustomContext, **kwargs):
    print(memo.create_tpl.format(**kwargs))

@kopf.on.delete('kopfexamples')
def delete_fn(memo: CustomContext, **kwargs):
    print(memo.delete_tpl.format(**kwargs))

if __name__ == '__main__':
    kopf.configure(verbose=True)
    asyncio.run(kopf.operator(
        memo=CustomContext(
            create_tpl="Hello, {name}!",
            delete_tpl="Good bye, {name}!",
        ),
    ))
```

Alternatively or in addition to that, a default `memo` dictionary (`kopf.Memo`) can be populated in the operator-level startup handlers, and all the keys will also be seen in all the resource-level handlers.

With Python's mutable structures as values (lists, dicts, or new memos), all handlers can exchange information across all resources of all resource kinds if needed — i.e. globally (an equivalent of global variables).

```python
import kopf
import queue
import threading

@kopf.on.startup()
def start_background_worker(memo: kopf.Memo, **_):
    memo.my_queue = queue.Queue()
    memo.my_thread = threading.Thread(target=background, args=(memo.my_queue,))
    memo.my_thread.start()

@kopf.on.cleanup()
def stop_background_worker(memo: kopf.Memo, **_):
    memo['my_queue'].put(None)
    memo['my_thread'].join()

def background(queue: queue.Queue):
    while True:
        item = queue.get()
        if item is None:
            break
        else:
            print(item)

@kopf.on.event('KopfExample')
def pinged(memo: kopf.Memo, namespace: str, name: str, **_):
    if not memo.get('is_seen'):
        memo.my_queue.put(f"{namespace}/{name}")
        memo.is_seen = True
```

closes #347, closes #367 