### PR TITLE
Improve and align throttling error reporting in Python 3.7 with 3.8+

### DIFF
--- a/kopf/reactor/effects.py
+++ b/kopf/reactor/effects.py
@@ -181,11 +181,11 @@ async def throttled(
             throttler.source_of_delays = iter(delays)
 
         # Choose a delay. If there are none, avoid throttling at all.
-        throttle_delay = next(throttler.source_of_delays, throttler.last_used_delay)
-        if throttle_delay is not None:
-            throttler.last_used_delay = throttle_delay
-            throttler.active_until = time.monotonic() + throttle_delay
-            logger.exception(f"Throttling for {throttle_delay} seconds due to an unexpected error:")
+        delay = next(throttler.source_of_delays, throttler.last_used_delay)
+        if delay is not None:
+            throttler.last_used_delay = delay
+            throttler.active_until = time.monotonic() + delay
+            logger.exception(f"Throttling for {delay} seconds due to an unexpected error: {e!r}")
 
     else:
         # Reset the throttling. Release the iterator to keep the memory free during normal run.

--- a/kopf/reactor/effects.py
+++ b/kopf/reactor/effects.py
@@ -161,6 +161,11 @@ async def throttled(
     try:
         yield should_run
 
+    except asyncio.CancelledError:
+        # CancelledError is a BaseException in 3.8 & 3.9, but a regular Exception in 3.7.
+        # Behave as if it is a BaseException -- to enabled tests with async-timeout.
+        raise
+
     except Exception as e:
 
         # If it is not an error-of-interest, escalate normally. BaseExceptions are escalated always.

--- a/tests/timing/test_throttling.py
+++ b/tests/timing/test_throttling.py
@@ -33,6 +33,7 @@ async def test_remains_inactive_on_success():
     pytest.param(Exception, dict(errors=ValueError), id='child'),
     pytest.param(RuntimeError, dict(errors=ValueError), id='sibling'),
     pytest.param(RuntimeError, dict(errors=(ValueError, TypeError)), id='tuple'),
+    pytest.param(asyncio.CancelledError, dict(), id='cancelled'),
 ])
 async def test_escalates_unexpected_errors(exc_cls, kwargs):
     logger = logging.getLogger()

--- a/tests/timing/test_throttling.py
+++ b/tests/timing/test_throttling.py
@@ -291,10 +291,10 @@ async def test_logging_when_deactivates_immediately(caplog):
     throttler = Throttler()
 
     async with throttled(throttler=throttler, logger=logger, delays=[123]):
-        raise Exception()
+        raise Exception("boo!")
 
     assert caplog.messages == [
-        "Throttling for 123 seconds due to an unexpected error:",
+        "Throttling for 123 seconds due to an unexpected error: Exception('boo!')",
         "Throttling is over. Switching back to normal operations.",
     ]
 
@@ -306,13 +306,13 @@ async def test_logging_when_deactivates_on_reentry(sleep, caplog):
 
     sleep.return_value = 55  # simulated sleep time left
     async with throttled(throttler=throttler, logger=logger, delays=[123]):
-        raise Exception()
+        raise Exception("boo!")
 
     sleep.return_value = None  # simulated sleep time left
     async with throttled(throttler=throttler, logger=logger, delays=[...]):
         pass
 
     assert caplog.messages == [
-        "Throttling for 123 seconds due to an unexpected error:",
+        "Throttling for 123 seconds due to an unexpected error: Exception('boo!')",
         "Throttling is over. Switching back to normal operations.",
     ]


### PR DESCRIPTION
* Ignore CancelledErrors in throttling in Python 3.7
* Record exceptions' reprs for throttling errors

A note for the latter one:

In tests, in the `caplog` fixture, the exception stack trace is not converted to strings yet (it is done later in the standard logging). As a result, it is difficult to debug tests when neither the exception nor its stack trace is known at the breakpoints. By this fix, the exceptions' rudimentary info will be put directly to the exception message collected by `caplog`.

This problem does not affect normal logging to stdout/stderr or other streams, which get the fully formatted exception stack traces.
