### PR TITLE
Give some care to the hierarchies toolkit

### DIFF
--- a/docs/hierarchies.rst
+++ b/docs/hierarchies.rst
@@ -3,14 +3,15 @@ Hierarchies
 ===========
 
 One of the most common patterns of the operators is to create
-children objects in the same Kubernetes cluster.
-Kopf provides some tools to simplify connecting these objects together.
+children resources in the same Kubernetes cluster.
+Kopf provides some tools to simplify connecting these resources together
+by manipulating their content before it is sent to the Kubernetes API.
 
 .. note::
 
     Kopf is not a Kubernetes client library.
-    It does not provide any means to manipulate the Kubernetes objects
-    or to talk to the Kubernetes API.
+    It does not provide any means to manipulate the Kubernetes resources
+    in the cluster or to directly talk to the Kubernetes API in any other way.
     Use any of the existing libraries for that purpose,
     such as the official `kubernetes client`_, pykorm_, or pykube-ng_.
 
@@ -18,72 +19,262 @@ Kopf provides some tools to simplify connecting these objects together.
 .. _pykorm: https://github.com/Frankkkkk/pykorm
 .. _pykube-ng: https://github.com/hjacobs/pykube
 
+In all examples below, ``obj`` and ``objs`` are either a supported object type
+(dictionaries, mappings) or a list/tuple/iterable with several objects.
 
-Labelling
-=========
 
-To mark the created objects with labels::
+Labels
+======
 
-    kopf.label(obj, {'label1': 'value1', 'label2': 'value2')
+To label the resources to be created, use :func:`kopf.label`:
 
-To mark it with the same labels as another (e.g. parent) object:
+.. code-block:: python
 
-    kopf.label(objs, labels=owner.metadata.labels)
+    @kopf.on.create('KopfExample')
+    def create_fn(**_):
+        objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
+        kopf.label(objs, {'label1': 'value1', 'label2': 'value2'})
+        print(objs)
+        # [{'kind': 'Job',
+        #   'metadata': {'labels': {'label1': 'value1', 'label2': 'value2'}}},
+        #  {'kind': 'Deployment',
+        #   'metadata': {'labels': {'label1': 'value1', 'label2': 'value2'}}}]
 
-Where ``obj`` or ``objs`` is either a dict of the object fields,
-or a list/tuple of dicts with multiple objects.
+
+To label the specified resource(s) with the same labels as the resource being
+processed at the moment, omit the labels or set them to ``None`` (note, it is
+not the same as an empty dict ``{}`` -- which is equivalent to doing nothing):
+
+.. code-block:: python
+
+    @kopf.on.create('KopfExample')
+    def create_fn(**_):
+        objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
+        kopf.label(objs)
+        print(objs)
+        # [{'kind': 'Job',
+        #   'metadata': {'labels': {'somelabel': 'somevalue'}}},
+        #  {'kind': 'Deployment',
+        #   'metadata': {'labels': {'somelabel': 'somevalue'}}}]
+
+
+By default, if some of the requested labels already exist, they will not
+be overwritten. To overwrite labels, use ``forced=True``:
+
+.. code-block:: python
+
+    @kopf.on.create('KopfExample')
+    def create_fn(**_):
+        objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
+        kopf.label(objs, {'label1': 'value1', 'somelabel': 'not-this'}, forced=True)
+        kopf.label(objs, forced=True)
+        print(objs)
+        # [{'kind': 'Job',
+        #   'metadata': {'labels': {'label1': 'value1', 'somelabel': 'somevalue'}}},
+        #  {'kind': 'Deployment',
+        #   'metadata': {'labels': {'label1': 'value1', 'somelabel': 'somevalue'}}}]
+
+
+Nested labels
+=============
+
+For some resources, e.g. ``Job`` or ``Deployment``, additional fields have
+to be modified to affect the double-nested children (``Pod`` in this case).
+
+For this, their nested fields must be mentioned in a ``nested=[...]`` iterable.
+If this is only one nested field, it can be passed directly as ``nested='...'``.
+
+If the nested structures are absent in the target resources, they are ignored
+and no labels are added. The labels are added only to pre-existing structures:
+
+.. code-block:: python
+
+    @kopf.on.create('KopfExample')
+    def create_fn(**_):
+        objs = [{'kind': 'Job'}, {'kind': 'Deployment', 'spec': {'template': {}}}]
+        kopf.label(objs, {'label1': 'value1'}, nested='spec.template')
+        kopf.label(objs, nested='spec.template')
+        print(objs)
+        # [{'kind': 'Job',
+        #   'metadata': {'labels': {'label1': 'value1', 'somelabel': 'somevalue'}}},
+        #  {'kind': 'Deployment',
+        #   'metadata': {'labels': {'label1': 'value1', 'somelabel': 'somevalue'}},
+        #   'spec': {'template': {'metadata': {'labels': {'label1': 'value1', 'somelabel': 'somevalue'}}}}}]
+
+The nested structures are treated as if they were the root-level resources, i.e.
+they are expected to have or automatically get the ``metadata`` structure added.
+
+The nested resources are labelled *in addition* to the target resources.
+To label only the nested resources without the root resource, pass them
+to the function directly (e.g., `kopf.label(obj['spec']['template'], ...)`).
 
 
 Owner references
 ================
 
-Kubernetes natively supports the owner references, when one object (child)
-can be marked as "owned" by one or more other objects (owners or parents).
-
+Kubernetes natively supports the owner references: a child resource
+can be marked as "owned" by one or more other resources (owners or parents).
 If the owner is deleted, its children will be deleted too, automatically,
 and no additional handlers are needed.
 
-To mark an object or objects as owned by another object::
+To set the ownership, use :func:`kopf.append_owner_reference`.
+To remive the ownershio, use :func:`kopf.remove_owner_reference`:
 
-    kopf.append_owner_reference(objs, owner=owner)
+.. code-block:: python
 
-To unmark::
+    kopf.append_owner_reference(objs, owner)
+    kopf.remove_owner_reference(objs, owner)
 
-    kopf.remove_owner_reference(objs, owner=owner)
+To add/remove the ownership of the requested resource(s) by the resource being
+processed at the moment, omit the explicit owner argument or set it to ``None``:
 
-The currently handled object is the owner by default (if not specified)::
+.. code-block:: python
 
-    kopf.append_owner_reference(objs)
-    kopf.remove_owner_reference(objs)
+    @kopf.on.create('KopfExample')
+    def create_fn(**_):
+        objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
+        kopf.append_owner_reference(objs)
+        print(objs)
+        # [{'kind': 'Job',
+        #   'metadata': {'ownerReferences': [{'controller': True,
+        #      'blockOwnerDeletion': True,
+        #      'apiVersion': 'kopf.dev/v1',
+        #      'kind': 'KopfExample',
+        #      'name': 'kopf-example-1',
+        #      'uid': '6b931859-5d50-4b5c-956b-ea2fed0d1058'}]}},
+        #  {'kind': 'Deployment',
+        #   'metadata': {'ownerReferences': [{'controller': True,
+        #      'blockOwnerDeletion': True,
+        #      'apiVersion': 'kopf.dev/v1',
+        #      'kind': 'KopfExample',
+        #      'name': 'kopf-example-1',
+        #      'uid': '6b931859-5d50-4b5c-956b-ea2fed0d1058'}]}}]
 
 .. seealso::
     :doc:`walkthrough/deletion`.
 
 
-Name generation
-===============
+Names
+=====
 
-If the object has its ``metadata.name`` field set, that name will be used.
+It is common to name the children resources after the parent resource:
+either strictly as the parent, or with a random suffix.
 
-Alternatively, the operator can request Kubernetes to generate the name
-with the specified prefix and random suffix.
-This is done by setting ``metadata.generateName`` field.
+To give the resource(s) a name, use :func:`kopf.harmonize_naming`.
+If the resource has its ``metadata.name`` field set, that name will be used.
+If it does not, the specified name will be used.
+It can be enforced with ``forced=True``:
 
-This is commonly used for the parent objects that orchestrate multiple
-children objects of the same kind (e.g. as pods in the deployment).
+.. code-block:: python
+
+    kopf.harmonize_naming(objs, 'some-name')
+    kopf.harmonize_naming(objs, 'some-name', forced=True)
+
+By default, the specified name is used as a prefix, and a random suffix
+is requested from Kubernetes (via ``metadata.generateName``). This is the
+most widely used mode with multiple children resource of the same kind.
+To ensure the exact name for single-child cases, pass ``strict=True``:
+
+.. code-block:: python
+
+    kopf.harmonize_naming(objs, 'some-name', strict=True)
+    kopf.harmonize_naming(objs, 'some-name', strict=True, forced=True)
+
+To align the name of the target resource(s) with the name of the resource
+being processed at the moment, omit the name or set it to ``None``
+(both ``strict=True`` and ``forced=True`` are supported in this form too):
+
+.. code-block:: python
+
+    @kopf.on.create('KopfExample')
+    def create_fn(**_):
+        objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
+        kopf.harmonize_naming(objs, forced=True, strict=True)
+        print(objs)
+        # [{'kind': 'Job', 'metadata': {'name': 'kopf-example-1'}},
+        #  {'kind': 'Deployment', 'metadata': {'name': 'kopf-example-1'}}]
+
+Alternatively, the operator can request Kubernetes to generate a name
+with the specified prefix and a random suffix (via ``metadata.generateName``).
+The actual name will be known only after the resource is actually created:
+
+.. code-block:: python
+
+    @kopf.on.create('KopfExample')
+    def create_fn(**_):
+        objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
+        kopf.harmonize_naming(objs)
+        print(objs)
+        # [{'kind': 'Job', 'metadata': {'generateName': 'kopf-example-1-'}},
+        #  {'kind': 'Deployment', 'metadata': {'generateName': 'kopf-example-1-'}}]
+
+Both ways are commonly used for parent resources that orchestrate multiple
+children resources of the same kind (e.g., pods in the deployment).
 
 
-Same namespaces
-===============
+Namespaces
+==========
 
-Usually, it is expected that the children objects are created in the same
+Usually, it is expected that the children resources are created in the same
 namespace as their parent (unless there are strong reasons to do differently).
+
+To set the desired namespace, use :func:`kopf.adjust_namespace`:
+
+.. code-block:: python
+
+    kopf.adjust_namespace(objs, 'namespace')
+
+If the namespace is already set, it will not be overwritten.
+To overwrite, pass ``forced=True``:
+
+.. code-block:: python
+
+    kopf.adjust_namespace(objs, 'namespace', forced=True)
+
+To align the namespace of the specified resource(s) with the namespace
+of the resource being processed, omit the namespace or set it to ``None``:
+
+.. code-block:: python
+
+    @kopf.on.create('KopfExample')
+    def create_fn(**_):
+        objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
+        kopf.adjust_namespace(objs, forced=True)
+        print(objs)
+        # [{'kind': 'Job', 'metadata': {'namespace': 'default'}},
+        #  {'kind': 'Deployment', 'metadata': {'namespace': 'default'}}]
 
 
 Adopting
 ========
 
-All of the above can be done in one call::
+All of the above can be done in one call with :func:`kopf.adopt`; ``forced``,
+``strict``, ``nested`` flags are passed to all functions that support them:
 
-    kopf.adopt(obj)
-    kopf.adopt([obj1, obj2])
+.. code-block:: python
+
+    @kopf.on.create('KopfExample')
+    def create_fn(**_):
+        objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
+        kopf.adopt(objs, strict=True, forced=True, nested='spec.template')
+        print(objs)
+        # [{'kind': 'Job',
+        #   'metadata': {'ownerReferences': [{'controller': True,
+        #      'blockOwnerDeletion': True,
+        #      'apiVersion': 'kopf.dev/v1',
+        #      'kind': 'KopfExample',
+        #      'name': 'kopf-example-1',
+        #      'uid': '4a15f2c2-d558-4b6e-8cf0-00585d823511'}],
+        #    'name': 'kopf-example-1',
+        #    'namespace': 'default',
+        #    'labels': {'somelabel': 'somevalue'}}},
+        #  {'kind': 'Deployment',
+        #   'metadata': {'ownerReferences': [{'controller': True,
+        #      'blockOwnerDeletion': True,
+        #      'apiVersion': 'kopf.dev/v1',
+        #      'kind': 'KopfExample',
+        #      'name': 'kopf-example-1',
+        #      'uid': '4a15f2c2-d558-4b6e-8cf0-00585d823511'}],
+        #    'name': 'kopf-example-1',
+        #    'namespace': 'default',
+        #    'labels': {'somelabel': 'somevalue'}}}]

--- a/kopf/toolkits/hierarchies.py
+++ b/kopf/toolkits/hierarchies.py
@@ -51,7 +51,7 @@ def remove_owner_reference(
 
 def label(
         objs: K8sObjects,
-        labels: Mapping[str, Union[None, str]],
+        labels: Optional[Mapping[str, Union[None, str]]] = None,
         *,
         forced: bool = False,
         nested: Optional[Iterable[dicts.FieldSpec]] = None,
@@ -64,6 +64,12 @@ def label(
         warnings.warn("force= is deprecated in kopf.label(); use forced=...", DeprecationWarning)
         forced = force
 
+    # Try to use the current object being handled if possible.
+    if labels is None:
+        real_owner = _guess_owner(None)
+        labels = real_owner.get('metadata', {}).get('labels', {})
+
+    # Set labels based on the explicitly specified or guessed ones.
     for obj in cast(Iterator[K8sObject], dicts.walk(objs, nested=nested)):
         obj_labels = obj.setdefault('metadata', {}).setdefault('labels', {})
         for key, val in labels.items():

--- a/kopf/toolkits/hierarchies.py
+++ b/kopf/toolkits/hierarchies.py
@@ -59,12 +59,13 @@ def label(
         labels: Optional[Mapping[str, Union[None, str]]] = None,
         *,
         forced: bool = False,
-        nested: Optional[Iterable[dicts.FieldSpec]] = None,
+        nested: Optional[Union[str, Iterable[dicts.FieldSpec]]] = None,
         force: Optional[bool] = None,  # deprecated
 ) -> None:
     """
     Apply the labels to the object(s).
     """
+    nested = [nested] if isinstance(nested, str) else nested
     if force is not None:
         warnings.warn("force= is deprecated in kopf.label(); use forced=...", DeprecationWarning)
         forced = force
@@ -169,7 +170,7 @@ def adopt(
         objs: K8sObjects,
         owner: Optional[bodies.Body] = None,
         *,
-        nested: Optional[Iterable[dicts.FieldSpec]] = None,
+        nested: Optional[Union[str, Iterable[dicts.FieldSpec]]] = None,
 ) -> None:
     """
     The children should be in the same namespace, named after their parent, and owned by it.

--- a/kopf/toolkits/hierarchies.py
+++ b/kopf/toolkits/hierarchies.py
@@ -99,6 +99,8 @@ def harmonize_naming(
     if name is None:
         real_owner = _guess_owner(None)
         name = real_owner.get('metadata', {}).get('name', None)
+    if name is None:
+        raise LookupError("Name must be set explicitly: couldn't find it automatically.")
 
     # Set name/prefix based on the explicitly specified or guessed name.
     for obj in cast(Iterator[K8sObject], dicts.walk(objs)):
@@ -133,6 +135,8 @@ def adjust_namespace(
     if namespace is None:
         real_owner = _guess_owner(None)
         namespace = real_owner.get('metadata', {}).get('namespace', None)
+    if namespace is None:
+        raise LookupError("Namespace must be set explicitly: couldn't find it automatically.")
 
     # Set namespace based on the explicitly specified or guessed namespace.
     for obj in cast(Iterator[K8sObject], dicts.walk(objs)):

--- a/kopf/toolkits/hierarchies.py
+++ b/kopf/toolkits/hierarchies.py
@@ -100,7 +100,8 @@ def harmonize_naming(
 
     # Set name/prefix based on the explicitly specified or guessed name.
     for obj in cast(Iterator[K8sObject], dicts.walk(objs)):
-        if obj.get('metadata', {}).get('name', None) is None:
+        noname = 'metadata' not in obj or not set(obj['metadata']) & {'name', 'generateName'}
+        if noname:
             if strict:
                 obj.setdefault('metadata', {}).setdefault('name', name)
             else:

--- a/kopf/toolkits/hierarchies.py
+++ b/kopf/toolkits/hierarchies.py
@@ -170,16 +170,21 @@ def adopt(
         objs: K8sObjects,
         owner: Optional[bodies.Body] = None,
         *,
+        forced: bool = False,
+        strict: bool = False,
         nested: Optional[Union[str, Iterable[dicts.FieldSpec]]] = None,
 ) -> None:
     """
     The children should be in the same namespace, named after their parent, and owned by it.
     """
     real_owner = _guess_owner(owner)
+    real_owner_name = real_owner.get('metadata', {}).get('name', None)
+    real_owner_namespace = real_owner.get('metadata', {}).get('namespace', None)
+    real_owner_labels = real_owner.get('metadata', {}).get('labels', {})
     append_owner_reference(objs, owner=real_owner)
-    harmonize_naming(objs, name=real_owner.get('metadata', {}).get('name', None))
-    adjust_namespace(objs, namespace=real_owner.get('metadata', {}).get('namespace', None))
-    label(objs, labels=real_owner.get('metadata', {}).get('labels', {}), nested=nested)
+    harmonize_naming(objs, forced=forced, strict=strict, name=real_owner_name)
+    adjust_namespace(objs, forced=forced, namespace=real_owner_namespace)
+    label(objs, forced=forced, nested=nested, labels=real_owner_labels)
 
 
 def _guess_owner(

--- a/kopf/toolkits/hierarchies.py
+++ b/kopf/toolkits/hierarchies.py
@@ -1,6 +1,7 @@
 """
 All the functions to properly build the object hierarchies.
 """
+import warnings
 from typing import Any, Iterable, Iterator, Mapping, MutableMapping, Optional, Union, cast
 
 from kopf.reactor import causation, handling
@@ -52,16 +53,21 @@ def label(
         objs: K8sObjects,
         labels: Mapping[str, Union[None, str]],
         *,
-        force: bool = False,
+        forced: bool = False,
         nested: Optional[Iterable[dicts.FieldSpec]] = None,
+        force: Optional[bool] = None,  # deprecated
 ) -> None:
     """
     Apply the labels to the object(s).
     """
+    if force is not None:
+        warnings.warn("force= is deprecated in kopf.label(); use forced=...", DeprecationWarning)
+        forced = force
+
     for obj in cast(Iterator[K8sObject], dicts.walk(objs, nested=nested)):
         obj_labels = obj.setdefault('metadata', {}).setdefault('labels', {})
         for key, val in labels.items():
-            if force:
+            if forced:
                 obj_labels[key] = val
             else:
                 obj_labels.setdefault(key, val)

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -1,3 +1,5 @@
+import copy
+
 import logging
 
 import pytest
@@ -31,30 +33,31 @@ OWNER = RawBody(
 
 @pytest.fixture(params=['state-changing-cause', 'event-watching-cause'])
 def owner(request, resource):
+    body = Body(copy.deepcopy(OWNER))
     if request.param == 'state-changing-cause':
         cause = ResourceChangingCause(
             logger=logging.getLogger('kopf.test.fake.logger'),
             resource=resource,
             patch=Patch(),
             memo=Memo(),
-            body=Body(OWNER),
+            body=body,
             initial=False,
             reason=Reason.NOOP,
         )
         with context([(cause_var, cause)]):
-            yield
+            yield body
     elif request.param == 'event-watching-cause':
         cause = ResourceWatchingCause(
             logger=logging.getLogger('kopf.test.fake.logger'),
             resource=resource,
             patch=Patch(),
             memo=Memo(),
-            body=Body(OWNER),
+            body=body,
             type='irrelevant',
             raw=RawEvent(type='irrelevant', object=OWNER),
         )
         with context([(cause_var, cause)]):
-            yield
+            yield body
     else:
         raise RuntimeError(f"Wrong param for `owner` fixture: {request.param!r}")
 
@@ -87,6 +90,27 @@ def test_when_unset_for_adopting():
     with pytest.raises(LookupError) as e:
         kopf.adopt([])
     assert 'Owner must be set explicitly' in str(e.value)
+
+
+def test_when_empty_for_name_harmonization(owner):
+    owner._replace_with({})
+    with pytest.raises(LookupError) as e:
+        kopf.harmonize_naming([])
+    assert 'Name must be set explicitly' in str(e.value)
+
+
+def test_when_empty_for_namespace_adjustment(owner):
+    owner._replace_with({})
+    with pytest.raises(LookupError) as e:
+        kopf.adjust_namespace([])
+    assert 'Namespace must be set explicitly' in str(e.value)
+
+
+def test_when_empty_for_adopting(owner):
+    owner._replace_with({})
+    with pytest.raises(LookupError):
+        kopf.adopt([])
+    # any error message: the order of functions is not specific.
 
 
 def test_when_set_for_name_harmonization(owner):

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -1,5 +1,4 @@
 import copy
-
 import logging
 
 import pytest
@@ -86,6 +85,12 @@ def test_when_unset_for_namespace_adjustment():
     assert 'Owner must be set explicitly' in str(e.value)
 
 
+def test_when_unset_for_labelling():
+    with pytest.raises(LookupError) as e:
+        kopf.label([])
+    assert 'Owner must be set explicitly' in str(e.value)
+
+
 def test_when_unset_for_adopting():
     with pytest.raises(LookupError) as e:
         kopf.adopt([])
@@ -137,3 +142,9 @@ def test_when_set_for_owner_references_removal(owner):
     kopf.append_owner_reference(obj)  # assumed to work, tested above
     kopf.remove_owner_reference(obj)  # this one is being tested here
     assert not obj['metadata']['ownerReferences']
+
+
+def test_when_set_for_labelling(owner):
+    obj = {}
+    kopf.label(obj)
+    assert obj['metadata']['labels'] == {'label-1': 'value-1', 'label-2': 'value-2'}

--- a/tests/hierarchies/test_labelling.py
+++ b/tests/hierarchies/test_labelling.py
@@ -5,9 +5,7 @@ import kopf
 
 def test_adding_to_dict():
     obj = {}
-
     kopf.label(obj, {'label-1': 'value-1', 'label-2': 'value-2'})
-
     assert 'metadata' in obj
     assert 'labels' in obj['metadata']
     assert isinstance(obj['metadata']['labels'], dict)
@@ -18,13 +16,11 @@ def test_adding_to_dict():
     assert obj['metadata']['labels']['label-2'] == 'value-2'
 
 
-def test_adding_to_multiple_objects(multicls):
+def test_adding_to_dicts(multicls):
     obj1 = {}
     obj2 = {}
     objs = multicls([obj1, obj2])
-
     kopf.label(objs, {'label-1': 'value-1', 'label-2': 'value-2'})
-
     assert isinstance(obj1['metadata']['labels'], dict)
     assert len(obj1['metadata']['labels']) == 2
     assert 'label-1' in obj1['metadata']['labels']
@@ -54,25 +50,25 @@ def test_forcing_false_warns_on_deprecated_option():
     assert obj['metadata']['labels']['label'] == 'old-value'
 
 
-def test_forcing_true():
+def test_forcing_true_to_dict():
     obj = {'metadata': {'labels': {'label': 'old-value'}}}
     kopf.label(obj, {'label': 'new-value'}, forced=True)
     assert obj['metadata']['labels']['label'] == 'new-value'
 
 
-def test_forcing_false():
+def test_forcing_false_to_dict():
     obj = {'metadata': {'labels': {'label': 'old-value'}}}
     kopf.label(obj, {'label': 'new-value'}, forced=False)
     assert obj['metadata']['labels']['label'] == 'old-value'
 
 
-def test_forcing_default():
+def test_forcing_default_to_dict():
     obj = {'metadata': {'labels': {'label': 'old-value'}}}
     kopf.label(obj, {'label': 'new-value'})
     assert obj['metadata']['labels']['label'] == 'old-value'
 
 
-def test_nested_with_forced_true():
+def test_nested_with_forced_true_to_dict():
     obj = {'metadata': {'labels': {'label': 'old-value'}},
            'spec': {'template': {}}}
     kopf.label(obj, {'label': 'new-value'}, nested=['spec.template'], forced=True)
@@ -80,7 +76,7 @@ def test_nested_with_forced_true():
     assert obj['spec']['template']['metadata']['labels']['label'] == 'new-value'
 
 
-def test_nested_with_forced_false():
+def test_nested_with_forced_false_to_dict():
     obj = {'metadata': {'labels': {'label': 'old-value'}},
            'spec': {'template': {}}}
     kopf.label(obj, {'label': 'new-value'}, nested=['spec.template'], forced=False)

--- a/tests/hierarchies/test_labelling.py
+++ b/tests/hierarchies/test_labelling.py
@@ -68,17 +68,29 @@ def test_forcing_default_to_dict():
     assert obj['metadata']['labels']['label'] == 'old-value'
 
 
-def test_nested_with_forced_true_to_dict():
+@pytest.mark.parametrize('nested', [
+    pytest.param(('spec.jobTemplate',), id='tuple'),
+    pytest.param(['spec.jobTemplate'], id='list'),
+    pytest.param({'spec.jobTemplate'}, id='set'),
+    pytest.param('spec.jobTemplate', id='string'),
+])
+def test_nested_with_forced_true_to_dict(nested):
     obj = {'metadata': {'labels': {'label': 'old-value'}},
-           'spec': {'template': {}}}
-    kopf.label(obj, {'label': 'new-value'}, nested=['spec.template'], forced=True)
+           'spec': {'jobTemplate': {}}}
+    kopf.label(obj, {'label': 'new-value'}, nested=nested, forced=True)
     assert obj['metadata']['labels']['label'] == 'new-value'
-    assert obj['spec']['template']['metadata']['labels']['label'] == 'new-value'
+    assert obj['spec']['jobTemplate']['metadata']['labels']['label'] == 'new-value'
 
 
-def test_nested_with_forced_false_to_dict():
+@pytest.mark.parametrize('nested', [
+    pytest.param(('spec.jobTemplate',), id='tuple'),
+    pytest.param(['spec.jobTemplate'], id='list'),
+    pytest.param({'spec.jobTemplate'}, id='set'),
+    pytest.param('spec.jobTemplate', id='string'),
+])
+def test_nested_with_forced_false_to_dict(nested):
     obj = {'metadata': {'labels': {'label': 'old-value'}},
-           'spec': {'template': {}}}
-    kopf.label(obj, {'label': 'new-value'}, nested=['spec.template'], forced=False)
+           'spec': {'jobTemplate': {}}}
+    kopf.label(obj, {'label': 'new-value'}, nested=nested, forced=False)
     assert obj['metadata']['labels']['label'] == 'old-value'
-    assert obj['spec']['template']['metadata']['labels']['label'] == 'new-value'
+    assert obj['spec']['jobTemplate']['metadata']['labels']['label'] == 'new-value'

--- a/tests/hierarchies/test_labelling.py
+++ b/tests/hierarchies/test_labelling.py
@@ -1,3 +1,5 @@
+import pytest
+
 import kopf
 
 
@@ -38,15 +40,29 @@ def test_adding_to_multiple_objects(multicls):
     assert obj2['metadata']['labels']['label-2'] == 'value-2'
 
 
+def test_forcing_true_warns_on_deprecated_option():
+    obj = {'metadata': {'labels': {'label': 'old-value'}}}
+    with pytest.deprecated_call(match=r"use forced="):
+        kopf.label(obj, {'label': 'new-value'}, force=True)
+    assert obj['metadata']['labels']['label'] == 'new-value'
+
+
+def test_forcing_false_warns_on_deprecated_option():
+    obj = {'metadata': {'labels': {'label': 'old-value'}}}
+    with pytest.deprecated_call(match=r"use forced="):
+        kopf.label(obj, {'label': 'new-value'}, force=False)
+    assert obj['metadata']['labels']['label'] == 'old-value'
+
+
 def test_forcing_true():
     obj = {'metadata': {'labels': {'label': 'old-value'}}}
-    kopf.label(obj, {'label': 'new-value'}, force=True)
+    kopf.label(obj, {'label': 'new-value'}, forced=True)
     assert obj['metadata']['labels']['label'] == 'new-value'
 
 
 def test_forcing_false():
     obj = {'metadata': {'labels': {'label': 'old-value'}}}
-    kopf.label(obj, {'label': 'new-value'}, force=False)
+    kopf.label(obj, {'label': 'new-value'}, forced=False)
     assert obj['metadata']['labels']['label'] == 'old-value'
 
 
@@ -59,7 +75,7 @@ def test_forcing_default():
 def test_nested_with_forced_true():
     obj = {'metadata': {'labels': {'label': 'old-value'}},
            'spec': {'template': {}}}
-    kopf.label(obj, {'label': 'new-value'}, nested=['spec.template'], force=True)
+    kopf.label(obj, {'label': 'new-value'}, nested=['spec.template'], forced=True)
     assert obj['metadata']['labels']['label'] == 'new-value'
     assert obj['spec']['template']['metadata']['labels']['label'] == 'new-value'
 
@@ -67,6 +83,6 @@ def test_nested_with_forced_true():
 def test_nested_with_forced_false():
     obj = {'metadata': {'labels': {'label': 'old-value'}},
            'spec': {'template': {}}}
-    kopf.label(obj, {'label': 'new-value'}, nested=['spec.template'], force=False)
+    kopf.label(obj, {'label': 'new-value'}, nested=['spec.template'], forced=False)
     assert obj['metadata']['labels']['label'] == 'old-value'
     assert obj['spec']['template']['metadata']['labels']['label'] == 'new-value'

--- a/tests/hierarchies/test_name_harmonizing.py
+++ b/tests/hierarchies/test_name_harmonizing.py
@@ -4,6 +4,19 @@ import pytest
 
 import kopf
 
+forced_mode = pytest.mark.parametrize('forcedness', [
+    pytest.param(dict(forced=True), id='forcedTrue'),
+])
+non_forced_mode = pytest.mark.parametrize('forcedness', [
+    pytest.param(dict(forced=False), id='forcedFalse'),
+    pytest.param(dict(), id='forcedAbsent'),
+])
+any_forced_mode = pytest.mark.parametrize('forcedness', [
+    pytest.param(dict(forced=True), id='forcedTrue'),
+    pytest.param(dict(forced=False), id='forcedFalse'),
+    pytest.param(dict(), id='forcedAbsent'),
+])
+
 strict_mode = pytest.mark.parametrize('strictness', [
     pytest.param(dict(strict=True), id='strictTrue'),
 ])
@@ -37,13 +50,14 @@ obj2_without_names = pytest.mark.parametrize('obj2', [
 ])
 
 
-# The EXISTING names are preserved.
+# In the NON-FORCED mode, the EXISTING names are preserved.
 # The strictness is not involved due to this (no new names added).
 @obj1_with_names
 @any_strict_mode
-def test_preserved_name_of_dict(strictness, obj1):
+@non_forced_mode
+def test_preserved_name_of_dict(forcedness, strictness, obj1):
     obj1 = copy.deepcopy(obj1)
-    kopf.harmonize_naming(obj1, name='provided-name', **strictness)
+    kopf.harmonize_naming(obj1, name='provided-name', **forcedness, **strictness)
     assert obj1['metadata'].get('name') != 'provided-name'
     assert obj1['metadata'].get('generateName') != 'provided-name'
 
@@ -51,23 +65,81 @@ def test_preserved_name_of_dict(strictness, obj1):
 @obj2_with_names
 @obj1_with_names
 @any_strict_mode
-def test_preserved_names_of_dicts(strictness, multicls, obj1, obj2):
+@non_forced_mode
+def test_preserved_names_of_dicts(forcedness, strictness, multicls, obj1, obj2):
     obj1, obj2 = copy.deepcopy(obj1), copy.deepcopy(obj2)
     objs = multicls([obj1, obj2])
-    kopf.harmonize_naming(objs, name='provided-name', **strictness)
+    kopf.harmonize_naming(objs, name='provided-name', **forcedness, **strictness)
     assert obj1['metadata'].get('name') != 'provided-name'
     assert obj2['metadata'].get('name') != 'provided-name'
     assert obj1['metadata'].get('generateName') != 'provided-name'
     assert obj2['metadata'].get('generateName') != 'provided-name'
 
 
-# When names are ABSENT, they are added.
+# In the FORCED mode, the EXISTING names are overwritten.
+# It only depends which of the names -- regular or generated -- is left.
+@obj1_with_names
+@strict_mode
+@forced_mode
+def test_overwriting_of_strict_name_of_dict(forcedness, strictness, obj1):
+    obj1 = copy.deepcopy(obj1)
+    kopf.harmonize_naming(obj1, name='provided-name', **forcedness, **strictness)
+    assert 'name' in obj1['metadata']
+    assert 'generateName' not in obj1['metadata']
+    assert obj1['metadata']['name'] == 'provided-name'
+
+
+@obj2_with_names
+@obj1_with_names
+@strict_mode
+@forced_mode
+def test_overwriting_of_strict_names_of_dicts(forcedness, strictness, multicls, obj1, obj2):
+    obj1, obj2 = copy.deepcopy(obj1), copy.deepcopy(obj2)
+    objs = multicls([obj1, obj2])
+    kopf.harmonize_naming(objs, name='provided-name', **forcedness, **strictness)
+    assert 'name' in obj1['metadata']
+    assert 'name' in obj2['metadata']
+    assert 'generateName' not in obj1['metadata']
+    assert 'generateName' not in obj2['metadata']
+    assert obj2['metadata']['name'] == 'provided-name'
+    assert obj1['metadata']['name'] == 'provided-name'
+
+
+@obj1_with_names
+@non_strict_mode
+@forced_mode
+def test_overwriting_of_relaxed_name_of_dict(forcedness, strictness, obj1):
+    obj1 = copy.deepcopy(obj1)
+    kopf.harmonize_naming(obj1, name='provided-name', **forcedness, **strictness)
+    assert 'name' not in obj1['metadata']
+    assert 'generateName' in obj1['metadata']
+    assert obj1['metadata']['generateName'] == 'provided-name-'
+
+
+@obj2_with_names
+@obj1_with_names
+@non_strict_mode
+@forced_mode
+def test_overwriting_of_relaxed_names_of_dicts(forcedness, strictness, multicls, obj1, obj2):
+    obj1, obj2 = copy.deepcopy(obj1), copy.deepcopy(obj2)
+    objs = multicls([obj1, obj2])
+    kopf.harmonize_naming(objs, name='provided-name', **forcedness, **strictness)
+    assert 'name' not in obj1['metadata']
+    assert 'name' not in obj2['metadata']
+    assert 'generateName' in obj1['metadata']
+    assert 'generateName' in obj2['metadata']
+    assert obj1['metadata']['generateName'] == 'provided-name-'
+    assert obj2['metadata']['generateName'] == 'provided-name-'
+
+
+# When names are ABSENT, they are added regardless of the forced mode.
 # The only varying part is which name is added: regular or generated.
 @obj1_without_names
 @strict_mode
-def test_assignment_of_strict_name_of_dict(strictness, obj1):
+@any_forced_mode
+def test_assignment_of_strict_name_of_dict(forcedness, strictness, obj1):
     obj1 = copy.deepcopy(obj1)
-    kopf.harmonize_naming(obj1, name='provided-name', **strictness)
+    kopf.harmonize_naming(obj1, name='provided-name', **forcedness, **strictness)
     assert 'name' in obj1['metadata']
     assert 'generateName' not in obj1['metadata']
     assert obj1['metadata']['name'] == 'provided-name'
@@ -76,10 +148,11 @@ def test_assignment_of_strict_name_of_dict(strictness, obj1):
 @obj2_without_names
 @obj1_without_names
 @strict_mode
-def test_assignment_of_strict_names_of_dicts(strictness, multicls, obj1, obj2):
+@any_forced_mode
+def test_assignment_of_strict_names_of_dicts(forcedness, strictness, multicls, obj1, obj2):
     obj1, obj2 = copy.deepcopy(obj1), copy.deepcopy(obj2)
     objs = multicls([obj1, obj2])
-    kopf.harmonize_naming(objs, name='provided-name', **strictness)
+    kopf.harmonize_naming(objs, name='provided-name', **forcedness, **strictness)
     assert 'name' in obj1['metadata']
     assert 'name' in obj2['metadata']
     assert 'generateName' not in obj1['metadata']
@@ -90,9 +163,10 @@ def test_assignment_of_strict_names_of_dicts(strictness, multicls, obj1, obj2):
 
 @obj1_without_names
 @non_strict_mode
-def test_assignment_of_nonstrict_name_of_dict(strictness, obj1):
+@any_forced_mode
+def test_assignment_of_nonstrict_name_of_dict(forcedness, strictness, obj1):
     obj1 = copy.deepcopy(obj1)
-    kopf.harmonize_naming(obj1, name='provided-name', **strictness)
+    kopf.harmonize_naming(obj1, name='provided-name', **forcedness, **strictness)
     assert 'name' not in obj1['metadata']
     assert 'generateName' in obj1['metadata']
     assert obj1['metadata']['generateName'] == 'provided-name-'
@@ -101,10 +175,11 @@ def test_assignment_of_nonstrict_name_of_dict(strictness, obj1):
 @obj2_without_names
 @obj1_without_names
 @non_strict_mode
-def test_assignment_of_nonstrict_names_of_dicts(strictness, multicls, obj1, obj2):
+@any_forced_mode
+def test_assignment_of_nonstrict_names_of_dicts(forcedness, strictness, multicls, obj1, obj2):
     obj1, obj2 = copy.deepcopy(obj1), copy.deepcopy(obj2)
     objs = multicls([obj1, obj2])
-    kopf.harmonize_naming(objs, name='provided-name', **strictness)
+    kopf.harmonize_naming(objs, name='provided-name', **forcedness, **strictness)
     assert 'name' not in obj1['metadata']
     assert 'name' not in obj2['metadata']
     assert 'generateName' in obj1['metadata']

--- a/tests/hierarchies/test_name_harmonizing.py
+++ b/tests/hierarchies/test_name_harmonizing.py
@@ -1,114 +1,113 @@
+import copy
+
 import pytest
 
 import kopf
 
+strict_mode = pytest.mark.parametrize('strictness', [
+    pytest.param(dict(strict=True), id='strictTrue'),
+])
+non_strict_mode = pytest.mark.parametrize('strictness', [
+    pytest.param(dict(strict=False), id='strictFalse'),
+    pytest.param(dict(), id='strictAbsent'),
+])
+any_strict_mode = pytest.mark.parametrize('strictness', [
+    pytest.param(dict(strict=True), id='strictTrue'),
+    pytest.param(dict(strict=False), id='strictFalse'),
+    pytest.param(dict(), id='strictAbsent'),
+])
 
-@pytest.fixture(params=[
-    dict(strict=True),
-    dict(strict=False),
-    dict(),
-], ids=['strict', 'relaxed', 'default'])
-def all_modes_kwargs(request):
-    return request.param
-
-
-@pytest.fixture(params=[
-    dict(strict=True),
-], ids=['strict'])
-def strict_kwargs(request):
-    return request.param
-
-
-@pytest.fixture(params=[
-    dict(strict=False),
-    dict(),  # no kwargs, the function defaults are used.
-], ids=['relaxed', 'default'])
-def relaxed_kwargs(request):
-    return request.param
-
-#
-# No matter what `strict` mode is, the pre-existing names are preserved.
-#
-
-def test_preserved_name_of_dict(all_modes_kwargs):
-    obj = {'metadata': {'name': 'preexisting-name'}}
-
-    kopf.harmonize_naming(obj, name='provided-name', **all_modes_kwargs)
-
-    assert 'name' in obj['metadata']
-    assert 'generateName' not in obj['metadata']
-    assert obj['metadata']['name'] == 'preexisting-name'
+obj1_with_names = pytest.mark.parametrize('obj1', [
+    pytest.param({'metadata': {'name': 'a'}}, id='regularname'),
+    pytest.param({'metadata': {'generateName': 'b'}}, id='generatename'),
+    pytest.param({'metadata': {'name': 'c', 'generateName': 'd'}}, id='bothnames'),
+])
+obj2_with_names = pytest.mark.parametrize('obj2', [
+    pytest.param({'metadata': {'name': 'a'}}, id='regularname'),
+    pytest.param({'metadata': {'generateName': 'b'}}, id='generatename'),
+    pytest.param({'metadata': {'name': 'c', 'generateName': 'd'}}, id='bothnames'),
+])
+obj1_without_names = pytest.mark.parametrize('obj1', [
+    pytest.param({}, id='withoutmeta'),
+    pytest.param({'metadata': {}}, id='withmeta'),
+])
+obj2_without_names = pytest.mark.parametrize('obj2', [
+    pytest.param({}, id='withoutmeta'),
+    pytest.param({'metadata': {}}, id='withmeta'),
+])
 
 
-def test_preserved_names_of_multiple_objects(all_modes_kwargs, multicls):
-    obj1 = {'metadata': {'name': 'preexisting-name-1'}}
-    obj2 = {'metadata': {'name': 'preexisting-name-2'}}
+# The EXISTING names are preserved.
+# The strictness is not involved due to this (no new names added).
+@obj1_with_names
+@any_strict_mode
+def test_preserved_name_of_dict(strictness, obj1):
+    obj1 = copy.deepcopy(obj1)
+    kopf.harmonize_naming(obj1, name='provided-name', **strictness)
+    assert obj1['metadata'].get('name') != 'provided-name'
+    assert obj1['metadata'].get('generateName') != 'provided-name'
+
+
+@obj2_with_names
+@obj1_with_names
+@any_strict_mode
+def test_preserved_names_of_dicts(strictness, multicls, obj1, obj2):
+    obj1, obj2 = copy.deepcopy(obj1), copy.deepcopy(obj2)
     objs = multicls([obj1, obj2])
+    kopf.harmonize_naming(objs, name='provided-name', **strictness)
+    assert obj1['metadata'].get('name') != 'provided-name'
+    assert obj2['metadata'].get('name') != 'provided-name'
+    assert obj1['metadata'].get('generateName') != 'provided-name'
+    assert obj2['metadata'].get('generateName') != 'provided-name'
 
-    kopf.harmonize_naming(objs, name='provided-name', **all_modes_kwargs)
 
+# When names are ABSENT, they are added.
+# The only varying part is which name is added: regular or generated.
+@obj1_without_names
+@strict_mode
+def test_assignment_of_strict_name_of_dict(strictness, obj1):
+    obj1 = copy.deepcopy(obj1)
+    kopf.harmonize_naming(obj1, name='provided-name', **strictness)
     assert 'name' in obj1['metadata']
     assert 'generateName' not in obj1['metadata']
-    assert obj1['metadata']['name'] == 'preexisting-name-1'
-
-    assert 'name' in obj2['metadata']
-    assert 'generateName' not in obj2['metadata']
-    assert obj2['metadata']['name'] == 'preexisting-name-2'
-
-#
-# In strict mode and with the absent names, the provided name is used.
-#
-
-def test_assigned_name_of_dict(strict_kwargs):
-    obj = {}
-
-    kopf.harmonize_naming(obj, name='provided-name', **strict_kwargs)
-
-    assert 'name' in obj['metadata']
-    assert 'generateName' not in obj['metadata']
-    assert obj['metadata']['name'] == 'provided-name'
+    assert obj1['metadata']['name'] == 'provided-name'
 
 
-def test_assigned_names_of_multiple_objects(strict_kwargs, multicls):
-    obj1 = {'metadata': {'name': 'preexisting-name-1'}}
-    obj2 = {'metadata': {'name': 'preexisting-name-2'}}
+@obj2_without_names
+@obj1_without_names
+@strict_mode
+def test_assignment_of_strict_names_of_dicts(strictness, multicls, obj1, obj2):
+    obj1, obj2 = copy.deepcopy(obj1), copy.deepcopy(obj2)
     objs = multicls([obj1, obj2])
-
-    kopf.harmonize_naming(objs, name='provided-name', **strict_kwargs)
-
+    kopf.harmonize_naming(objs, name='provided-name', **strictness)
     assert 'name' in obj1['metadata']
-    assert 'generateName' not in obj1['metadata']
-    assert obj1['metadata']['name'] == 'preexisting-name-1'
-
     assert 'name' in obj2['metadata']
+    assert 'generateName' not in obj1['metadata']
     assert 'generateName' not in obj2['metadata']
-    assert obj2['metadata']['name'] == 'preexisting-name-2'
-
-#
-# In relaxed mode, if the names are absent, they are auto-generated.
-#
-
-def test_prefixed_name_of_dict(relaxed_kwargs):
-    obj = {}
-
-    kopf.harmonize_naming(obj, name='provided-name', **relaxed_kwargs)
-
-    assert 'name' not in obj['metadata']
-    assert 'generateName' in obj['metadata']
-    assert obj['metadata']['generateName'] == 'provided-name-'
+    assert obj1['metadata']['name'] == 'provided-name'
+    assert obj2['metadata']['name'] == 'provided-name'
 
 
-def test_prefixed_names_of_multiple_objects(relaxed_kwargs, multicls):
-    obj1 = {}
-    obj2 = {}
-    objs = multicls([obj1, obj2])
-
-    kopf.harmonize_naming(objs, name='provided-name', **relaxed_kwargs)
-
+@obj1_without_names
+@non_strict_mode
+def test_assignment_of_nonstrict_name_of_dict(strictness, obj1):
+    obj1 = copy.deepcopy(obj1)
+    kopf.harmonize_naming(obj1, name='provided-name', **strictness)
     assert 'name' not in obj1['metadata']
     assert 'generateName' in obj1['metadata']
     assert obj1['metadata']['generateName'] == 'provided-name-'
 
+
+@obj2_without_names
+@obj1_without_names
+@non_strict_mode
+def test_assignment_of_nonstrict_names_of_dicts(strictness, multicls, obj1, obj2):
+    obj1, obj2 = copy.deepcopy(obj1), copy.deepcopy(obj2)
+    objs = multicls([obj1, obj2])
+    kopf.harmonize_naming(objs, name='provided-name', **strictness)
+    assert 'name' not in obj1['metadata']
     assert 'name' not in obj2['metadata']
+    assert 'generateName' in obj1['metadata']
     assert 'generateName' in obj2['metadata']
+    assert obj1['metadata']['generateName'] == 'provided-name-'
     assert obj2['metadata']['generateName'] == 'provided-name-'

--- a/tests/hierarchies/test_namespace_adjusting.py
+++ b/tests/hierarchies/test_namespace_adjusting.py
@@ -1,53 +1,62 @@
+import copy
+
+import pytest
+
 import kopf
 
-#
-# If namespace is set, it should be preserved, unmodified.
-#
+obj1_with_namespace = pytest.mark.parametrize('obj1', [
+    pytest.param({'metadata': {'namespace': 'a'}}, id='withnamespace'),
+])
+obj2_with_namespace = pytest.mark.parametrize('obj2', [
+    pytest.param({'metadata': {'namespace': 'a'}}, id='withnamespace'),
+])
+obj1_without_namespace = pytest.mark.parametrize('obj1', [
+    pytest.param({}, id='withoutmetadata'),
+    pytest.param({'metadata': {}}, id='withoutnamespace'),
+])
+obj2_without_namespace = pytest.mark.parametrize('obj2', [
+    pytest.param({}, id='withoutmetadata'),
+    pytest.param({'metadata': {}}, id='withoutnamespace'),
+])
 
-def test_preserved_namespace_of_dict():
-    obj = {'metadata': {'namespace': 'preexisting-namespace'}}
 
-    kopf.adjust_namespace(obj, namespace='provided-namespace')
-
-    assert 'namespace' in obj['metadata']
-    assert obj['metadata']['namespace'] == 'preexisting-namespace'
-
-
-def test_preserved_namespace_of_multiple_objects(multicls):
-    obj1 = {'metadata': {'namespace': 'preexisting-namespace-1'}}
-    obj2 = {'metadata': {'namespace': 'preexisting-namespace-2'}}
-    objs = multicls([obj1, obj2])
-
-    kopf.adjust_namespace(objs, namespace='provided-namespace')
-
+# The EXISTING namespaces are preserved.
+@obj1_with_namespace
+def test_preserved_namespace_of_dict(obj1):
+    obj1 = copy.deepcopy(obj1)
+    kopf.adjust_namespace(obj1, namespace='provided-namespace')
     assert 'namespace' in obj1['metadata']
-    assert obj1['metadata']['namespace'] == 'preexisting-namespace-1'
-
-    assert 'namespace' in obj2['metadata']
-    assert obj2['metadata']['namespace'] == 'preexisting-namespace-2'
-
-#
-# If the namespace is absent, it should be assigned as provided.
-#
-
-def test_assigned_namespace_of_dict():
-    obj = {}
-
-    kopf.adjust_namespace(obj, namespace='provided-namespace')
-
-    assert 'namespace' in obj['metadata']
-    assert obj['metadata']['namespace'] == 'provided-namespace'
+    assert obj1['metadata']['namespace'] != 'provided-namespace'
 
 
-def test_assigned_namespace_of_multiple_objects(multicls):
-    obj1 = {}
-    obj2 = {}
+@obj2_with_namespace
+@obj1_with_namespace
+def test_preserved_namespaces_of_dicts(multicls, obj1, obj2):
+    obj1, obj2 = copy.deepcopy(obj1), copy.deepcopy(obj2)
     objs = multicls([obj1, obj2])
-
     kopf.adjust_namespace(objs, namespace='provided-namespace')
+    assert 'namespace' in obj1['metadata']
+    assert 'namespace' in obj2['metadata']
+    assert obj1['metadata']['namespace'] != 'provided-namespace'
+    assert obj2['metadata']['namespace'] != 'provided-namespace'
 
+
+# When namespaces are ABSENT, they are added.
+@obj1_without_namespace
+def test_assignment_of_namespace_of_dict(obj1):
+    obj1 = copy.deepcopy(obj1)
+    kopf.adjust_namespace(obj1, namespace='provided-namespace')
     assert 'namespace' in obj1['metadata']
     assert obj1['metadata']['namespace'] == 'provided-namespace'
 
+
+@obj2_without_namespace
+@obj1_without_namespace
+def test_assignment_of_namespaces_of_dicts(multicls, obj1, obj2):
+    obj1, obj2 = copy.deepcopy(obj1), copy.deepcopy(obj2)
+    objs = multicls([obj1, obj2])
+    kopf.adjust_namespace(objs, namespace='provided-namespace')
+    assert 'namespace' in obj1['metadata']
     assert 'namespace' in obj2['metadata']
+    assert obj1['metadata']['namespace'] == 'provided-namespace'
     assert obj2['metadata']['namespace'] == 'provided-namespace'

--- a/tests/hierarchies/test_owner_referencing.py
+++ b/tests/hierarchies/test_owner_referencing.py
@@ -38,7 +38,7 @@ def test_appending_to_dict():
     assert obj['metadata']['ownerReferences'][0]['uid'] == OWNER_UID
 
 
-def test_appending_to_multiple_objects(multicls):
+def test_appending_to_dicts(multicls):
     obj1 = {}
     obj2 = {}
     objs = multicls([obj1, obj2])
@@ -117,7 +117,7 @@ def test_removal_from_dict():
     assert len(obj['metadata']['ownerReferences']) == 0
 
 
-def test_removal_from_multiple_objects(multicls):
+def test_removal_from_dicts(multicls):
     obj1 = {}
     obj2 = {}
     objs = multicls([obj1, obj2])
@@ -180,10 +180,8 @@ def test_removal_distinguishes_by_uid():
     uids = {ref['uid'] for ref in obj['metadata']['ownerReferences']}
     assert uids == {'uid-b', 'uid-c'}
 
-#
-# Not related to owner references only, but uses the OWNER constants.
-#
 
+# Not related to owner references only, but uses the OWNER constants.
 def test_adopting(mocker):
     # These methods are tested in their own tests.
     # We just check that they are called at all.

--- a/tests/hierarchies/test_type_validation.py
+++ b/tests/hierarchies/test_type_validation.py
@@ -1,0 +1,40 @@
+import pytest
+
+import kopf
+from kopf.structs.bodies import Body
+
+
+def test_in_owner_reference_appending():
+    with pytest.raises(TypeError) as e:
+        kopf.append_owner_reference(object(), Body({}))
+    assert "K8s object class is not supported" in str(e.value)
+
+
+def test_in_owner_reference_removal():
+    with pytest.raises(TypeError) as e:
+        kopf.remove_owner_reference(object(), Body({}))
+    assert "K8s object class is not supported" in str(e.value)
+
+
+def test_in_name_harmonization():
+    with pytest.raises(TypeError) as e:
+        kopf.harmonize_naming(object(), 'x')
+    assert "K8s object class is not supported" in str(e.value)
+
+
+def test_in_namepace_adjustment():
+    with pytest.raises(TypeError) as e:
+        kopf.adjust_namespace(object(), 'x')
+    assert "K8s object class is not supported" in str(e.value)
+
+
+def test_in_labelling():
+    with pytest.raises(TypeError) as e:
+        kopf.label(object(), {})
+    assert "K8s object class is not supported" in str(e.value)
+
+
+def test_in_adopting():
+    with pytest.raises(TypeError) as e:
+        kopf.adopt(object(), Body({}))
+    assert "K8s object class is not supported" in str(e.value)


### PR DESCRIPTION
Kopf provides a toolkit of functions to manage hierarchies slightly more easy than by directly manipulating children object — and automatically does that in the context of an object being processed at the moment if no specific values were given to those functions.

Before now, this library was somewhat difficult to use, as it had inconsistent flags, options, and possibilities exposed via different functions.

Now, it more in sync and easier to use. The functionality remains the same though. See the list of comments for tiny improvements:

* Better documentation on hierarchies toolkit, with detailed examples.
* `forced` flag in all functions: for names, namespaces, and labels (but not for owner references, as it makes no use there).
* Name harmonisation detects any of 2 possible names: `.metadata.name` and `.metadata.generateName`, and assumes the object is already named if any of them is present. _(See a compatibility note below.)_
* Fails if the current owner has no name/namespace (when the owner is implied and its name/namespaced is needed) — in addition to failing when there is no owner at all.
* Relabels the target resources as per the current owner of no specific labels are given (consistent with names, namespaces, and adoption).
* Fail if an unsupported object type is fed into the functions -- with a clear message, not KeyErrors.
* `nested=` now accepts a single string too: `nested="spec.jobTemplate"` (previously: strictly an iterable of strings).
* `adopt()` has got `forced` & `strict` options (in addition to `nested`), passed down to all involved functions.

**Backward compatibility:** all of these changes are backwards compatible, and they cover the feature spaces not available before, except for one:

* Previously, if `generateName` was present in the target, but `name` was not —exactly in this condition— then the `name` was assigned. Now, it will not be (without `forced=True`) — since the name is already implied by the target. If that condition was ever relied on, it was clearly a bug in an operator code's, so I assume it was not what was wanted, and it can be fixed. If this is a problem, then the SOLUTION is to add `forced=True`.

Related: #286, done as a preparation for #672 