### PR TITLE
Isolate low-level "invocation" from higher-level "causation" & "callbacks"

### DIFF
--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -9,9 +9,10 @@ activities, when there is no underlying Kubernetes object to patch'n'watch.
 """
 import asyncio
 import collections.abc
+import datetime
 import logging
 from contextvars import ContextVar
-from typing import Any, Collection, Iterable, Mapping, MutableMapping, Optional, Set, Union
+from typing import Collection, Iterable, Mapping, MutableMapping, Optional, Set, Union
 
 from kopf.engines import loggers
 from kopf.reactor import causation, invocation, lifecycles, registries
@@ -264,10 +265,10 @@ async def execute_handler_once(
             raise HandlerRetriesError(f"{handler} has exceeded {state.retries} retries.")
 
         result = await invoke_handler(
-            handler,
+            handler=handler,
             cause=cause,
             retry=state.retries,
-            started=state.started,
+            started=state.started or datetime.datetime.utcnow(),  # "or" is for type-checking.
             runtime=state.runtime,
             settings=settings,
             lifecycle=lifecycle,  # just a default for the sub-handlers, not used directly.
@@ -323,13 +324,15 @@ async def execute_handler_once(
 
 
 async def invoke_handler(
+        *,
         handler: handlers_.BaseHandler,
-        *args: Any,
         cause: causation.BaseCause,
+        retry: int,
+        started: datetime.datetime,
+        runtime: datetime.timedelta,
         settings: configuration.OperatorSettings,
         lifecycle: Optional[lifecycles.LifeCycleFn],
         subrefs: Set[ids.HandlerId],
-        **kwargs: Any,
 ) -> Optional[callbacks.Result]:
     """
     Invoke one handler only, according to the calling conventions.
@@ -367,11 +370,14 @@ async def invoke_handler(
         # as if it was done inside of the handler (i.e. under try-finally block).
         result = await invocation.invoke(
             handler.fn,
-            *args,
             settings=settings,
             cause=cause,
-            param=handler.param,
-            **kwargs,
+            kwargs=dict(
+                param=handler.param,
+                retry=retry,
+                started=started,
+                runtime=runtime,
+            ),
         )
 
         if not subexecuted_var.get() and isinstance(cause, causation.ResourceChangingCause):

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -200,7 +200,7 @@ async def execute_handlers_once(
 
     # Filter and select the handlers to be executed right now, on this event reaction cycle.
     handlers_todo = [h for h in handlers if state[h.id].awakened]
-    handlers_plan = lifecycle(handlers_todo, **invocation.build_kwargs(cause=cause, state=state))
+    handlers_plan = lifecycle(handlers_todo, state=state, **cause.kwargs)
 
     # Execute all planned (selected) handlers in one event reaction cycle, even if there are few.
     outcomes: MutableMapping[ids.HandlerId, states.HandlerOutcome] = {}
@@ -371,7 +371,7 @@ async def invoke_handler(
         result = await invocation.invoke(
             handler.fn,
             settings=settings,
-            cause=cause,
+            kwargsrc=cause,
             kwargs=dict(
                 param=handler.param,
                 retry=retry,

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -18,7 +18,7 @@ from types import FunctionType, MethodType
 from typing import Any, Callable, Collection, Container, Generic, Iterable, Iterator, List, \
                    Mapping, MutableMapping, Optional, Sequence, Set, Tuple, TypeVar, cast
 
-from kopf.reactor import causation, invocation
+from kopf.reactor import causation
 from kopf.structs import dicts, filters, handlers, ids, references
 from kopf.utilities import piggybacking
 
@@ -445,7 +445,7 @@ def _matches_metadata(
             continue
         elif callable(value):
             if not kwargs:
-                kwargs.update(invocation.build_kwargs(cause=cause))
+                kwargs.update(cause.kwargs)
             if value(content.get(key, None), **kwargs):
                 continue
             else:
@@ -468,7 +468,7 @@ def _matches_field_values(
         return True
 
     if not kwargs:
-        kwargs.update(invocation.build_kwargs(cause=cause))
+        kwargs.update(cause.kwargs)
 
     absent = _UNSET.token  # or any other identifyable object
     if isinstance(cause, causation.ResourceChangingCause):
@@ -502,7 +502,7 @@ def _matches_field_changes(
         return True
 
     if not kwargs:
-        kwargs.update(invocation.build_kwargs(cause=cause))
+        kwargs.update(cause.kwargs)
 
     absent = _UNSET.token  # or any other identifyable object
     old = dicts.resolve(cause.old, handler.field, absent)
@@ -533,7 +533,7 @@ def _matches_filter_callback(
     if handler.when is None:
         return True
     if not kwargs:
-        kwargs.update(invocation.build_kwargs(cause=cause))
+        kwargs.update(cause.kwargs)
     return handler.when(**kwargs)
 
 

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -10,9 +10,9 @@ a corresponding type or class ``kopf.Whatever`` with all the typing tricks
 """
 import datetime
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Collection, \
-                   Coroutine, List, NewType, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Collection, List, NewType, Optional, TypeVar, Union
 
+from kopf.reactor import invocation
 from kopf.structs import bodies, configuration, diffs, ephemera, \
                          patches, primitives, references, reviews
 
@@ -24,25 +24,15 @@ Logger = Union[logging.Logger, logging.LoggerAdapter]
 # to not be mixed with other arbitrary Any values, where it is indeed "any".
 Result = NewType('Result', object)
 
-# An internal typing hack shows that the handler can be sync fn with the result,
-# or an async fn which returns a coroutine which, in turn, returns the result.
-# Used in some protocols only and is never exposed to other modules.
-_R = TypeVar('_R')
-_SyncOrAsync = Union[_R, Coroutine[None, None, _R]]
-
-# A generic sync-or-async callable with no args/kwargs checks (unlike in protocols).
-# Used for the BaseHandler and generic invocation methods (which do not care about protocols).
-BaseFn = Callable[..., _SyncOrAsync[Optional[object]]]
-
 if not TYPE_CHECKING:  # pragma: nocover
     # Define unspecified protocols for the runtime annotations -- to avoid "quoting".
-    ActivityFn = Callable[..., _SyncOrAsync[Optional[object]]]
-    ResourceIndexingFn = Callable[..., _SyncOrAsync[Optional[object]]]
-    ResourceWatchingFn = Callable[..., _SyncOrAsync[Optional[object]]]
-    ResourceChangingFn = Callable[..., _SyncOrAsync[Optional[object]]]
-    ResourceWebhookFn = Callable[..., _SyncOrAsync[None]]
-    ResourceDaemonFn = Callable[..., _SyncOrAsync[Optional[object]]]
-    ResourceTimerFn = Callable[..., _SyncOrAsync[Optional[object]]]
+    ActivityFn = Callable[...,  invocation.SyncOrAsync[Optional[object]]]
+    ResourceIndexingFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
+    ResourceWatchingFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
+    ResourceChangingFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
+    ResourceWebhookFn = Callable[..., invocation.SyncOrAsync[None]]
+    ResourceDaemonFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
+    ResourceTimerFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
     WhenFilterFn = Callable[..., bool]  # strictly sync, no async!
     MetaFilterFn = Callable[..., bool]  # strictly sync, no async!
 else:
@@ -63,7 +53,7 @@ else:
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
         ],
-        _SyncOrAsync[Optional[object]]
+        invocation.SyncOrAsync[Optional[object]]
     ]
 
     ResourceIndexingFn = Callable[
@@ -84,7 +74,7 @@ else:
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
         ],
-        _SyncOrAsync[Optional[object]]
+        invocation.SyncOrAsync[Optional[object]]
     ]
 
     ResourceWatchingFn = Callable[
@@ -107,7 +97,7 @@ else:
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
         ],
-        _SyncOrAsync[Optional[object]]
+        invocation.SyncOrAsync[Optional[object]]
     ]
 
     ResourceChangingFn = Callable[
@@ -135,7 +125,7 @@ else:
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
         ],
-        _SyncOrAsync[Optional[object]]
+        invocation.SyncOrAsync[Optional[object]]
     ]
 
     ResourceWebhookFn = Callable[
@@ -161,7 +151,7 @@ else:
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
         ],
-        _SyncOrAsync[None]
+        invocation.SyncOrAsync[None]
     ]
 
     ResourceDaemonFn = Callable[
@@ -186,7 +176,7 @@ else:
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
         ],
-        _SyncOrAsync[Optional[object]]
+        invocation.SyncOrAsync[Optional[object]]
     ]
 
     ResourceTimerFn = Callable[
@@ -208,7 +198,7 @@ else:
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
         ],
-        _SyncOrAsync[Optional[object]]
+        invocation.SyncOrAsync[Optional[object]]
     ]
 
     WhenFilterFn = Callable[

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -2,6 +2,7 @@ import dataclasses
 import enum
 from typing import Any, Optional
 
+from kopf.reactor import invocation
 from kopf.structs import callbacks, dicts, filters, ids, references
 
 
@@ -73,7 +74,7 @@ TITLES = {
 @dataclasses.dataclass
 class BaseHandler:
     id: ids.HandlerId
-    fn: callbacks.BaseFn
+    fn: invocation.Invokable
     param: Optional[Any]
     errors: Optional[ErrorsMode]
     timeout: Optional[float]

--- a/tests/basic-structs/test_causes.py
+++ b/tests/basic-structs/test_causes.py
@@ -37,7 +37,7 @@ def test_resource_watching_cause(mocker):
     patch = mocker.Mock()
     memo = mocker.Mock()
     type = mocker.Mock()
-    raw = mocker.Mock()
+    event = mocker.Mock()
     cause = ResourceWatchingCause(
         resource=resource,
         indices=indices,
@@ -46,7 +46,7 @@ def test_resource_watching_cause(mocker):
         patch=patch,
         memo=memo,
         type=type,
-        raw=raw,
+        event=event,
     )
     assert cause.resource is resource
     assert cause.indices is indices
@@ -55,7 +55,7 @@ def test_resource_watching_cause(mocker):
     assert cause.patch is patch
     assert cause.memo is memo
     assert cause.type is type
-    assert cause.raw is raw
+    assert cause.event is event
 
 
 def test_resource_changing_cause_with_all_args(mocker):

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -56,7 +56,7 @@ def owner(request, resource):
             memo=Memo(),
             body=body,
             type='irrelevant',
-            raw=RawEvent(type='irrelevant', object=OWNER),
+            event=RawEvent(type='irrelevant', object=OWNER),
         )
         with context([(cause_var, cause)]):
             yield body

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -149,15 +149,12 @@ async def test_result_returned(fn):
 @fns
 async def test_explicit_args_passed_properly(fn):
     fn = MagicMock(fn)
-    await invoke(fn, 100, 200, kw1=300, kw2=400)
+    await invoke(fn, kwargs=dict(kw1=300, kw2=400))
 
     assert fn.called
     assert fn.call_count == 1
 
-    assert len(fn.call_args[0]) == 2
-    assert fn.call_args[0][0] == 100
-    assert fn.call_args[0][1] == 200
-
+    assert len(fn.call_args[0]) == 0
     assert len(fn.call_args[1]) >= 2  # also the magic kwargs
     assert fn.call_args[1]['kw1'] == 300
     assert fn.call_args[1]['kw2'] == 400

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -182,7 +182,7 @@ async def test_special_kwargs_added(fn, resource):
     )
 
     fn = MagicMock(fn)
-    await invoke(fn, cause=cause)
+    await invoke(fn, kwargsrc=cause)
 
     assert fn.called
     assert fn.call_count == 1

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -5,7 +5,6 @@ import pytest
 import kopf
 from kopf.reactor.causation import ResourceChangingCause
 from kopf.reactor.indexing import OperatorIndexers
-from kopf.reactor.invocation import build_kwargs
 from kopf.storage.states import State
 from kopf.structs.bodies import Body
 from kopf.structs.ephemera import Memo
@@ -38,6 +37,6 @@ async def test_protocol_invocation(lifecycle, resource):
         reason=Reason.NOOP,
     )
     handlers = []
-    selected = lifecycle(handlers, **build_kwargs(cause=cause, state=state))
+    selected = lifecycle(handlers, state=state, **cause.kwargs)
     assert isinstance(selected, (tuple, list))
     assert len(selected) == 0

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -5,6 +5,7 @@ import pytest
 import kopf
 from kopf.reactor.causation import ResourceChangingCause
 from kopf.reactor.indexing import OperatorIndexers
+from kopf.reactor.invocation import build_kwargs
 from kopf.storage.states import State
 from kopf.structs.bodies import Body
 from kopf.structs.ephemera import Memo
@@ -37,6 +38,6 @@ async def test_protocol_invocation(lifecycle, resource):
         reason=Reason.NOOP,
     )
     handlers = []
-    selected = lifecycle(handlers, state=state, **cause.kwargs)
+    selected = lifecycle(handlers, **build_kwargs(cause=cause, state=state))
     assert isinstance(selected, (tuple, list))
     assert len(selected) == 0

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -5,7 +5,6 @@ import pytest
 import kopf
 from kopf.reactor.causation import ResourceChangingCause
 from kopf.reactor.indexing import OperatorIndexers
-from kopf.reactor.invocation import invoke
 from kopf.storage.states import State
 from kopf.structs.bodies import Body
 from kopf.structs.ephemera import Memo
@@ -38,6 +37,6 @@ async def test_protocol_invocation(lifecycle, resource):
         reason=Reason.NOOP,
     )
     handlers = []
-    selected = await invoke(lifecycle, handlers, cause=cause, state=state)
+    selected = lifecycle(handlers, state=state, **cause.kwargs)
     assert isinstance(selected, (tuple, list))
     assert len(selected) == 0

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -86,8 +86,8 @@ def cause_factory(resource):
             cls=ResourceChangingCause,
             *,
             resource=resource,
+            event=None,
             type=None,
-            raw=None,
             body=None,
             diff=(),
             old=None,
@@ -123,7 +123,7 @@ def cause_factory(resource):
                 memo=Memo(),
                 body=Body(body if body is not None else {}),
                 type=type,
-                raw=raw,
+                event=event,
             )
         if cls is ResourceChangingCause or cls is ResourceChangingRegistry:
             return ResourceChangingCause(


### PR DESCRIPTION
As part of a bigger refactoring, "invocation" module should shift to lower levels within reactor, so it must stop depending on higher-level causes. For this, extract kwargs generation as an abstract protocol, and make causes an implementation of it (the only one, to the moment).

---

In the historically established design, the kwargs were formed by the invocation routines, for which they had to know each and every cause class and extract its fields as kwargs. As a result, when more and more causes were added over time, the kwarg-building routine was growing. 

The worst part of this was that the cause classes could not be moved to their relevant modules where they are locally used: e.g. `DaemonCause` is needed only within `daemons.py` and nowhere else; the same for `ActivityCause` and `activities.py`. Any attempt to move the specialised causes to their specialised modules led to an extra dependency of the "invocation" module on these specialised modules, which in turn often depended on the "invocation" module (directly or indirectly via the "handling" module) — thus creating a circular dependency.

With this split & shift of kwargs construction, the "invocation" module has no need to know about all cause classes existing in the framework, it only needs a source of kwargs — the dynamic nature of kwargs is implemented via polymorphism of cause classes.

Some extra complexity is added for the separation of sync-vs-async — which is currently only used in daemons for the daemon-stopping flags: they must have specialised `stopped.wait()` method. The same for overriding kwargs (now: only for indices). This is an acceptable trade-off for better cohesion and overall code quality.
