### PR TITLE
Rename `master` branch to `main`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
+      - main
       - release/**
   workflow_dispatch: {}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.9
       - run: pip install --upgrade setuptools wheel twine
       - run: python setup.py sdist bdist_wheel
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -1,4 +1,4 @@
-# The thorough tests run only on the master branch after everything is merged,
+# The thorough tests run only on the main branch after everything is merged,
 # and regularly by time —- on order to detect bugs and incompatibility with
 # the new versions of freshly released software (e.g. K8s, K3s, Python libs).
 # The first part fully includes the CI workflow, with more versions of K3d/K3s.
@@ -7,7 +7,7 @@ name: Thorough tests
 on:
   push:
     branches:
-      - master
+      - main
       - release/**
   schedule:
     - cron: "13 3 * * 6"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Kubernetes Operator Pythonic Framework (Kopf)
 
 [![CI](https://github.com/nolar/kopf/workflows/Thorough%20tests/badge.svg)](https://github.com/nolar/kopf/actions)
-[![codecov](https://codecov.io/gh/nolar/kopf/branch/master/graph/badge.svg)](https://codecov.io/gh/nolar/kopf)
-[![Coverage Status](https://coveralls.io/repos/github/nolar/kopf/badge.svg?branch=master)](https://coveralls.io/github/nolar/kopf?branch=master)
+[![codecov](https://codecov.io/gh/nolar/kopf/branch/main/graph/badge.svg)](https://codecov.io/gh/nolar/kopf)
+[![Coverage Status](https://coveralls.io/repos/github/nolar/kopf/badge.svg?branch=main)](https://coveralls.io/github/nolar/kopf?branch=main)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/nolar/kopf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nolar/kopf/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/nolar/kopf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nolar/kopf/context:python)
 
@@ -76,7 +76,7 @@ deployment files like RBAC roles, bindings, service accounts, network policies
 
 ## Examples
 
-See [examples](https://github.com/nolar/kopf/tree/master/examples)
+See [examples](https://github.com/nolar/kopf/tree/main/examples)
 for the examples of the typical use-cases.
 
 A minimalistic operator can look like this:
@@ -139,12 +139,12 @@ See `kopf run --help` for others ways of attaching the handlers.
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](https://github.com/nolar/kopf/blob/master/CONTRIBUTING.md)
+Please read [CONTRIBUTING.md](https://github.com/nolar/kopf/blob/main/CONTRIBUTING.md)
 for details on our process for submitting pull requests to us, and please ensure
-you follow the [CODE_OF_CONDUCT.md](https://github.com/nolar/kopf/blob/master/CODE_OF_CONDUCT.md).
+you follow the [CODE_OF_CONDUCT.md](https://github.com/nolar/kopf/blob/main/CODE_OF_CONDUCT.md).
 
 To install the environment for the local development,
-read [DEVELOPMENT.md](https://github.com/nolar/kopf/blob/master/DEVELOPMENT.md).
+read [DEVELOPMENT.md](https://github.com/nolar/kopf/blob/main/DEVELOPMENT.md).
 
 
 ## Versioning
@@ -156,7 +156,7 @@ see the [releases on this repository](https://github.com/nolar/kopf/releases).
 ## License
 
 This project is licensed under the MIT License —
-see the [LICENSE](https://github.com/nolar/kopf/blob/master/LICENSE) file for details.
+see the [LICENSE](https://github.com/nolar/kopf/blob/main/LICENSE) file for details.
 
 
 ## Acknowledgments

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ def linkcode_resolve(domain, info):
     if not info['module']:
         return None
     filename = info['module'].replace('.', '/')
-    return "https://github.com/nolar/kopf/blob/master/%s.py" % filename
+    return "https://github.com/nolar/kopf/blob/main/%s.py" % filename
 
 
 ###############################################################################

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -30,11 +30,11 @@ The recommended setup:
         git remote add upstream git@github.com:nolar/kopf.git
         git fetch upstream
 
-* Sync your ``master`` branch with the upstream regularly::
+* Sync your ``main`` branch with the upstream regularly::
 
-        git checkout master
-        git pull upstream master --ff
-        git push origin master
+        git checkout main
+        git pull upstream main --ff
+        git push origin main
 
 Work in the feature branches of your fork, not in the upstream's branches:
 


### PR DESCRIPTION
Those who cloned this repo locally should do:

```
git branch -m master main
git fetch origin
git branch -u origin/main main
```

The forks and existing PRs are all fine as they are.

The rest is taken care of by GitHub as documented:

* https://github.com/github/renaming