### PR TITLE
Auto-detect cluster type for proper webhook server's hostname

### DIFF
--- a/docs/admission.rst
+++ b/docs/admission.rst
@@ -354,10 +354,17 @@ each with its configuration parameters (see their descriptions):
 usually to a locally running *webhook server*.
 
 * `kopf.WebhookNgrokTunnel` established a tunnel through ngrok_.
-* `kopf.WebhookInletsTunnel` tunnels the traffic through inlets_.
 
 .. _ngrok: https://ngrok.com/
-.. _inlets: https://inlets.dev/
+
+For ease of use, the cluster type can be recognised automatically in some cases:
+
+* `kopf.WebhookAutoServer` runs locally, detects Minikube & K3s, and uses them
+  via their special hostnames. If it cannot detect the cluster type, it runs
+  a simple local webhook server. The auto-server never tunnels.
+* `kopf.WebhookAutoTunnel` attempts to use an auto-server if possible.
+  If not, it uses one of the available tunnels (currently, only ngrok).
+  This is the most universal way to make any environment work.
 
 .. note::
     External tunnelling services usually limit the number of requests.
@@ -369,7 +376,7 @@ usually to a locally running *webhook server*.
 
 .. note::
     A reminder: using development-mode tunnels and self-signed certificates
-    requires an extra: ``pip install kopf[dev]``.
+    requires extra dependencies: ``pip install kopf[dev]``.
 
 
 Authenticate apiservers
@@ -545,7 +552,7 @@ do not support HTTPS tunnelling (or require paid subscriptions):
 
     @kopf.on.startup()
     def config(settings: kopf.OperatorSettings, **_):
-        settings.admission.server = kopf.WebhookServer(insecure=True)
+        settings.admission.server = kopf.¶ver(insecure=True)
 
 
 Custom servers/tunnels

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -160,6 +160,8 @@ from kopf.toolkits.webhooks import (
     WebhookK3dServer,
     WebhookMinikubeServer,
     WebhookNgrokTunnel,
+    WebhookAutoServer,
+    WebhookAutoTunnel,
 )
 from kopf.utilities.piggybacking import (
     login_via_pykube,
@@ -194,6 +196,8 @@ __all__ = [
     'WebhookK3dServer',
     'WebhookMinikubeServer',
     'WebhookNgrokTunnel',
+    'WebhookAutoServer',
+    'WebhookAutoTunnel',
     'PermanentError',
     'TemporaryError',
     'HandlerTimeoutError',

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
             'pyngrok',          # 1.00 MB + downloaded binary
             'oscrypto',         # 2.80 MB (smaller than cryptography: 8.7 MB)
             'certbuilder',      # +0.1 MB (2.90 MB if alone)
+            'certvalidator',    # +0.1 MB (2.90 MB if alone)
         ],
     },
     package_data={"kopf": ["py.typed"]},

--- a/tests/admission/conftest.py
+++ b/tests/admission/conftest.py
@@ -3,6 +3,8 @@ import dataclasses
 import warnings
 from unittest.mock import Mock
 
+import pyngrok.conf
+import pyngrok.ngrok
 import pytest
 
 from kopf.reactor.indexing import OperatorIndexers
@@ -139,3 +141,13 @@ def k8s_mocked(mocker):
         post_event=mocker.patch('kopf.clients.events.post_event'),
         sleep_or_wait=mocker.patch('kopf.structs.primitives.sleep_or_wait', return_value=None),
     )
+
+
+@pytest.fixture(autouse=True)
+def pyngrok_mock(mocker):
+    mocker.patch.object(pyngrok.conf, 'get_default')
+    mocker.patch.object(pyngrok.ngrok, 'set_auth_token')
+    mocker.patch.object(pyngrok.ngrok, 'connect')
+    mocker.patch.object(pyngrok.ngrok, 'disconnect')
+    pyngrok.ngrok.connect.return_value.public_url = 'https://nowhere'
+    return pyngrok

--- a/tests/admission/test_webhook_detection.py
+++ b/tests/admission/test_webhook_detection.py
@@ -1,0 +1,103 @@
+import pytest
+
+from kopf.toolkits.webhooks import ClusterDetector, WebhookAutoServer, WebhookAutoTunnel
+
+
+# Reproducing the realistic environment would be costly and difficult,
+# so we mock all external(!) libraries to return the results as we expect them.
+# This reduces the quality of the tests, but makes them simple.
+@pytest.fixture(autouse=True)
+def pathmock(mocker, fake_vault, enforced_context, aresponses, hostname):
+    mocker.patch('ssl.get_server_certificate', return_value='')
+    mocker.patch('certvalidator.ValidationContext')
+    validator = mocker.patch('certvalidator.CertificateValidator')
+    pathmock = validator.return_value.validate_tls.return_value
+    pathmock.first.issuer.native = {}
+    pathmock.first.subject.native = {}
+    return pathmock
+
+
+async def test_no_detection(hostname, aresponses):
+    aresponses.add(hostname, '/version', 'get', {'gitVersion': 'v1.2.3'})
+    hostname = await ClusterDetector().guess_host()
+    assert hostname is None
+
+
+async def test_dependencies(hostname, aresponses, no_certvalidator):
+    aresponses.add(hostname, '/version', 'get', {'gitVersion': 'v1.2.3'})
+    with pytest.raises(ImportError) as err:
+        await ClusterDetector().guess_host()
+    assert "pip install certvalidator" in str(err.value)
+
+
+async def test_minikube_via_issuer_cn(pathmock):
+    pathmock.first.issuer.native = {'common_name': 'minikubeCA'}
+    hostname = await ClusterDetector().guess_host()
+    assert hostname == 'host.minikube.internal'
+
+
+async def test_minikube_via_subject_cn(pathmock):
+    pathmock.first.subject.native = {'common_name': 'minikube'}
+    hostname = await ClusterDetector().guess_host()
+    assert hostname == 'host.minikube.internal'
+
+
+async def test_k3d_via_issuer_cn(pathmock):
+    pathmock.first.issuer.native = {'common_name': 'k3s-ca-server-12345'}
+    hostname = await ClusterDetector().guess_host()
+    assert hostname == 'host.k3d.internal'
+
+
+async def test_k3d_via_subject_cn(pathmock):
+    pathmock.first.subject.native = {'common_name': 'k3s'}
+    hostname = await ClusterDetector().guess_host()
+    assert hostname == 'host.k3d.internal'
+
+
+async def test_k3d_via_subject_org(pathmock):
+    pathmock.first.subject.native = {'organization_name': 'k3s'}
+    hostname = await ClusterDetector().guess_host()
+    assert hostname == 'host.k3d.internal'
+
+
+async def test_k3d_via_version_infix(hostname, aresponses):
+    aresponses.add(hostname, '/version', 'get', {'gitVersion': 'v1.20.4+k3s1'})
+    hostname = await ClusterDetector().guess_host()
+    assert hostname == 'host.k3d.internal'
+
+
+async def test_server_detects(responder, aresponses, hostname, caplog, assert_logs):
+    caplog.set_level(0)
+    aresponses.add(hostname, '/version', 'get', {'gitVersion': 'v1.20.4+k3s1'})
+    server = WebhookAutoServer(insecure=True)
+    async for _ in server(responder.fn):
+        break  # do not sleep
+    assert_logs(["Cluster detection found the hostname: host.k3d.internal"])
+
+
+async def test_server_works(
+        responder, aresponses, hostname, caplog, assert_logs):
+    caplog.set_level(0)
+    aresponses.add(hostname, '/version', 'get', {'gitVersion': 'v1.20.4'})
+    server = WebhookAutoServer(insecure=True)
+    async for _ in server(responder.fn):
+        break  # do not sleep
+    assert_logs(["Cluster detection failed, running a simple local server"])
+
+
+async def test_tunnel_detects(responder, pyngrok_mock, aresponses, hostname, caplog, assert_logs):
+    caplog.set_level(0)
+    aresponses.add(hostname, '/version', 'get', {'gitVersion': 'v1.20.4+k3s1'})
+    server = WebhookAutoTunnel()
+    async for _ in server(responder.fn):
+        break  # do not sleep
+    assert_logs(["Cluster detection found the hostname: host.k3d.internal"])
+
+
+async def test_tunnel_works(responder, pyngrok_mock, aresponses, hostname, caplog, assert_logs):
+    caplog.set_level(0)
+    aresponses.add(hostname, '/version', 'get', {'gitVersion': 'v1.20.4'})
+    server = WebhookAutoTunnel()
+    async for _ in server(responder.fn):
+        break  # do not sleep
+    assert_logs(["Cluster detection failed, using an ngrok tunnel."])

--- a/tests/admission/test_webhook_ngrok.py
+++ b/tests/admission/test_webhook_ngrok.py
@@ -1,20 +1,8 @@
 import asyncio
 
-import pyngrok.conf
-import pyngrok.ngrok
 import pytest
 
 from kopf.toolkits.webhooks import WebhookNgrokTunnel
-
-
-@pytest.fixture(autouse=True)
-def pyngrok_mock(mocker):
-    mocker.patch.object(pyngrok.conf, 'get_default')
-    mocker.patch.object(pyngrok.ngrok, 'set_auth_token')
-    mocker.patch.object(pyngrok.ngrok, 'connect')
-    mocker.patch.object(pyngrok.ngrok, 'disconnect')
-    pyngrok.ngrok.connect.return_value.public_url = 'https://nowhere'
-    return pyngrok
 
 
 async def test_missing_pyngrok(no_pyngrok, responder):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -508,6 +508,11 @@ def no_certbuilder():
     yield from _with_module_absent('certbuilder')
 
 
+@pytest.fixture()
+def no_certvalidator():
+    yield from _with_module_absent('certvalidator')
+
+
 #
 # Helpers for the timing checks.
 #


### PR DESCRIPTION
In #708, the webhook server was made specific (and K3d/K3s is configured). However, when tested in the "thorough tests" after the merge, the e2e tests failed on the Minikube cluster — because it has a different magic hostname: `host.minikube.internal` instead of `host.k3d.internal`.

To make it work automatically in CI/CD, and in most other cases, this PR adds a feature to automatically detect the cluster type (among the limited list of options: Minikube, K3d/K3s only). Users can also configure auto-tunnel, which will fall back to ngrok if the cluster type cannot be detected; the auto-server will run a simple local server in that case.

