### PR TITLE
Parse E2E flags/configs with AST instead of RegExps

### DIFF
--- a/examples/03-exceptions/example.py
+++ b/examples/03-exceptions/example.py
@@ -1,10 +1,5 @@
 import kopf
 
-E2E_TRACEBACKS = True
-E2E_CREATION_STOP_WORDS = ['Something has changed,']
-E2E_SUCCESS_COUNTS = {'eventual_success_with_few_messages': 1}
-E2E_FAILURE_COUNTS = {'eventual_failure_with_tracebacks': 1, 'instant_failure_with_traceback': 1, 'instant_failure_with_only_a_message': 1}
-
 
 class MyException(Exception):
     pass
@@ -29,3 +24,12 @@ def eventual_failure_with_tracebacks(**kwargs):
 @kopf.on.create('kopfexamples', errors=kopf.ErrorsMode.PERMANENT, backoff=1.0)
 def instant_failure_with_traceback(**kwargs):
     raise MyException("An error that is supposed to be recoverable.")
+
+
+# Marks for the e2e tests (see tests/e2e/test_examples.py):
+E2E_ALLOW_TRACEBACKS = True
+E2E_CREATION_STOP_WORDS = ['Something has changed,']
+E2E_SUCCESS_COUNTS = {'eventual_success_with_few_messages': 1}
+E2E_FAILURE_COUNTS = {'eventual_failure_with_tracebacks': 1,
+                      'instant_failure_with_traceback': 1,
+                      'instant_failure_with_only_a_message': 1}

--- a/examples/08-events/example.py
+++ b/examples/08-events/example.py
@@ -1,9 +1,5 @@
 import kopf
 
-# Marks for the e2e tests (see tests/e2e/test_examples.py):
-E2E_TRACEBACKS = True
-E2E_SUCCESS_COUNTS = {'normal_event_fn': 2}
-
 
 @kopf.on.event('kopfexamples')
 def event_fn_with_error(**kwargs):
@@ -13,3 +9,8 @@ def event_fn_with_error(**kwargs):
 @kopf.on.event('kopfexamples')
 def normal_event_fn(event, **kwargs):
     print(f"Event received: {event!r}")
+
+
+# Marks for the e2e tests (see tests/e2e/test_examples.py):
+E2E_ALLOW_TRACEBACKS = True
+E2E_SUCCESS_COUNTS = {'normal_event_fn': 2}

--- a/examples/10-builtins/example.py
+++ b/examples/10-builtins/example.py
@@ -1,10 +1,8 @@
 import asyncio
+from typing import Dict
 
 import kopf
 import pykube
-
-from typing import Dict
-
 
 tasks: Dict[str, Dict[str, asyncio.Task]] = {}  # dict{namespace: dict{name: asyncio.Task}}
 

--- a/examples/13-hooks/example.py
+++ b/examples/13-hooks/example.py
@@ -5,11 +5,6 @@ from typing import Dict
 import kopf
 import pykube
 
-E2E_STARTUP_STOP_WORDS = ['Served by the background task.']
-E2E_CLEANUP_STOP_WORDS = ['Hung tasks', 'Root tasks']
-E2E_SUCCESS_COUNTS = {'startup_fn_simple': 1, 'startup_fn_retried': 1, 'cleanup_fn': 1}
-E2E_FAILURE_COUNTS = {}  # type: Dict[str, int]
-
 LOCK: asyncio.Lock  # requires a loop on creation
 STOPPERS: Dict[str, Dict[str, asyncio.Event]] = {}  # [namespace][name]
 
@@ -86,3 +81,9 @@ async def _task_fn(logger, shouldstop: asyncio.Event):
         await asyncio.sleep(random.randint(1, 10))
         logger.info("Served by the background task.")
     logger.info("Serving is finished by request.")
+
+
+# Marks for the e2e tests (see tests/e2e/test_examples.py):
+E2E_STARTUP_STOP_WORDS = ['Served by the background task.']
+E2E_CLEANUP_STOP_WORDS = ['Hung tasks', 'Root tasks']
+E2E_SUCCESS_COUNTS = {'startup_fn_simple': 1, 'startup_fn_retried': 1, 'cleanup_fn': 1}

--- a/examples/14-daemons/example.py
+++ b/examples/14-daemons/example.py
@@ -33,5 +33,8 @@ async def background_async(spec, logger, retry, **_):
         await asyncio.sleep(5.0)
 
 
+# Marks for the e2e tests (see tests/e2e/test_examples.py):
 E2E_CREATION_STOP_WORDS = ["=> Ping from"]
-E2E_DELETION_STOP_WORDS = ["'background_async' is cancelled", "'background_sync' is cancelled", "'background_async' has exited"]
+E2E_DELETION_STOP_WORDS = ["'background_async' is cancelled",
+                           "'background_sync' is cancelled",
+                           "'background_async' has exited"]

--- a/examples/16-indexing/example.py
+++ b/examples/16-indexing/example.py
@@ -6,8 +6,8 @@ import kopf
 @kopf.index('pods')
 def is_running(namespace, name, status, **_):
     return {(namespace, name): status.get('phase') == 'Running'}
-    # {('kube-system', 'traefik-...-...'): True,
-    #  ('kube-system', 'helm-install-traefik-...'): False,
+    # {('kube-system', 'traefik-...-...'): [True],
+    #  ('kube-system', 'helm-install-traefik-...'): [False],
     #    ...}
 
 
@@ -42,4 +42,7 @@ def intervalled(is_running: kopf.Index, by_label: kopf.Index, patch: kopf.Patch,
 
 
 # Marks for the e2e tests (see tests/e2e/test_examples.py):
-E2E_SUCCESS_COUNTS = {}  # type: ignore # we do not care: pods can have 6-10 updates here.
+# We do not care: pods can have 6-10 updates here.
+from typing import Dict
+
+E2E_SUCCESS_COUNTS: Dict[str, int] = {}

--- a/examples/17-admission/example.py
+++ b/examples/17-admission/example.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Dict, List
+from typing import List
 
 import kopf
 
@@ -76,4 +76,6 @@ def mutate1(patch: kopf.Patch, **_):
 
 # Marks for the e2e tests (see tests/e2e/test_examples.py):
 # We do not care: pods can have 6-10 updates here.
-E2E_SUCCESS_COUNTS = {}  # type: Dict[str, int]
+from typing import Dict
+
+E2E_SUCCESS_COUNTS: Dict[str, int] = {}

--- a/examples/99-all-at-once/example.py
+++ b/examples/99-all-at-once/example.py
@@ -1,6 +1,3 @@
-"""
-Kubernetes operator example: all the features at once (for debugging & testing).
-"""
 import asyncio
 import pprint
 import time
@@ -8,17 +5,6 @@ import time
 import kopf
 import pykube
 import yaml
-
-from typing import Dict
-
-# Marks for the e2e tests (see tests/e2e/test_examples.py):
-E2E_STARTUP_STOP_WORDS = ['Served by the background task.']
-E2E_CLEANUP_STOP_WORDS = ['Hung tasks', 'Root tasks']
-E2E_CREATION_STOP_WORDS = ['Creation is processed:']
-E2E_DELETION_STOP_WORDS = ['Deleted, really deleted']
-E2E_SUCCESS_COUNTS = {'create_1': 1, 'create_2': 1, 'create_pod': 1, 'delete': 1, 'startup_fn_simple': 1, 'startup_fn_retried': 1, 'cleanup_fn': 1}
-E2E_FAILURE_COUNTS = {}  # type: Dict[str, int]
-E2E_TRACEBACKS = True
 
 
 @kopf.on.startup()
@@ -117,3 +103,13 @@ def create_pod(**kwargs):
 @kopf.on.event('pods', labels={'application': 'kopf-example-10'})
 def example_pod_change(logger, **kwargs):
     logger.info("This pod is special for us.")
+
+
+# Marks for the e2e tests (see tests/e2e/test_examples.py):
+E2E_ALLOW_TRACEBACKS = True
+E2E_STARTUP_STOP_WORDS = ['Served by the background task.']
+E2E_CLEANUP_STOP_WORDS = ['Hung tasks', 'Root tasks']
+E2E_CREATION_STOP_WORDS = ['Creation is processed:']
+E2E_DELETION_STOP_WORDS = ['Deleted, really deleted']
+E2E_SUCCESS_COUNTS = {'create_1': 1, 'create_2': 1, 'create_pod': 1, 'delete': 1,
+                      'startup_fn_simple': 1, 'startup_fn_retried': 1, 'cleanup_fn': 1}

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,6 @@ isort>=5.5.0
 certvalidator
 certbuilder
 pyngrok
+lxml
 astpath[xpath]
 import-linter

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -73,7 +73,7 @@ def test_all_examples_are_runnable(mocker, settings, with_crd, exampledir, caplo
         assert '[default/kopf-example-1] Deletion is in progress:' in runner.stdout
     if e2e.has_changing_handlers:
         assert '[default/kopf-example-1] Deleted, really deleted' in runner.stdout
-    if not e2e.tracebacks:
+    if not e2e.allow_tracebacks:
         assert 'Traceback (most recent call last):' not in runner.stdout
 
     # Verify that once a handler succeeds, it is never re-executed again.
@@ -183,8 +183,8 @@ class E2EParser:
         return self.configs.get('E2E_DELETION_STOP_WORDS')
 
     @property
-    def tracebacks(self) -> Optional[bool]:
-        return self.configs.get('E2E_TRACEBACKS')
+    def allow_tracebacks(self) -> Optional[bool]:
+        return self.configs.get('E2E_ALLOW_TRACEBACKS')
 
     @property
     def success_counts(self) -> Optional[Dict[str, int]]:


### PR DESCRIPTION
Parsing the AST allows us to have multi-line E2E-configs (e.g. lists), enriched with comments where needed. RegExps are limited to simple one-line values, and this does not fit into 100 chars limit sometimes.
