### PR TITLE
Avoid dummy-patching for out-of-scope handlers (via check_done/get_delays functions)

### DIFF
--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -120,7 +120,7 @@ async def run_activity(
     handlers = registry._activities.get_handlers(activity=activity)
     state = states.State.from_scratch().with_handlers(handlers)
     outcomes: MutableMapping[ids.HandlerId, states.HandlerOutcome] = {}
-    while not state.done:
+    while not state.check_done(handlers):
         current_outcomes = await handling.execute_handlers_once(
             lifecycle=lifecycle,
             settings=settings,
@@ -130,7 +130,7 @@ async def run_activity(
         )
         outcomes.update(current_outcomes)
         state = state.with_outcomes(current_outcomes)
-        await primitives.sleep_or_wait(state.delay)
+        await primitives.sleep_or_wait(state.get_delays(handlers))
 
     # Activities assume that all handlers must eventually succeed.
     # We raise from the 1st exception only: just to have something real in the tracebacks.

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -175,8 +175,8 @@ async def execute(
             subrefs_container.add(key)
 
     # Escalate `HandlerChildrenRetry` if the execute should be continued on the next iteration.
-    if not state.done:
-        raise HandlerChildrenRetry(delay=state.delay)
+    if not state.check_done(cause_handlers):
+        raise HandlerChildrenRetry(delay=min(state.get_delays(cause_handlers)))
 
 
 async def execute_handlers_once(

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -415,7 +415,7 @@ async def process_resource_changing_cause(
             state.store(body=cause.body, patch=cause.patch, storage=storage)
             states.deliver_results(outcomes=outcomes, patch=cause.patch)
 
-            if state.done:
+            if state.check_done(cause_handlers):
                 counters = state.counts  # calculate only once
                 logger.info(f"{title.capitalize()} is processed: "
                             f"{counters.success} succeeded; "
@@ -423,8 +423,8 @@ async def process_resource_changing_cause(
                 state.purge(body=cause.body, patch=cause.patch,
                             storage=storage, handlers=owned_handlers)
 
-            done = state.done
-            delays = state.delays
+            done = state.check_done(cause_handlers)
+            delays = state.get_delays(cause_handlers)
         else:
             skip = True
 


### PR DESCRIPTION
In #686, a complicated bug is well-described and discussed: Kopf floods the K8s API with dummy patches with no pause between them in certain initial conditions. Specifically, when there is a persisted state of a handler that didn't finish (with either success or failure) and came of out scope during the processing cycle (e.g. due to filters).

The bug was there since the purposes were introduced in #606, but was activated and made visible by #674.

Reproducible with:

```python
import kopf


@kopf.on.startup()
def configure(settings: kopf.OperatorSettings, **_):
    # Status storage must not intervene with its data:
    settings.persistence.progress_storage = kopf.AnnotationsProgressStorage()


@kopf.on.resume("configmaps", id="aaa")
@kopf.on.update("configmaps", id="bbb",
    when=lambda **_: False,  # <<< comment it, and the bug is gone.
)
def the_handler(**_):
    print("the_handler called")
```

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  annotations:
    kopf.zalando.org/last-handled-configuration: |
      {"simulated-change":123}
    kopf.zalando.org/bbb: '{"started":"2021-03-01T12:34:03.155586","purpose":"update","retries":0,"success":false,"failure":false}'
  name: bug
```

```
kubectl delete -f _issue686.yaml
kubectl create -f _issue686.yaml
kopf run _issue686.py --verbose -n default
```

The fix (this PR) replaces the state's "done"/"delays" computation logic:

* AS-IS: _all recorded handlers with the matching purpose._
* TO-BE: _all handlers currently in scope._

If a handler falls out of scope during the processing cycle, it will not be taken into account in the next "done"/"delays" computation, even it was not finished before — this was the behaviour before "purposes" were introduced in #606.

---

TODOs:

* [x] Reverify all other side-effects.
* [x] Reverify the differences of `0` vs. `None` delays in handler states (see #686's discussion).
* [x] Check if the purpose checking in "done"/"delays" is still needed and makes sense with explicitly requested handlers.
* [ ] If the logic is correct, adjust the tests.
* [ ] Consider getting rid of "purposes" at all — but they might be needed for "extras"/"counts", where the "currently in-scope handler" might be not enough, but "ever-were in-scope handlers" should be counted.
