### PR TITLE
Support  3rd-party clients in the hierarchy toolkit

### DIFF
--- a/docs/hierarchies.rst
+++ b/docs/hierarchies.rst
@@ -20,7 +20,7 @@ by manipulating their content before it is sent to the Kubernetes API.
 .. _pykube-ng: https://github.com/hjacobs/pykube
 
 In all examples below, ``obj`` and ``objs`` are either a supported object type
-(dictionaries, mappings) or a list/tuple/iterable with several objects.
+(native or 3rd-party, see below) or a list/tuple/iterable with several objects.
 
 
 Labels
@@ -278,3 +278,59 @@ All of the above can be done in one call with :func:`kopf.adopt`; ``forced``,
         #    'name': 'kopf-example-1',
         #    'namespace': 'default',
         #    'labels': {'somelabel': 'somevalue'}}}]
+
+
+3rd-party libraries
+===================
+
+All described methods support resource-related classes of selected libraries
+the same way as the native Python dictionaries (or any mutable mappings).
+Currently, that is `pykube-ng`_ (classes based on ``pykube.objects.APIObject``)
+and `kubernetes client`_ (resource models from ``kubernetes.client.models``).
+
+.. code-block:: python
+
+    import kopf
+    import pykube
+
+    @kopf.on.create('KopfExample')
+    def create_fn(**_):
+        api = pykube.HTTPClient(pykube.KubeConfig.from_env())
+        pod = pykube.objects.Pod(api, {})
+        kopf.adopt(pod)
+
+.. code-block:: python
+
+    import kopf
+    import kubernetes.client
+
+    @kopf.on.create('KopfExample')
+    def create_fn(**_):
+        pod = kubernetes.client.V1Pod()
+        kopf.adopt(pod)
+        print(pod)
+        # {'api_version': None,
+        #  'kind': None,
+        #  'metadata': {'annotations': None,
+        #               'cluster_name': None,
+        #               'creation_timestamp': None,
+        #               'deletion_grace_period_seconds': None,
+        #               'deletion_timestamp': None,
+        #               'finalizers': None,
+        #               'generate_name': 'kopf-example-1-',
+        #               'generation': None,
+        #               'labels': {'somelabel': 'somevalue'},
+        #               'managed_fields': None,
+        #               'name': None,
+        #               'namespace': 'default',
+        #               'owner_references': [{'api_version': 'kopf.dev/v1',
+        #                                     'block_owner_deletion': True,
+        #                                     'controller': True,
+        #                                     'kind': 'KopfExample',
+        #                                     'name': 'kopf-example-1',
+        #                                     'uid': 'a114fa89-e696-4e84-9b80-b29fbccc460c'}],
+        #               'resource_version': None,
+        #               'self_link': None,
+        #               'uid': None},
+        #  'spec': None,
+        #  'status': None}

--- a/kopf/utilities/thirdparty.py
+++ b/kopf/utilities/thirdparty.py
@@ -1,0 +1,43 @@
+"""
+Type definitions from optional 3rd-party libraries, e.g. pykube-ng & kubernetes.
+
+This utility does all the trickery needed to import the libraries if possible,
+or to skip them and make typing/runtime dummies for the rest of the codebase.
+"""
+import abc
+from typing import Any, Optional
+
+
+# Since client libraries are optional, support their objects only if they are installed.
+# If not installed, use a dummy class to miss all isinstance() checks for that library.
+class _dummy: pass
+
+
+try:
+    from pykube.objects import APIObject as PykubeObject
+except ImportError:
+    PykubeObject = _dummy
+
+try:
+    from kubernetes.client import V1ObjectMeta, V1OwnerReference
+except ImportError:
+    V1ObjectMeta = V1OwnerReference = None
+
+
+# Kubernetes client does not have any common base classes, its code is fully generated.
+# Only recognise classes from a specific module. Ignore all API/HTTP/auth-related tools.
+class KubernetesModel(abc.ABC):
+    @classmethod
+    def __subclasshook__(cls, subcls: Any) -> Any:  # suppress types in this hack
+        if cls is KubernetesModel:
+            if any(C.__module__.startswith('kubernetes.client.models.') for C in subcls.__mro__):
+                return True
+        return NotImplemented
+
+    @property
+    def metadata(self) -> Optional[V1ObjectMeta]:
+        raise NotImplementedError
+
+    @metadata.setter
+    def metadata(self, _: Optional[V1ObjectMeta]) -> None:
+        raise NotImplementedError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,6 +333,7 @@ def hostname():
 class LoginMocks:
     pykube_in_cluster: Mock = None
     pykube_from_file: Mock = None
+    pykube_from_env: Mock = None
     client_in_cluster: Mock = None
     client_from_file: Mock = None
 
@@ -359,6 +360,7 @@ def login_mocks(mocker):
         kwargs.update(
             pykube_in_cluster=mocker.patch.object(pykube.KubeConfig, 'from_service_account', return_value=cfg),
             pykube_from_file=mocker.patch.object(pykube.KubeConfig, 'from_file', return_value=cfg),
+            pykube_from_env=mocker.patch.object(pykube.KubeConfig, 'from_env', return_value=cfg),
         )
     try:
         import kubernetes

--- a/tests/dicts/test_resolving.py
+++ b/tests/dicts/test_resolving.py
@@ -15,20 +15,27 @@ The test design notes:
   and the default value is returned or a ``KeyError`` is raised.
 
 """
+import types
+
 import pytest
 
-from kopf.structs.dicts import resolve
+from kopf.structs.dicts import resolve, resolve_obj
 
 default = object()
 
 
-def test_existent_key_with_no_default():
+#
+# Both resolve functions should behave exactly the same for dicts.
+#
+@pytest.mark.parametrize('resolve', [resolve, resolve_obj])
+def test_dict_with_existent_key_with_no_default(resolve):
     d = {'abc': {'def': {'hij': 'val'}}}
     r = resolve(d, ['abc', 'def', 'hij'])
     assert r == 'val'
 
 
-def test_existent_key_with_default():
+@pytest.mark.parametrize('resolve', [resolve, resolve_obj])
+def test_dict_with_existent_key_with_default(resolve):
     d = {'abc': {'def': {'hij': 'val'}}}
     r = resolve(d, ['abc', 'def', 'hij'], default)
     assert r == 'val'
@@ -39,7 +46,8 @@ def test_existent_key_with_default():
     pytest.param(['abc', 'uvw', 'xyz'], id='2ndlvl'),
     pytest.param(['abc', 'def', 'xyz'], id='3rdlvl'),
 ])
-def test_inexistent_key_with_no_default(key):
+@pytest.mark.parametrize('resolve', [resolve, resolve_obj])
+def test_dict_with_inexistent_key_with_no_default(resolve, key):
     d = {'abc': {'def': {'hij': 'val'}}}
     with pytest.raises(KeyError):
         resolve(d, key)
@@ -50,32 +58,133 @@ def test_inexistent_key_with_no_default(key):
     pytest.param(['abc', 'uvw', 'xyz'], id='2ndlvl'),
     pytest.param(['abc', 'def', 'xyz'], id='3rdlvl'),
 ])
-def test_inexistent_key_with_default(key):
+@pytest.mark.parametrize('resolve', [resolve, resolve_obj])
+def test_dict_with_inexistent_key_with_default(resolve, key):
     d = {'abc': {'def': {'hij': 'val'}}}
     r = resolve(d, key, default)
     assert r is default
 
 
-def test_nonmapping_with_no_default():
+@pytest.mark.parametrize('resolve', [resolve, resolve_obj])
+def test_dict_with_nonmapping_with_no_default(resolve):
     d = {'key': 'val'}
     with pytest.raises(TypeError):
         resolve(d, ['key', 'sub'])
 
 
-def test_nonmapping_with_default():
+@pytest.mark.parametrize('resolve', [resolve, resolve_obj])
+def test_dict_with_nonmapping_with_default(resolve):
     d = {'key': 'val'}
     r = resolve(d, ['key', 'sub'], default)
     assert r is default
 
 
-def test_none_is_treated_as_a_regular_default_value():
+@pytest.mark.parametrize('resolve', [resolve, resolve_obj])
+def test_dict_with_none_is_treated_as_a_regular_default_value(resolve):
     d = {'abc': {'def': {'hij': 'val'}}}
     r = resolve(d, ['abc', 'def', 'xyz'], None)
     assert r is None
 
 
-def test_empty_path():
+@pytest.mark.parametrize('resolve', [resolve, resolve_obj])
+def test_dict_with_empty_path(resolve):
     d = {'key': 'val'}
     r = resolve(d, [])
     assert r == d
     assert r is d
+
+
+#
+# Specialised drill-down for objects.
+#
+class FakeKubernetesModel:  # no bases!
+    __module__ = 'kubernetes.client.models.fake-for-tests'
+
+    @property
+    def metadata(self):
+        return None
+
+    attribute_map = {
+        'AbC': 'abc',
+        'zzz': 'dez',
+    }
+
+
+@pytest.fixture(params=[FakeKubernetesModel, types.SimpleNamespace])
+def obj(request):
+    cls = request.param
+    obj = cls()
+    if cls is FakeKubernetesModel:
+        # With attribute mapping in mind.
+        obj.key = 'val'
+        obj.AbC = cls()
+        obj.AbC.zzz = cls()
+        obj.AbC.zzz.hij = 'val'
+    else:
+        # Exactly as they will be requested.
+        obj.key = 'val'
+        obj.abc = cls()
+        obj.abc.dez = cls()
+        obj.abc.dez.hij = 'val'
+    return obj
+
+
+def test_object_with_existent_key_with_no_default(obj):
+    r = resolve_obj(obj, ['abc', 'dez', 'hij'])
+    assert r == 'val'
+
+
+def test_object_with_existent_key_with_default(obj):
+    r = resolve_obj(obj, ['abc', 'dez', 'hij'], default)
+    assert r == 'val'
+
+
+@pytest.mark.parametrize('key', [
+    pytest.param(['rst', 'uvw', 'xyz'], id='1stlvl'),
+    pytest.param(['abc', 'uvw', 'xyz'], id='2ndlvl'),
+    pytest.param(['abc', 'dez', 'xyz'], id='3rdlvl'),
+])
+def test_object_with_inexistent_key_with_no_default(obj, key):
+    with pytest.raises(AttributeError):
+        resolve_obj(obj, key)
+
+
+@pytest.mark.parametrize('key', [
+    pytest.param(['rst', 'uvw', 'xyz'], id='1stlvl'),
+    pytest.param(['abc', 'uvw', 'xyz'], id='2ndlvl'),
+    pytest.param(['abc', 'dez', 'xyz'], id='3rdlvl'),
+])
+def test_object_with_inexistent_key_with_default(obj, key):
+    r = resolve_obj(obj, key, default)
+    assert r is default
+
+
+def test_object_with_nonmapping_with_no_default(obj):
+    with pytest.raises(TypeError):
+        resolve_obj(obj, ['key', 'sub'])
+
+
+def test_object_with_nonmapping_with_default(obj):
+    r = resolve_obj(obj, ['key', 'sub'], default)
+    assert r is default
+
+
+def test_object_with_none_is_treated_as_a_regular_default_value(obj):
+    r = resolve_obj(obj, ['abc', 'dez', 'xyz'], None)
+    assert r is None
+
+
+def test_object_with_empty_path(obj):
+    r = resolve_obj(obj, [])
+    assert r == obj
+    assert r is obj
+
+
+#
+# Some special cases.
+#
+@pytest.mark.parametrize('cls', (tuple, list, set, frozenset, str, bytes))
+def test_raises_for_builtins(cls):
+    obj = cls()
+    with pytest.raises(TypeError):
+        resolve_obj(obj, ['__class__'])

--- a/tests/hierarchies/conftest.py
+++ b/tests/hierarchies/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 
@@ -14,3 +16,27 @@ class CustomIterable:
                 ids=['list', 'tuple', 'custom'])
 def multicls(request):
     return request.param
+
+
+@pytest.fixture()
+def pykube_object(pykube):
+    obj = pykube.objects.CronJob(Mock(), {
+        'metadata': {},
+        'spec': {
+            'jobTemplate': {},
+        },
+    })
+    return obj
+
+
+@pytest.fixture()
+def kubernetes_model(kubernetes):
+    # The most tricky class -- with attribute-to-key mapping (jobTemplate).
+    obj = kubernetes.client.V1beta1CronJob(
+        metadata=kubernetes.client.V1ObjectMeta(),
+        spec=kubernetes.client.V1beta1CronJobSpec(
+            schedule='* * * * *',
+            job_template=kubernetes.client.V1beta1JobTemplateSpec(),
+        ),
+    )
+    return obj

--- a/tests/hierarchies/test_labelling.py
+++ b/tests/hierarchies/test_labelling.py
@@ -36,6 +36,26 @@ def test_adding_to_dicts(multicls):
     assert obj2['metadata']['labels']['label-2'] == 'value-2'
 
 
+def test_adding_to_pykube_object(pykube_object):
+    del pykube_object.obj['metadata']
+    kopf.label(pykube_object, {'label-1': 'value-1', 'label-2': 'value-2'})
+    assert len(pykube_object.labels) == 2
+    assert 'label-1' in pykube_object.labels
+    assert 'label-2' in pykube_object.labels
+    assert pykube_object.labels['label-1'] == 'value-1'
+    assert pykube_object.labels['label-2'] == 'value-2'
+
+
+def test_adding_to_kubernetes_model(kubernetes_model):
+    kubernetes_model.metadata = None
+    kopf.label(kubernetes_model, {'label-1': 'value-1', 'label-2': 'value-2'})
+    assert len(kubernetes_model.metadata.labels) == 2
+    assert 'label-1' in kubernetes_model.metadata.labels
+    assert 'label-2' in kubernetes_model.metadata.labels
+    assert kubernetes_model.metadata.labels['label-1'] == 'value-1'
+    assert kubernetes_model.metadata.labels['label-2'] == 'value-2'
+
+
 def test_forcing_true_warns_on_deprecated_option():
     obj = {'metadata': {'labels': {'label': 'old-value'}}}
     with pytest.deprecated_call(match=r"use forced="):
@@ -68,10 +88,46 @@ def test_forcing_default_to_dict():
     assert obj['metadata']['labels']['label'] == 'old-value'
 
 
+def test_forcing_true_to_pykube_object(pykube_object):
+    pykube_object.labels['label'] = 'old-value'
+    kopf.label(pykube_object, {'label': 'new-value'}, forced=True)
+    assert pykube_object.labels['label'] == 'new-value'
+
+
+def test_forcing_false_to_pykube_object(pykube_object):
+    pykube_object.labels['label'] = 'old-value'
+    kopf.label(pykube_object, {'label': 'new-value'}, forced=False)
+    assert pykube_object.labels['label'] == 'old-value'
+
+
+def test_forcing_default_to_pykube_object(pykube_object):
+    pykube_object.labels['label'] = 'old-value'
+    kopf.label(pykube_object, {'label': 'new-value'})
+    assert pykube_object.labels['label'] == 'old-value'
+
+
+def test_forcing_true_to_kubernetes_model(kubernetes_model):
+    kubernetes_model.metadata.labels = {'label': 'old-value'}
+    kopf.label(kubernetes_model, {'label': 'new-value'}, forced=True)
+    assert kubernetes_model.metadata.labels['label'] == 'new-value'
+
+
+def test_forcing_false_to_kubernetes_model(kubernetes_model):
+    kubernetes_model.metadata.labels = {'label': 'old-value'}
+    kopf.label(kubernetes_model, {'label': 'new-value'}, forced=False)
+    assert kubernetes_model.metadata.labels['label'] == 'old-value'
+
+
+def test_forcing_default_to_kubernetes_model(kubernetes_model):
+    kubernetes_model.metadata.labels = {'label': 'old-value'}
+    kopf.label(kubernetes_model, {'label': 'new-value'})
+    assert kubernetes_model.metadata.labels['label'] == 'old-value'
+
+
 @pytest.mark.parametrize('nested', [
-    pytest.param(('spec.jobTemplate',), id='tuple'),
-    pytest.param(['spec.jobTemplate'], id='list'),
-    pytest.param({'spec.jobTemplate'}, id='set'),
+    pytest.param(('spec.jobTemplate', 'spec.unexistent'), id='tuple'),
+    pytest.param(['spec.jobTemplate', 'spec.unexistent'], id='list'),
+    pytest.param({'spec.jobTemplate', 'spec.unexistent'}, id='set'),
     pytest.param('spec.jobTemplate', id='string'),
 ])
 def test_nested_with_forced_true_to_dict(nested):
@@ -80,12 +136,42 @@ def test_nested_with_forced_true_to_dict(nested):
     kopf.label(obj, {'label': 'new-value'}, nested=nested, forced=True)
     assert obj['metadata']['labels']['label'] == 'new-value'
     assert obj['spec']['jobTemplate']['metadata']['labels']['label'] == 'new-value'
+    assert 'unexistent' not in obj['spec']
 
 
 @pytest.mark.parametrize('nested', [
-    pytest.param(('spec.jobTemplate',), id='tuple'),
-    pytest.param(['spec.jobTemplate'], id='list'),
-    pytest.param({'spec.jobTemplate'}, id='set'),
+    pytest.param(('spec.jobTemplate', 'spec.unexistent'), id='tuple'),
+    pytest.param(['spec.jobTemplate', 'spec.unexistent'], id='list'),
+    pytest.param({'spec.jobTemplate', 'spec.unexistent'}, id='set'),
+    pytest.param('spec.jobTemplate', id='string'),
+])
+def test_nested_with_forced_true_to_pykube_object(nested, pykube_object):
+    pykube_object.labels.update({'label': 'old-value'})
+    pykube_object.obj.update({'spec': {'jobTemplate': {}}})
+    kopf.label(pykube_object, {'label': 'new-value'}, nested=nested, forced=True)
+    assert pykube_object.labels['label'] == 'new-value'
+    assert pykube_object.obj['spec']['jobTemplate']['metadata']['labels']['label'] == 'new-value'
+    assert 'unexistent' not in pykube_object.obj['spec']
+
+
+@pytest.mark.parametrize('nested', [
+    pytest.param(('spec.jobTemplate', 'spec.unexistent'), id='tuple'),
+    pytest.param(['spec.jobTemplate', 'spec.unexistent'], id='list'),
+    pytest.param({'spec.jobTemplate', 'spec.unexistent'}, id='set'),
+    pytest.param('spec.jobTemplate', id='string'),
+])
+def test_nested_with_forced_true_to_kubernetes_model(nested, kubernetes_model):
+    kubernetes_model.metadata.labels = {'label': 'old-value'}
+    kopf.label(kubernetes_model, {'label': 'new-value'}, nested=nested, forced=True)
+    assert kubernetes_model.metadata.labels['label'] == 'new-value'
+    assert kubernetes_model.spec.job_template.metadata.labels['label'] == 'new-value'
+    assert not hasattr(kubernetes_model.spec, 'unexistent')
+
+
+@pytest.mark.parametrize('nested', [
+    pytest.param(('spec.jobTemplate', 'spec.unexistent'), id='tuple'),
+    pytest.param(['spec.jobTemplate', 'spec.unexistent'], id='list'),
+    pytest.param({'spec.jobTemplate', 'spec.unexistent'}, id='set'),
     pytest.param('spec.jobTemplate', id='string'),
 ])
 def test_nested_with_forced_false_to_dict(nested):
@@ -94,3 +180,33 @@ def test_nested_with_forced_false_to_dict(nested):
     kopf.label(obj, {'label': 'new-value'}, nested=nested, forced=False)
     assert obj['metadata']['labels']['label'] == 'old-value'
     assert obj['spec']['jobTemplate']['metadata']['labels']['label'] == 'new-value'
+    assert 'unexistent' not in obj['spec']
+
+
+@pytest.mark.parametrize('nested', [
+    pytest.param(('spec.jobTemplate', 'spec.unexistent'), id='tuple'),
+    pytest.param(['spec.jobTemplate', 'spec.unexistent'], id='list'),
+    pytest.param({'spec.jobTemplate', 'spec.unexistent'}, id='set'),
+    pytest.param('spec.jobTemplate', id='string'),
+])
+def test_nested_with_forced_false_to_pykube_object(nested, pykube_object):
+    pykube_object.labels.update({'label': 'old-value'})
+    pykube_object.obj.update({'spec': {'jobTemplate': {}}})
+    kopf.label(pykube_object, {'label': 'new-value'}, nested=nested, forced=False)
+    assert pykube_object.labels['label'] == 'old-value'
+    assert pykube_object.obj['spec']['jobTemplate']['metadata']['labels']['label'] == 'new-value'
+    assert 'unexistent' not in pykube_object.obj['spec']
+
+
+@pytest.mark.parametrize('nested', [
+    pytest.param(('spec.jobTemplate', 'spec.unexistent'), id='tuple'),
+    pytest.param(['spec.jobTemplate', 'spec.unexistent'], id='list'),
+    pytest.param({'spec.jobTemplate', 'spec.unexistent'}, id='set'),
+    pytest.param('spec.jobTemplate', id='string'),
+])
+def test_nested_with_forced_false_to_kubernetes_model(nested, kubernetes_model):
+    kubernetes_model.metadata.labels = {'label': 'old-value'}
+    kopf.label(kubernetes_model, {'label': 'new-value'}, nested=nested, forced=False)
+    assert kubernetes_model.metadata.labels['label'] == 'old-value'
+    assert kubernetes_model.spec.job_template.metadata.labels['label'] == 'new-value'
+    assert not hasattr(kubernetes_model.spec, 'unexistent')

--- a/tests/hierarchies/test_name_harmonizing.py
+++ b/tests/hierarchies/test_name_harmonizing.py
@@ -76,6 +76,27 @@ def test_preserved_names_of_dicts(forcedness, strictness, multicls, obj1, obj2):
     assert obj2['metadata'].get('generateName') != 'provided-name'
 
 
+@obj1_with_names
+@any_strict_mode
+@non_forced_mode
+def test_preserved_names_of_pykube_object(forcedness, strictness, pykube_object, obj1):
+    pykube_object.obj = copy.deepcopy(obj1)
+    kopf.harmonize_naming(pykube_object, name='provided-name', **forcedness, **strictness)
+    assert pykube_object.obj['metadata'].get('name') != 'provided-name'
+    assert pykube_object.obj['metadata'].get('generateName') != 'provided-name'
+
+
+@obj1_with_names
+@any_strict_mode
+@non_forced_mode
+def test_preserved_names_of_kubernetes_model(forcedness, strictness, kubernetes_model, obj1):
+    kubernetes_model.metadata.name = obj1.get('metadata', {}).get('name')
+    kubernetes_model.metadata.generate_name = obj1.get('metadata', {}).get('generateName')
+    kopf.harmonize_naming(kubernetes_model, name='provided-name', **forcedness, **strictness)
+    assert kubernetes_model.metadata.name != 'provided-name'
+    assert kubernetes_model.metadata.generate_name != 'provided-name'
+
+
 # In the FORCED mode, the EXISTING names are overwritten.
 # It only depends which of the names -- regular or generated -- is left.
 @obj1_with_names
@@ -106,6 +127,27 @@ def test_overwriting_of_strict_names_of_dicts(forcedness, strictness, multicls, 
 
 
 @obj1_with_names
+@strict_mode
+@forced_mode
+def test_overwriting_of_strict_name_of_pykube_object(forcedness, strictness, pykube_object, obj1):
+    pykube_object.obj = copy.deepcopy(obj1)
+    kopf.harmonize_naming(pykube_object, name='provided-name', **forcedness, **strictness)
+    assert pykube_object.obj['metadata'].get('name') == 'provided-name'
+    assert pykube_object.obj['metadata'].get('generateName') is None
+
+
+@obj1_with_names
+@strict_mode
+@forced_mode
+def test_overwriting_of_strict_name_of_kubernetes_model(forcedness, strictness, kubernetes_model, obj1):
+    kubernetes_model.metadata.name = obj1.get('metadata', {}).get('name')
+    kubernetes_model.metadata.generate_name = obj1.get('metadata', {}).get('generateName')
+    kopf.harmonize_naming(kubernetes_model, name='provided-name', **forcedness, **strictness)
+    assert kubernetes_model.metadata.name == 'provided-name'
+    assert kubernetes_model.metadata.generate_name is None
+
+
+@obj1_with_names
 @non_strict_mode
 @forced_mode
 def test_overwriting_of_relaxed_name_of_dict(forcedness, strictness, obj1):
@@ -130,6 +172,27 @@ def test_overwriting_of_relaxed_names_of_dicts(forcedness, strictness, multicls,
     assert 'generateName' in obj2['metadata']
     assert obj1['metadata']['generateName'] == 'provided-name-'
     assert obj2['metadata']['generateName'] == 'provided-name-'
+
+
+@obj1_with_names
+@non_strict_mode
+@forced_mode
+def test_overwriting_of_relaxed_name_of_pykube_object(forcedness, strictness, pykube_object, obj1):
+    pykube_object.obj = copy.deepcopy(obj1)
+    kopf.harmonize_naming(pykube_object, name='provided-name', **forcedness, **strictness)
+    assert pykube_object.obj['metadata'].get('name') is None
+    assert pykube_object.obj['metadata'].get('generateName') == 'provided-name-'
+
+
+@obj1_with_names
+@non_strict_mode
+@forced_mode
+def test_overwriting_of_relaxed_name_of_kubernetes_model(forcedness, strictness, kubernetes_model, obj1):
+    kubernetes_model.metadata.name = obj1.get('metadata', {}).get('name')
+    kubernetes_model.metadata.generate_name = obj1.get('metadata', {}).get('generateName')
+    kopf.harmonize_naming(kubernetes_model, name='provided-name', **forcedness, **strictness)
+    assert kubernetes_model.metadata.name is None
+    assert kubernetes_model.metadata.generate_name == 'provided-name-'
 
 
 # When names are ABSENT, they are added regardless of the forced mode.
@@ -162,6 +225,25 @@ def test_assignment_of_strict_names_of_dicts(forcedness, strictness, multicls, o
 
 
 @obj1_without_names
+@strict_mode
+@any_forced_mode
+def test_assignment_of_strict_name_of_pykube_object(forcedness, strictness, pykube_object, obj1):
+    pykube_object.obj = copy.deepcopy(obj1)
+    kopf.harmonize_naming(pykube_object, name='provided-name', **forcedness, **strictness)
+    assert pykube_object.obj['metadata'].get('name') == 'provided-name'
+    assert pykube_object.obj['metadata'].get('generateName') is None
+
+
+@strict_mode
+@any_forced_mode
+def test_assignment_of_strict_name_of_kubernetes_model(forcedness, strictness, kubernetes_model):
+    kubernetes_model.metadata = None
+    kopf.harmonize_naming(kubernetes_model, name='provided-name', **forcedness, **strictness)
+    assert kubernetes_model.metadata.name == 'provided-name'
+    assert kubernetes_model.metadata.generate_name is None
+
+
+@obj1_without_names
 @non_strict_mode
 @any_forced_mode
 def test_assignment_of_nonstrict_name_of_dict(forcedness, strictness, obj1):
@@ -186,3 +268,22 @@ def test_assignment_of_nonstrict_names_of_dicts(forcedness, strictness, multicls
     assert 'generateName' in obj2['metadata']
     assert obj1['metadata']['generateName'] == 'provided-name-'
     assert obj2['metadata']['generateName'] == 'provided-name-'
+
+
+@obj1_without_names
+@non_strict_mode
+@any_forced_mode
+def test_assignment_of_nonstrict_name_of_pykube_object(forcedness, strictness, pykube_object, obj1):
+    pykube_object.obj = copy.deepcopy(obj1)
+    kopf.harmonize_naming(pykube_object, name='provided-name', **forcedness, **strictness)
+    assert pykube_object.obj['metadata'].get('name') is None
+    assert pykube_object.obj['metadata'].get('generateName') == 'provided-name-'
+
+
+@non_strict_mode
+@any_forced_mode
+def test_assignment_of_nonstrict_name_of_kubernetes_model(forcedness, strictness, kubernetes_model):
+    kubernetes_model.metadata = None
+    kopf.harmonize_naming(kubernetes_model, name='provided-name', **forcedness, **strictness)
+    assert kubernetes_model.metadata.name is None
+    assert kubernetes_model.metadata.generate_name == 'provided-name-'

--- a/tests/hierarchies/test_namespace_adjusting.py
+++ b/tests/hierarchies/test_namespace_adjusting.py
@@ -56,6 +56,22 @@ def test_preserved_namespaces_of_dicts(forcedness, multicls, obj1, obj2):
     assert obj2['metadata']['namespace'] != 'provided-namespace'
 
 
+@obj1_with_namespace
+@non_forced_mode
+def test_preserved_namespace_of_pykube_object(forcedness, pykube_object, obj1):
+    pykube_object.obj = copy.deepcopy(obj1)
+    kopf.adjust_namespace(pykube_object, namespace='provided-namespace', **forcedness)
+    assert pykube_object.obj['metadata'].get('namespace') != 'provided-namespace'
+
+
+@obj1_with_namespace
+@non_forced_mode
+def test_preserved_namespace_of_kubernetes_model(forcedness, kubernetes_model, obj1):
+    kubernetes_model.metadata.namespace = obj1.get('metadata', {}).get('namespace')
+    kopf.adjust_namespace(kubernetes_model, namespace='provided-namespace', **forcedness)
+    assert kubernetes_model.metadata.namespace != 'provided-namespace'
+
+
 #
 # In the FORCED mode, the EXISTING namespaces are overwritten.
 #
@@ -81,6 +97,22 @@ def test_overwriting_of_namespaces_of_dicts(forcedness, multicls, obj1, obj2):
     assert obj2['metadata']['namespace'] == 'provided-namespace'
 
 
+@obj1_with_namespace
+@forced_mode
+def test_overwriting_namespace_of_pykube_object(forcedness, pykube_object, obj1):
+    pykube_object.obj = copy.deepcopy(obj1)
+    kopf.adjust_namespace(pykube_object, namespace='provided-namespace', **forcedness)
+    assert pykube_object.obj['metadata'].get('namespace') == 'provided-namespace'
+
+
+@obj1_with_namespace
+@forced_mode
+def test_overwriting_namespace_of_kubernetes_model(forcedness, kubernetes_model, obj1):
+    kubernetes_model.metadata.namespace = obj1.get('metadata', {}).get('namespace')
+    kopf.adjust_namespace(kubernetes_model, namespace='provided-namespace', **forcedness)
+    assert kubernetes_model.metadata.namespace == 'provided-namespace'
+
+
 #
 # When namespaces are ABSENT, they are added regardless of the forced mode.
 #
@@ -104,3 +136,18 @@ def test_assignment_of_namespaces_of_dicts(forcedness, multicls, obj1, obj2):
     assert 'namespace' in obj2['metadata']
     assert obj1['metadata']['namespace'] == 'provided-namespace'
     assert obj2['metadata']['namespace'] == 'provided-namespace'
+
+
+@obj1_without_namespace
+@any_forced_mode
+def test_assignment_namespace_of_pykube_object(forcedness, pykube_object, obj1):
+    pykube_object.obj = copy.deepcopy(obj1)
+    kopf.adjust_namespace(pykube_object, namespace='provided-namespace', **forcedness)
+    assert pykube_object.obj['metadata'].get('namespace') == 'provided-namespace'
+
+
+@any_forced_mode
+def test_assignment_namespace_of_kubernetes_model(forcedness, kubernetes_model):
+    kubernetes_model.metadata = None
+    kopf.adjust_namespace(kubernetes_model, namespace='provided-namespace', **forcedness)
+    assert kubernetes_model.metadata.namespace == 'provided-namespace'

--- a/tests/hierarchies/test_owner_referencing.py
+++ b/tests/hierarchies/test_owner_referencing.py
@@ -62,6 +62,33 @@ def test_appending_to_dicts(multicls):
     assert obj2['metadata']['ownerReferences'][0]['uid'] == OWNER_UID
 
 
+def test_appending_to_pykube_object(pykube_object):
+    del pykube_object.obj['metadata']
+    kopf.append_owner_reference(pykube_object, owner=Body(OWNER))
+    assert 'metadata' in pykube_object.obj
+    assert 'ownerReferences' in pykube_object.obj['metadata']
+    assert isinstance(pykube_object.obj['metadata']['ownerReferences'], list)
+    assert len(pykube_object.obj['metadata']['ownerReferences']) == 1
+    assert isinstance(pykube_object.obj['metadata']['ownerReferences'][0], dict)
+    assert pykube_object.obj['metadata']['ownerReferences'][0]['apiVersion'] == OWNER_API_VERSION
+    assert pykube_object.obj['metadata']['ownerReferences'][0]['kind'] == OWNER_KIND
+    assert pykube_object.obj['metadata']['ownerReferences'][0]['name'] == OWNER_NAME
+    assert pykube_object.obj['metadata']['ownerReferences'][0]['uid'] == OWNER_UID
+
+
+def test_appending_to_kubernetes_model(kubernetes_model):
+    kubernetes_model.metadata = None
+    kopf.append_owner_reference(kubernetes_model, owner=Body(OWNER))
+    assert kubernetes_model.metadata is not None
+    assert kubernetes_model.metadata.owner_references is not None
+    assert isinstance(kubernetes_model.metadata.owner_references, list)
+    assert len(kubernetes_model.metadata.owner_references) == 1
+    assert kubernetes_model.metadata.owner_references[0].api_version == OWNER_API_VERSION
+    assert kubernetes_model.metadata.owner_references[0].kind == OWNER_KIND
+    assert kubernetes_model.metadata.owner_references[0].name == OWNER_NAME
+    assert kubernetes_model.metadata.owner_references[0].uid == OWNER_UID
+
+
 def test_appending_deduplicates_by_uid():
     """
     The uid is the only necessary criterion to identify same objects.
@@ -136,6 +163,26 @@ def test_removal_from_dicts(multicls):
     assert 'ownerReferences' in obj2['metadata']
     assert isinstance(obj2['metadata']['ownerReferences'], list)
     assert len(obj2['metadata']['ownerReferences']) == 0
+
+
+def test_removal_from_pykube_object(pykube_object):
+    del pykube_object.obj['metadata']
+    kopf.append_owner_reference(pykube_object, owner=Body(OWNER))
+    kopf.remove_owner_reference(pykube_object, owner=Body(OWNER))
+    assert 'metadata' in pykube_object.obj
+    assert 'ownerReferences' in pykube_object.obj['metadata']
+    assert isinstance(pykube_object.obj['metadata']['ownerReferences'], list)
+    assert len(pykube_object.obj['metadata']['ownerReferences']) == 0
+
+
+def test_removal_from_kubernetes_model(kubernetes_model):
+    kubernetes_model.metadata = None
+    kopf.append_owner_reference(kubernetes_model, owner=Body(OWNER))
+    kopf.remove_owner_reference(kubernetes_model, owner=Body(OWNER))
+    assert kubernetes_model.metadata is not None
+    assert kubernetes_model.metadata.owner_references is not None
+    assert isinstance(kubernetes_model.metadata.owner_references, list)
+    assert len(kubernetes_model.metadata.owner_references) == 0
 
 
 def test_removal_identifies_by_uid():

--- a/tests/test_thirdparty.py
+++ b/tests/test_thirdparty.py
@@ -1,0 +1,22 @@
+import types
+
+import pytest
+
+from kopf.utilities.thirdparty import KubernetesModel
+
+
+@pytest.mark.parametrize('name', ['V1Pod', 'V1ObjectMeta', 'V1PodSpec', 'V1PodTemplateSpec'])
+def test_kubernetes_model_classes_detection(kubernetes, name):
+    cls = getattr(kubernetes.client, name)
+    assert issubclass(cls, KubernetesModel)
+
+
+@pytest.mark.parametrize('name', ['CoreV1Api', 'ApiClient', 'Configuration'])
+def test_kubernetes_other_classes_detection(kubernetes, name):
+    cls = getattr(kubernetes.client, name)
+    assert not issubclass(cls, KubernetesModel)
+
+
+@pytest.mark.parametrize('cls', [object, types.SimpleNamespace])
+def test_non_kubernetes_classes_detection(kubernetes, cls):
+    assert not issubclass(cls, KubernetesModel)


### PR DESCRIPTION
Support models from `pykube-ng` & `kubernetes` for hierarchy-managment functions.

For `pykube-ng`, it is all descendants from `pykube.objects.APIObject`. Since pykube-ng does not expose all the fields as attributes/properties, and those exposed are not directly mapped to the actual K8s API schema fields & their locations (mind `obj.labels` <-> `.metadata.labels`), the objects are manipulated as usual dicts via their `.obj` field. As the result, overridden getter/setter properties are never invoked.

For `kubernetes`, where there are no base classes or OOP at all, a special trick is made to identify K8s models: it is everything defined in `kubernetes.client.models.*` modules, which has `.metadata` field. This covers the root-level models, such as pods, cronjobs, etc, and also the nested templates, such as pods-in-deployments, jobs-in-cronjobs, etc.

Related: based on #671. Solves #286 