### PR TITLE
Prevent log spill in CI tests

### DIFF
--- a/tests/logging/conftest.py
+++ b/tests/logging/conftest.py
@@ -1,6 +1,29 @@
+import asyncio
+
 import pytest
+
+from kopf.engines.posting import event_queue_loop_var, event_queue_var
 
 
 @pytest.fixture(autouse=True)
 def _caplog_all_levels(caplog):
     caplog.set_level(0)
+
+
+@pytest.fixture(autouse=True)
+def event_queue_loop(event_loop):
+    token = event_queue_loop_var.set(event_loop)
+    try:
+        yield event_loop
+    finally:
+        event_queue_loop_var.reset(token)
+
+
+@pytest.fixture(autouse=True)
+def event_queue():
+    queue = asyncio.Queue()
+    token = event_queue_var.set(queue)
+    try:
+        yield queue
+    finally:
+        event_queue_var.reset(token)

--- a/tests/logging/test_configuration.py
+++ b/tests/logging/test_configuration.py
@@ -16,6 +16,9 @@ def _clear_own_handlers():
         if not isinstance(handler, logging.StreamHandler) or
            not isinstance(handler.formatter, ObjectFormatter)
     ]
+    original_handlers = logger.handlers[:]
+    yield
+    logger.handlers[:] = original_handlers
 
 
 def _get_own_handlers(logger: logging.Logger) -> Collection[logging.Handler]:

--- a/tests/logging/test_loggers.py
+++ b/tests/logging/test_loggers.py
@@ -4,20 +4,23 @@ from kopf.engines.loggers import LocalObjectLogger, ObjectLogger
 from kopf.structs.bodies import Body
 
 
+# Async -- to make the log enqueueing loop running.
 @pytest.mark.parametrize('cls', [ObjectLogger, LocalObjectLogger])
-def test_mandatory_body(cls, settings, caplog):
+async def test_mandatory_body(cls, settings, caplog):
     with pytest.raises(TypeError):
         cls(settings=settings)
 
 
+# Async -- to make the log enqueueing loop running.
 @pytest.mark.parametrize('cls', [ObjectLogger, LocalObjectLogger])
-def test_mandatory_settings(cls, settings, caplog):
+async def test_mandatory_settings(cls, settings, caplog):
     with pytest.raises(TypeError):
         cls(body=Body({}))
 
 
+# Async -- to make the log enqueueing loop running.
 @pytest.mark.parametrize('cls', [ObjectLogger, LocalObjectLogger])
-def test_extras_from_metadata(cls, settings, caplog):
+async def test_extras_from_metadata(cls, settings, caplog):
     body = Body({
         'kind': 'kind1',
         'apiVersion': 'api1/v1',
@@ -38,8 +41,9 @@ def test_extras_from_metadata(cls, settings, caplog):
     }
 
 
+# Async -- to make the log enqueueing loop running.
 @pytest.mark.parametrize('cls', [ObjectLogger])
-def test_k8s_posting_enabled_in_a_regular_logger(cls, settings, caplog):
+async def test_k8s_posting_enabled_in_a_regular_logger(cls, settings, caplog):
     body = Body({})
 
     logger = cls(body=body, settings=settings)
@@ -50,8 +54,9 @@ def test_k8s_posting_enabled_in_a_regular_logger(cls, settings, caplog):
     assert caplog.records[0].k8s_skip is False
 
 
+# Async -- to make the log enqueueing loop running.
 @pytest.mark.parametrize('cls', [LocalObjectLogger])
-def test_k8s_posting_disabled_in_a_local_logger(cls, settings, caplog):
+async def test_k8s_posting_disabled_in_a_local_logger(cls, settings, caplog):
     body = Body({})
 
     logger = cls(body=body, settings=settings)


### PR DESCRIPTION
Everything executed after `tests/logging/test_configuration.py` was spilling its logs to stdout/stderr, though not affecting the tests themselves. This made pytest results reading more difficult, and their visually red colour in IDE made them look like errors, which they are not.

Now, all is good, no spilling.
