### PR TITLE
Stop daemons & timers while the operator is on peering freeze

### DIFF
--- a/kopf/reactor/orchestration.py
+++ b/kopf/reactor/orchestration.py
@@ -87,8 +87,8 @@ async def ochestrator(
         settings: configuration.OperatorSettings,
         identity: peering.Identity,
         insights: references.Insights,
+        freeze_checker: primitives.ToggleSet,
 ) -> None:
-    freeze_checker = primitives.ToggleSet()
     freeze_blocker = await freeze_checker.make_toggle(name='peering CRD is absent')
     ensemble = Ensemble(freeze_blocker=freeze_blocker, freeze_checker=freeze_checker)
     try:

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -177,6 +177,7 @@ async def spawn_tasks(
     event_queue: posting.K8sEventQueue = asyncio.Queue()
     signal_flag: aiotasks.Future = asyncio.Future()
     started_flag: asyncio.Event = asyncio.Event()
+    freeze_checker = primitives.ToggleSet()
     tasks: MutableSequence[aiotasks.Task] = []
 
     # Map kwargs into the settings object.
@@ -223,7 +224,8 @@ async def spawn_tasks(
         name="daemon killer", flag=started_flag, logger=logger,
         coro=daemons.daemon_killer(
             settings=settings,
-            memories=memories)))
+            memories=memories,
+            freeze_checker=freeze_checker)))
 
     # Keeping the credentials fresh and valid via the authentication handlers on demand.
     tasks.append(aiotasks.create_guarded_task(
@@ -281,6 +283,7 @@ async def spawn_tasks(
                 settings=settings,
                 insights=insights,
                 identity=identity,
+                freeze_checker=freeze_checker,
                 processor=functools.partial(processing.process_resource_event,
                                             lifecycle=lifecycle,
                                             registry=registry,

--- a/kopf/structs/primitives.py
+++ b/kopf/structs/primitives.py
@@ -230,6 +230,7 @@ class DaemonStoppingReason(enum.Flag):
     DONE = enum.auto()  # whatever the reason and the status, the asyncio task has exited.
     FILTERS_MISMATCH = enum.auto()  # the resource does not match the filters anymore.
     RESOURCE_DELETED = enum.auto()  # the resource was deleted, the asyncio task is still awaited.
+    OPERATOR_PAUSING = enum.auto()  # the operator is pausing, the asyncio task is still awaited.
     OPERATOR_EXITING = enum.auto()  # the operator is exiting, the asyncio task is still awaited.
     DAEMON_SIGNALLED = enum.auto()  # the stopper flag was set, the asyncio task is still awaited.
     DAEMON_CANCELLED = enum.auto()  # the asyncio task was cancelled, the thread can be running.

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -18,7 +18,7 @@ async def test_daemon_exits_gracefully_and_instantly_via_stopper(
         dummy.steps['called'].set()
         await kwargs['stopped'].wait()
 
-    # 0th cycle:tTrigger spawning and wait until ready. Assume the finalizers are already added.
+    # 0th cycle: trigger spawning and wait until ready. Assume the finalizers are already added.
     finalizer = settings.persistence.finalizer
     event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
@@ -37,6 +37,41 @@ async def test_daemon_exits_gracefully_and_instantly_via_stopper(
     assert k8s_mocked.sleep_or_wait.call_count == 0
     assert k8s_mocked.patch_obj.call_count == 1
     assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['metadata']['finalizers'] == []
+
+
+@pytest.mark.usefixtures('background_daemon_killer')
+async def test_daemon_exits_gracefully_and_instantly_via_peering_freeze(
+        settings, memories, resource, dummy, simulate_cycle, freeze_toggle,
+        caplog, assert_logs, k8s_mocked, frozen_time, mocker, timer):
+    caplog.set_level(logging.DEBUG)
+
+    # A daemon-under-test.
+    @kopf.daemon(*resource, id='fn')
+    async def fn(**kwargs):
+        dummy.kwargs = kwargs
+        dummy.steps['called'].set()
+        await kwargs['stopped'].wait()
+
+    # 0th cycle: trigger spawning and wait until ready. Assume the finalizers are already added.
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer]}}
+    await simulate_cycle(event_object)
+    await dummy.steps['called'].wait()
+
+    # 1st stage: trigger termination due to peering freeze.
+    mocker.resetall()
+    await freeze_toggle.turn_to(True)
+
+    # Check that the daemon has exited near-instantly, with no delays.
+    with timer:
+        await dummy.wait_for_daemon_done()
+    assert timer.seconds < 0.01  # near-instantly
+
+    # There is no way to test for re-spawning here: it is done by watch-events,
+    # which are tested by the peering freezes elsewhere (test_daemon_spawning.py).
+    # We only test that it is capable for respawning (not forever-stopped):
+    memory = await memories.recall(event_object)
+    assert not memory.forever_stopped
 
 
 async def test_daemon_exits_instantly_via_cancellation_with_backoff(


### PR DESCRIPTION
When the operator goes to peering freeze, all the watch streams disconnect from the API and wait until the operator is resumed.

However, this mode was not passed to the daemons & timers subsystem, so they continued running — while not getting any updates on the resource's state from the cluster (because the watch-streams are frozen).

This fix synchronizes the daemons & timers to the global operator freeze:

Once an operator is frozen, all daemons & timers are stopped almost the same way as when the operator exits (e.g. due to SIGTERM/SIGINT) — with all the cancellation backoffs, timeouts, and other procedures of graceful & forced termination.

Once the operator is resumed, nothing is done explicitly: the resumed watch-streams will naturally spawn new daemons/timers for all matching resources to the moment — as if those started to match the filters, all at once. (This will implicitly cover the case of "up to date" relevance: those resources that did not exist before the freeze, will be spawned too; those that has gone, will not be resumed.)

TODOs left:

* [x] Edge case: prematurely stop the stopping of daemons if the operator is resumed before all of them are stopped.
  * Uncertain: just unset the stopping reasons? but what if the daemon's code is already in the existing clause? finish the stopping? then, how is it re-spawned if no new events arrive for the resource after that?
* [x] Tests.

Fixes #673.