### PR TITLE
Resolve circular imports bound to HandlerId

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -119,9 +119,11 @@ from kopf.structs.filters import (
     PRESENT,
 )
 from kopf.structs.handlers import (
-    HandlerId,
     ErrorsMode,
     Reason,
+)
+from kopf.structs.ids import (
+    HandlerId,
 )
 from kopf.structs.patches import (
     Patch,

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -7,7 +7,7 @@ from typing import MutableMapping, Optional, Tuple
 import aiohttp.web
 
 from kopf.reactor import activities, lifecycles, registries
-from kopf.structs import callbacks, configuration, ephemera, handlers
+from kopf.structs import callbacks, configuration, ephemera, handlers, ids
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ async def health_reporter(
     is cancelled or failed). Once it will stop responding for any reason,
     Kubernetes will assume the pod is not alive anymore, and will restart it.
     """
-    probing_container: MutableMapping[handlers.HandlerId, callbacks.Result] = {}
+    probing_container: MutableMapping[ids.HandlerId, callbacks.Result] = {}
     probing_timestamp: Optional[datetime.datetime] = None
     probing_max_age = datetime.timedelta(seconds=10.0)
     probing_lock = asyncio.Lock()

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -21,8 +21,8 @@ from typing import Mapping, MutableMapping, NoReturn
 
 from kopf.reactor import causation, handling, lifecycles, registries
 from kopf.storage import states
-from kopf.structs import callbacks, configuration, credentials, \
-                         ephemera, handlers as handlers_, primitives
+from kopf.structs import callbacks, configuration, credentials, ephemera, \
+                         handlers as handlers_, ids, primitives
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class ActivityError(Exception):
             self,
             msg: str,
             *,
-            outcomes: Mapping[handlers_.HandlerId, states.HandlerOutcome],
+            outcomes: Mapping[ids.HandlerId, states.HandlerOutcome],
     ) -> None:
         super().__init__(msg)
         self.outcomes = outcomes
@@ -106,7 +106,7 @@ async def run_activity(
         activity: handlers_.Activity,
         indices: ephemera.Indices,
         memo: ephemera.AnyMemo,
-) -> Mapping[handlers_.HandlerId, callbacks.Result]:
+) -> Mapping[ids.HandlerId, callbacks.Result]:
     logger = logging.getLogger(f'kopf.activities.{activity.value}')
 
     # For the activity handlers, we have neither bodies, nor patches, just the state.
@@ -119,7 +119,7 @@ async def run_activity(
     )
     handlers = registry._activities.get_handlers(activity=activity)
     state = states.State.from_scratch().with_handlers(handlers)
-    outcomes: MutableMapping[handlers_.HandlerId, states.HandlerOutcome] = {}
+    outcomes: MutableMapping[ids.HandlerId, states.HandlerOutcome] = {}
     while not state.done:
         current_outcomes = await handling.execute_handlers_once(
             lifecycle=lifecycle,

--- a/kopf/reactor/admission.py
+++ b/kopf/reactor/admission.py
@@ -14,7 +14,7 @@ from kopf.engines import loggers
 from kopf.reactor import causation, handling, lifecycles, registries
 from kopf.storage import states
 from kopf.structs import bodies, configuration, containers, ephemera, filters, \
-                         handlers, patches, primitives, references, reviews
+                         handlers, ids, patches, primitives, references, reviews
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ async def serve_admission_request(
         # Optional for webhook servers that can recognise this information:
         headers: Optional[Mapping[str, str]] = None,
         sslpeer: Optional[Mapping[str, Any]] = None,
-        webhook: Optional[handlers.HandlerId] = None,
+        webhook: Optional[ids.HandlerId] = None,
         reason: Optional[handlers.WebhookType] = None,  # TODO: undocumented: requires typing clarity!
         # Injected by partial() from spawn_tasks():
         settings: configuration.OperatorSettings,
@@ -168,7 +168,7 @@ def find_resource(
 def build_response(
         *,
         request: reviews.Request,
-        outcomes: Mapping[handlers.HandlerId, states.HandlerOutcome],
+        outcomes: Mapping[ids.HandlerId, states.HandlerOutcome],
         warnings: Collection[str],
         jsonpatch: patches.JSONPatch,
 ) -> reviews.Response:
@@ -411,7 +411,7 @@ def _build_labels_selector(labels: Optional[filters.MetaFilter]) -> Optional[Map
 BAD_WEBHOOK_NAME = re.compile(r'[^\w\d\.-]')
 
 
-def _normalize_name(id: handlers.HandlerId, suffix: str) -> str:
+def _normalize_name(id: ids.HandlerId, suffix: str) -> str:
     """
     Normalize the webhook name to what Kubernetes accepts as normal.
 
@@ -427,7 +427,7 @@ def _normalize_name(id: handlers.HandlerId, suffix: str) -> str:
     return f'{name}.{suffix}' if suffix else name
 
 
-def _inject_handler_id(config: reviews.WebhookClientConfig, id: handlers.HandlerId) -> reviews.WebhookClientConfig:
+def _inject_handler_id(config: reviews.WebhookClientConfig, id: ids.HandlerId) -> reviews.WebhookClientConfig:
     config = copy.deepcopy(config)
 
     url_id = urllib.parse.quote(id)

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -25,7 +25,7 @@ from typing import Any, List, Mapping, Optional, TypeVar, Union
 
 from kopf.storage import finalizers
 from kopf.structs import bodies, configuration, diffs, ephemera, handlers, \
-                         patches, primitives, references, reviews
+                         ids, patches, primitives, references, reviews
 
 
 @dataclasses.dataclass
@@ -52,7 +52,7 @@ class ResourceCause(BaseCause):
 class ResourceWebhookCause(ResourceCause):
     dryrun: bool
     reason: Optional[handlers.WebhookType]  # None means "all" or expects the webhook id
-    webhook: Optional[handlers.HandlerId]  # None means "all"
+    webhook: Optional[ids.HandlerId]  # None means "all"
     headers: Mapping[str, str]
     sslpeer: Mapping[str, Any]
     userinfo: reviews.UserInfo

--- a/kopf/reactor/daemons.py
+++ b/kopf/reactor/daemons.py
@@ -30,7 +30,7 @@ import aiojobs
 from kopf.engines import loggers
 from kopf.reactor import causation, effects, handling, lifecycles
 from kopf.storage import states
-from kopf.structs import configuration, containers, handlers as handlers_, patches, primitives
+from kopf.structs import configuration, containers, handlers as handlers_, ids, patches, primitives
 from kopf.utilities import aiotasks
 
 
@@ -38,7 +38,7 @@ async def spawn_resource_daemons(
         *,
         settings: configuration.OperatorSettings,
         handlers: Sequence[handlers_.ResourceSpawningHandler],
-        daemons: MutableMapping[handlers_.HandlerId, containers.Daemon],
+        daemons: MutableMapping[ids.HandlerId, containers.Daemon],
         cause: causation.ResourceSpawningCause,
         memory: containers.ResourceMemory,
 ) -> Collection[float]:
@@ -83,7 +83,7 @@ async def match_resource_daemons(
         *,
         settings: configuration.OperatorSettings,
         handlers: Sequence[handlers_.ResourceSpawningHandler],
-        daemons: MutableMapping[handlers_.HandlerId, containers.Daemon],
+        daemons: MutableMapping[ids.HandlerId, containers.Daemon],
 ) -> Collection[float]:
     """
     Re-match the running daemons with the filters, and stop those mismatching.
@@ -107,7 +107,7 @@ async def match_resource_daemons(
 async def stop_resource_daemons(
         *,
         settings: configuration.OperatorSettings,
-        daemons: Mapping[handlers_.HandlerId, containers.Daemon],
+        daemons: Mapping[ids.HandlerId, containers.Daemon],
         reason: primitives.DaemonStoppingReason = primitives.DaemonStoppingReason.RESOURCE_DELETED,
 ) -> Collection[float]:
     """
@@ -355,7 +355,7 @@ async def _wait_for_instant_exit(
 async def _runner(
         *,
         settings: configuration.OperatorSettings,
-        daemons: MutableMapping[handlers_.HandlerId, containers.Daemon],
+        daemons: MutableMapping[ids.HandlerId, containers.Daemon],
         handler: handlers_.ResourceSpawningHandler,
         memory: containers.ResourceMemory,
         cause: causation.DaemonCause,

--- a/kopf/reactor/indexing.py
+++ b/kopf/reactor/indexing.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, Generic, Iterable, Iterator, \
 
 from kopf.reactor import causation, handling, lifecycles, registries
 from kopf.storage import states
-from kopf.structs import bodies, configuration, containers, ephemera, handlers, patches, references
+from kopf.structs import bodies, configuration, containers, ephemera, \
+                         handlers, ids, patches, references
 
 Key = Tuple[references.Namespace, Optional[str], Optional[str]]
 _K = TypeVar('_K')
@@ -168,7 +169,7 @@ class OperatorIndexer:
         self.index._replace(key, obj)
 
 
-class OperatorIndexers(Dict[handlers.HandlerId, OperatorIndexer]):
+class OperatorIndexers(Dict[ids.HandlerId, OperatorIndexer]):
 
     def __init__(self) -> None:
         super().__init__()
@@ -196,7 +197,7 @@ class OperatorIndexers(Dict[handlers.HandlerId, OperatorIndexer]):
     def replace(
             self,
             body: bodies.Body,
-            outcomes: Mapping[handlers.HandlerId, states.HandlerOutcome],
+            outcomes: Mapping[ids.HandlerId, states.HandlerOutcome],
     ) -> None:
         """ Interpret the indexing results and apply them to the indices. """
         key = self.make_key(body)
@@ -263,7 +264,7 @@ class OperatorIndices(ephemera.Indices):
         return iter(self.__indexers)
 
     def __getitem__(self, id: str) -> Index[Any, Any]:
-        return self.__indexers[handlers.HandlerId(id)].index
+        return self.__indexers[ids.HandlerId(id)].index
 
     def __contains__(self, id: object) -> bool:
         return id in self.__indexers

--- a/kopf/storage/progress.py
+++ b/kopf/storage/progress.py
@@ -46,7 +46,7 @@ from typing import Any, Collection, Dict, Mapping, Optional, cast
 from typing_extensions import TypedDict
 
 from kopf.storage import conventions
-from kopf.structs import bodies, dicts, handlers, patches
+from kopf.structs import bodies, dicts, ids, patches
 
 
 class ProgressRecord(TypedDict, total=True):
@@ -59,7 +59,7 @@ class ProgressRecord(TypedDict, total=True):
     success: Optional[bool]
     failure: Optional[bool]
     message: Optional[str]
-    subrefs: Optional[Collection[handlers.HandlerId]]
+    subrefs: Optional[Collection[ids.HandlerId]]
 
 
 class ProgressStorage(conventions.StorageStanzaCleaner, metaclass=abc.ABCMeta):
@@ -84,7 +84,7 @@ class ProgressStorage(conventions.StorageStanzaCleaner, metaclass=abc.ABCMeta):
     def fetch(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             body: bodies.Body,
     ) -> Optional[ProgressRecord]:
         raise NotImplementedError
@@ -93,7 +93,7 @@ class ProgressStorage(conventions.StorageStanzaCleaner, metaclass=abc.ABCMeta):
     def store(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             record: ProgressRecord,
             body: bodies.Body,
             patch: patches.Patch,
@@ -104,7 +104,7 @@ class ProgressStorage(conventions.StorageStanzaCleaner, metaclass=abc.ABCMeta):
     def purge(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             body: bodies.Body,
             patch: patches.Patch,
     ) -> None:
@@ -177,7 +177,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
     def fetch(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             body: bodies.Body,
     ) -> Optional[ProgressRecord]:
         for full_key in self.make_keys(key, body=body):
@@ -191,7 +191,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
     def store(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             record: ProgressRecord,
             body: bodies.Body,
             patch: patches.Patch,
@@ -206,7 +206,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
     def purge(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             body: bodies.Body,
             patch: patches.Patch,
     ) -> None:
@@ -314,17 +314,17 @@ class StatusProgressStorage(ProgressStorage):
     def fetch(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             body: bodies.Body,
     ) -> Optional[ProgressRecord]:
-        container: Mapping[handlers.HandlerId, ProgressRecord]
+        container: Mapping[ids.HandlerId, ProgressRecord]
         container = dicts.resolve(body, self.field, {})
         return container.get(key, None)
 
     def store(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             record: ProgressRecord,
             body: bodies.Body,
             patch: patches.Patch,
@@ -335,7 +335,7 @@ class StatusProgressStorage(ProgressStorage):
     def purge(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             body: bodies.Body,
             patch: patches.Patch,
     ) -> None:
@@ -383,7 +383,7 @@ class MultiProgressStorage(ProgressStorage):
     def fetch(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             body: bodies.Body,
     ) -> Optional[ProgressRecord]:
         for storage in self.storages:
@@ -395,7 +395,7 @@ class MultiProgressStorage(ProgressStorage):
     def store(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             record: ProgressRecord,
             body: bodies.Body,
             patch: patches.Patch,
@@ -406,7 +406,7 @@ class MultiProgressStorage(ProgressStorage):
     def purge(
             self,
             *,
-            key: handlers.HandlerId,
+            key: ids.HandlerId,
             body: bodies.Body,
             patch: patches.Patch,
     ) -> None:

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -14,7 +14,7 @@ import time
 from typing import Dict, Iterator, MutableMapping, Optional, Set, Union
 
 from kopf.storage import states
-from kopf.structs import bodies, ephemera, handlers, primitives
+from kopf.structs import bodies, ephemera, handlers, ids, primitives
 from kopf.utilities import aiotasks
 
 
@@ -51,8 +51,8 @@ class ResourceMemory:
     # For background and timed threads/tasks (invoked with the kwargs of the last-seen body).
     live_fresh_body: Optional[bodies.Body] = None
     idle_reset_time: float = dataclasses.field(default_factory=time.monotonic)
-    forever_stopped: Set[handlers.HandlerId] = dataclasses.field(default_factory=set)
-    running_daemons: Dict[handlers.HandlerId, Daemon] = dataclasses.field(default_factory=dict)
+    forever_stopped: Set[ids.HandlerId] = dataclasses.field(default_factory=set)
+    running_daemons: Dict[ids.HandlerId, Daemon] = dataclasses.field(default_factory=dict)
 
     # For indexing errors backoffs/retries/timeouts. It is None when successfully indexed.
     indexing_state: Optional[states.State] = None

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -1,12 +1,8 @@
 import dataclasses
 import enum
-from typing import Any, NewType, Optional
+from typing import Any, Optional
 
-from kopf.structs import callbacks, dicts, filters, references
-
-# Strings are taken from the users, but then tainted as this type for stricter type-checking:
-# to prevent usage of some other strings (e.g. operator id) as the handlers ids.
-HandlerId = NewType('HandlerId', str)
+from kopf.structs import callbacks, dicts, filters, ids, references
 
 
 class ErrorsMode(enum.Enum):
@@ -76,7 +72,7 @@ TITLES = {
 # FIXME:    expected "Union[LifeCycleFn, ActivityHandlerFn, ResourceHandlerFn]"
 @dataclasses.dataclass
 class BaseHandler:
-    id: HandlerId
+    id: ids.HandlerId
     fn: callbacks.BaseFn
     param: Optional[Any]
     errors: Optional[ErrorsMode]

--- a/kopf/structs/ids.py
+++ b/kopf/structs/ids.py
@@ -1,0 +1,6 @@
+from typing import NewType
+
+# Strings are taken from the users, but then tainted as this type for stricter type-checking:
+# to prevent usage of some other strings (e.g. operator id) as the handlers ids.
+# It is so much ubiquitous that it deserves its own module to avoid circular dependencies.
+HandlerId = NewType('HandlerId', str)

--- a/tests/admission/test_serving_handler_selection.py
+++ b/tests/admission/test_serving_handler_selection.py
@@ -4,7 +4,8 @@ import pytest
 
 import kopf
 from kopf.reactor.admission import serve_admission_request
-from kopf.structs.handlers import HandlerId, WebhookType
+from kopf.structs.handlers import WebhookType
+from kopf.structs.ids import HandlerId
 
 
 async def test_all_handlers_with_no_id_or_reason_requested(

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -10,7 +10,8 @@ from kopf.reactor.lifecycles import all_at_once
 from kopf.reactor.registries import OperatorRegistry
 from kopf.storage.states import HandlerOutcome
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import Activity, ActivityHandler, HandlerId
+from kopf.structs.handlers import Activity, ActivityHandler
+from kopf.structs.ids import HandlerId
 
 
 def test_activity_error_exception():

--- a/tests/persistence/test_annotations_hashing.py
+++ b/tests/persistence/test_annotations_hashing.py
@@ -6,7 +6,7 @@ from kopf.storage.conventions import StorageKeyFormingConvention
 from kopf.storage.diffbase import AnnotationsDiffBaseStorage
 from kopf.storage.progress import AnnotationsProgressStorage, ProgressRecord, SmartProgressStorage
 from kopf.structs.bodies import Body
-from kopf.structs.handlers import HandlerId
+from kopf.structs.ids import HandlerId
 from kopf.structs.patches import Patch
 
 ANNOTATIONS_POPULATING_STORAGES = [

--- a/tests/persistence/test_storing_of_progress.py
+++ b/tests/persistence/test_storing_of_progress.py
@@ -6,7 +6,7 @@ import pytest
 from kopf.storage.progress import AnnotationsProgressStorage, ProgressRecord, ProgressStorage, \
                                   SmartProgressStorage, StatusProgressStorage
 from kopf.structs.bodies import Body
-from kopf.structs.handlers import HandlerId
+from kopf.structs.ids import HandlerId
 from kopf.structs.patches import Patch
 
 ALL_STORAGES = [AnnotationsProgressStorage, StatusProgressStorage, SmartProgressStorage]

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -12,7 +12,8 @@ from kopf.reactor.registries import ActivityRegistry, OperatorRegistry, Resource
 from kopf.structs.bodies import Body
 from kopf.structs.diffs import Diff, DiffItem
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import HandlerId, ResourceChangingHandler
+from kopf.structs.handlers import ResourceChangingHandler
+from kopf.structs.ids import HandlerId
 from kopf.structs.patches import Patch
 
 


### PR DESCRIPTION
The chain of dependencies this time was (introduced in e89ac21333e3849a4819ca616d5a410ea5bb5c22, #708's "examples"):

* `callbacks` imported `configuration` for the "settings" kwarg.
* `configuration` imported `storage.progress` for its persistence settings.
* `storage.progress` imported `handlers` for only `HandlerId`.
* `handlers` imported `callbacks` for handlers' function types.

The chain is broken at the `progress`->`handlers` dependency: it is now `progress`->`ids`.

This was a frequent problem before, so `HandlerId` deserves its dedicated moduled until all modules are rebalanced (later).
