### PR TITLE
Test with extras optionally installed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,8 +29,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        install-extras: [ "", "full-auth" ]
         python-version: [ "3.7", "3.8", "3.9" ]
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python-version }} ${{ matrix.install-extras }}
     runs-on: ubuntu-20.04
     timeout-minutes: 5  # usually 2-3 mins
     steps:
@@ -40,6 +41,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: pip install -r requirements.txt
+      - run: pip install -e .[${{ matrix.install-extras }}]
+        if: ${{ matrix.install-extras }}
+
       - run: mypy kopf --strict --pretty
       - run: pytest --color=yes --cov=kopf --cov-branch
 

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -33,8 +33,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        install-extras: [ "", "full-auth" ]
         python-version: [ "3.7", "3.8", "3.9" ]
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.python-version }} ${{ matrix.install-extras }}
     runs-on: ubuntu-20.04
     timeout-minutes: 5  # usually 2-3 mins
     steps:
@@ -44,6 +45,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: pip install -r requirements.txt
+      - run: pip install -e .[${{ matrix.install-extras }}]
+        if: ${{ matrix.install-extras }}
+
       - run: mypy kopf --strict --pretty
       - run: pytest --color=yes --cov=kopf --cov-branch
 

--- a/tests/cli/test_logging.py
+++ b/tests/cli/test_logging.py
@@ -51,20 +51,15 @@ def test_verbosity(invoke, caplog, options, envvars, expect_debug, expect_info, 
     (['--verbose']),
 ], ids=['default', 'q', 'quiet', 'v', 'verbose'])
 def test_no_lowlevel_dumps_in_nondebug(invoke, caplog, options, preload, real_run):
-    kubernetes = pytest.importorskip('kubernetes')
-
     result = invoke(['run'] + options)
     assert result.exit_code == 0
 
     # TODO: This also goes to the pytest's output. Try to suppress it there (how?).
-    logging.getLogger('kubernetes').error('boom!')
     logging.getLogger('asyncio').error('boom!')
-    logging.getLogger('urllib3').error('boom!')
 
     alien_records = [m for m in caplog.records if not m.name.startswith('kopf')]
     assert len(alien_records) == 0
     assert not asyncio.get_event_loop().get_debug()
-    assert not kubernetes.client.configuration.Configuration().debug
 
 
 @pytest.mark.parametrize('options', [
@@ -72,16 +67,11 @@ def test_no_lowlevel_dumps_in_nondebug(invoke, caplog, options, preload, real_ru
     (['--debug']),
 ], ids=['d', 'debug'])
 def test_lowlevel_dumps_in_debug_mode(invoke, caplog, options, preload, real_run):
-    kubernetes = pytest.importorskip('kubernetes')
-
     result = invoke(['run'] + options)
     assert result.exit_code == 0
 
-    logging.getLogger('kubernetes').debug('hello!')
     logging.getLogger('asyncio').debug('hello!')
-    logging.getLogger('urllib3').debug('hello!')
 
     alien_records = [m for m in caplog.records if not m.name.startswith('kopf')]
-    assert len(alien_records) == 3
+    assert len(alien_records) == 1
     assert asyncio.get_event_loop().get_debug()
-    assert kubernetes.client.configuration.Configuration().debug


### PR DESCRIPTION
After `pykube-ng` & `kubernetes` were removed as mandatory or CI-only dependencies in #655, the framework also was not tested in its presence. Yet, it started to fail in some tests — e.g. on verbose logging, where we stopped hacking the loggers of those libraries in e40f5d2a29d5cdf6a07d68fec0b86c6c35d58a06.

Now, with this PR, run the unit-tests in 2 modes: with and without 3rd-party libraries. And fix those tests that were breaking.