### PR TITLE
Fix grammar and style as recommended by Grammarly

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the same packages, the same developer(s).
 
 * Simple, but powerful:
   * A full-featured operator in just 2 files: a `Dockerfile` + a Python file (*).
-  * Handling functions registered via decorators with declarative approach. 
+  * Handling functions registered via decorators with a declarative approach. 
   * No infrastructure boilerplate code with K8s API communication.
   * Both sync and async handlers, with sync ones being threaded under the hood.
   * Detailed documentation with examples.
@@ -36,7 +36,7 @@ the same packages, the same developer(s).
   * Marshalling of handlers' results to the resources' statuses.
   * Publishing of logging messages as Kubernetes events linked to the resources.
 * Support anything that exists in K8s:
-  * Custom K8s resources, obviously.
+  * Custom K8s resources.
   * Builtin K8s resources (pods, namespaces, etc).
   * Multiple resource types in one operator.
   * Both cluster and namespaced operators.
@@ -58,7 +58,7 @@ the same packages, the same developer(s).
   * Tolerance to restarts and lengthy downtimes: handles the changes afterwards.
 * Awareness of other Kopf-based operators:
   * Configurable identities for different Kopf-based operators for the same resource kinds.
-  * Avoiding of double-processing due to cross-pod awareness of the same operator ("peering").
+  * Avoiding double-processing due to cross-pod awareness of the same operator ("peering").
   * Pausing of a deployed operator when a dev-mode operator runs outside of the cluster.
 * Extra toolkits and integrations:
   * Some limited support for object hierarchies with name/labels propagation.
@@ -93,7 +93,7 @@ Numerous kwargs are available, such as `body`, `meta`, `spec`, `status`,
 `name`, `namespace`, `retry`, `diff`, `old`, `new`, `logger`, etc: 
 see [Arguments](https://kopf.readthedocs.io/en/latest/kwargs/)
 
-To run a non-exiting function for every resource as long as it exists:
+To run a never-exiting function for every resource as long as it exists:
 
 ```python
 import time
@@ -122,7 +122,7 @@ That easy! For more features, see the [documentation](https://kopf.readthedocs.i
 ## Usage
 
 We assume that when the operator is executed in the cluster, it must be packaged
-into a docker image with CI/CD tool of your preference.
+into a docker image with a CI/CD tool of your preference.
 
 ```dockerfile
 FROM python:3.7
@@ -134,7 +134,7 @@ CMD kopf run /src/handlers.py --verbose
 Where `handlers.py` is your Python script with the handlers
 (see `examples/*/example.py` for the examples).
 
-See `kopf run --help` for others ways of attaching the handlers.
+See `kopf run --help` for other ways of attaching the handlers.
 
 
 ## Contributing

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -7,22 +7,22 @@ Metacontroller
 
 The closest equivalent of Kopf is Metacontroller_.
 It targets the same goal as Kopf does:
-to make the Kubernetes operators development easy,
+to make the development of Kubernetes operators easy,
 with no need for in-depth knowledge of Kubernetes or Go.
 
 However, it does that in a different way than Kopf does:
-with few yaml files describing the structure of your operator
-(beside the custom resource definition),
+with a few YAML files describing the structure of your operator
+(besides the custom resource definition),
 and by wrapping your core domain logic into the Function-as-a-Service
 or into the in-cluster HTTP API deployments,
-which in turn react to the changes of the custom resources.
+which in turn react to the changes in the custom resources.
 
 An operator developer still has to implement the infrastructure
 of the API calls in these HTTP APIs and/or Lambdas.
 The APIs must be reachable from inside the cluster,
 which means that they must be deployed there.
 
-Kopf, on the other hand, attempts to keep the things explicit
+Kopf, on the other hand, attempts to keep things explicit
 (as per the `Zen of Python`_: *explicit is better than implicit*),
 keeping the whole operator's logic in one place, in one syntax (Python).
 
@@ -36,11 +36,11 @@ keeping the whole operator's logic in one place, in one syntax (Python).
 
 Kopf also makes the effort to keep the operator development human-friendly,
 which means at least the ease of debugging (e.g. with the breakpoints,
-running in a local IDE, not in the cloud), the logs readability,
+running in a local IDE, not in the cloud), the readability of the logs,
 and other little pleasant things.
 
 And also Kopf allows to write *any* arbitrary domain logic of the resources,
-especially if it spans over long time periods (hours, days if needed),
+especially if it spans over long periods (hours, days if needed),
 and is not limited to the timeout restrictions of the HTTP APIs with their
 expectation of nearly-immediate outcome (i.e. in seconds or milliseconds).
 
@@ -58,9 +58,9 @@ Side8's k8s-operator
 ====================
 
 Side8's k8s-operator_ is another direct equivalent.
-It was actually the initial inspiration for writing Kopf.
+It was the initial inspiration for writing Kopf.
 
-Side8's k8s-operator is written with Python3, and allows to write
+Side8's k8s-operator is written with Python3 and allows to write
 the domain logic in the apply/delete scripts in any language.
 The scripts run locally on the same machine where the controller is running
 (usually the same pod, or a developer's computer).
@@ -70,7 +70,7 @@ and the environment variables as the input,
 which is only good if the scripts are written in shell/bash.
 Writing the complicated domain logic in bash can be troublesome.
 
-The scripts in other languages, such as Python, are supported, but require
+The scripts in other languages, such as Python, are supported but require
 the inner infrastructure logic to parse the input and to render the output
 and to perform the logging properly:
 e.g., so that no single byte of garbage output is ever printed to stdout,
@@ -84,7 +84,7 @@ in the operator codebase.
 CoreOS Operator SDK & Framework
 ===============================
 
-`CoreOS Operator SDK`_ is not actually an operator framework.
+`CoreOS Operator SDK`_ is not an operator framework.
 It is an SDK, i.e. a Software Development Kit,
 which generates the skeleton code for the operators-to-be,
 and users should enrich it with the domain logic code as needed.

--- a/docs/async.rst
+++ b/docs/async.rst
@@ -13,10 +13,10 @@ Kopf supports asynchronous handler functions::
     async def create_fn(spec, **_):
         await asyncio.sleep(1.0)
 
-Async functions have the additional benefit over the non-async ones
+Async functions have an additional benefit over the non-async ones
 to make the full stack trace available when exceptions occur
-or IDE breakpoints are used, since the async functions are executed
-directly inside of Kopf's own event loop in the main thread.
+or IDE breakpoints are used since the async functions are executed
+directly inside of Kopf's event loop in the main thread.
 
 Regular synchronous handlers, despite supported for convenience,
 are executed in parallel threads (via the default executor of the loop),
@@ -34,5 +34,5 @@ and can only see the stack traces up to the thread entry point.
     processed in parallel, and the Kubernetes event-watching/-queueing cycles.
 
     This can come unnoticed in the development environment
-    with only few resources and no external timeouts,
+    with only a few resources and no external timeouts,
     but can hit hard in the production environments with high load.

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -7,15 +7,15 @@ They are usually taken either from the environment (environment variables),
 or from the ``~/.kube/config`` file, or from external authentication services.
 
 Kopf does not try to maintain all the authentication methods possible.
-Instead, it allows the operator developers to implement their own custom
-authentication methods, and piggybacks the existing Kubernetes clients.
+Instead, it allows the operator developers to implement their custom
+authentication methods and piggybacks the existing Kubernetes clients.
 
 
 Custom authentication
 =====================
 
-To implement a custom authentication method, one or few login-handlers
-can be added. The login handlers should either return nothing (``None``),
+To implement a custom authentication method, one or a few login-handlers
+can be added. The login handlers should either return nothing (``None``)
 or an instance of `kopf.ConnectionInfo`::
 
     import kopf
@@ -61,11 +61,11 @@ No matter how the endpoints or credentials are retrieved, they are directly
 mapped to TCP/SSL/HTTPS protocols in the API clients. It is the responsibility
 of the authentication handlers to ensure that the values are consistent
 and valid (e.g. via internal verification calls). It is in theory possible
-to mix all authentication methods at once, or to have none of them at all.
+to mix all authentication methods at once or to have none of them at all.
 If the credentials are inconsistent or invalid, there will be permanent
 re-authentication happening.
 
-Multiple handlers can be declared to retrieve different credentials,
+Multiple handlers can be declared to retrieve different credentials
 or the same credentials via different libraries. All of the retrieved
 credentials will be used in random order with no specific priority.
 
@@ -95,7 +95,7 @@ If few of the piggybacked libraries are installed,
 all of them will be attempted (as if multiple handlers are installed),
 and all the credentials will be utilised in random order.
 
-If that is not the desired case, and only one of the libraries is neeed,
+If that is not the desired case, and only one of the libraries is needed,
 declare a custom login handler explicitly, and use only the preferred library
 by calling one of the piggybacking functions::
 
@@ -131,20 +131,20 @@ Credentials lifecycle
 =====================
 
 Internally, all the credentials are gathered from all the active handlers
-(either the declared ones, or all the fallback piggybacking ones)
+(either the declared ones or all the fallback piggybacking ones)
 in no particular order, and are fed into a *vault*.
 
 The Kubernetes API calls then use random credentials from that *vault*.
 If the API call fails with an HTTP 401 error, these credentials are marked
 invalid, excluded from further use, and the next random credentials are tried.
 
-When the *vault* is fully depleted, it freezes all the API calls, and triggers
+When the *vault* is fully depleted, it freezes all the API calls and triggers
 the login handlers for re-authentication. Only the new credentials are used.
 The credentials, which previously were known to be invalid, are ignored
 to prevent a permanent never-ending re-authentication loop.
 
-There is no credentials validation by making fake API calls.
-Instead, the real API calls validate the credentials by using them,
+There is no validation of credentials by making fake API calls.
+Instead, the real API calls validate the credentials by using them
 and reporting them back to the *vault* as invalid (or keeping them as valid),
 potentially causing new re-authentication activities.
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -18,7 +18,7 @@ can also be considered as a part of the solution.
 ----
 
 The **Kubernetes controller** is the logic (i.e. the behaviour) behind most
-objects, both built-in and added as extension of Kubernetes.
+objects, both built-in and added as extensions of Kubernetes.
 Examples of objects are ReplicaSet and Pods, created when a Deployment object
 is created, with the rolling version upgrades, and so on.
 
@@ -45,12 +45,12 @@ watching the objects and reacting to the objects' events (usually the changes).
 
 **Kopf** is a framework to build Kubernetes operators in Python.
 
-As any framework, Kopf provides both the "outer" toolkit to run the operator,
+Like any framework, Kopf provides both the "outer" toolkit to run the operator,
 to talk to the Kubernetes cluster, and to marshal the Kubernetes events
 into the pure-Python functions of the Kopf-based operator,
 and the "inner" libraries to assist with a limited set of common tasks
 of manipulating the Kubernetes objects
-(however, it is not a yet another Kubernetes client library).
+(however, it is not yet another Kubernetes client library).
 
 .. seealso::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -120,7 +120,7 @@ The following log formats are supported on CLI:
 Logging events
 ==============
 
-``settings.posting`` allows to control which log messages should be post as
+``settings.posting`` allows to control which log messages should be posted as
 Kubernetes events. Use ``logging`` constants or integer values to set the level:
 e.g., ``logging.WARNING``, ``logging.ERROR``, etc.
 The default is ``logging`.INFO``.
@@ -150,8 +150,8 @@ The event-posting can be disabled completely (the default is to be enabled):
     `kopf.info`, `kopf.warn`, `kopf.exception`, etc --
     even if they are called explicitly in the code.
 
-    To avoid these settings having impact on your code, post events
-    directly with an API client library instead of Kopf-provided toolkit.
+    To avoid these settings having an impact on your code, post events
+    directly with an API client library instead of the Kopf-provided toolkit.
 
 
 .. _configure-sync-handlers:
@@ -159,7 +159,7 @@ The event-posting can be disabled completely (the default is to be enabled):
 Synchronous handlers
 ====================
 
-``settings.execution`` allows to set the number of synchronous workers used
+``settings.execution`` allows setting the number of synchronous workers used
 by the operator for synchronous handlers, or replace the asyncio executor
 with another one:
 
@@ -189,7 +189,7 @@ handler itself. To avoid it, make the on-startup handler asynchronous:
         settings.execution.executor = concurrent.futures.ThreadPoolExecutor()
 
 The same executor is used both for regular sync handlers and for sync daemons.
-If you expect large number of synchronous daemons (e.g. for large clusters),
+If you expect a large number of synchronous daemons (e.g. for large clusters),
 make sure to pre-scale the executor accordingly
 (the default in Python is 5x times the CPU cores):
 
@@ -209,13 +209,13 @@ Few timeouts can be controlled when communicating with Kubernetes API:
 
 ``settings.watching.server_timeout`` (seconds) is how long the session
 with a watching request will exist before closing it from the **server** side.
-This value is passed to the server side in a query string, and the server
+This value is passed to the server-side in a query string, and the server
 decides on how to follow it. The watch-stream is then gracefully closed.
 The default is to use the server setup (``None``).
 
 ``settings.watching.client_timeout`` (seconds) is how long the session
 with a watching request will exist before closing it from the **client** side.
-This includes the connection establishing and event streaming.
+This includes establishing the connection and event streaming.
 The default is forever (``None``).
 
 ``settings.watching.connect_timeout`` (seconds) is how long a connection
@@ -223,7 +223,7 @@ can be established before failing. (With current aiohttp-based implementation,
 this corresponds to ``sock_connect=`` timeout, not to ``connect=`` timeout,
 which would also include the time for getting a connection from the pool.)
 
-It makes no sense to set the client-side timeout shorter than the server side
+It makes no sense to set the client-side timeout shorter than the server-side
 timeout, but it is given to the developers' responsibility to decide.
 
 The server-side timeouts are unpredictable, they can be 10 seconds or
@@ -231,8 +231,8 @@ The server-side timeouts are unpredictable, they can be 10 seconds or
 (especially since it works without timeouts defined, just produces extra logs).
 
 ``settings.watching.reconnect_backoff`` (seconds) is a backoff interval between
-watching requests -- in order to prevent API flooding in case of errors
-or disconnects. The default is 0.1 seconds (nearly instant, but not flooding).
+watching requests -- to prevent API flooding in case of errors or disconnects.
+The default is 0.1 seconds (nearly instant, but not flooding).
 
 .. code-block:: python
 
@@ -274,11 +274,11 @@ The default is the one that was hard-coded before:
 Handling progress
 =================
 
-In order to keep the handling state across multiple handling cycles, and to be
-resilient to errors and tolerable to restarts and downtimes, the operator keeps
-its state in a configured state storage. See more in :doc:`continuity`.
+To keep the handling state across multiple handling cycles, and to be resilient
+to errors and tolerable to restarts and downtimes, the operator keeps its state
+in a configured state storage. See more in :doc:`continuity`.
 
-To store the state only in the annotations with your own prefix:
+To store the state only in the annotations with a preferred prefix:
 
 .. code-block:: python
 
@@ -338,13 +338,13 @@ For this, inherit from `kopf.ProgressStorage` and implement its abstract methods
     ``kopf.StatusProgressStorage(field='status.kopf.progress')``.
 
     Starting with Kubernetes 1.16, both custom and built-in resources have
-    strict structural schemas with pruning of unknown fields
+    strict structural schemas with the pruning of unknown fields
     (more information is in `Future of CRDs: Structural Schemas`__).
 
     __ https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
 
     Long story short, unknown fields are silently pruned by Kubernetes API.
-    As a result, Kopf's status storage will not be able to actually store
+    As a result, Kopf's status storage will not be able to store
     anything in the resource, as it will be instantly lost.
     (See `#321 <https://github.com/zalando-incubator/kopf/issues/321>`_.)
 
@@ -383,7 +383,7 @@ Change detection
 
 For change-detecting handlers, Kopf keeps the last handled configuration --
 i.e. the last state that has been successfully handled. New changes are compared
-against the last handled configuration, and a diff is formed.
+against the last handled configuration, and a diff list is formed.
 
 The last-handled configuration is also used to detect if there were any
 essential changes at all -- i.e. not just the system or status fields.
@@ -405,7 +405,7 @@ The default is an equivalent of:
 The stored content is a JSON-serialised essence of the object (i.e., only
 the important fields, with system fields and status stanza removed).
 
-It is generally not a good idea to override this store, unless multiple
+It is generally not a good idea to override this store unless multiple
 Kopf-based operators must handle the same resources, and they should not
 collide with each other. In that case, they must take different names.
 
@@ -422,7 +422,7 @@ Storage transition
     will start handling each of them again -- which can lead to duplicated
     children or other side-effects.
 
-To ensure smooth transition, use a composite multi-storage, with the
+To ensure a smooth transition, use a composite multi-storage, with the
 new storage as a first child, and the old storage as the second child
 (both are used for writing, the first found value is used for reading).
 
@@ -440,7 +440,7 @@ for diff-base storage, apply this configuration:
             kopf.AnnotationsDiffBaseStorage('kopf.zalando.org/last-handled-configuration'),
         ])
 
-Run the operator for some time. Let all resources to change or force this:
+Run the operator for some time. Let all resources change or force this:
 e.g. by arbitrarily labelling them, so that a new diff-base is generated:
 
 .. code-block:: shell
@@ -453,7 +453,7 @@ Then, switch to the new storage alone, without the transitional setup.
 Error throttling
 ================
 
-To prevent uncontrollable flood of activities in case of errors that prevent
+To prevent an uncontrollable flood of activities in case of errors that prevent
 the resources being marked as handled, which could lead to Kubernetes API
 flooding, it is possible to throttle the activities on a per-resource basis:
 
@@ -476,7 +476,7 @@ The back-offs are not persisted, so they are lost on the operator restarts.
 
 These back-offs do not cover errors in the handlers -- the handlers have their
 own configurable per-handler back-off intervals. These back-offs are for Kopf
-and for Kubernetes API mostly (and other environment issues).
+and the Kubernetes API mostly (and other issues of the environment).
 
 To disable throttling (on your own risk!), set the error delays to
 an empty list (``[]``) or an empty tuple (``()``).

--- a/docs/continuity.rst
+++ b/docs/continuity.rst
@@ -7,7 +7,7 @@ Persistence
 
 Kopf does not have any database. It stores all the information directly
 on the objects in the Kubernetes cluster (which means ``etcd`` usually).
-All information is retrieved and stored via Kubernetes API.
+All information is retrieved and stored via the Kubernetes API.
 
 Specifically:
 
@@ -32,7 +32,7 @@ See how to configure the stores in :doc:`configuration`
 Restarts
 ========
 
-It is safe to kill the operator's pod (or process), and allow it to restart.
+It is safe to kill the operator's pod (or process) and allow it to restart.
 
 The handlers that succeeded previously will not be re-executed.
 The handlers that did not execute yet, or were scheduled for retrying,
@@ -49,14 +49,14 @@ Downtime
 
 If the operator is down and not running, any changes to the objects
 are ignored and not handled. They will be handled when the operator starts:
-every time a Kopf-based operator starts, it lists all objects of the served
+every time a Kopf-based operator starts, it lists all objects of the
 resource kind, and checks for their state; if the state has changed since
 the object was last handled (no matter how long time ago),
 a new handling cycle starts.
 
 Only the last state is taken into account. All the intermediate changes
 are accumulated and handled together.
-This corresponds to the Kubernetes's concept of eventual consistency
+This corresponds to Kubernetes's concept of eventual consistency
 and level triggering (as opposed to edge triggering).
 
 .. warning::
@@ -64,4 +64,4 @@ and level triggering (as opposed to edge triggering).
     as they may contain the Kopf's finalizers in ``metadata.finalizers``,
     and Kubernetes blocks the deletion until all finalizers are removed.
     If the operator is not running, the finalizers will never be removed.
-    See: :ref:`finalizers-blocking-deletion` for a work-around. 
+    See: :ref:`finalizers-blocking-deletion` for a workaround.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -7,8 +7,8 @@ Contributing
 In a nutshell, to contribute, follow this scenario:
 
 * Fork the repo in GitHub.
-* Clone your own fork.
-* Checkout a feature branch.
+* Clone the fork.
+* Check out a feature branch.
 * **Implement the changes.**
 * Sign-off your commits.
 * Create a pull request.
@@ -58,7 +58,7 @@ Git conventions
 
 The more rules you have, the less they are followed.
 
-Kopf tries to avoid any written rules, and to follow the human habits
+Kopf tries to avoid any written rules and to follow human habits
 and intuitive expectations where possible. Therefore:
 
 * Write clear and explanatory commit messages and PR titles.
@@ -76,7 +76,7 @@ DCO sign-off
 
 All contributions (including pull requests) must agree
 to the Developer Certificate of Origin (DCO) version 1.1.
-This is exactly the same one created and used by the Linux kernel developers
+This is the same one created and used by the Linux kernel developers
 and posted on http://developercertificate.org/.
 
 This is a developer's certification that they have the right to submit
@@ -86,7 +86,7 @@ Simply submitting a contribution implies this agreement.
 However, please include a "Signed-off-by" tag in every patch
 (this tag is a conventional way to confirm that you agree to the DCO):
 
-The sign-off can be either written manually, or added with `git commit -s`.
+The sign-off can be either written manually or added with `git commit -s`.
 If you contribute often, you can automate this in Kopf's repo with
 a [Git hook](https://stackoverflow.com/a/46536244/857383).
 
@@ -98,7 +98,7 @@ Common sense is the best code formatter.
 Blend your code into the surrounding code style.
 
 Kopf does not use and will never use strict code formatters
-(at least, until they acquire common sense and context awareness).
+(at least until they acquire common sense and context awareness).
 In case of doubt, adhere to PEP-8 and [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
 
 For imports, use [isort](https://github.com/PyCQA/isort)::

--- a/docs/daemons.rst
+++ b/docs/daemons.rst
@@ -2,7 +2,7 @@
 Daemons
 =======
 
-Daemons are a special type of handler for background logic that accompanies
+Daemons are a special type of handlers for background logic that accompanies
 the Kubernetes resources during their life cycle.
 
 Unlike event-driven short-running handlers declared with ``@kopf.on``,
@@ -18,7 +18,7 @@ Spawning
 ========
 
 To have a daemon accompanying a resource of some kind, decorate a function
-with ``@kopf.daemon`` and make it run for long time or forever:
+with ``@kopf.daemon`` and make it run for a long time or forever:
 
 .. code-block:: python
 
@@ -43,7 +43,7 @@ executed directly in the asyncio event loop of the operator -- same as with
 regular handlers. See :doc:`async`.
 
 The same executor is used both for regular sync handlers and for sync daemons.
-If you expect large number of synchronous daemons (e.g. for large clusters),
+If you expect a large number of synchronous daemons (e.g. for large clusters),
 make sure to pre-scale the executor accordingly.
 See :doc:`configuration` (:ref:`configure-sync-handlers`).
 
@@ -94,7 +94,7 @@ it is cancelled when the operator exits and stops all "hung" left-over tasks
 .. note::
 
     The MUST_ / SHOULD_ separation is due to Python having no way to terminate
-    a thread unless the thread exits by its own. The :kwarg:`stopped` flag
+    a thread unless the thread exits on its own. The :kwarg:`stopped` flag
     is a way to signal the thread it should exit. If :kwarg:`stopped` is not
     checked, the synchronous daemons will run forever or until an error happens.
 
@@ -118,7 +118,7 @@ The termination sequence parameters can be controlled when declaring a daemon:
         while not stopped:
             await asyncio.sleep(1)
 
-There are three stages how the daemon is terminated:
+There are three stages of how the daemon is terminated:
 
 * 1. Graceful termination:
   * ``stopped`` is set immediately (unconditionally).
@@ -140,9 +140,9 @@ The total termination time is ``cancellation_backoff + cancellation_timeout``.
 
 .. warning::
 
-    When the operator is exiting, it has its own timeout of 5 seconds
+    When the operator is terminating, it has its timeout of 5 seconds
     for all "hung" tasks. This includes the daemons after they are requested
-    to exit gracefully and all timeouts are reached.
+    to finish gracefully and all timeouts are reached.
 
     If the daemon termination takes longer than this for any reason,
     the daemon will be cancelled (by the operator, not by the daemon guard)
@@ -230,8 +230,8 @@ Restarting
 ==========
 
 It is generally expected that daemons are designed to run forever.
-However, it is possible for a daemon to exit prematurely, i.e. before
-the resource is deleted or the operator is exiting.
+However, a daemon can exit prematurely, i.e. before the resource is deleted
+or the operator terminates.
 
 In that case, the daemon will not be restarted again during the lifecycle
 of this resource in this operator process (however, it will be spawned again
@@ -306,8 +306,8 @@ and will not be updated as the object changes.
 Results delivery
 ================
 
-As with any other handlers, it is possible for the daemons to return
-arbitrary JSON-serializable values to be put on the resource's status:
+As with any other handlers, the daemons can return arbitrary JSON-serializable
+values to be put on the resource's status:
 
 .. code-block:: python
 
@@ -376,8 +376,8 @@ The criteria themselves are not re-evaluated if nothing changes.
 
 .. warning::
 
-    A daemon that is being terminated is considered as still running, therefore
-    it will not be re-spawned until the termination ends. It will be re-spawned
+    A daemon that is terminating is considered as still running, therefore
+    it will not be re-spawned until it fully terminates. It will be re-spawned
     the next time a watch-event arrives after the daemon has truly exited.
 
 
@@ -387,12 +387,12 @@ System resources
 .. warning::
 
     A separate OS thread or asyncio task is started
-    for each individual resource and each individual handler.
+    for each resource and each handler.
 
     Having hundreds or thousands of OS threads or asyncio tasks can consume
     system resources significantly. Make sure you only have daemons and timers
     with appropriate filters (e.g., by labels, annotations, or so).
 
     For the same reason, prefer to use async handlers (with properly designed
-    async/await code), since asyncio tasks are a somewhat cheaper than threads.
+    async/await code), since asyncio tasks are somewhat cheaper than threads.
     See :doc:`async` for details.

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -23,7 +23,7 @@ First of all, the operator must be packaged as a docker image with Python 3.7:
 
 Build and push it to some repository of your choice.
 Here, we will use DockerHub_
-(with a personal account "nolar" -- replace it with your own name or namespace;
+(with a personal account "nolar" -- replace it with your name or namespace;
 you may also want to add the versioning tags instead of the implied "latest"):
 
 .. code-block:: bash
@@ -92,7 +92,7 @@ and attached to the operator's pod via a service account.
 
 .. _RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 
-Here is an example of what a RBAC config should look like
+Here is an example of what an RBAC config should look like
 (remove the parts which are not needed: e.g. the cluster roles/bindings
 for the strictly namespace-bound operator):
 

--- a/docs/embedding.rst
+++ b/docs/embedding.rst
@@ -13,7 +13,7 @@ Manual orchestration
 ====================
 
 Since Kopf is fully asynchronous, the best way to run Kopf is to provide
-an event-loop specially for Kopf in a separate thread, while running
+an event-loop dedicated to Kopf in a separate thread, while running
 the main application in the main thread.
 
 .. code-block:: python
@@ -37,7 +37,7 @@ the main application in the main thread.
         # ...
         thread.join()
 
-In case of :command:`kopf run`, the main application is Kopf itself,
+In the case of :command:`kopf run`, the main application is Kopf itself,
 so its event-loop runs in the main thread.
 
 .. note::
@@ -55,7 +55,7 @@ themselves. The example above is an equivalent of the following:
         tasks = loop.run_until_complete(kopf.spawn_tasks())
         loop.run_until_complete(kopf.run_tasks(tasks, return_when=asyncio.FIRST_COMPLETED))
 
-Or, if proper cancellation and termination is not expected, of the following:
+Or, if proper cancellation and termination are not expected, of the following:
 
 .. code-block:: python
 
@@ -103,7 +103,7 @@ in :mod:`contextvars` containers with values isolated per-loop and per-task.
 
 
 .. warning::
-    It is not recommended to run Kopf in the same event-loop with other routines
+    It is not recommended to run Kopf in the same event-loop as other routines
     or applications: it considers all tasks in the event-loop as spawned by its
     workers and handlers, and cancels them when it exits.
 

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -39,7 +39,7 @@ from being handled (such as deletion or parallel handlers/sub-handlers).
     as to be retried immediately, where it continues with the remaining
     handlers.
 
-    The only difference is that this special case produces less logs.
+    The only difference is that this special case produces fewer logs.
 
 
 Permanent errors
@@ -60,7 +60,7 @@ is no need to retry over time, as it will not become better::
             raise kopf.PermanentError("The object is not valid anymore.")
 
 See also: :ref:`never-again-filters` to prevent handlers from being invoked
-for the future change-sets even after operator restarts.
+for the future change-sets even after the operator restarts.
 
 
 Regular errors
@@ -68,9 +68,9 @@ Regular errors
 
 Kopf assumes that any arbitrary errors
 (i.e. not `TemporaryError` and not `PermanentError`)
-are environment issues and can self-resolve after some time.
+are the environment's issues and can self-resolve after some time.
 
-As such, as a default behaviour,
+As such, as default behaviour,
 Kopf retries the handlers with arbitrary errors
 infinitely until the handlers either succeed or fail permanently.
 

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -28,7 +28,7 @@ for the handled objects as Kubernetes events::
                    reason='SomeReason',
                    message='Some message')
 
-The type and reason are arbitrary, and can be anything.
+The type and reason are arbitrary and can be anything.
 Some restrictions apply (e.g. no spaces).
 The message is also arbitrary free-text.
 However, newlines are not rendered nicely
@@ -91,7 +91,7 @@ at the moment (and not event the children)::
 .. note::
     Events are not persistent.
     They are usually garbage-collected after some time, e.g. one hour.
-    All the reported information must be only for a short-term use.
+    All the reported information must be only for short-term use.
 
 
 Events for events

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -14,11 +14,11 @@ There are only a few kinds of checks:
 
 * Specific values -- expressed with Python literals such as ``"a string"``.
 * Presence of values -- with special markers ``kopf.PRESENT/kopf.ABSENT``.
-* Per-value callbacks -- with anything callable and evaluatable to true/false.
-* Whole-body callbacks -- with anything callable and evaluatable to true/false.
+* Per-value callbacks -- with anything callable which evaluates to true/false.
+* Whole-body callbacks -- with anything callable which evaluates to true/false.
 
 But there are multiple places where these checks can be applied,
-each has its own specifics.
+each has its specifics.
 
 
 Metadata filters
@@ -63,7 +63,7 @@ i.e. they are considered as present on the resource.
 Field filters
 =============
 
-Specific fields can be checked for specific values or for presence/absence,
+Specific fields can be checked for specific values or presence/absence,
 similar to the metadata filters:
 
 .. code-block:: python
@@ -97,8 +97,8 @@ with any value (for update handlers: present before or after the change).
 
 Since the field name is part of the handler id (e.g., ``"fn/spec.field"``),
 multiple decorators can be defined to react to different fields with the same
-function, and it will be invoked multiple times with different old & new values
-relevant to the specified fields, so as different :kwarg:`param`:
+function and it will be invoked multiple times with different old & new values
+relevant to the specified fields, so as different values of :kwarg:`param`:
 
 .. code-block:: python
 
@@ -111,7 +111,7 @@ However, different causes --mostly resuming + one of creation/update/deletion--
 will not be distinguished, so e.g. resume+create pair with the same field
 will be called only once.
 
-Due to a special nature of the update handlers (``@on.update``, ``@on.field``),
+Due to the special nature of update handlers (``@on.update``, ``@on.field``),
 described in a note below, this filtering semantics is extended for them:
 
 The ``field=`` filter restricts the update-handlers to cases when the specified
@@ -137,7 +137,7 @@ the transitioning resource still satisfies the filter in its "old" state.
     in-between the old and new states, and therefore belong to both of them.
 
     **In general,** the resource-changing handlers are an abstraction on top
-    of the low level K8s machinery for eventual processing of such state
+    of the low-level K8s machinery for eventual processing of such state
     transitions, so their semantics can differ from K8s's low-level semantics.
     In most cases, this is not visible or important to the operator developers,
     except for such cases, where it might affect the semantics of e.g. filters.
@@ -225,7 +225,7 @@ Instead of specific values or special markers, all the value-based filters can
 use arbitrary per-value callbacks (as an advanced use-case for advanced logic).
 
 The value callbacks must receive the same :doc:`keyword arguments <kwargs>`
-as the respective handlers (with ``**kwargs/**_`` for forward compatibility),
+as the respective handlers (with ``**kwargs/**_`` for forwards compatibility),
 plus one *positional* (not keyword!) argument with the value being checked.
 The passed value will be ``None`` if the value is absent in the resource.
 
@@ -245,7 +245,7 @@ Callback filters
 ================
 
 The resource callbacks must receive the same :doc:`keyword arguments <kwargs>`
-as the respective handlers (with ``**kwargs/**_`` for forward compatibility).
+as the respective handlers (with ``**kwargs/**_`` for forwards compatibility).
 
 .. code-block:: python
 
@@ -313,7 +313,7 @@ Stealth mode
 
     As the result, when the object is updated to match the filters some time
     later (e.g. by putting labels/annotations on it, or changing its spec),
-    this will not be considered as an update, but as a creation.
+    this will not be considered as an update but as a creation.
 
     From the operator's point of view, the object has suddenly appeared
     in sight with no diff-base, which means that it is a newly created object;

--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -23,7 +23,7 @@ More on that, since Kopf stores the state of the handlers on the object itself,
 these state changes also cause the events, which are seen by the operators
 and any other watchers.
 
-To hide the complexity of the state storing, Kopf provides the cause detection:
+To hide the complexity of the state storing, Kopf provides a cause detection:
 whenever an event happens for the object, the framework detects what happened
 actually, as follows:
 
@@ -57,7 +57,7 @@ Low-level events can be intercepted and handled silently, without
 storing the handlers' status (errors, retries, successes) on the object.
 
 This can be useful if the operator needs to watch over the objects
-of another operator or controller, without adding its own data.
+of another operator or controller, without adding its data.
 
 The following event-handler is available::
 
@@ -84,7 +84,7 @@ State-changing handlers
 =======================
 
 Kopf goes further and beyond: it detects the actual causes of these events,
-i.e. what actually happened to the object:
+i.e. what happened to the object:
 
 * Was the object just created?
 * Was the object deleted (marked for deletion)?
@@ -94,7 +94,7 @@ i.e. what actually happened to the object:
 .. note::
     Worth noting that Kopf stores the status of the handlers, such as their
     progress or errors or retries, in the object itself (``.status`` stanza),
-    which triggers its own low-level events, but these events are not detected
+    which triggers its low-level events, but these events are not detected
     as separate causes, as there is nothing changed *essentially*.
 
 The following 3 core cause-handlers are available::
@@ -116,9 +116,9 @@ The following 3 core cause-handlers are available::
 .. note::
     Kopf's finalizers will be added to the object when there are delete
     handlers specified. Finalizers block Kubernetes from fully deleting
-    objects, and Kubernetes will only actually delete objects when all
+    objects and Kubernetes will only actually delete objects when all
     finalizers are removed, i.e. only if the Kopf operator is running to
-    remove them (check: :ref:`finalizers-blocking-deletion` for a work-around).
+    remove them (check: :ref:`finalizers-blocking-deletion` for a workaround).
     If a delete handler is added but finalizers are not required to block the
     actual deletion, i.e. the handler is optional, the optional argument
     ``optional=True`` can be passed to the delete cause decorator.
@@ -127,7 +127,7 @@ The following 3 core cause-handlers are available::
 Resuming handlers
 =================
 
-An special kind of handlers can be used for cases when the operator restarts
+A special kind of handlers can be used for cases when the operator restarts
 and detects an object that existed before::
 
     @kopf.on.resume('kopfexamples')
@@ -140,7 +140,7 @@ With the resuming handler in addition to creation/update/deletion handlers,
 no object will be left unattended even if it does not change over time.
 
 The resuming handlers are guaranteed to execute only once per operator
-life time for each individual resource (except if errors are retried).
+lifetime for each resource object (except if errors are retried).
 
 Normally, the resume handlers are mixed-in to the creation and updating
 handling cycles, and are executed in the order they are declared.
@@ -192,7 +192,7 @@ with ``deleted=True`` option::
         pass
 
 In that case, both the deletion and resuming handlers will be invoked. It is
-the developer's responsibility to ensure this does not lead to the memory leaks.
+the developer's responsibility to ensure this does not lead to memory leaks.
 
 
 Field handlers

--- a/docs/hierarchies.rst
+++ b/docs/hierarchies.rst
@@ -4,7 +4,7 @@ Hierarchies
 
 One of the most common patterns of the operators is to create
 children resources in the same Kubernetes cluster.
-Kopf provides some tools to simplify connecting these resources together
+Kopf provides some tools to simplify connecting these resources
 by manipulating their content before it is sent to the Kubernetes API.
 
 .. note::
@@ -196,7 +196,7 @@ being processed at the moment, omit the name or set it to ``None``
 
 Alternatively, the operator can request Kubernetes to generate a name
 with the specified prefix and a random suffix (via ``metadata.generateName``).
-The actual name will be known only after the resource is actually created:
+The actual name will be known only after the resource is created:
 
 .. code-block:: python
 

--- a/docs/idempotence.rst
+++ b/docs/idempotence.rst
@@ -10,8 +10,8 @@ to schedule arbitrary sub-handlers for the execution in the current cycle.
 `kopf.execute` coroutine executes arbitrary sub-handlers
 directly in the place of invocation, and returns when all they have succeeded.
 
-Every of the sub-handlers is tracked by Kopf, and will not be executed twice
-within one handling cycle.
+Every one of the sub-handlers is tracked by Kopf, and will not be executed
+twice within one handling cycle.
 
 .. code-block:: python
 
@@ -43,11 +43,11 @@ and the main handler succeeds too.
 The first one, ``create_a``, will succeed on the 3rd attempt after ~20s.
 The second one, ``create_b``, will succeed only on the 7th attempt after ~60s.
 
-However, despite ``create_a`` will be submitted every time when ``create``
+However, despite ``create_a`` will be submitted whenever ``create``
 and ``create_b`` are retried, it will not be executed in the 20s..60s range,
 as it has succeeded already, and the record about this is stored on the object.
 
-This approach can be used to perform operations, which needs the protection
+This approach can be used to perform operations, which needs protection
 from double-execution, such as the children object creation with randomly
 generated names (e.g. Pods, Jobs, PersistentVolumeClaims, etc).
 

--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -361,7 +361,7 @@ as they are capable of delaying the operator startup and resource processing.
 For this reason, in case of errors in handlers, the handlers are never retried.
 
 Arbitrary exceptions with ``errors=IGNORED`` (the default) make the framework
-to ignore the error and keep the existing indexed values (which are now stale).
+ignore the error and keep the existing indexed values (which are now stale).
 It means that the new values are expected to appear soon, but the old values
 are good enough meanwhile (which is usually highly probable). This is the same
 as returning ``None``, except that the exception's stack trace is logged too:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ To install Kopf::
     pip install kopf
 
 If you use some of the managed Kubernetes services which require a sophisticated
-authentication beyond username+password, fixed tokens, or client ssl certs
+authentication beyond username+password, fixed tokens, or client SSL certs
 (also see :ref:`authentication piggy-backing <auth-piggybacking>`)::
 
     pip install kopf[full-auth]

--- a/docs/kwargs.rst
+++ b/docs/kwargs.rst
@@ -87,11 +87,11 @@ Operator configuration
 
 ``settings`` is passed to activity handlers (but not to resource handlers).
 
-It is an object with predefined nested structure of containers with values,
+It is an object with a predefined nested structure of containers with values,
 which defines the operator's behaviour. See also: `kopf.OperatorSettings`.
 
 It can be modified if needed (usually in the startup handlers). Every operator
-(if there are more than one in the same process) has its own config.
+(if there are more than one in the same process) has its config.
 
 See also: :doc:`configuration`.
 
@@ -143,7 +143,7 @@ Logging
 namespace/name.
 
 Some of the log messages are also sent as Kubernetes events according to the
-log level configuration (default is INFO, WARNINGs, ERRORs).
+log-level configuration (default is INFO, WARNINGs, ERRORs).
 
 
 .. kwarg:: patch
@@ -167,7 +167,7 @@ The values can be accessed as either object attributes or dictionary keys.
 
 For resource handlers, ``memo`` is shared by all handlers of the same
 individual resource (not of the resource kind, but of the resource object).
-For operator handlers, ``memo`` is shared by all handlers of the same operator,
+For operator handlers, ``memo`` is shared by all handlers of the same operator
 and later used to populate the resources' ``memo`` containers.
 
 .. seealso::
@@ -183,7 +183,7 @@ In-memory indices
 Indices are in-memory overviews of matching resources in the cluster.
 They are populated according to ``@kopf.index`` handlers and their filters.
 
-Each individual index is exposed in kwargs under its own name (function name)
+Each index is exposed in kwargs under its name (function name)
 or id (if overridden with ``id=``). There is no global structure to access
 all indices at once. If needed, use ``**kwargs`` itself.
 
@@ -213,7 +213,7 @@ it is a dict with ``['type']`` & ``['object']`` keys.
 Resource-changing kwargs
 ========================
 
-Kopf provides functionality for change detection, and triggers the handlers
+Kopf provides functionality for change detection and triggers the handlers
 for those changes (not for every event coming from the Kubernetes API).
 Few extra kwargs are provided for these handlers, exposing the detected changes:
 

--- a/docs/loading.rst
+++ b/docs/loading.rst
@@ -5,7 +5,7 @@ Kopf requires the source files with the handlers on the command line.
 It does not do any attempts to guess the user's intentions
 or to introduce any conventions (at least, now).
 
-There are two way to specify them (both mimicking the Python's own way):
+There are two ways to specify them (both mimicking the Python interpreter):
 
 * Direct script files::
 
@@ -20,7 +20,7 @@ There are two way to specify them (both mimicking the Python's own way):
     kopf run file1.py file2.py -m package1.module1 -m package2.module2
 
 Which way to use depends on how the source code is structured,
-and is out of scope of Kopf.
+and is out of the scope of Kopf.
 
 Each of the mentioned files and modules will be imported.
 The handlers should be registered during the import.

--- a/docs/memos.rst
+++ b/docs/memos.rst
@@ -2,7 +2,7 @@
 In-memory containers
 ====================
 
-Kopf prodives several ways of storing and exchanging the data in-memory
+Kopf provides several ways of storing and exchanging the data in-memory
 between handlers and operators.
 
 
@@ -14,7 +14,7 @@ It is an in-memory container for arbitrary runtime-only keys-values.
 The values can be accessed as either object attributes or dictionary keys.
 
 The memo is shared by all handlers of the same individual resource
-(not of the resource kind, but of a resource object).
+(not of the resource kind, but a resource object).
 If the resource is deleted and re-created with the same name,
 the memo is also re-created (technically, it is a new resource).
 
@@ -74,7 +74,7 @@ or passed from outside of the operator when :doc:`embedding` is used, or both:
     The mixed style here is for demonstration purposes only.
 
 The operator's memo is later used to populate the per-resource memos.
-All keys & values are shallow-copied into each individual resource's memo,
+All keys & values are shallow-copied into each resource's memo,
 where they can be mixed with the per-resource values:
 
 .. code-block:: python
@@ -86,14 +86,14 @@ where they can be mixed with the per-resource values:
             memo.my_queue.put(f"{namespace}/{name}")
             memo.is_seen = True
 
-Any changes to the operator's container since the first appearence
+Any changes to the operator's container since the first appearance
 of the resource are **not** replicated to the existing resources' containers,
 and are not guaranteed to be seen by the new resources (even if they are now).
 
 However, due to shallow copying, the mutable objects (lists, dicts, and even
 custom instances of :class:`kopf.Memo` itself) in the operator's container
 can be modified from outside, and these changes will be seen in all individual
-resource handlers & daemons which use their own per-resource containers.
+resource handlers & daemons which use their per-resource containers.
 
 
 Custom memo classes
@@ -158,8 +158,8 @@ to the process lifetime, such as concurrency primitives: locks, tasks, threadsâ€
 For persistent values, use the status stanza or annotations of the resources.
 
 Essentially, the operator's memo is not much different from global variables
-(unless there are 2+ embedded operator tasks running) or asyncio contextvars,
-except that it provides the same interface as for per-resource memos.
+(unless 2+ embedded operator tasks are running there) or asyncio contextvars,
+except that it provides the same interface as for the per-resource memos.
 
 .. seealso::
 

--- a/docs/naming.rst
+++ b/docs/naming.rst
@@ -8,7 +8,7 @@ Kopf is an abbreviation either for
 
 "Kopf" also means "head" in German.
 
-It is capitalised in all natural language texts:
+It is capitalised in natural language texts:
 
     *I like using Kopf to manage my domain in Kubernetes.*
 

--- a/docs/peering.rst
+++ b/docs/peering.rst
@@ -14,7 +14,7 @@ notices that other operators start with a higher priority, it pauses
 its operation until those operators stop working.
 
 This is done to prevent collisions of multiple operators handling
-the same objects. If two operators runs with the same priority, all operators
+the same objects. If two operators run with the same priority, all operators
 issue a warning and pause, so that the cluster is not served anymore.
 
 To set the operator's priority, use :option:`--priority`:
@@ -49,7 +49,7 @@ Kopf automatically chooses which one to use, depending on whether
 the operator is restricted to a namespace with :option:`--namespace`,
 or it is running cluster-wide with :option:`--all-namespaces`.
 
-Create the peering objects as needed with one of:
+Create a peering object as needed with one of:
 
 .. code-block:: yaml
 
@@ -68,10 +68,10 @@ Create the peering objects as needed with one of:
 
 .. note::
 
-    In ``kopf<0.11`` (until May'2019), ``KopfPeering`` was the only CRD,
-    and it was cluster-scoped. In ``kopf>=0.11,<1.29`` (until Dec'2020),
+    In ``kopf<0.11`` (until May 2019), ``KopfPeering`` was the only CRD,
+    and it was cluster-scoped. In ``kopf>=0.11,<1.29`` (until Dec 2020),
     this mode was deprecated but supported if the old CRD existed.
-    Since ``kopf>=1.29`` (Jan'2021), it is not supported anymore.
+    Since ``kopf>=1.29`` (Jan 2021), it is not supported anymore.
     To upgrade, delete and re-create the peering CRDs to the new ones.
 
 .. note::
@@ -107,10 +107,10 @@ Or:
 Depending on :option:`--namespace` or :option:`--all-namespaces`,
 either ``ClusterKopfPeering`` or ``KopfPeering`` will be used automatically.
 
-If the peering object does not exist, the operator will pause at start.
+If the peering object does not exist, the operator will pause at the start.
 Using :option:`--peering` assumes that the peering is mandatory.
 
-Please note that in the startup handler, this is not exactly the same:
+Please note that in the startup handler, this is not the same:
 the mandatory mode must be set explicitly. Otherwise, the operator will try
 to auto-detect the presence of the custom peering object, but will not pause
 if it is absent -- unlike with the ``--peering=`` CLI option.
@@ -148,9 +148,9 @@ for the same events.
 Automatic peering
 =================
 
-If there is a peering object detected with name `default` (either
-cluster-scoped or namespace-scoped), then it is used by default
-as the peering object.
+If there is a peering object detected with the name ``default``
+(either cluster-scoped or namespace-scoped),
+then it is used by default as the peering object.
 
 Otherwise, Kopf will run the operator in the standalone mode.
 
@@ -165,7 +165,7 @@ will stop until the operator's pod is restarted (and if restarted at all).
 To start multiple operator pods, they must be distinctly prioritised.
 In that case, only one operator will be active --- the one with the highest
 priority. All other operators will pause and wait until this operator exits.
-Once it dies, the second highest priority operator will come into play.
+Once it dies, the second-highest priority operator will come into play.
 And so on.
 
 For this, assign a monotonically growing or random priority to each
@@ -195,14 +195,14 @@ You can also use the pod's IP address in its numeric form as the priority,
 or any other source of integers.
 
 
-Stealth keep-alives
-===================
+Stealth keep-alive
+==================
 
 Every few seconds (60 by default), the operator will send a keep-alive update
 to the chosen peering, showing that it is still functioning. Other operators
 will notice that and make decisions on their pausing or resuming.
 
-The operator also logs a keep-alive activity to its own logs. This can be
+The operator also logs a keep-alive activity to its logs. This can be
 distracting. To disable:
 
 .. code-block:: python
@@ -216,4 +216,4 @@ distracting. To disable:
 
 There is no equivalent CLI option for that.
 
-Please note that it only affects logging. The keep-alive are sent anyway.
+Please note that it only affects logging. The keep-alive is sent anyway.

--- a/docs/probing.rst
+++ b/docs/probing.rst
@@ -49,7 +49,7 @@ __ https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-r
 .. seealso::
 
     Please be aware of the readiness vs. liveness probing.
-    In case of operators, readiness probing makes no practical sense,
+    In the case of operators, readiness probing makes no practical sense,
     as operators do not serve traffic under the load balancing or with services.
     Liveness probing can help in disastrous cases (e.g. the operator is stuck),
     but will not help in case of partial failures (one of the API calls stuck).
@@ -83,7 +83,7 @@ probing handlers:
         return random.randint(0, 1_000_000)
 
 The probe handlers will be executed on the requests to the liveness URL,
-and cached for a reasonable period of time to prevent overloading
+and cached for a reasonable time to prevent overloading
 by mass-requesting the status.
 
 The handler results will be reported as the content of the liveness response:
@@ -94,13 +94,13 @@ The handler results will be reported as the content of the liveness response:
     {"now": "2019-11-07T18:03:52.513803", "random": 765846}
 
 .. note::
-    Liveless status report is simplistic and minimalistic at the moment.
+    The liveness status report is simplistic and minimalistic at the moment.
     It only reports success if the health-reporting task runs at all.
     It can happen so that some of the operator's tasks, threads, or streams
     do break, freeze, or become unresponsive, while the health-reporting task
-    continues to run. The probability of such case is low, but not zero.
+    continues to run. The probability of such a case is low, but not zero.
 
-    There are no checks that operator actually operates anything
+    There are no checks that the operator operates anything
     (unless they are implemented explicitly with the probe-handlers),
     as there are no reliable criteria for that -- total absence of handled
     resources or events can be an expected state of the cluster.

--- a/docs/reconciliation.rst
+++ b/docs/reconciliation.rst
@@ -14,7 +14,7 @@ Therefore, it knows nothing about the *desired state* or *actual state*
 Kopf-based operators must implement the checks and reactions to the changes,
 so that both states are synchronised according to the operator's concepts.
 
-Kopf only provides few ways and tools of achieving this easily.
+Kopf only provides a few ways and tools fir achieving this easily.
 
 
 Event-driven reactions
@@ -22,15 +22,15 @@ Event-driven reactions
 
 Normally, Kopf triggers the on-creation/on-update/on-deletion handlers
 every time anything changes on the object, as reported by Kubernetes API.
-It provides both the current state of the object, and a diff with the last
-handled state.
+It provides both the current state of the object and a diff list
+with the last handled state.
 
 The event-driven approach is the best, as it saves system resources (RAM & CPU),
-and does not trigger any activity when it is not needed, and does not consume
+and does not trigger any activity when it is not needed and does not consume
 memory for keeping the object's last known state permanently in memory.
 
 But it is more difficult to develop, and is not suitable for some cases:
-e.g., when an external non-Kubernetes system is monitored via its own API.
+e.g., when an external non-Kubernetes system is monitored via its API.
 
 .. seealso::
     :doc:`handlers`
@@ -39,10 +39,10 @@ e.g., when an external non-Kubernetes system is monitored via its own API.
 Regularly scheduled timers
 ==========================
 
-Timers are triggered on regular schedule, regardless of whether anything
+Timers are triggered on a regular schedule, regardless of whether anything
 changes or does not change in the resource itself. This can be used to
 verify both the resource's body, and the state of other related resources
-though API calls, and update the original resource's status/content.
+through API calls, and update the original resource's status/content.
 
 .. seealso::
     :doc:`timers`
@@ -51,7 +51,7 @@ though API calls, and update the original resource's status/content.
 Permanently running daemons
 ===========================
 
-As a last resort, a developer can implement their own background task,
+As a last resort, a developer can implement a background task,
 which checks the status of the system and reacts when the "actual" state
 diverts from the "desired" state.
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -51,7 +51,7 @@ to an empty API group name. The following specifications are equivalent:
     def fn(**_):
         pass
 
-If neither API group nor API version are specified,
+If neither the API group nor the API version is specified,
 all resources with that name would match regardless of the API groups/versions.
 However, it is reasonable to expect only one:
 
@@ -65,7 +65,7 @@ However, it is reasonable to expect only one:
 
 In all examples above, where the resource identifier is expected, it can be
 any name: plural, singular, kind, or a short name. As it is impossible to guess
-which one is which, the name is rememebered as is, and is later checked for all
+which one is which, the name is remembered as is, and is later checked for all
 possible names of the specific resources once those are discovered:
 
 .. code-block:: python
@@ -115,7 +115,7 @@ of the mandatory resource name:
     def fn(**_):
         pass
 
-As a consequence of the above, to handle each and every resource in the cluster
+As a consequence of the above, to handle every resource in the cluster
 -- which might be not the best idea per se, but is technically possible --
 omit the API group/version, and use the marker only:
 
@@ -165,7 +165,7 @@ if there are some accidental overlaps in the specifications.
 
     This only applies to resource specifications where it is intended to have
     a specific resource by its name; specifications with intentional
-    multi-resource mode are served as usualy (e.g. by categories).
+    multi-resource mode are served as usually (e.g. by categories).
 
     However, ``v1`` resources have priority over all other resources. This
     resolves the conflict of ``pods.v1`` vs. ``pods.v1beta1.metrics.k8s.io``,

--- a/docs/scopes.rst
+++ b/docs/scopes.rst
@@ -38,7 +38,7 @@ because it does not match the initial decisive glob::
 
     kopf run --namespace=myapp-*,!*-pr-*,*-pr-123 ...
 
-In all cases, the operator monitors the namespaces that exist at startup
+In all cases, the operator monitors the namespaces that exist at the startup
 or are created/deleted at runtime, and starts/stops serving them accordingly.
 
 If there are no permissions to list/watch the namespaces, the operator falls
@@ -50,7 +50,7 @@ If a namespace does not exist, `Kubernetes permits watching over it anyway`__.
 The only difference is when the resource watching starts: if the permissions
 are sufficient, the watching starts only after the namespace is created;
 if not sufficient, the watching starts immediately (for an unexistent namespace)
-and the resources will be actually served once that namespace is created.
+and the resources will be served once that namespace is created.
 
 __ https://github.com/kubernetes/kubernetes/issues/75537
 

--- a/docs/shutdown.rst
+++ b/docs/shutdown.rst
@@ -3,7 +3,7 @@ Shutdown
 ========
 
 The cleanup handlers are executed when the operator exits
-either by a signal (e.g. SIGTERM), or by catching an exception,
+either by a signal (e.g. SIGTERM) or by catching an exception,
 or by raising the stop-flag, or by cancelling the operator's task
 (for :doc:`embedded operators </embedding>`)::
 
@@ -16,7 +16,7 @@ or by raising the stop-flag, or by cancelling the operator's task
 The cleanup handlers are not guaranteed to be fully executed if they take
 too long -- due to a limited graceful period or non-graceful termination.
 
-Similarly, the cleanup handlers are not executed if the operator
+Similarly, the clean up handlers are not executed if the operator
 is force-killed with no possibility to react (e.g. by SIGKILL).
 
 .. note::

--- a/docs/startup.rst
+++ b/docs/startup.rst
@@ -19,7 +19,7 @@ the loop-bound variables -- which is impossible in the module-level code::
         global LOCK
         LOCK = asyncio.Lock()  # uses the running asyncio loop by default
 
-If any of the startup handlers fails, the operator fails to start
+If any of the startup handlers fail, the operator fails to start
 without making any external API calls.
 
 .. note::

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -13,7 +13,7 @@ Background runner
 while the original testing thread does the object manipulation and assertions:
 
 When the ``with`` block exits, the operator stops, and its exceptions,
-exit code, and output are available to the test (for additional assertions).
+exit code and output are available to the test (for additional assertions).
 
 .. code-block:: python
     :caption: test_example_operator.py

--- a/docs/timers.rst
+++ b/docs/timers.rst
@@ -28,7 +28,7 @@ Sharpness
 
 Usually (by default), the timers are invoked with the specified interval
 between each call. The time taken by the handler itself is not taken into
-account. It is possible to define timers with sharp schedule: i.e. invoked
+account. It is possible to define timers with a sharp schedule: i.e. invoked
 every number of seconds sharp, no matter how long it takes to execute it:
 
 .. code-block:: python
@@ -61,15 +61,16 @@ be invoked when it is stable for some time:
     def ping_kex(spec, **kwargs):
         print(f"FIELD={spec['field']}")
 
-Creation of a resource is considered as a change, so idling also shifts
+The creation of a resource is considered as a change, so idling also shifts
 the very first invocation by that time.
 
 The default is to have no idle time, just the intervals.
 
 It is possible to have a timer with both idling and interval. In that case,
-the timer will be invoked only if there were no changes for specified duration
-(idle), and every N seconds after that (interval), as long as the object does
-not change. Once changed, the timer will stop and wait for the new idling time:
+the timer will be invoked only if there were no changes in the resource
+for the specified duration (idle time),
+and every N seconds after that (interval) as long as the object does not change.
+Once changed, the timer will stop and wait for the new idling time:
 
 .. code-block:: python
 
@@ -106,7 +107,7 @@ resource/operator lifecycle in the very beginning.
 Combined timing
 ===============
 
-It is possible to combine all schedule intervals to achieve the desired effect.
+It is possible to combine all scheduled intervals to achieve the desired effect.
 For example, to give an operator 1 minute for warming up, and then pinging
 the resources every 10 seconds if they are unmodified for 10 minutes:
 

--- a/docs/vision.rst
+++ b/docs/vision.rst
@@ -10,19 +10,19 @@ __ https://www.google.com/search?q=kubernetes+standard+de+facto&oq=kuerbenetes+s
 Kubernetes operators have become a common way to extend Kubernetes
 with domain objects and domain logic.
 
-At the moment (2018-2019), operators are mostly written in Go,
-and require the advanced knowledge both of Go and of Kubernetes internals.
+At the moment (2018-2019), operators are mostly written in Go
+and require advanced knowledge both of Go and Kubernetes internals.
 This raises the entry barrier to the operator development field.
 
 In a perfect world of Kopf, Kubernetes operators are a commodity,
 used to build the domain logic on top of Kubernetes fast and with ease,
-requiring little or no skills in the infrastructure management.
+requiring little or no skills in infrastructure management.
 
 For this, Kopf hides the low-level infrastructure details from the user
 (i.e. the operator developer),
 exposing only the APIs and DSLs needed to express the user's domain.
 
-In addition, Kopf does this in one of the widely used, easy to learn
+Besides, Kopf does this in one of the widely used, easy to learn
 programming languages: Python.
 
 But Kopf does not go too far in abstracting the Kubernetes internals away:

--- a/docs/walkthrough/cleanup.rst
+++ b/docs/walkthrough/cleanup.rst
@@ -2,7 +2,7 @@
 Cleanup
 =======
 
-To cleanup the cluster after all the experiments are finished:
+To clean up the cluster after all the experiments are finished:
 
 .. code-block:: bash
 

--- a/docs/walkthrough/creation.rst
+++ b/docs/walkthrough/creation.rst
@@ -4,7 +4,7 @@ Creating the objects
 
 Previously (:doc:`starting`),
 we have created a skeleton operator and learned to start it and see the logs.
-Now, let's add few meaningful reactions to solve our problem (:doc:`problem`).
+Now, let's add a few meaningful reactions to solve our problem (:doc:`problem`).
 
 We want to create a real ``PersistentVolumeClaim`` object
 immediately when an ``EphemeralVolumeClaim`` is created this way:
@@ -93,7 +93,7 @@ Wait 1-2 seconds, and take a look:
 Now, the PVC can be attached to the pods by the same name, as EVC is named.
 
 .. note::
-    If you have to re-run the operator, and hit a HTTP 409 error saying
+    If you have to re-run the operator and hit an HTTP 409 error saying
     "persistentvolumeclaims "my-claim" already exists",
     then remove it manually:
 

--- a/docs/walkthrough/deletion.rst
+++ b/docs/walkthrough/deletion.rst
@@ -21,7 +21,7 @@ Or maybe not.
 
 We want to make sure the child PVC is deleted when the parent EVC is deleted.
 
-The straighforward way would be to implement a deletion handler
+The straightforward way would be to implement a deletion handler
 with `kopf.on.delete`. But we will go another way, and use the
 built-in feature of Kubernetes: `the owner references`__.
 
@@ -65,11 +65,11 @@ Let's extend the creation handler:
         return {'pvc-name': obj.metadata.name}
 
 With this one line, `kopf.adopt` marks the PVC as a child of EVC.
-This includes: the name auto-generation (if absent), the label propagation,
+This includes the name auto-generation (if absent), the label propagation,
 the namespace assignment to the parent's object namespace,
 and, finally, the owner referencing.
 
 The PVC is now "owned" by the EVC, i.e. it has an owner reference.
 When the parent EVC object is deleted,
 the child PVC will also be deleted (and terminated in case of pods),
-so that we have no need to control this ourselves.
+so that we do not need to control this ourselves.

--- a/docs/walkthrough/diffs.rst
+++ b/docs/walkthrough/diffs.rst
@@ -64,7 +64,7 @@ since Kubernetes notifies the operators only with the newest state of the object
 Diffs
 =====
 
-Kopf tracks the state of the objects, and calculates the diffs.
+Kopf tracks the state of the objects and calculates the diffs.
 The diffs are provided as the :kwarg:`diff` kwarg; the old & new states
 of the object or field -- as the :kwarg:`old` & :kwarg:`new` kwargs.
 
@@ -84,7 +84,7 @@ For example, if the field is ``metadata.labels``::
      ('change', ('label2',), 'old-value', 'new-value'),
      ('remove', ('label3',), 'old-value', None)]
 
-Now, let's use this feature to explicitly react to re-labelling of the EVCs.
+Now, let's use this feature to explicitly react to the re-labelling of the EVCs.
 Note that the ``new`` value for the removed dict key is ``None``,
 exactly as needed for the patch object (i.e. the field is present there):
 

--- a/docs/walkthrough/problem.rst
+++ b/docs/walkthrough/problem.rst
@@ -12,10 +12,10 @@ Problem Statement
 
 In Kubernetes, there are no ephemeral volumes of big sizes, e.g. 500 GB.
 By ephemeral, it means that the volume does not persist after it is used.
-Such volumes can be used as workspace for large data-crunching jobs.
+Such volumes can be used as a workspace for large data-crunching jobs.
 
 There is `Local Ephemeral Storage`__, which allocates some space on a node's
-root partition, shared with the docker images and other containers,
+root partition shared with the docker images and other containers,
 but it is often limited in size depending on the node/cluster config:
 
 __ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#local-ephemeral-storage
@@ -51,13 +51,13 @@ We will implement the ``EphemeralVolumeClaim`` object kind,
 which will be directly equivalent to ``PersistentVolumeClaim``
 (and will use it internally), but with a little extension:
 
-It will be *designated* for a pod or pods with a specific selection criteria.
+It will be *designated* for a pod or pods with specific selection criteria.
 
 Once used, and all those pods are gone and are not going to be restarted,
 the ephemeral volume claim will be deleted after a *grace period*.
 
 For safety, there will be an *expiry period* for the cases when the claim
-was not used: e.g. if the pod could not start for some reasons,
+was not used: e.g. if the pod could not start for some reasons
 so that the claim does not remain stale forever.
 
 The lifecycle of an ``EphemeralVolumeClaim`` is this:

--- a/docs/walkthrough/starting.rst
+++ b/docs/walkthrough/starting.rst
@@ -7,7 +7,7 @@ and created the :doc:`custom resource definitions <resources>`
 for the ephemeral volume claims.
 
 Now, we are ready to write some logic for this kind of objects.
-Let's start with the an operator skeleton that does nothing useful --
+Let's start with an operator skeleton that does nothing useful --
 just to see how it can be started.
 
 .. code-block:: python
@@ -53,7 +53,7 @@ The output looks like this:
     [2019-05-31 10:42:12,362] kopf.reactor.handlin [DEBUG   ] [default/my-claim] Patching with: {'status': {'kopf': {'progress': None}}, 'metadata': {'annotations': {'kopf.zalando.org/last-handled-configuration': '{"apiVersion": "kopf.dev/v1", "kind": "EphemeralVolumeClaim", "metadata": {"name": "my-claim", "namespace": "default"}, "spec": {}}'}}}
 
 Note that the operator has noticed an object created before the operator
-was even started, and handled it -- since it was not handled before.
+was even started, and handled the object because it was not handled before.
 
 Now, you can stop the operator with Ctrl-C (twice), and start it again:
 
@@ -62,7 +62,7 @@ Now, you can stop the operator with Ctrl-C (twice), and start it again:
     kopf run ephemeral.py --verbose
 
 The operator will not handle the object, as now it is already successfully
-handled. This is important in case of the operator is restarted if it runs
+handled. This is important in case the operator is restarted if it runs
 in a normally deployed pod, or when you restart the operator for debugging.
 
 Let's delete and re-create the same object to see the operator reacting:

--- a/docs/walkthrough/updates.rst
+++ b/docs/walkthrough/updates.rst
@@ -67,12 +67,14 @@ We can see that with kubectl:
       kopf: {}
 
 .. note::
-    If the above change causes ``Patching failed with inconsistencies`` 
-    debug warnings and/or your EVC yaml doesn't show a ``.status`` field, make sure
-    you have set the ``x-kubernetes-preserve-unknown-fields: true`` field in your CRD
-    on either the entire object or just the ``.status`` field as detailed in :doc:`resources`. 
-    Without setting this field, Kubernetes will prune the ``.status`` field when Kopf tries to 
-    update it. For more info on field pruning, see `the Kubernetes docs  
+    If the above change causes ``Patching failed with inconsistencies``
+    debug warnings and/or your EVC YAML doesn't show a ``.status`` field,
+    make sure you have set the ``x-kubernetes-preserve-unknown-fields: true``
+    field in your CRD on either the entire object or just the ``.status`` field
+    as detailed in :doc:`resources`.
+    Without setting this field, Kubernetes will prune the ``.status`` field
+    when Kopf tries to update it. For more info on field pruning,
+    see `the Kubernetes docs
     <https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning>`_.
 
 Let's add a yet another handler, but for the "update" cause.
@@ -112,7 +114,7 @@ Or by patching it:
 
 Keep in mind the PVC size can only be increased, never decreased.
 
-Give the operator few seconds to handle the change.
+Give the operator a few seconds to handle the change.
 
 Check the size of the actual PV behind the PVC, which is now increased:
 
@@ -128,5 +130,5 @@ Check the size of the actual PV behind the PVC, which is now increased:
 .. warning::
     Kubernetes & ``kubectl`` improperly show the capacity of PVCs:
     it remains the same (1G) event after the change.
-    The size of actual PV (Persistent Volume) of each PVC is important!
+    The size of the actual PV (Persistent Volume) of each PVC is important!
     This issue is not related to Kopf, so we go around it.


### PR DESCRIPTION
Only the documentation is covered, not the docstrings in the source code.