### PR TITLE
Remove leading zeros from IPv4 in tests

### DIFF
--- a/tests/admission/test_certificates.py
+++ b/tests/admission/test_certificates.py
@@ -17,7 +17,7 @@ def test_missing_certbuilder(no_certbuilder):
 
 
 def test_certificate_generation():
-    names = ['hostname1', 'hostname2', '001.002.003.004', '0:0:0:0:0:0:0:1']
+    names = ['hostname1', 'hostname2', '1.2.3.4', '0:0:0:0:0:0:0:1']
     cert, pkey = WebhookServer.build_certificate(names)
     context = certvalidator.ValidationContext(extra_trust_roots=[cert])
     validator = certvalidator.CertificateValidator(cert, validation_context=context)


### PR DESCRIPTION
Leading zeros are no longer tolerated since Python 3.10 and 3.9.5 (see https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv4Address). This was breaking the tests due to a mismatch of the IP addresses in SSL certificates, as they were treated as regular hostnames after this change, and includes "as is" (not compacted).

> Changed in version 3.8: Leading zeros are tolerated, even in ambiguous cases that look like octal notation.
> 
> Changed in version 3.10: Leading zeros are no longer tolerated and are treated as an error. IPv4 address strings are now parsed as strict as glibc inet_pton().
> 
> Changed in version 3.9.5: The above change was also included in Python 3.9 starting with version 3.9.5.

This is a bug in the tests, not in the framework.