### PR TITLE
Expose typings for the library users

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,16 @@ jobs:
         if: ${{ matrix.install-extras }}
 
       - run: mypy kopf --strict --pretty
+      - run: |
+          # Mypying the examples
+          exit_codes=0
+          for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
+          do
+            echo "Checking ${d}"
+            mypy $d --pretty
+            exit_codes=$[${exit_codes} + $?]
+          done
+          exit ${exit_codes}
       - run: pytest --color=yes --cov=kopf --cov-branch
 
       - name: Publish coverage to Coveralls.io

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -49,6 +49,16 @@ jobs:
         if: ${{ matrix.install-extras }}
 
       - run: mypy kopf --strict --pretty
+      - run: |
+          # Mypying the examples
+          exit_codes=0
+          for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
+          do
+            echo "Checking ${d}"
+            mypy $d --pretty
+            exit_codes=$[${exit_codes} + $?]
+          done
+          exit ${exit_codes}
       - run: pytest --color=yes --cov=kopf --cov-branch
 
       - name: Publish coverage to Coveralls.io

--- a/examples/10-builtins/example.py
+++ b/examples/10-builtins/example.py
@@ -3,7 +3,10 @@ import asyncio
 import kopf
 import pykube
 
-tasks = {}  # dict{namespace: dict{name: asyncio.Task}}
+from typing import Dict
+
+
+tasks: Dict[str, Dict[str, asyncio.Task]] = {}  # dict{namespace: dict{name: asyncio.Task}}
 
 
 @kopf.on.resume('pods')

--- a/examples/11-filtering-handlers/example.py
+++ b/examples/11-filtering-handlers/example.py
@@ -1,11 +1,11 @@
 import kopf
 
 
-def say_yes(value, spec, **_):
+def say_yes(value, spec, **_) -> bool:
     return value == 'somevalue' and spec.get('field') is not None
 
 
-def say_no(value, spec, **_):
+def say_no(value, spec, **_) -> bool:
     return value == 'somevalue' and spec.get('field') == 'not-this-value-for-sure'
 
 

--- a/examples/12-embedded/example.py
+++ b/examples/12-embedded/example.py
@@ -2,19 +2,20 @@ import asyncio
 import contextlib
 import threading
 import time
+from typing import Union
 
 import kopf
 import pykube
 
 
 @kopf.on.create('kopfexamples')
-def create_fn(memo: kopf.Memo, **kwargs):
-    print(memo.create_tpl.format(**kwargs))
+def create_fn(memo: Union[kopf.Memo, object], **kwargs):
+    print(memo.create_tpl.format(**kwargs))  # type: ignore
 
 
 @kopf.on.delete('kopfexamples')
-def delete_fn(memo: kopf.Memo, **kwargs):
-    print(memo.delete_tpl.format(**kwargs))
+def delete_fn(memo: Union[kopf.Memo, object], **kwargs):
+    print(memo.delete_tpl.format(**kwargs))  # type: ignore
 
 
 def kopf_thread(

--- a/examples/13-hooks/example.py
+++ b/examples/13-hooks/example.py
@@ -1,6 +1,6 @@
 import asyncio
 import random
-from typing import Dict, NoReturn
+from typing import Dict
 
 import kopf
 import pykube
@@ -8,7 +8,7 @@ import pykube
 E2E_STARTUP_STOP_WORDS = ['Served by the background task.']
 E2E_CLEANUP_STOP_WORDS = ['Hung tasks', 'Root tasks']
 E2E_SUCCESS_COUNTS = {'startup_fn_simple': 1, 'startup_fn_retried': 1, 'cleanup_fn': 1}
-E2E_FAILURE_COUNTS = {}
+E2E_FAILURE_COUNTS = {}  # type: Dict[str, int]
 
 LOCK: asyncio.Lock  # requires a loop on creation
 STOPPERS: Dict[str, Dict[str, asyncio.Event]] = {}  # [namespace][name]
@@ -81,7 +81,7 @@ async def pod_task(namespace, name, logger, **_):
             asyncio.create_task(_task_fn(logger, shouldstop=flag))
 
 
-async def _task_fn(logger, shouldstop: asyncio.Event) -> NoReturn:
+async def _task_fn(logger, shouldstop: asyncio.Event):
     while not shouldstop.is_set():
         await asyncio.sleep(random.randint(1, 10))
         logger.info("Served by the background task.")

--- a/examples/16-indexing/example.py
+++ b/examples/16-indexing/example.py
@@ -20,17 +20,17 @@ def by_label(labels, name, **_):
     #    ...}
 
 
-@kopf.on.probe()
+@kopf.on.probe()  # type: ignore
 def pod_count(is_running: kopf.Index, **_):
     return len(is_running)
 
 
-@kopf.on.probe()
+@kopf.on.probe()  # type: ignore
 def pod_names(is_running: kopf.Index, **_):
     return [name for _, name in is_running]
 
 
-@kopf.timer('kex', interval=5)
+@kopf.timer('kex', interval=5)  # type: ignore
 def intervalled(is_running: kopf.Index, by_label: kopf.Index, patch: kopf.Patch, **_):
     pprint.pprint(dict(by_label))
     patch.status['running-pods'] = [
@@ -42,4 +42,4 @@ def intervalled(is_running: kopf.Index, by_label: kopf.Index, patch: kopf.Patch,
 
 
 # Marks for the e2e tests (see tests/e2e/test_examples.py):
-E2E_SUCCESS_COUNTS = {}  # we do not care: pods can have 6-10 updates here.
+E2E_SUCCESS_COUNTS = {}  # type: ignore # we do not care: pods can have 6-10 updates here.

--- a/examples/99-all-at-once/example.py
+++ b/examples/99-all-at-once/example.py
@@ -9,13 +9,15 @@ import kopf
 import pykube
 import yaml
 
+from typing import Dict
+
 # Marks for the e2e tests (see tests/e2e/test_examples.py):
 E2E_STARTUP_STOP_WORDS = ['Served by the background task.']
 E2E_CLEANUP_STOP_WORDS = ['Hung tasks', 'Root tasks']
 E2E_CREATION_STOP_WORDS = ['Creation is processed:']
 E2E_DELETION_STOP_WORDS = ['Deleted, really deleted']
 E2E_SUCCESS_COUNTS = {'create_1': 1, 'create_2': 1, 'create_pod': 1, 'delete': 1, 'startup_fn_simple': 1, 'startup_fn_retried': 1, 'cleanup_fn': 1}
-E2E_FAILURE_COUNTS = {}
+E2E_FAILURE_COUNTS: Dict[str, int] = {}
 E2E_TRACEBACKS = True
 
 

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -16,12 +16,12 @@ from typing import Any, Callable, Optional, Union
 from kopf.reactor import handling, registries
 from kopf.structs import callbacks, dicts, filters, handlers, references
 
-ActivityDecorator = Callable[[callbacks.ActivityFn], callbacks.ActivityFn]
-ResourceIndexingDecorator = Callable[[callbacks.ResourceIndexingFn], callbacks.ResourceIndexingFn]
-ResourceWatchingDecorator = Callable[[callbacks.ResourceWatchingFn], callbacks.ResourceWatchingFn]
-ResourceChangingDecorator = Callable[[callbacks.ResourceChangingFn], callbacks.ResourceChangingFn]
-ResourceDaemonDecorator = Callable[[callbacks.ResourceDaemonFn], callbacks.ResourceDaemonFn]
-ResourceTimerDecorator = Callable[[callbacks.ResourceTimerFn], callbacks.ResourceTimerFn]
+ActivityDecorator = Callable[["callbacks.ActivityFn"], "callbacks.ActivityFn"]
+ResourceIndexingDecorator = Callable[["callbacks.ResourceIndexingFn"], "callbacks.ResourceIndexingFn"]
+ResourceWatchingDecorator = Callable[["callbacks.ResourceWatchingFn"], "callbacks.ResourceWatchingFn"]
+ResourceChangingDecorator = Callable[["callbacks.ResourceChangingFn"], "callbacks.ResourceChangingFn"]
+ResourceDaemonDecorator = Callable[["callbacks.ResourceDaemonFn"], "callbacks.ResourceDaemonFn"]
+ResourceTimerDecorator = Callable[["callbacks.ResourceTimerFn"], "callbacks.ResourceTimerFn"]
 
 
 def startup(  # lgtm[py/similar-function]
@@ -37,8 +37,8 @@ def startup(  # lgtm[py/similar-function]
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityDecorator:
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ActivityFn,
-    ) -> callbacks.ActivityFn:
+            fn: "callbacks.ActivityFn",
+    ) -> "callbacks.ActivityFn":
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
@@ -64,8 +64,8 @@ def cleanup(  # lgtm[py/similar-function]
         registry: Optional[registries.OperatorRegistry] = None,
 ) -> ActivityDecorator:
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ActivityFn,
-    ) -> callbacks.ActivityFn:
+            fn: "callbacks.ActivityFn",
+    ) -> "callbacks.ActivityFn":
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
@@ -92,8 +92,8 @@ def login(  # lgtm[py/similar-function]
 ) -> ActivityDecorator:
     """ ``@kopf.on.login()`` handler for custom (re-)authentication. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ActivityFn,
-    ) -> callbacks.ActivityFn:
+            fn: "callbacks.ActivityFn",
+    ) -> "callbacks.ActivityFn":
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
@@ -120,8 +120,8 @@ def probe(  # lgtm[py/similar-function]
 ) -> ActivityDecorator:
     """ ``@kopf.on.probe()`` handler for arbitrary liveness metrics. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ActivityFn,
-    ) -> callbacks.ActivityFn:
+            fn: "callbacks.ActivityFn",
+    ) -> "callbacks.ActivityFn":
         real_registry = registry if registry is not None else registries.get_default_registry()
         real_id = registries.generate_id(fn=fn, id=id)
         handler = handlers.ActivityHandler(
@@ -158,7 +158,7 @@ def resume(  # lgtm[py/similar-function]
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
-        when: Optional[callbacks.WhenFilterFn] = None,
+        when: Optional["callbacks.WhenFilterFn"] = None,
         field: Optional[dicts.FieldSpec] = None,
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
@@ -166,8 +166,8 @@ def resume(  # lgtm[py/similar-function]
 ) -> ResourceChangingDecorator:
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: "callbacks.ResourceChangingFn",
+    ) -> "callbacks.ResourceChangingFn":
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -214,7 +214,7 @@ def create(  # lgtm[py/similar-function]
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
-        when: Optional[callbacks.WhenFilterFn] = None,
+        when: Optional["callbacks.WhenFilterFn"] = None,
         field: Optional[dicts.FieldSpec] = None,
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
@@ -222,8 +222,8 @@ def create(  # lgtm[py/similar-function]
 ) -> ResourceChangingDecorator:
     """ ``@kopf.on.create()`` handler for the object creation. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: "callbacks.ResourceChangingFn",
+    ) -> "callbacks.ResourceChangingFn":
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -270,7 +270,7 @@ def update(  # lgtm[py/similar-function]
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
-        when: Optional[callbacks.WhenFilterFn] = None,
+        when: Optional["callbacks.WhenFilterFn"] = None,
         field: Optional[dicts.FieldSpec] = None,
         value: Optional[filters.ValueFilter] = None,
         old: Optional[filters.ValueFilter] = None,
@@ -280,8 +280,8 @@ def update(  # lgtm[py/similar-function]
 ) -> ResourceChangingDecorator:
     """ ``@kopf.on.update()`` handler for the object update or change. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: "callbacks.ResourceChangingFn",
+    ) -> "callbacks.ResourceChangingFn":
         _warn_conflicting_values(field, value, old, new)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -329,7 +329,7 @@ def delete(  # lgtm[py/similar-function]
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
-        when: Optional[callbacks.WhenFilterFn] = None,
+        when: Optional["callbacks.WhenFilterFn"] = None,
         field: Optional[dicts.FieldSpec] = None,
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
@@ -337,8 +337,8 @@ def delete(  # lgtm[py/similar-function]
 ) -> ResourceChangingDecorator:
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: "callbacks.ResourceChangingFn",
+    ) -> "callbacks.ResourceChangingFn":
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -385,7 +385,7 @@ def field(  # lgtm[py/similar-function]
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
-        when: Optional[callbacks.WhenFilterFn] = None,
+        when: Optional["callbacks.WhenFilterFn"] = None,
         field: dicts.FieldSpec,
         value: Optional[filters.ValueFilter] = None,
         old: Optional[filters.ValueFilter] = None,
@@ -395,8 +395,8 @@ def field(  # lgtm[py/similar-function]
 ) -> ResourceChangingDecorator:
     """ ``@kopf.on.field()`` handler for the individual field changes. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: "callbacks.ResourceChangingFn",
+    ) -> "callbacks.ResourceChangingFn":
         _warn_conflicting_values(field, value, old, new)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -443,7 +443,7 @@ def index(  # lgtm[py/similar-function]
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
-        when: Optional[callbacks.WhenFilterFn] = None,
+        when: Optional["callbacks.WhenFilterFn"] = None,
         field: Optional[dicts.FieldSpec] = None,
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
@@ -451,8 +451,8 @@ def index(  # lgtm[py/similar-function]
 ) -> ResourceIndexingDecorator:
     """ ``@kopf.index()`` handler for the indexing callbacks. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceIndexingFn,
-    ) -> callbacks.ResourceIndexingFn:
+            fn: "callbacks.ResourceIndexingFn",
+    ) -> "callbacks.ResourceIndexingFn":
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -493,7 +493,7 @@ def event(  # lgtm[py/similar-function]
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
-        when: Optional[callbacks.WhenFilterFn] = None,
+        when: Optional["callbacks.WhenFilterFn"] = None,
         field: Optional[dicts.FieldSpec] = None,
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
@@ -501,8 +501,8 @@ def event(  # lgtm[py/similar-function]
 ) -> ResourceWatchingDecorator:
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceWatchingFn,
-    ) -> callbacks.ResourceWatchingFn:
+            fn: "callbacks.ResourceWatchingFn",
+    ) -> "callbacks.ResourceWatchingFn":
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -551,7 +551,7 @@ def daemon(  # lgtm[py/similar-function]
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
-        when: Optional[callbacks.WhenFilterFn] = None,
+        when: Optional["callbacks.WhenFilterFn"] = None,
         field: Optional[dicts.FieldSpec] = None,
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
@@ -559,8 +559,8 @@ def daemon(  # lgtm[py/similar-function]
 ) -> ResourceDaemonDecorator:
     """ ``@kopf.daemon()`` decorator for the background threads/tasks. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceDaemonFn,
-    ) -> callbacks.ResourceDaemonFn:
+            fn: "callbacks.ResourceDaemonFn",
+    ) -> "callbacks.ResourceDaemonFn":
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -613,7 +613,7 @@ def timer(  # lgtm[py/similar-function]
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
-        when: Optional[callbacks.WhenFilterFn] = None,
+        when: Optional["callbacks.WhenFilterFn"] = None,
         field: Optional[dicts.FieldSpec] = None,
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
@@ -621,8 +621,8 @@ def timer(  # lgtm[py/similar-function]
 ) -> ResourceTimerDecorator:
     """ ``@kopf.timer()`` handler for the regular events. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceTimerFn,
-    ) -> callbacks.ResourceTimerFn:
+            fn: "callbacks.ResourceTimerFn",
+    ) -> "callbacks.ResourceTimerFn":
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -658,7 +658,7 @@ def subhandler(  # lgtm[py/similar-function]
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
-        when: Optional[callbacks.WhenFilterFn] = None,
+        when: Optional["callbacks.WhenFilterFn"] = None,
         field: Optional[dicts.FieldSpec] = None,
         value: Optional[filters.ValueFilter] = None,
         old: Optional[filters.ValueFilter] = None,  # only for on.update's subhandlers
@@ -693,8 +693,8 @@ def subhandler(  # lgtm[py/similar-function]
     create function will have its own value, not the latest in the for-cycle.
     """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: "callbacks.ResourceChangingFn",
+    ) -> "callbacks.ResourceChangingFn":
         parent_handler = handling.handler_var.get()
         if not isinstance(parent_handler, handlers.ResourceChangingHandler):
             raise TypeError("Sub-handlers are only supported for resource-changing handlers.")
@@ -720,7 +720,7 @@ def subhandler(  # lgtm[py/similar-function]
 
 
 def register(  # lgtm[py/similar-function]
-        fn: callbacks.ResourceChangingFn,
+        fn: "callbacks.ResourceChangingFn",
         *,
         # Handler's behaviour specification:
         id: Optional[str] = None,
@@ -732,8 +732,8 @@ def register(  # lgtm[py/similar-function]
         # Resource object specification:
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
-        when: Optional[callbacks.WhenFilterFn] = None,
-) -> callbacks.ResourceChangingFn:
+        when: Optional["callbacks.WhenFilterFn"] = None,
+) -> "callbacks.ResourceChangingFn":
     """
     Register a function as a sub-handler of the currently executed handler.
 

--- a/kopf/py.typed
+++ b/kopf/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -62,7 +62,7 @@ cause_var: ContextVar[causation.BaseCause] = ContextVar('cause_var')
 
 async def execute(
         *,
-        fns: Optional[Iterable[callbacks.ResourceChangingFn]] = None,
+        fns: Optional[Iterable["callbacks.ResourceChangingFn"]] = None,
         handlers: Optional[Iterable[handlers_.ResourceChangingHandler]] = None,
         registry: Optional[registries.ResourceChangingRegistry] = None,
         lifecycle: Optional[lifecycles.LifeCycleFn] = None,

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -16,22 +16,26 @@ import enum
 import functools
 from types import FunctionType, MethodType
 from typing import Any, Callable, Collection, Container, Generic, Iterable, Iterator, List, \
-                   Mapping, MutableMapping, Optional, Sequence, Set, Tuple, TypeVar, cast
+                   Mapping, MutableMapping, Optional, Sequence, Set, Tuple, TypeVar, cast, \
+                   TYPE_CHECKING
 
 from kopf.reactor import causation, invocation
-from kopf.structs import callbacks, dicts, filters, handlers, references
+from kopf.structs import dicts, filters, handlers, references
 from kopf.utilities import piggybacking
+
+if TYPE_CHECKING:  # pragma: nocover
+    from kopf.structs import callbacks
 
 # We only type-check for known classes of handlers/callbacks, and ignore any custom subclasses.
 CauseT = TypeVar('CauseT', bound=causation.BaseCause)
 HandlerT = TypeVar('HandlerT', bound=handlers.BaseHandler)
 ResourceHandlerT = TypeVar('ResourceHandlerT', bound=handlers.ResourceHandler)
 HandlerFnT = TypeVar('HandlerFnT',
-                     callbacks.ActivityFn,
-                     callbacks.ResourceIndexingFn,
-                     callbacks.ResourceWatchingFn,
-                     callbacks.ResourceSpawningFn,
-                     callbacks.ResourceChangingFn)
+                     "callbacks.ActivityFn",
+                     "callbacks.ResourceIndexingFn",
+                     "callbacks.ResourceWatchingFn",
+                     "callbacks.ResourceSpawningFn",
+                     "callbacks.ResourceChangingFn")
 
 
 class GenericRegistry(Generic[HandlerFnT, HandlerT]):
@@ -50,7 +54,7 @@ class GenericRegistry(Generic[HandlerFnT, HandlerT]):
 
 
 class ActivityRegistry(GenericRegistry[
-        callbacks.ActivityFn,
+        "callbacks.ActivityFn",
         handlers.ActivityHandler]):
 
     def get_handlers(
@@ -124,7 +128,7 @@ class ResourceRegistry(
 
 class ResourceIndexingRegistry(ResourceRegistry[
         causation.ResourceIndexingCause,
-        callbacks.ResourceIndexingFn,
+        "callbacks.ResourceIndexingFn",
         handlers.ResourceIndexingHandler]):
 
     def iter_handlers(
@@ -140,7 +144,7 @@ class ResourceIndexingRegistry(ResourceRegistry[
 
 class ResourceWatchingRegistry(ResourceRegistry[
         causation.ResourceWatchingCause,
-        callbacks.ResourceWatchingFn,
+        "callbacks.ResourceWatchingFn",
         handlers.ResourceWatchingHandler]):
 
     def iter_handlers(
@@ -156,7 +160,7 @@ class ResourceWatchingRegistry(ResourceRegistry[
 
 class ResourceSpawningRegistry(ResourceRegistry[
         causation.ResourceSpawningCause,
-        callbacks.ResourceSpawningFn,
+        "callbacks.ResourceSpawningFn",
         handlers.ResourceSpawningHandler]):
 
     def iter_handlers(
@@ -187,7 +191,7 @@ class ResourceSpawningRegistry(ResourceRegistry[
 
 class ResourceChangingRegistry(ResourceRegistry[
         causation.ResourceChangingCause,
-        callbacks.ResourceChangingFn,
+        "callbacks.ResourceChangingFn",
         handlers.ResourceChangingHandler]):
 
     def iter_handlers(
@@ -266,7 +270,7 @@ class SmartOperatorRegistry(OperatorRegistry):
         else:
             self._activities.append(handlers.ActivityHandler(
                 id=handlers.HandlerId('login_via_pykube'),
-                fn=cast(callbacks.ActivityFn, piggybacking.login_via_pykube),
+                fn=cast("callbacks.ActivityFn", piggybacking.login_via_pykube),
                 activity=handlers.Activity.AUTHENTICATION,
                 errors=handlers.ErrorsMode.IGNORED,
                 param=None, timeout=None, retries=None, backoff=None,
@@ -279,7 +283,7 @@ class SmartOperatorRegistry(OperatorRegistry):
         else:
             self._activities.append(handlers.ActivityHandler(
                 id=handlers.HandlerId('login_via_client'),
-                fn=cast(callbacks.ActivityFn, piggybacking.login_via_client),
+                fn=cast("callbacks.ActivityFn", piggybacking.login_via_client),
                 activity=handlers.Activity.AUTHENTICATION,
                 errors=handlers.ErrorsMode.IGNORED,
                 param=None, timeout=None, retries=None, backoff=None,

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -5,9 +5,9 @@ Since these signatures contain a lot of copy-pasted kwargs and are
 not so important for the codebase, they are moved to this separate module.
 """
 import logging
-from typing import Any, Callable, Collection, Coroutine, NewType, Optional, TypeVar, Union
-
-from typing_extensions import Protocol
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any, Callable, Collection, \
+                   Coroutine, Dict, NewType, Optional, TypeVar, Union
 
 from kopf.structs import bodies, diffs, ephemera, patches, primitives, references
 
@@ -24,189 +24,224 @@ _SyncOrAsyncResult = Union[Optional[Result], Coroutine[None, None, Optional[Resu
 # Used for the BaseHandler and generic invocation methods (which do not care about protocols).
 BaseFn = Callable[..., _SyncOrAsyncResult]
 
-
-class ActivityFn(Protocol):
-    def __call__(  # lgtm[py/similar-function]
-            self,
-            *args: Any,
-            logger: Union[logging.Logger, logging.LoggerAdapter],
-            memo: ephemera.AnyMemo,
-            **kwargs: Any,
-    ) -> _SyncOrAsyncResult: ...
+LoggerType = Union[logging.Logger, logging.LoggerAdapter]
 
 
-class ResourceIndexingFn(Protocol):
-    def __call__(  # lgtm[py/similar-function]
-            self,
-            *args: Any,
-            body: bodies.Body,
-            meta: bodies.Meta,
-            spec: bodies.Spec,
-            status: bodies.Status,
-            uid: Optional[str],
-            name: Optional[str],
-            namespace: Optional[str],
-            patch: patches.Patch,
-            logger: Union[logging.Logger, logging.LoggerAdapter],
-            resource: references.Resource,
-            memo: ephemera.AnyMemo,
-            **kwargs: Any,
-    ) -> _SyncOrAsyncResult: ...
+if TYPE_CHECKING:  # pragma: nocover
+    from mypy_extensions import Arg, DefaultNamedArg, KwArg, NamedArg, VarArg
+
+    # TODO: Try using ParamSpec to support index type checking in callbacks 
+    # when PEP 612 is released (https://www.python.org/dev/peps/pep-0612/)
+    ActivityFn = Callable[
+        [
+            NamedArg(ephemera.Index, "*"),
+            NamedArg(int, "retry"),
+            NamedArg(datetime, "started"),
+            NamedArg(timedelta, "runtime"),
+
+            NamedArg(LoggerType, "logger"),
+            NamedArg(ephemera.AnyMemo, "memo"),
+            DefaultNamedArg(Any, "param"),
+            KwArg(Any),
+        ],
+        _SyncOrAsyncResult
+    ]
 
 
-class ResourceWatchingFn(Protocol):
-    def __call__(  # lgtm[py/similar-function]
-            self,
-            *args: Any,
-            type: str,
-            event: bodies.RawEvent,
-            body: bodies.Body,
-            meta: bodies.Meta,
-            spec: bodies.Spec,
-            status: bodies.Status,
-            uid: Optional[str],
-            name: Optional[str],
-            namespace: Optional[str],
-            patch: patches.Patch,
-            logger: Union[logging.Logger, logging.LoggerAdapter],
-            resource: references.Resource,
-            memo: ephemera.AnyMemo,
-            **kwargs: Any,
-    ) -> _SyncOrAsyncResult: ...
+    ResourceIndexingFn = Callable[
+        [
+            NamedArg(Dict[str, str], "labels"),
+            NamedArg(Dict[str, str], "annotations"),
+            NamedArg(bodies.Body, "body"),
+            NamedArg(bodies.Meta, "meta"),
+            NamedArg(bodies.Spec, "spec"),
+            NamedArg(bodies.Status, "status"),
+            NamedArg(references.Resource, "resource"),
+            NamedArg(Optional[str], "uid"),
+            NamedArg(Optional[str], "name"),
+            NamedArg(Optional[str], "namespace"),
+            NamedArg(patches.Patch, "patch"),
+
+            NamedArg(LoggerType, "logger"),
+            NamedArg(ephemera.AnyMemo, "memo"),
+            DefaultNamedArg(Any, "param"),
+            KwArg(Any),
+        ],
+        _SyncOrAsyncResult
+    ]
 
 
-class ResourceChangingFn(Protocol):
-    def __call__(  # lgtm[py/similar-function]
-            self,
-            *args: Any,
-            body: bodies.Body,
-            meta: bodies.Meta,
-            spec: bodies.Spec,
-            status: bodies.Status,
-            uid: Optional[str],
-            name: Optional[str],
-            namespace: Optional[str],
-            patch: patches.Patch,
-            logger: Union[logging.Logger, logging.LoggerAdapter],
-            diff: diffs.Diff,
-            old: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
-            new: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
-            resource: references.Resource,
-            memo: ephemera.AnyMemo,
-            **kwargs: Any,
-    ) -> _SyncOrAsyncResult: ...
+    ResourceWatchingFn = Callable[
+        [
+            NamedArg(str, "type"),
+            NamedArg(bodies.RawEvent, "event"),
+
+            NamedArg(Dict[str, str], "labels"),
+            NamedArg(Dict[str, str], "annotations"),
+            NamedArg(bodies.Body, "body"),
+            NamedArg(bodies.Meta, "meta"),
+            NamedArg(bodies.Spec, "spec"),
+            NamedArg(bodies.Status, "status"),
+            NamedArg(references.Resource, "resource"),
+            NamedArg(Optional[str], "uid"),
+            NamedArg(Optional[str], "name"),
+            NamedArg(Optional[str], "namespace"),
+            NamedArg(patches.Patch, "patch"),
+            
+            NamedArg(LoggerType, "logger"),
+            NamedArg(ephemera.AnyMemo, "memo"),
+            DefaultNamedArg(Any, "param"),
+            KwArg(Any),
+        ],
+        _SyncOrAsyncResult
+    ]
 
 
-class ResourceDaemonSyncFn(Protocol):
-    def __call__(  # lgtm[py/similar-function]  # << different mode
-            self,
-            *args: Any,
-            body: bodies.Body,
-            meta: bodies.Meta,
-            spec: bodies.Spec,
-            status: bodies.Status,
-            uid: Optional[str],
-            name: Optional[str],
-            namespace: Optional[str],
-            patch: patches.Patch,
-            logger: Union[logging.Logger, logging.LoggerAdapter],
-            stopped: primitives.SyncDaemonStopperChecker,  # << different type
-            resource: references.Resource,
-            memo: ephemera.AnyMemo,
-            **kwargs: Any,
-    ) -> Optional[Result]: ...
+    ResourceChangingFn = Callable[
+        [
+            NamedArg(int, "retry"),
+            NamedArg(datetime, "started"),
+            NamedArg(timedelta, "runtime"),
+
+            NamedArg(Dict[str, str], "labels"),
+            NamedArg(Dict[str, str], "annotations"),
+            NamedArg(bodies.Body, "body"),
+            NamedArg(bodies.Meta, "meta"),
+            NamedArg(bodies.Spec, "spec"),
+            NamedArg(bodies.Status, "status"),
+            NamedArg(references.Resource, "resource"),
+            NamedArg(Optional[str], "uid"),
+            NamedArg(Optional[str], "name"),
+            NamedArg(Optional[str], "namespace"),
+            NamedArg(patches.Patch, "patch"),
+
+            NamedArg(str, "reason"),
+            NamedArg(diffs.Diff, "diff"),
+            NamedArg(Optional[Union[bodies.BodyEssence, Any]], "old"),
+            NamedArg(Optional[Union[bodies.BodyEssence, Any]], "new"),
+
+            NamedArg(LoggerType, "logger"),
+            NamedArg(ephemera.AnyMemo, "memo"),
+            DefaultNamedArg(Any, "param"),
+            KwArg(Any),
+        ],
+        _SyncOrAsyncResult
+    ]
 
 
-class ResourceDaemonAsyncFn(Protocol):
-    async def __call__(  # lgtm[py/similar-function]  # << different mode
-            self,
-            *args: Any,
-            body: bodies.Body,
-            meta: bodies.Meta,
-            spec: bodies.Spec,
-            status: bodies.Status,
-            uid: Optional[str],
-            name: Optional[str],
-            namespace: Optional[str],
-            patch: patches.Patch,
-            logger: Union[logging.Logger, logging.LoggerAdapter],
-            stopped: primitives.AsyncDaemonStopperChecker,  # << different type
-            resource: references.Resource,
-            memo: ephemera.AnyMemo,
-            **kwargs: Any,
-    ) -> Optional[Result]: ...
+    ResourceDaemonFn = Callable[
+        [
+            NamedArg(primitives.SyncDaemonStopperChecker, "stopped"),
+
+            NamedArg(int, "retry"),
+            NamedArg(datetime, "started"),
+            NamedArg(timedelta, "runtime"),
+
+            NamedArg(Dict[str, str], "labels"),
+            NamedArg(Dict[str, str], "annotations"),
+            NamedArg(bodies.Body, "body"),
+            NamedArg(bodies.Meta, "meta"),
+            NamedArg(bodies.Spec, "spec"),
+            NamedArg(bodies.Status, "status"),
+            NamedArg(references.Resource, "resource"),
+            NamedArg(Optional[str], "uid"),
+            NamedArg(Optional[str], "name"),
+            NamedArg(Optional[str], "namespace"),
+            NamedArg(patches.Patch, "patch"),
+            
+            NamedArg(LoggerType, "logger"),
+            NamedArg(ephemera.AnyMemo, "memo"),
+            DefaultNamedArg(Any, "param"),
+            KwArg(Any),
+        ],
+        _SyncOrAsyncResult
+    ]
 
 
-ResourceDaemonFn = Union[ResourceDaemonSyncFn, ResourceDaemonAsyncFn]
+    ResourceTimerFn = Callable[
+        [
+            NamedArg(ephemera.Index, "*"),
+
+            NamedArg(Dict[str, str], "labels"),
+            NamedArg(Dict[str, str], "annotations"),
+            NamedArg(bodies.Body, "body"),
+            NamedArg(bodies.Meta, "meta"),
+            NamedArg(bodies.Spec, "spec"),
+            NamedArg(bodies.Status, "status"),
+            NamedArg(references.Resource, "resource"),
+            NamedArg(Optional[str], "uid"),
+            NamedArg(Optional[str], "name"),
+            NamedArg(Optional[str], "namespace"),
+            NamedArg(patches.Patch, "patch"),
+
+            NamedArg(LoggerType, "logger"),
+            NamedArg(ephemera.AnyMemo, "memo"),
+            DefaultNamedArg(Any, "param"),
+            KwArg(Any),
+        ],
+        _SyncOrAsyncResult
+    ]
 
 
-class ResourceTimerFn(Protocol):
-    def __call__(  # lgtm[py/similar-function]
-            self,
-            *args: Any,
-            body: bodies.Body,
-            meta: bodies.Meta,
-            spec: bodies.Spec,
-            status: bodies.Status,
-            uid: Optional[str],
-            name: Optional[str],
-            namespace: Optional[str],
-            patch: patches.Patch,
-            logger: Union[logging.Logger, logging.LoggerAdapter],
-            resource: references.Resource,
-            memo: ephemera.AnyMemo,
-            **kwargs: Any,
-    ) -> _SyncOrAsyncResult: ...
+    ResourceSpawningFn = Union[ResourceDaemonFn, ResourceTimerFn]
+
+    WhenFilterFn = Callable[
+        [
+            NamedArg(str, "type"),
+            NamedArg(bodies.RawEvent, "event"),
+
+            NamedArg(Dict[str, str], "labels"),
+            NamedArg(Dict[str, str], "annotations"),
+            NamedArg(bodies.Body, "body"),
+            NamedArg(bodies.Meta, "meta"),
+            NamedArg(bodies.Spec, "spec"),
+            NamedArg(bodies.Status, "status"),
+            NamedArg(references.Resource, "resource"),
+            NamedArg(Optional[str], "uid"),
+            NamedArg(Optional[str], "name"),
+            NamedArg(Optional[str], "namespace"),
+            NamedArg(patches.Patch, "patch"),
+            
+            NamedArg(diffs.Diff, "diff"),
+            NamedArg(Optional[Union[bodies.BodyEssence, Any]], "old"),
+            NamedArg(Optional[Union[bodies.BodyEssence, Any]], "new"),
+            
+            NamedArg(LoggerType, "logger"),
+            NamedArg(ephemera.AnyMemo, "memo"),
+            DefaultNamedArg(Any, "param"),
+            KwArg(Any),
+        ],
+        bool
+    ]
 
 
-ResourceSpawningFn = Union[ResourceDaemonFn, ResourceTimerFn]
+    MetaFilterFn = Callable[
+        [
+            Arg(Any, "value"),
+            NamedArg(str, "type"),
+
+            NamedArg(Dict[str, str], "labels"),
+            NamedArg(Dict[str, str], "annotations"),
+            NamedArg(bodies.Body, "body"),
+            NamedArg(bodies.Meta, "meta"),
+            NamedArg(bodies.Spec, "spec"),
+            NamedArg(bodies.Status, "status"),
+            NamedArg(references.Resource, "resource"),
+            NamedArg(Optional[str], "uid"),
+            NamedArg(Optional[str], "name"),
+            NamedArg(Optional[str], "namespace"),
+            NamedArg(patches.Patch, "patch"),
+
+            NamedArg(LoggerType, "logger"),
+            NamedArg(ephemera.AnyMemo, "memo"),
+            DefaultNamedArg(Any, "param"),
+            KwArg(Any),
+        ],
+        bool
+    ]
 
 
-class WhenFilterFn(Protocol):
-    def __call__(  # lgtm[py/similar-function]
-            self,
-            *args: Any,
-            type: str,
-            event: bodies.RawEvent,
-            body: bodies.Body,
-            meta: bodies.Meta,
-            spec: bodies.Spec,
-            status: bodies.Status,
-            uid: Optional[str],
-            name: Optional[str],
-            namespace: Optional[str],
-            patch: patches.Patch,
-            logger: Union[logging.Logger, logging.LoggerAdapter],
-            diff: diffs.Diff,
-            old: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
-            new: Optional[Union[bodies.BodyEssence, Any]],  # "Any" is for field-handlers.
-            resource: references.Resource,
-            memo: ephemera.AnyMemo,
-            **kwargs: Any,
-    ) -> bool: ...
-
-
-class MetaFilterFn(Protocol):
-    def __call__(  # lgtm[py/similar-function]
-            self,
-            value: Any,
-            *args: Any,
-            body: bodies.Body,
-            meta: bodies.Meta,
-            spec: bodies.Spec,
-            status: bodies.Status,
-            uid: Optional[str],
-            name: Optional[str],
-            namespace: Optional[str],
-            patch: patches.Patch,
-            logger: Union[logging.Logger, logging.LoggerAdapter],
-            resource: references.Resource,
-            memo: ephemera.AnyMemo,
-            **kwargs: Any,
-    ) -> bool: ...
-
-
-_FnT = TypeVar('_FnT', WhenFilterFn, MetaFilterFn)
+_FnT = TypeVar('_FnT', "WhenFilterFn", "MetaFilterFn")
 
 
 def not_(fn: _FnT) -> _FnT:

--- a/kopf/structs/filters.py
+++ b/kopf/structs/filters.py
@@ -1,7 +1,8 @@
 import enum
-from typing import Any, Mapping, Union
+from typing import Any, Mapping, Union, TYPE_CHECKING
 
-from kopf.structs import callbacks
+if TYPE_CHECKING:  # pragma: nocover
+    from kopf.structs import callbacks
 
 
 class MetaFilterToken(enum.Enum):
@@ -15,8 +16,8 @@ ABSENT = MetaFilterToken.ABSENT
 PRESENT = MetaFilterToken.PRESENT
 
 # Filters for handler specifications (not the same as the object's values).
-MetaFilter = Mapping[str, Union[str, MetaFilterToken, callbacks.MetaFilterFn]]
+MetaFilter = Mapping[str, Union[str, MetaFilterToken, "callbacks.MetaFilterFn"]]
 
 # Filters for old/new values of a field.
 # NB: `Any` covers all other values, but we want to highlight that they are specially treated.
-ValueFilter = Union[None, Any, MetaFilterToken, callbacks.MetaFilterFn]
+ValueFilter = Union[None, Any, MetaFilterToken, "callbacks.MetaFilterFn"]

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -83,7 +83,7 @@ class BaseHandler:
 
 @dataclasses.dataclass
 class ActivityHandler(BaseHandler):
-    fn: callbacks.ActivityFn  # type clarification
+    fn: "callbacks.ActivityFn"  # type clarification
     activity: Optional[Activity]
     _fallback: bool = False  # non-public!
 
@@ -96,7 +96,7 @@ class ResourceHandler(BaseHandler):
     selector: Optional[references.Selector]  # None is used only in sub-handlers
     labels: Optional[filters.MetaFilter]
     annotations: Optional[filters.MetaFilter]
-    when: Optional[callbacks.WhenFilterFn]
+    when: Optional["callbacks.WhenFilterFn"]
     field: Optional[dicts.FieldPath]
     value: Optional[filters.ValueFilter]
 
@@ -107,7 +107,7 @@ class ResourceHandler(BaseHandler):
 
 @dataclasses.dataclass
 class ResourceIndexingHandler(ResourceHandler):
-    fn: callbacks.ResourceIndexingFn  # type clarification
+    fn: "callbacks.ResourceIndexingFn"  # type clarification
 
     def __str__(self) -> str:
         return f"Indexer {self.id!r}"
@@ -119,7 +119,7 @@ class ResourceIndexingHandler(ResourceHandler):
 
 @dataclasses.dataclass
 class ResourceWatchingHandler(ResourceHandler):
-    fn: callbacks.ResourceWatchingFn  # type clarification
+    fn: "callbacks.ResourceWatchingFn"  # type clarification
 
     @property
     def requires_patching(self) -> bool:
@@ -128,7 +128,7 @@ class ResourceWatchingHandler(ResourceHandler):
 
 @dataclasses.dataclass
 class ResourceChangingHandler(ResourceHandler):
-    fn: callbacks.ResourceChangingFn  # type clarification
+    fn: "callbacks.ResourceChangingFn"  # type clarification
     reason: Optional[Reason]
     initial: Optional[bool]
     deleted: Optional[bool]  # used for mixed-in (initial==True) @on.resume handlers only.
@@ -146,7 +146,7 @@ class ResourceSpawningHandler(ResourceHandler):
 
 @dataclasses.dataclass
 class ResourceDaemonHandler(ResourceSpawningHandler):
-    fn: callbacks.ResourceDaemonFn  # type clarification
+    fn: "callbacks.ResourceDaemonFn"  # type clarification
     cancellation_backoff: Optional[float]  # how long to wait before actual cancellation.
     cancellation_timeout: Optional[float]  # how long to wait before giving up on cancellation.
     cancellation_polling: Optional[float]  # how often to check for cancellation status.
@@ -157,7 +157,7 @@ class ResourceDaemonHandler(ResourceSpawningHandler):
 
 @dataclasses.dataclass
 class ResourceTimerHandler(ResourceSpawningHandler):
-    fn: callbacks.ResourceTimerFn  # type clarification
+    fn: "callbacks.ResourceTimerFn"  # type clarification
     sharp: Optional[bool]
     idle: Optional[float]
     interval: Optional[float]

--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,5 @@ setup(
     extras_require={
         'full-auth': ['pykube-ng', 'kubernetes'],
     },
+    package_data={"kopf": ["py.typed"]},
 )


### PR DESCRIPTION
## What do these changes do?

These changes expose the type hints for the library users and fix the callbacks interfaces issue. The exposing is described in the [PEP561](https://www.python.org/dev/peps/pep-0561/).
## Description

If there is no `py.typed` file in the library root, `mypy` doesn't discover the type hints from the sources.
So for the following command:

```
mypy -c "import kopf"
...
```

fails with message: 

```
<string>:1: error: Skipping analyzing 'kopf': found module but no type hints or library stubs
<string>:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

After the PR will be merged the command above should pass successfully:

```
mypy -c "import kopf"
Success: no issues found in 1 source file
```

The change does not affect the end-users and there are no breaking changes.

## Type of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [ ] Unit tests for the changes that exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
