### PR TITLE
Drop Kubernetes 1.14

### DIFF
--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s: [v1.16.15, v1.15.12, v1.14.10]
+        k8s: [v1.16.15, v1.15.12]
         crdapi: [v1beta1]
     name: K8s ${{matrix.k8s}} ${{matrix.crdapi && format('CRD={0}', matrix.crdapi) || ''}}
     runs-on: ubuntu-20.04


### PR DESCRIPTION
The trigger of change is that it fails with admission requests in Kubernetes <1.15 (1.14 is the latest supported by Kopf), with v1beta1 admission reviews, with DELETE operations — the "object" is NULL there. It would require significant complexity on our side with remembering and recalling the object bodies in memory (which we have for daemons/timers anyway, but not for admissions).

Kubernetes 1.14 was released March 2019 (2 years ago). The usual support policy by Kubernetes is 1 year (https://kubernetes.io/docs/setup/release/version-skew-policy/).

AWS supports Kubernetes 1.15+ (https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html).

GCP supports Kubernetes 1.15+ (https://cloud.google.com/kuberun/docs/cluster-versions). In practice, new clusters are 1.16+ in the "stable" channel.

There is no reason for Kopf to support 1.14 anymore. New versions of Kopf will most likely continue working with old features — except for the new admission hooks — but are not tested against 1.14. If needed, pin Kopf's version to the one that worked (1.30.x).
