### PR TITLE
Fix unexpected (unused but passed) kwargs to peering routines

### DIFF
--- a/kopf/engines/peering.py
+++ b/kopf/engines/peering.py
@@ -95,6 +95,9 @@ async def process_peering_event(
         autoclean: bool = True,
         stream_pressure: Optional[asyncio.Event] = None,  # None for tests
         conflicts_found: Optional[primitives.Toggle] = None,  # None for tests & observation
+        # Must be accepted whether used or not -- as passed by watcher()/worker().
+        resource_indexed: Optional[primitives.Toggle] = None,  # None for tests & observation
+        operator_indexed: Optional[primitives.ToggleSet] = None,  # None for tests & observation
 ) -> None:
     """
     Handle a single update of the peers by us or by other operators.


### PR DESCRIPTION
The error is:

```
TypeError: process_peering_event() got an unexpected keyword argument 'resource_indexed'
```

The kwarg is added in 1.30.0 for indexing, added as unused to all processing routines except the peering, and this was not caught in testing (both in automated and manual) — because the kwargs are unused and the peering is usually disabled in tests to not produce unnecessary logs/steps.

Only affects the operator when the peering is enabled — either explicitly or auto-detected — i.e. when the peering CRDs & CRs are present. Non-peered operators are not affected.

Fixes #710