### PR TITLE
Clarify type annotations for daemon stopping flags

### DIFF
--- a/docs/kwargs.rst
+++ b/docs/kwargs.rst
@@ -252,7 +252,7 @@ Stop-flag
 ---------
 
 The daemons also have ``stopped``. It is a flag object for sync daemons
-to check if they should stop. See also: `DaemonStoppingFlag`.
+to check if they should stop. See also: `kopf.DaemonStoppingFlag`.
 
 To check, ``.is_set()`` method can be called, or the object itself can be used
 as a boolean expression: e.g. ``while not stopped: ...``.

--- a/docs/kwargs.rst
+++ b/docs/kwargs.rst
@@ -252,7 +252,7 @@ Stop-flag
 ---------
 
 The daemons also have ``stopped``. It is a flag object for sync daemons
-to check if they should stop. See also: `DaemonStopperChecker`.
+to check if they should stop. See also: `DaemonStoppingFlag`.
 
 To check, ``.is_set()`` method can be called, or the object itself can be used
 as a boolean expression: e.g. ``while not stopped: ...``.

--- a/examples/11-filtering-handlers/example.py
+++ b/examples/11-filtering-handlers/example.py
@@ -86,7 +86,7 @@ def update_with_field_change_satisfied(logger, **kwargs):
 
 
 @kopf.daemon('kopfexamples', field='spec.field', value='value')
-def daemon_with_field(stopped, logger, **kwargs):
+def daemon_with_field(stopped: kopf.DaemonStoppingFlag, logger, **kwargs):
     while not stopped:
         logger.info("Field daemon is satisfied.")
         stopped.wait(1)

--- a/examples/14-daemons/example.py
+++ b/examples/14-daemons/example.py
@@ -7,7 +7,7 @@ import kopf
 # Sync daemons in threads are non-interruptable, they must check for the `stopped` flag.
 # This daemon exits after 3 attempts and then 30 seconds of running (unless stopped).
 @kopf.daemon('kopfexamples', backoff=3)
-def background_sync(spec, stopped, logger, retry, patch, **_):
+def background_sync(stopped: kopf.DaemonStoppingFlag, spec, logger, retry, patch, **_):
     if retry < 3:
         patch.status['message'] = f"Failed {retry+1} times."
         raise kopf.TemporaryError("Simulated failure.", delay=1)

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -130,9 +130,10 @@ from kopf.structs.patches import (
     Patch,
 )
 from kopf.structs.primitives import (
+    DaemonStoppingFlag,
     DaemonStoppingReason,
-    SyncDaemonStopperChecker,
-    AsyncDaemonStopperChecker,
+    SyncDaemonStoppingFlag as SyncDaemonStopperChecker,  # deprecated
+    AsyncDaemonStoppingFlag as AsyncDaemonStopperChecker,  # deprecated
 )
 from kopf.structs.references import (
     Resource,
@@ -218,7 +219,6 @@ __all__ = [
     'StatusProgressStorage',
     'MultiProgressStorage',
     'SmartProgressStorage',
-    'DaemonStoppingReason',
     'RawEventType',
     'RawEvent',
     'RawBody',
@@ -243,7 +243,9 @@ __all__ = [
     'HandlerId',
     'Reason',
     'Patch',
-    'SyncDaemonStopperChecker',
-    'AsyncDaemonStopperChecker',
+    'DaemonStoppingFlag',
+    'DaemonStoppingReason',
+    'SyncDaemonStopperChecker',  # deprecated
+    'AsyncDaemonStopperChecker',  # deprecated
     'Resource', 'EVERYTHING',
 ]

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -95,7 +95,7 @@ def build_kwargs(
         )
     if isinstance(cause, causation.DaemonCause) and _sync is not None:
         new_kwargs.update(
-            stopped=cause.stopper.sync_checker if _sync else cause.stopper.async_checker,
+            stopped=cause.stopper.sync_flag if _sync else cause.stopper.async_flag,
         )
 
     # Inject indices in the end, so that they overwrite regular kwargs.

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -166,7 +166,7 @@ else:
 
     ResourceDaemonFn = Callable[
         [
-            NamedArg(primitives.SyncAsyncDaemonStopperChecker, "stopped"),
+            NamedArg(primitives.DaemonStoppingFlag, "stopped"),
             NamedArg(int, "retry"),
             NamedArg(datetime.datetime, "started"),
             NamedArg(datetime.timedelta, "runtime"),

--- a/tests/invocations/test_kwargs.py
+++ b/tests/invocations/test_kwargs.py
@@ -283,7 +283,7 @@ def test_daemon_sync_stopper(resource, indices):
         stopper=DaemonStopper(),
     )
     kwargs = build_kwargs(cause=cause, _sync=True)
-    assert kwargs['stopped'] is cause.stopper.sync_checker
+    assert kwargs['stopped'] is cause.stopper.sync_flag
 
 
 def test_daemon_async_stopper(resource, indices):
@@ -297,4 +297,4 @@ def test_daemon_async_stopper(resource, indices):
         stopper=DaemonStopper(),
     )
     kwargs = build_kwargs(cause=cause, _sync=False)
-    assert kwargs['stopped'] is cause.stopper.async_checker
+    assert kwargs['stopped'] is cause.stopper.async_flag


### PR DESCRIPTION
Previously, `Union` of sync & async checkers was used in the daemon protocol. As a result, it forced the operator developers to accept both types and do proper handling of both cases — when in fact only one checker was passed according to the daemon type (sync/async).

To simplify type-checking of operators, both sync & async checkers are now downgraded to _implementation details_ (but remain exported for backwards compatibility), while only the base class is exposed for type annotations of the `stopped` kwarg. To achieve this, some "clean" (as in, "not dirty") trickery was implemented — see the docstring of the new "waiter" class.

All public interfaces should remain supported without breaking it. Even evaluating the results of `stopped.wait()` as booleans remains there: the returned value is the flag/checker itself, but it is bool-evaluable (unless `x is True`/`x is False` conditions were used).

Related #747. Fixes #746. Replaced by #757.