### PR TITLE
Change terminology for streams of events

### DIFF
--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -93,7 +93,7 @@ async def process_peering_event(
         identity: Identity,
         settings: configuration.OperatorSettings,
         autoclean: bool = True,
-        replenished: Optional[asyncio.Event] = None,  # None for tests
+        stream_pressure: Optional[asyncio.Event] = None,  # None for tests
         conflicts_found: Optional[primitives.Toggle] = None,  # None for tests & observation
 ) -> None:
     """
@@ -143,7 +143,7 @@ async def process_peering_event(
     # from other peers that existed a moment earlier, this should not be a problem.
     now = datetime.datetime.utcnow()
     delays = [(peer.deadline - now).total_seconds() for peer in same_peers + prio_peers]
-    unslept = await primitives.sleep_or_wait(delays, wakeup=replenished)
+    unslept = await primitives.sleep_or_wait(delays, wakeup=stream_pressure)
     if unslept is None and delays:
         await touch(
             identity=identity,

--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -93,7 +93,7 @@ async def process_peering_event(
         identity: Identity,
         settings: configuration.OperatorSettings,
         autoclean: bool = True,
-        replenished: asyncio.Event,
+        replenished: Optional[asyncio.Event] = None,  # None for tests
         conflicts_found: Optional[primitives.Toggle] = None,  # None for tests & observation
 ) -> None:
     """

--- a/kopf/reactor/effects.py
+++ b/kopf/reactor/effects.py
@@ -49,7 +49,7 @@ async def apply(
         patch: patches.Patch,
         delays: Collection[float],
         logger: loggers.ObjectLogger,
-        replenished: asyncio.Event,
+        replenished: Optional[asyncio.Event] = None,  # None for tests
 ) -> bool:
     delay = min(delays) if delays else None
 

--- a/kopf/reactor/effects.py
+++ b/kopf/reactor/effects.py
@@ -49,7 +49,7 @@ async def apply(
         patch: patches.Patch,
         delays: Collection[float],
         logger: loggers.ObjectLogger,
-        replenished: Optional[asyncio.Event] = None,  # None for tests
+        stream_pressure: Optional[asyncio.Event] = None,  # None for tests
 ) -> bool:
     delay = min(delays) if delays else None
 
@@ -70,10 +70,10 @@ async def apply(
         if delay > WAITING_KEEPALIVE_INTERVAL:
             limit = WAITING_KEEPALIVE_INTERVAL
             logger.debug(f"Sleeping for {delay} (capped {limit}) seconds for the delayed handlers.")
-            unslept_delay = await primitives.sleep_or_wait(limit, replenished)
+            unslept_delay = await primitives.sleep_or_wait(limit, wakeup=stream_pressure)
         elif delay > 0:
             logger.debug(f"Sleeping for {delay} seconds for the delayed handlers.")
-            unslept_delay = await primitives.sleep_or_wait(delay, replenished)
+            unslept_delay = await primitives.sleep_or_wait(delay, wakeup=stream_pressure)
         else:
             unslept_delay = None  # no need to sleep? means: slept in full.
 

--- a/kopf/reactor/observation.py
+++ b/kopf/reactor/observation.py
@@ -135,7 +135,8 @@ async def process_discovered_namespace_event(
         raw_event: bodies.RawEvent,
         namespaces: Collection[references.NamespacePattern],
         insights: references.Insights,
-        replenished: Optional[asyncio.Event] = None,  # None for tests
+        # Must be accepted whether used or not -- as passed by watcher()/worker().
+        stream_pressure: Optional[asyncio.Event] = None,  # None for tests
 ) -> None:
     if raw_event['type'] is None:
         return
@@ -150,7 +151,8 @@ async def process_discovered_resource_event(
         raw_event: bodies.RawEvent,
         registry: registries.OperatorRegistry,
         insights: references.Insights,
-        replenished: Optional[asyncio.Event] = None,  # None for tests
+        # Must be accepted whether used or not -- as passed by watcher()/worker().
+        stream_pressure: Optional[asyncio.Event] = None,  # None for tests
 ) -> None:
     # Ignore the initial listing, as all custom resources were already noticed by API listing.
     # This prevents numerous unneccessary API requests at the the start of the operator.

--- a/kopf/reactor/observation.py
+++ b/kopf/reactor/observation.py
@@ -135,7 +135,7 @@ async def process_discovered_namespace_event(
         raw_event: bodies.RawEvent,
         namespaces: Collection[references.NamespacePattern],
         insights: references.Insights,
-        replenished: Optional[asyncio.Event] = None,
+        replenished: Optional[asyncio.Event] = None,  # None for tests
 ) -> None:
     if raw_event['type'] is None:
         return
@@ -150,7 +150,7 @@ async def process_discovered_resource_event(
         raw_event: bodies.RawEvent,
         registry: registries.OperatorRegistry,
         insights: references.Insights,
-        replenished: Optional[asyncio.Event] = None,
+        replenished: Optional[asyncio.Event] = None,  # None for tests
 ) -> None:
     # Ignore the initial listing, as all custom resources were already noticed by API listing.
     # This prevents numerous unneccessary API requests at the the start of the operator.

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -32,8 +32,8 @@ async def process_resource_event(
         memobase: memos.AnyMemo,
         resource: references.Resource,
         raw_event: bodies.RawEvent,
-        replenished: asyncio.Event,
         event_queue: posting.K8sEventQueue,
+        replenished: Optional[asyncio.Event] = None,  # None for tests
 ) -> None:
     """
     Handle a single custom object low-level watch-event.

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -33,7 +33,7 @@ async def process_resource_event(
         resource: references.Resource,
         raw_event: bodies.RawEvent,
         event_queue: posting.K8sEventQueue,
-        replenished: Optional[asyncio.Event] = None,  # None for tests
+        stream_pressure: Optional[asyncio.Event] = None,  # None for tests
 ) -> None:
     """
     Handle a single custom object low-level watch-event.
@@ -67,7 +67,7 @@ async def process_resource_event(
         throttler=memory.error_throttler,
         logger=loggers.LocalObjectLogger(body=body, settings=settings),
         delays=settings.batching.error_delays,
-        wakeup=replenished,
+        wakeup=stream_pressure,
     ) as should_run:
         if should_run:
 
@@ -100,7 +100,7 @@ async def process_resource_event(
                     patch=patch,
                     logger=logger,
                     delays=delays,
-                    replenished=replenished,
+                    stream_pressure=stream_pressure,
                 )
                 if applied and matched:
                     logger.debug(f"Handling cycle is finished, waiting for new changes since now.")

--- a/kopf/reactor/queueing.py
+++ b/kopf/reactor/queueing.py
@@ -49,7 +49,7 @@ class WatchStreamProcessor(Protocol):
             self,
             *,
             raw_event: bodies.RawEvent,
-            replenished: asyncio.Event,
+            replenished: Optional[asyncio.Event] = None,  # None for tests
     ) -> None: ...
 
 

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -67,7 +67,6 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
             memories=memories,
             memobase=Memo(),
             raw_event={'type': 'irrelevant', 'object': event_object},
-            replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
         )
 

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -30,7 +30,6 @@ async def test_create(registry, settings, handlers, resource, cause_mock, event_
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -71,7 +70,6 @@ async def test_update(registry, settings, handlers, resource, cause_mock, event_
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -114,7 +112,6 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
-        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -155,7 +152,6 @@ async def test_gone(registry, settings, handlers, resource, cause_mock, event_ty
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -186,7 +182,6 @@ async def test_free(registry, settings, handlers, resource, cause_mock, event_ty
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -218,7 +213,6 @@ async def test_noop(registry, settings, handlers, resource, cause_mock, event_ty
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -28,7 +28,6 @@ async def test_all_logs_are_prefixed(registry, settings, resource, handlers,
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 
@@ -59,7 +58,6 @@ async def test_diffs_logged_if_present(registry, settings, resource, handlers,
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
     assert_logs([
@@ -90,7 +88,6 @@ async def test_diffs_not_logged_if_absent(registry, settings, resource, handlers
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
     assert_logs([
@@ -134,7 +131,6 @@ async def test_supersession_is_logged(
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': body},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
     assert_logs([

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -41,7 +41,6 @@ async def test_delayed_handlers_progress(
             memories=ResourceMemories(),
             memobase=Memo(),
             raw_event={'type': event_type, 'object': {}},
-            replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
         )
 
@@ -98,7 +97,6 @@ async def test_delayed_handlers_sleep(
             memories=ResourceMemories(),
             memobase=Memo(),
             raw_event={'type': event_type, 'object': event_body},
-            replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
         )
 

--- a/tests/handling/test_error_handling.py
+++ b/tests/handling/test_error_handling.py
@@ -34,7 +34,6 @@ async def test_fatal_error_stops_handler(
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 
@@ -79,7 +78,6 @@ async def test_retry_error_delays_handler(
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 
@@ -125,7 +123,6 @@ async def test_arbitrary_error_delays_handler(
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -25,7 +25,6 @@ async def test_handlers_called_always(
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': 'ev-type', 'object': {'field': 'value'}},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 
@@ -61,7 +60,6 @@ async def test_errors_are_ignored(
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': 'ev-type', 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -36,7 +36,6 @@ async def test_1st_step_stores_progress_by_patching(
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 
@@ -96,7 +95,6 @@ async def test_2nd_step_finishes_the_handlers(caplog,
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -40,7 +40,6 @@ async def test_skipped_with_no_handlers(
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 
@@ -96,7 +95,6 @@ async def test_stealth_mode_with_mismatching_handlers(
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 

--- a/tests/handling/test_parametrization.py
+++ b/tests/handling/test_parametrization.py
@@ -25,7 +25,6 @@ async def test_parameter_is_passed_when_specified(resource, cause_mock, registry
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': None, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 
@@ -51,7 +50,6 @@ async def test_parameter_is_passed_even_if_not_specified(resource, cause_mock, r
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': None, 'object': {}},
-        replenished=asyncio.Event(),
         event_queue=event_queue,
     )
 

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -43,7 +43,6 @@ async def test_timed_out_handler_fails(
             memories=ResourceMemories(),
             memobase=Memo(),
             raw_event={'type': event_type, 'object': event_body},
-            replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
         )
 
@@ -93,7 +92,6 @@ async def test_retries_limited_handler_fails(
         memories=ResourceMemories(),
         memobase=Memo(),
         raw_event={'type': event_type, 'object': event_body},
-        replenished=asyncio.Event(),
         event_queue=asyncio.Queue(),
     )
 

--- a/tests/handling/test_timing_consistency.py
+++ b/tests/handling/test_timing_consistency.py
@@ -64,7 +64,6 @@ async def test_consistent_awakening(registry, settings, resource, k8s_mocked, mo
             memories=ResourceMemories(),
             memobase=Memo(),
             raw_event={'type': 'ADDED', 'object': body},
-            replenished=asyncio.Event(),
             event_queue=asyncio.Queue(),
         )
         assert datetime.datetime.utcnow() > ts0  # extra precaution

--- a/tests/observation/test_processing_of_namespaces.py
+++ b/tests/observation/test_processing_of_namespaces.py
@@ -15,7 +15,7 @@ async def test_initial_listing_is_ignored():
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_namespace_event(
-            insights=insights, raw_event=e1, namespaces=['ns*'], replenished=asyncio.Event())
+            insights=insights, raw_event=e1, namespaces=['ns*'])
 
     task = asyncio.create_task(delayed_injection(0))
     with pytest.raises(asyncio.TimeoutError):
@@ -35,7 +35,7 @@ async def test_followups_for_addition(timer, etype):
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_namespace_event(
-            insights=insights, raw_event=e1, namespaces=['ns*'], replenished=asyncio.Event())
+            insights=insights, raw_event=e1, namespaces=['ns*'])
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1):
@@ -55,7 +55,7 @@ async def test_followups_for_deletion(timer, etype):
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_namespace_event(
-            insights=insights, raw_event=e1, namespaces=['ns*'], replenished=asyncio.Event())
+            insights=insights, raw_event=e1, namespaces=['ns*'])
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1):

--- a/tests/observation/test_processing_of_resources.py
+++ b/tests/observation/test_processing_of_resources.py
@@ -100,7 +100,7 @@ async def test_initial_listing_is_ignored(registry, apis_mock, group1_mock):
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry, replenished=asyncio.Event())
+            insights=insights, raw_event=e1, registry=registry)
 
     task = asyncio.create_task(delayed_injection(0))
     with pytest.raises(asyncio.TimeoutError):
@@ -124,7 +124,7 @@ async def test_followups_for_addition(registry, apis_mock, group1_mock, timer, e
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry, replenished=asyncio.Event())
+            insights=insights, raw_event=e1, registry=registry)
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1.0):
@@ -148,7 +148,7 @@ async def test_followups_for_deletion_of_resource(registry, apis_mock, group1_em
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry, replenished=asyncio.Event())
+            insights=insights, raw_event=e1, registry=registry)
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1.0):
@@ -172,7 +172,7 @@ async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mo
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry, replenished=asyncio.Event())
+            insights=insights, raw_event=e1, registry=registry)
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1.0):
@@ -196,7 +196,7 @@ async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mo
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry, replenished=asyncio.Event())
+            insights=insights, raw_event=e1, registry=registry)
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1.0):
@@ -217,7 +217,7 @@ async def test_backbone_is_filled(registry, core_mock, corev1_mock, timer, etype
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry, replenished=asyncio.Event())
+            insights=insights, raw_event=e1, registry=registry)
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1.0):

--- a/tests/orchestration/test_task_adjustments.py
+++ b/tests/orchestration/test_task_adjustments.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+from typing import Optional
 from unittest.mock import Mock
 
 import pytest
@@ -11,7 +12,7 @@ from kopf.structs.references import Insights, Resource
 from kopf.utilities import aiotasks
 
 
-async def processor(*, raw_event: bodies.RawEvent, replenished: asyncio.Event) -> None:
+async def processor(*, raw_event: bodies.RawEvent, replenished: Optional[asyncio.Event]) -> None:
     pass
 
 

--- a/tests/orchestration/test_task_adjustments.py
+++ b/tests/orchestration/test_task_adjustments.py
@@ -12,7 +12,7 @@ from kopf.structs.references import Insights, Resource
 from kopf.utilities import aiotasks
 
 
-async def processor(*, raw_event: bodies.RawEvent, replenished: Optional[asyncio.Event]) -> None:
+async def processor(*, raw_event: bodies.RawEvent, stream_pressure: Optional[asyncio.Event]) -> None:
     pass
 
 

--- a/tests/peering/test_freeze_mode.py
+++ b/tests/peering/test_freeze_mode.py
@@ -1,4 +1,3 @@
-import asyncio
 import dataclasses
 from unittest.mock import Mock
 
@@ -40,7 +39,6 @@ async def test_other_peering_objects_are_ignored(
     settings.peering.name = 'our-name'
     await process_peering_event(
         raw_event=event,
-        replenished=asyncio.Event(),
         autoclean=False,
         identity='id',
         settings=settings,
@@ -80,7 +78,6 @@ async def test_toggled_on_for_higher_priority_peer_when_initially_off(
     await process_peering_event(
         raw_event=event,
         conflicts_found=conflicts_found,
-        replenished=asyncio.Event(),
         autoclean=False,
         namespace=peering_namespace,
         resource=peering_resource,
@@ -126,7 +123,6 @@ async def test_ignored_for_higher_priority_peer_when_already_on(
     await process_peering_event(
         raw_event=event,
         conflicts_found=conflicts_found,
-        replenished=asyncio.Event(),
         autoclean=False,
         namespace=peering_namespace,
         resource=peering_resource,
@@ -173,7 +169,6 @@ async def test_toggled_off_for_lower_priority_peer_when_initially_on(
     await process_peering_event(
         raw_event=event,
         conflicts_found=conflicts_found,
-        replenished=asyncio.Event(),
         autoclean=False,
         namespace=peering_namespace,
         resource=peering_resource,
@@ -219,7 +214,6 @@ async def test_ignored_for_lower_priority_peer_when_already_off(
     await process_peering_event(
         raw_event=event,
         conflicts_found=conflicts_found,
-        replenished=asyncio.Event(),
         autoclean=False,
         namespace=peering_namespace,
         resource=peering_resource,
@@ -266,7 +260,6 @@ async def test_toggled_on_for_same_priority_peer_when_initially_off(
     await process_peering_event(
         raw_event=event,
         conflicts_found=conflicts_found,
-        replenished=asyncio.Event(),
         autoclean=False,
         namespace=peering_namespace,
         resource=peering_resource,
@@ -314,7 +307,6 @@ async def test_ignored_for_same_priority_peer_when_already_on(
     await process_peering_event(
         raw_event=event,
         conflicts_found=conflicts_found,
-        replenished=asyncio.Event(),
         autoclean=False,
         namespace=peering_namespace,
         resource=peering_resource,
@@ -363,7 +355,6 @@ async def test_resumes_immediately_on_expiration_of_blocking_peers(
     await process_peering_event(
         raw_event=event,
         conflicts_found=conflicts_found,
-        replenished=asyncio.Event(),
         autoclean=False,
         namespace=peering_namespace,
         resource=peering_resource,

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -87,8 +87,8 @@ async def test_watchevent_demultiplexing(worker_mock, timer, resource, processor
         assert key in streams
 
         queue_events = []
-        while not streams[key].watchevents.empty():
-            queue_events.append(streams[key].watchevents.get_nowait())
+        while not streams[key].backlog.empty():
+            queue_events.append(streams[key].backlog.get_nowait())
 
         assert len(queue_events) == cnt + 1
         assert queue_events[-1] is EOS.token


### PR DESCRIPTION
Specifically:

* replenishment -> pressure (of a stream of events).
* watchevents -> backlog (of a stream of events).

The primary goal is to make the code more readable semantically (as if reading English).

**IMPORTANT:** The code and logic are exactly the same! Nothing is changed, just renamed. The public interface is not affected, only the internal things are.

