### PR TITLE
Fix absent namespaces for cluster-scoped resources in hierarchies

### DIFF
--- a/kopf/toolkits/hierarchies.py
+++ b/kopf/toolkits/hierarchies.py
@@ -2,6 +2,7 @@
 All the functions to properly build the object hierarchies.
 """
 import collections.abc
+import enum
 import warnings
 from typing import Any, Iterable, Iterator, Mapping, MutableMapping, Optional, Union, cast
 
@@ -11,6 +12,10 @@ from kopf.utilities import thirdparty
 
 K8sObject = Union[MutableMapping[Any, Any], thirdparty.PykubeObject, thirdparty.KubernetesModel]
 K8sObjects = Union[K8sObject, Iterable[K8sObject]]
+
+
+class _UNSET(enum.Enum):
+    token = enum.auto()
 
 
 def append_owner_reference(
@@ -82,7 +87,7 @@ def remove_owner_reference(
 
 def label(
         objs: K8sObjects,
-        labels: Optional[Mapping[str, Union[None, str]]] = None,
+        labels: Union[Mapping[str, Union[None, str]], _UNSET] = _UNSET.token,
         *,
         forced: bool = False,
         nested: Optional[Union[str, Iterable[dicts.FieldSpec]]] = None,
@@ -97,9 +102,11 @@ def label(
         forced = force
 
     # Try to use the current object being handled if possible.
-    if labels is None:
+    if isinstance(labels, _UNSET):
         real_owner = _guess_owner(None)
         labels = real_owner.get('metadata', {}).get('labels', {})
+    if isinstance(labels, _UNSET):
+        raise RuntimeError("Impossible error: labels are not resolved.")  # for type-checking
 
     # Set labels based on the explicitly specified or guessed ones.
     for obj in cast(Iterator[K8sObject], dicts.walk(objs, nested=nested)):
@@ -124,7 +131,7 @@ def label(
 
 def harmonize_naming(
         objs: K8sObjects,
-        name: Optional[str] = None,
+        name: Union[None, str, _UNSET] = _UNSET.token,
         *,
         forced: bool = False,
         strict: bool = False,
@@ -145,9 +152,11 @@ def harmonize_naming(
     """
 
     # Try to use the current object being handled if possible.
-    if name is None:
+    if isinstance(name, _UNSET):
         real_owner = _guess_owner(None)
         name = real_owner.get('metadata', {}).get('name', None)
+    if isinstance(name, _UNSET):
+        raise RuntimeError("Impossible error: the name is not resolved.")  # for type-checking
     if name is None:
         raise LookupError("Name must be set explicitly: couldn't find it automatically.")
 
@@ -184,7 +193,7 @@ def harmonize_naming(
 
 def adjust_namespace(
         objs: K8sObjects,
-        namespace: Optional[str] = None,
+        namespace: Union[None, str, _UNSET] = _UNSET.token,
         *,
         forced: bool = False,
 ) -> None:
@@ -198,11 +207,11 @@ def adjust_namespace(
     """
 
     # Try to use the current object being handled if possible.
-    if namespace is None:
+    if isinstance(namespace, _UNSET):
         real_owner = _guess_owner(None)
         namespace = real_owner.get('metadata', {}).get('namespace', None)
-    if namespace is None:
-        raise LookupError("Namespace must be set explicitly: couldn't find it automatically.")
+    if isinstance(namespace, _UNSET):
+        raise RuntimeError("Impossible error: the namespace is not resolved.")  # for type-checking
 
     # Set namespace based on the explicitly specified or guessed namespace.
     for obj in cast(Iterator[K8sObject], dicts.walk(objs)):

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -108,10 +108,11 @@ def test_when_empty_for_name_harmonization(owner):
 
 
 def test_when_empty_for_namespace_adjustment(owner):
+    # An absent namespace means a cluster-scoped resource -- a valid case.
+    obj = {}
     owner._replace_with({})
-    with pytest.raises(LookupError) as e:
-        kopf.adjust_namespace([])
-    assert 'Namespace must be set explicitly' in str(e.value)
+    kopf.adjust_namespace(obj)
+    assert obj['metadata']['namespace'] is None
 
 
 def test_when_empty_for_adopting(owner):


### PR DESCRIPTION
In #671, a case with cluster-scoped resources (which have no namespaces) was forgotten.

This PR fixes it: absent namespace in the owner object is not an error now, `None` is assigned as a namespace in children (as it was before the fix).

---

Besides, a little optimization for clarity: the current contextual owner is looked up ONLY if `namespace=` is really unset, not when it is passed as `None` — for the case when `adjust_namespace(…, namespace=None)` is called from `adopt()` where the owner lookup is already performed.

The same distinguishing logic of `None`-vs-unset is applied for "name" harmonization — also a string that can be sometimes absent in the owner — at least, in theory. 

The same for labels: passing `None` is a sign of an error (e.g., improper `.get('labels')`?): labels cannot be `None`, but they can be `{}` (as a default value in `adopt()`).

---

There are almost no changes in the tests because the contracts/signatures/behaviour do not change (except for namespaces of cluster-scoped resources), only the implementation is changed.

fixes #725 