### PR TITLE
Rename internal entities to not mention "resource(s)" explicitly

### DIFF
--- a/kopf/on.py
+++ b/kopf/on.py
@@ -17,12 +17,12 @@ from kopf.reactor import handling, registries
 from kopf.structs import callbacks, dicts, filters, handlers, references, reviews
 
 ActivityDecorator = Callable[[callbacks.ActivityFn], callbacks.ActivityFn]
-ResourceIndexingDecorator = Callable[[callbacks.ResourceIndexingFn], callbacks.ResourceIndexingFn]
-ResourceWatchingDecorator = Callable[[callbacks.ResourceWatchingFn], callbacks.ResourceWatchingFn]
-ResourceChangingDecorator = Callable[[callbacks.ResourceChangingFn], callbacks.ResourceChangingFn]
-ResourceWebhookDecorator = Callable[[callbacks.ResourceWebhookFn], callbacks.ResourceWebhookFn]
-ResourceDaemonDecorator = Callable[[callbacks.ResourceDaemonFn], callbacks.ResourceDaemonFn]
-ResourceTimerDecorator = Callable[[callbacks.ResourceTimerFn], callbacks.ResourceTimerFn]
+IndexingDecorator = Callable[[callbacks.IndexingFn], callbacks.IndexingFn]
+WatchingDecorator = Callable[[callbacks.WatchingFn], callbacks.WatchingFn]
+ChangingDecorator = Callable[[callbacks.ChangingFn], callbacks.ChangingFn]
+WebhookDecorator = Callable[[callbacks.WebhookFn], callbacks.WebhookFn]
+DaemonDecorator = Callable[[callbacks.DaemonFn], callbacks.DaemonFn]
+TimerDecorator = Callable[[callbacks.TimerFn], callbacks.TimerFn]
 
 
 def startup(  # lgtm[py/similar-function]
@@ -163,11 +163,11 @@ def validate(  # lgtm[py/similar-function]
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ResourceWebhookDecorator:
+) -> WebhookDecorator:
     """ ``@kopf.on.validate()`` handler for validating admission webhooks. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceWebhookFn,
-    ) -> callbacks.ResourceWebhookFn:
+            fn: callbacks.WebhookFn,
+    ) -> callbacks.WebhookFn:
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -178,7 +178,7 @@ def validate(  # lgtm[py/similar-function]
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
-        handler = handlers.ResourceWebhookHandler(
+        handler = handlers.WebhookHandler(
             fn=fn, id=real_id, param=param,
             errors=None, timeout=None, retries=None, backoff=None,  # TODO: add some meaning later
             selector=selector, labels=labels, annotations=annotations, when=when,
@@ -186,7 +186,7 @@ def validate(  # lgtm[py/similar-function]
             reason=handlers.WebhookType.VALIDATING, operation=operation,
             persistent=persistent, side_effects=side_effects, ignore_failures=ignore_failures,
         )
-        real_registry._resource_webhooks.append(handler)
+        real_registry._webhooks.append(handler)
         return fn
     return decorator
 
@@ -219,11 +219,11 @@ def mutate(  # lgtm[py/similar-function]
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ResourceWebhookDecorator:
+) -> WebhookDecorator:
     """ ``@kopf.on.mutate()`` handler for mutating admission webhooks. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceWebhookFn,
-    ) -> callbacks.ResourceWebhookFn:
+            fn: callbacks.WebhookFn,
+    ) -> callbacks.WebhookFn:
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -234,7 +234,7 @@ def mutate(  # lgtm[py/similar-function]
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
-        handler = handlers.ResourceWebhookHandler(
+        handler = handlers.WebhookHandler(
             fn=fn, id=real_id, param=param,
             errors=None, timeout=None, retries=None, backoff=None,  # TODO: add some meaning later
             selector=selector, labels=labels, annotations=annotations, when=when,
@@ -242,7 +242,7 @@ def mutate(  # lgtm[py/similar-function]
             reason=handlers.WebhookType.MUTATING, operation=operation,
             persistent=persistent, side_effects=side_effects, ignore_failures=ignore_failures,
         )
-        real_registry._resource_webhooks.append(handler)
+        real_registry._webhooks.append(handler)
         return fn
     return decorator
 
@@ -276,11 +276,11 @@ def resume(  # lgtm[py/similar-function]
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ResourceChangingDecorator:
+) -> ChangingDecorator:
     """ ``@kopf.on.resume()`` handler for the object resuming on operator (re)start. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: callbacks.ChangingFn,
+    ) -> callbacks.ChangingFn:
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -291,7 +291,7 @@ def resume(  # lgtm[py/similar-function]
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
-        handler = handlers.ResourceChangingHandler(
+        handler = handlers.ChangingHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
@@ -299,7 +299,7 @@ def resume(  # lgtm[py/similar-function]
             initial=True, deleted=deleted, requires_finalizer=None,
             reason=None,
         )
-        real_registry._resource_changing.append(handler)
+        real_registry._changing.append(handler)
         return fn
     return decorator
 
@@ -332,11 +332,11 @@ def create(  # lgtm[py/similar-function]
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ResourceChangingDecorator:
+) -> ChangingDecorator:
     """ ``@kopf.on.create()`` handler for the object creation. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: callbacks.ChangingFn,
+    ) -> callbacks.ChangingFn:
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -347,7 +347,7 @@ def create(  # lgtm[py/similar-function]
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
-        handler = handlers.ResourceChangingHandler(
+        handler = handlers.ChangingHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
@@ -355,7 +355,7 @@ def create(  # lgtm[py/similar-function]
             initial=None, deleted=None, requires_finalizer=None,
             reason=handlers.Reason.CREATE,
         )
-        real_registry._resource_changing.append(handler)
+        real_registry._changing.append(handler)
         return fn
     return decorator
 
@@ -390,11 +390,11 @@ def update(  # lgtm[py/similar-function]
         new: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ResourceChangingDecorator:
+) -> ChangingDecorator:
     """ ``@kopf.on.update()`` handler for the object update or change. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: callbacks.ChangingFn,
+    ) -> callbacks.ChangingFn:
         _warn_conflicting_values(field, value, old, new)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -405,7 +405,7 @@ def update(  # lgtm[py/similar-function]
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
-        handler = handlers.ResourceChangingHandler(
+        handler = handlers.ChangingHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
@@ -413,7 +413,7 @@ def update(  # lgtm[py/similar-function]
             initial=None, deleted=None, requires_finalizer=None,
             reason=handlers.Reason.UPDATE,
         )
-        real_registry._resource_changing.append(handler)
+        real_registry._changing.append(handler)
         return fn
     return decorator
 
@@ -447,11 +447,11 @@ def delete(  # lgtm[py/similar-function]
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ResourceChangingDecorator:
+) -> ChangingDecorator:
     """ ``@kopf.on.delete()`` handler for the object deletion. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: callbacks.ChangingFn,
+    ) -> callbacks.ChangingFn:
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -462,7 +462,7 @@ def delete(  # lgtm[py/similar-function]
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
-        handler = handlers.ResourceChangingHandler(
+        handler = handlers.ChangingHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
@@ -470,7 +470,7 @@ def delete(  # lgtm[py/similar-function]
             initial=None, deleted=None, requires_finalizer=bool(not optional),
             reason=handlers.Reason.DELETE,
         )
-        real_registry._resource_changing.append(handler)
+        real_registry._changing.append(handler)
         return fn
     return decorator
 
@@ -505,11 +505,11 @@ def field(  # lgtm[py/similar-function]
         new: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ResourceChangingDecorator:
+) -> ChangingDecorator:
     """ ``@kopf.on.field()`` handler for the individual field changes. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: callbacks.ChangingFn,
+    ) -> callbacks.ChangingFn:
         _warn_conflicting_values(field, value, old, new)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -520,7 +520,7 @@ def field(  # lgtm[py/similar-function]
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
-        handler = handlers.ResourceChangingHandler(
+        handler = handlers.ChangingHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
@@ -528,7 +528,7 @@ def field(  # lgtm[py/similar-function]
             initial=None, deleted=None, requires_finalizer=None,
             reason=None,
         )
-        real_registry._resource_changing.append(handler)
+        real_registry._changing.append(handler)
         return fn
     return decorator
 
@@ -561,11 +561,11 @@ def index(  # lgtm[py/similar-function]
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ResourceIndexingDecorator:
+) -> IndexingDecorator:
     """ ``@kopf.index()`` handler for the indexing callbacks. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceIndexingFn,
-    ) -> callbacks.ResourceIndexingFn:
+            fn: callbacks.IndexingFn,
+    ) -> callbacks.IndexingFn:
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -576,13 +576,13 @@ def index(  # lgtm[py/similar-function]
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
-        handler = handlers.ResourceIndexingHandler(
+        handler = handlers.IndexingHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value,
         )
-        real_registry._resource_indexing.append(handler)
+        real_registry._indexing.append(handler)
         return fn
     return decorator
 
@@ -611,11 +611,11 @@ def event(  # lgtm[py/similar-function]
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ResourceWatchingDecorator:
+) -> WatchingDecorator:
     """ ``@kopf.on.event()`` handler for the silent spies on the events. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceWatchingFn,
-    ) -> callbacks.ResourceWatchingFn:
+            fn: callbacks.WatchingFn,
+    ) -> callbacks.WatchingFn:
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -626,13 +626,13 @@ def event(  # lgtm[py/similar-function]
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
-        handler = handlers.ResourceWatchingHandler(
+        handler = handlers.WatchingHandler(
             fn=fn, id=real_id, param=param,
             errors=None, timeout=None, retries=None, backoff=None,
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value,
         )
-        real_registry._resource_watching.append(handler)
+        real_registry._watching.append(handler)
         return fn
     return decorator
 
@@ -669,11 +669,11 @@ def daemon(  # lgtm[py/similar-function]
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ResourceDaemonDecorator:
+) -> DaemonDecorator:
     """ ``@kopf.daemon()`` decorator for the background threads/tasks. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceDaemonFn,
-    ) -> callbacks.ResourceDaemonFn:
+            fn: callbacks.DaemonFn,
+    ) -> callbacks.DaemonFn:
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -684,7 +684,7 @@ def daemon(  # lgtm[py/similar-function]
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
-        handler = handlers.ResourceDaemonHandler(
+        handler = handlers.DaemonHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
@@ -694,7 +694,7 @@ def daemon(  # lgtm[py/similar-function]
             cancellation_timeout=cancellation_timeout,
             cancellation_polling=cancellation_polling,
         )
-        real_registry._resource_spawning.append(handler)
+        real_registry._spawning.append(handler)
         return fn
     return decorator
 
@@ -731,11 +731,11 @@ def timer(  # lgtm[py/similar-function]
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
-) -> ResourceTimerDecorator:
+) -> TimerDecorator:
     """ ``@kopf.timer()`` handler for the regular events. """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceTimerFn,
-    ) -> callbacks.ResourceTimerFn:
+            fn: callbacks.TimerFn,
+    ) -> callbacks.TimerFn:
         _warn_conflicting_values(field, value)
         _verify_filters(labels, annotations)
         real_registry = registry if registry is not None else registries.get_default_registry()
@@ -746,7 +746,7 @@ def timer(  # lgtm[py/similar-function]
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
-        handler = handlers.ResourceTimerHandler(
+        handler = handlers.TimerHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
@@ -754,7 +754,7 @@ def timer(  # lgtm[py/similar-function]
             initial_delay=initial_delay, requires_finalizer=True,
             sharp=sharp, idle=idle, interval=interval,
         )
-        real_registry._resource_spawning.append(handler)
+        real_registry._spawning.append(handler)
         return fn
     return decorator
 
@@ -776,7 +776,7 @@ def subhandler(  # lgtm[py/similar-function]
         value: Optional[filters.ValueFilter] = None,
         old: Optional[filters.ValueFilter] = None,  # only for on.update's subhandlers
         new: Optional[filters.ValueFilter] = None,  # only for on.update's subhandlers
-) -> ResourceChangingDecorator:
+) -> ChangingDecorator:
     """
     ``@kopf.subhandler()`` decorator for the dynamically generated sub-handlers.
 
@@ -806,10 +806,10 @@ def subhandler(  # lgtm[py/similar-function]
     create function will have its own value, not the latest in the for-cycle.
     """
     def decorator(  # lgtm[py/similar-function]
-            fn: callbacks.ResourceChangingFn,
-    ) -> callbacks.ResourceChangingFn:
+            fn: callbacks.ChangingFn,
+    ) -> callbacks.ChangingFn:
         parent_handler = handling.handler_var.get()
-        if not isinstance(parent_handler, handlers.ResourceChangingHandler):
+        if not isinstance(parent_handler, handlers.ChangingHandler):
             raise TypeError("Sub-handlers are only supported for resource-changing handlers.")
         _warn_incompatible_parent_with_oldnew(parent_handler, old, new)
         _warn_conflicting_values(field, value, old, new)
@@ -818,7 +818,7 @@ def subhandler(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id,
                                          prefix=parent_handler.id if parent_handler else None)
-        handler = handlers.ResourceChangingHandler(
+        handler = handlers.ChangingHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=None, labels=labels, annotations=annotations, when=when,
@@ -833,7 +833,7 @@ def subhandler(  # lgtm[py/similar-function]
 
 
 def register(  # lgtm[py/similar-function]
-        fn: callbacks.ResourceChangingFn,
+        fn: callbacks.ChangingFn,
         *,
         # Handler's behaviour specification:
         id: Optional[str] = None,
@@ -846,7 +846,7 @@ def register(  # lgtm[py/similar-function]
         labels: Optional[filters.MetaFilter] = None,
         annotations: Optional[filters.MetaFilter] = None,
         when: Optional[callbacks.WhenFilterFn] = None,
-) -> callbacks.ResourceChangingFn:
+) -> callbacks.ChangingFn:
     """
     Register a function as a sub-handler of the currently executed handler.
 
@@ -913,7 +913,7 @@ def _warn_incompatible_parent_with_oldnew(
         new: Any,
 ) -> None:
     if old is not None or new is not None:
-        if isinstance(handler, handlers.ResourceChangingHandler):
+        if isinstance(handler, handlers.ChangingHandler):
             is_on_update = handler.reason == handlers.Reason.UPDATE
             is_on_field = handler.reason is None and not handler.initial
             if not is_on_update and not is_on_field:

--- a/kopf/reactor/observation.py
+++ b/kopf/reactor/observation.py
@@ -91,11 +91,11 @@ async def resource_observer(
 
     # Scan only the resource-related handlers, ignore activies & co.
     all_handlers: List[handlers.ResourceHandler] = []
-    all_handlers.extend(registry._resource_webhooks.get_all_handlers())
-    all_handlers.extend(registry._resource_indexing.get_all_handlers())
-    all_handlers.extend(registry._resource_watching.get_all_handlers())
-    all_handlers.extend(registry._resource_spawning.get_all_handlers())
-    all_handlers.extend(registry._resource_changing.get_all_handlers())
+    all_handlers.extend(registry._webhooks.get_all_handlers())
+    all_handlers.extend(registry._indexing.get_all_handlers())
+    all_handlers.extend(registry._watching.get_all_handlers())
+    all_handlers.extend(registry._spawning.get_all_handlers())
+    all_handlers.extend(registry._changing.get_all_handlers())
     groups = {handler.selector.group for handler in all_handlers if handler.selector is not None}
     groups.update({selector.group for selector in insights.backbone.selectors})
 
@@ -205,11 +205,11 @@ def revise_resources(
 
     # Scan only the resource-related handlers, ignore activies & co.
     all_handlers: List[handlers.ResourceHandler] = []
-    all_handlers.extend(registry._resource_webhooks.get_all_handlers())
-    all_handlers.extend(registry._resource_indexing.get_all_handlers())
-    all_handlers.extend(registry._resource_watching.get_all_handlers())
-    all_handlers.extend(registry._resource_spawning.get_all_handlers())
-    all_handlers.extend(registry._resource_changing.get_all_handlers())
+    all_handlers.extend(registry._webhooks.get_all_handlers())
+    all_handlers.extend(registry._indexing.get_all_handlers())
+    all_handlers.extend(registry._watching.get_all_handlers())
+    all_handlers.extend(registry._spawning.get_all_handlers())
+    all_handlers.extend(registry._changing.get_all_handlers())
     all_selectors = {handler.selector for handler in all_handlers if handler.selector is not None}
 
     if group is None:
@@ -224,7 +224,7 @@ def revise_resources(
     for selector in all_selectors:
         insights.resources.update(selector.select(resources))
         insights.indexable.update(resource for resource in selector.select(resources)
-                                  if registry._resource_indexing.has_handlers(resource))
+                                  if registry._indexing.has_handlers(resource))
 
     # Detect ambiguous selectors and stop watching: 2+ distinct resources for the same selector.
     # E.g.: "pods.v1" & "pods.v1beta1.metrics.k8s.io", when specified as just "pods" (but only

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -198,7 +198,7 @@ async def spawn_tasks(
         settings.peering.priority = priority
 
     # Prepopulate indexers with empty indices -- to be available startup handlers.
-    indexers.ensure(registry._resource_indexing.get_all_handlers())
+    indexers.ensure(registry._indexing.get_all_handlers())
 
     # Global credentials store for this operator, also for CRD-reading & peering mode detection.
     auth.vault_var.set(vault)

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -27,12 +27,12 @@ Result = NewType('Result', object)
 if not TYPE_CHECKING:  # pragma: nocover
     # Define unspecified protocols for the runtime annotations -- to avoid "quoting".
     ActivityFn = Callable[...,  invocation.SyncOrAsync[Optional[object]]]
-    ResourceIndexingFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
-    ResourceWatchingFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
-    ResourceChangingFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
-    ResourceWebhookFn = Callable[..., invocation.SyncOrAsync[None]]
-    ResourceDaemonFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
-    ResourceTimerFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
+    IndexingFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
+    WatchingFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
+    ChangingFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
+    WebhookFn = Callable[..., invocation.SyncOrAsync[None]]
+    DaemonFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
+    TimerFn = Callable[..., invocation.SyncOrAsync[Optional[object]]]
     WhenFilterFn = Callable[..., bool]  # strictly sync, no async!
     MetaFilterFn = Callable[..., bool]  # strictly sync, no async!
 else:
@@ -56,7 +56,7 @@ else:
         invocation.SyncOrAsync[Optional[object]]
     ]
 
-    ResourceIndexingFn = Callable[
+    IndexingFn = Callable[
         [
             NamedArg(bodies.Annotations, "annotations"),
             NamedArg(bodies.Labels, "labels"),
@@ -77,7 +77,7 @@ else:
         invocation.SyncOrAsync[Optional[object]]
     ]
 
-    ResourceWatchingFn = Callable[
+    WatchingFn = Callable[
         [
             NamedArg(str, "type"),
             NamedArg(bodies.RawEvent, "event"),
@@ -100,7 +100,7 @@ else:
         invocation.SyncOrAsync[Optional[object]]
     ]
 
-    ResourceChangingFn = Callable[
+    ChangingFn = Callable[
         [
             NamedArg(int, "retry"),
             NamedArg(datetime.datetime, "started"),
@@ -128,7 +128,7 @@ else:
         invocation.SyncOrAsync[Optional[object]]
     ]
 
-    ResourceWebhookFn = Callable[
+    WebhookFn = Callable[
         [
             NamedArg(bool, "dryrun"),
             NamedArg(List[str], "warnings"),  # mutable!
@@ -154,7 +154,7 @@ else:
         invocation.SyncOrAsync[None]
     ]
 
-    ResourceDaemonFn = Callable[
+    DaemonFn = Callable[
         [
             NamedArg(primitives.SyncAsyncDaemonStopperChecker, "stopped"),
             NamedArg(int, "retry"),
@@ -179,7 +179,7 @@ else:
         invocation.SyncOrAsync[Optional[object]]
     ]
 
-    ResourceTimerFn = Callable[
+    TimerFn = Callable[
         [
             NamedArg(ephemera.Index, "*"),
             NamedArg(bodies.Annotations, "annotations"),
@@ -250,7 +250,7 @@ else:
         bool  # strictly sync, no async!
     ]
 
-ResourceSpawningFn = Union[ResourceDaemonFn, ResourceTimerFn]
+SpawningFn = Union[DaemonFn, TimerFn]
 _FnT = TypeVar('_FnT', WhenFilterFn, MetaFilterFn)
 
 

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -22,7 +22,7 @@ from kopf.utilities import aiotasks
 class Daemon:
     task: aiotasks.Task  # a guarding task of the daemon.
     logger: Union[logging.Logger, logging.LoggerAdapter]
-    handler: handlers.ResourceSpawningHandler
+    handler: handlers.SpawningHandler
     stopper: primitives.DaemonStopper  # a signaller for the termination and its reason.
 
 

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -111,8 +111,8 @@ class ResourceHandler(BaseHandler):
 
 
 @dataclasses.dataclass
-class ResourceWebhookHandler(ResourceHandler):
-    fn: callbacks.ResourceWebhookFn  # type clarification
+class WebhookHandler(ResourceHandler):
+    fn: callbacks.WebhookFn  # type clarification
     reason: WebhookType
     operation: Optional[str]
     persistent: Optional[bool]
@@ -128,8 +128,8 @@ class ResourceWebhookHandler(ResourceHandler):
 
 
 @dataclasses.dataclass
-class ResourceIndexingHandler(ResourceHandler):
-    fn: callbacks.ResourceIndexingFn  # type clarification
+class IndexingHandler(ResourceHandler):
+    fn: callbacks.IndexingFn  # type clarification
 
     def __str__(self) -> str:
         return f"Indexer {self.id!r}"
@@ -140,8 +140,8 @@ class ResourceIndexingHandler(ResourceHandler):
 
 
 @dataclasses.dataclass
-class ResourceWatchingHandler(ResourceHandler):
-    fn: callbacks.ResourceWatchingFn  # type clarification
+class WatchingHandler(ResourceHandler):
+    fn: callbacks.WatchingFn  # type clarification
 
     @property
     def requires_patching(self) -> bool:
@@ -149,8 +149,8 @@ class ResourceWatchingHandler(ResourceHandler):
 
 
 @dataclasses.dataclass
-class ResourceChangingHandler(ResourceHandler):
-    fn: callbacks.ResourceChangingFn  # type clarification
+class ChangingHandler(ResourceHandler):
+    fn: callbacks.ChangingFn  # type clarification
     reason: Optional[Reason]
     initial: Optional[bool]
     deleted: Optional[bool]  # used for mixed-in (initial==True) @on.resume handlers only.
@@ -161,14 +161,14 @@ class ResourceChangingHandler(ResourceHandler):
 
 
 @dataclasses.dataclass
-class ResourceSpawningHandler(ResourceHandler):
+class SpawningHandler(ResourceHandler):
     requires_finalizer: Optional[bool]
     initial_delay: Optional[float]
 
 
 @dataclasses.dataclass
-class ResourceDaemonHandler(ResourceSpawningHandler):
-    fn: callbacks.ResourceDaemonFn  # type clarification
+class DaemonHandler(SpawningHandler):
+    fn: callbacks.DaemonFn  # type clarification
     cancellation_backoff: Optional[float]  # how long to wait before actual cancellation.
     cancellation_timeout: Optional[float]  # how long to wait before giving up on cancellation.
     cancellation_polling: Optional[float]  # how often to check for cancellation status.
@@ -178,8 +178,8 @@ class ResourceDaemonHandler(ResourceSpawningHandler):
 
 
 @dataclasses.dataclass
-class ResourceTimerHandler(ResourceSpawningHandler):
-    fn: callbacks.ResourceTimerFn  # type clarification
+class TimerHandler(SpawningHandler):
+    fn: callbacks.TimerFn  # type clarification
     sharp: Optional[bool]
     idle: Optional[float]
     interval: Optional[float]

--- a/tests/admission/test_managed_webhooks.py
+++ b/tests/admission/test_managed_webhooks.py
@@ -16,7 +16,7 @@ def handlers(resource, registry):
     def mutate_fn(**_):
         pass
 
-    return registry._resource_webhooks.get_all_handlers()
+    return registry._webhooks.get_all_handlers()
 
 
 @pytest.mark.parametrize('id, field, exp_name', [
@@ -37,7 +37,7 @@ def test_name_is_normalised(registry, resource, decorator, id, field, exp_name):
         pass
 
     webhooks = build_webhooks(
-        registry._resource_webhooks.get_all_handlers(),
+        registry._webhooks.get_all_handlers(),
         resources=[resource],
         name_suffix='sfx',
         client_config={})
@@ -64,7 +64,7 @@ def test_url_is_suffixed(registry, resource, decorator, id, field, exp_url):
         pass
 
     webhooks = build_webhooks(
-        registry._resource_webhooks.get_all_handlers(),
+        registry._webhooks.get_all_handlers(),
         resources=[resource],
         name_suffix='sfx',
         client_config={'url': 'https://hostname/p1/p2'})
@@ -91,7 +91,7 @@ def test_path_is_suffixed(registry, resource, decorator, id, field, exp_path):
         pass
 
     webhooks = build_webhooks(
-        registry._resource_webhooks.get_all_handlers(),
+        registry._webhooks.get_all_handlers(),
         resources=[resource],
         name_suffix='sfx',
         client_config={'service': {'path': 'p1/p2'}})
@@ -114,7 +114,7 @@ def test_flat_options_are_mapped(registry, resource, decorator, opts, key, val):
         pass
 
     webhooks = build_webhooks(
-        registry._resource_webhooks.get_all_handlers(),
+        registry._webhooks.get_all_handlers(),
         resources=[resource],
         name_suffix='sfx',
         client_config={})
@@ -140,7 +140,7 @@ def test_rule_options_are_mapped(registry, resource, decorator, opts, key, val):
         pass
 
     webhooks = build_webhooks(
-        registry._resource_webhooks.get_all_handlers(),
+        registry._webhooks.get_all_handlers(),
         resources=[resource],
         name_suffix='sfx',
         client_config={})
@@ -166,7 +166,7 @@ def test_multiple_handlers(registry, resource, decorator):
         pass
 
     webhooks = build_webhooks(
-        registry._resource_webhooks.get_all_handlers(),
+        registry._webhooks.get_all_handlers(),
         resources=[resource],
         name_suffix='sfx',
         client_config={})
@@ -185,7 +185,7 @@ def test_irrelevant_resources_are_ignored(registry, resource, decorator):
 
     irrelevant_resource = Resource('grp', 'vers', 'plural')
     webhooks = build_webhooks(
-        registry._resource_webhooks.get_all_handlers(),
+        registry._webhooks.get_all_handlers(),
         resources=[irrelevant_resource],
         name_suffix='sfx',
         client_config={})
@@ -208,7 +208,7 @@ def test_labels_specific_filter(registry, resource, decorator, label_value, exp_
 
     irrelevant_resource = Resource('grp', 'vers', 'plural')
     webhooks = build_webhooks(
-        registry._resource_webhooks.get_all_handlers(),
+        registry._webhooks.get_all_handlers(),
         resources=[irrelevant_resource],
         name_suffix='sfx',
         client_config={})
@@ -226,7 +226,7 @@ def test_labels_callable_filter(registry, resource, decorator):
 
     irrelevant_resource = Resource('grp', 'vers', 'plural')
     webhooks = build_webhooks(
-        registry._resource_webhooks.get_all_handlers(),
+        registry._webhooks.get_all_handlers(),
         resources=[irrelevant_resource],
         name_suffix='sfx',
         client_config={})

--- a/tests/basic-structs/test_causes.py
+++ b/tests/basic-structs/test_causes.py
@@ -1,9 +1,9 @@
 import pytest
 
-from kopf.reactor.causation import ActivityCause, ResourceChangingCause, ResourceWatchingCause
+from kopf.reactor.causation import ActivityCause, ChangingCause, WatchingCause
 
 
-@pytest.mark.parametrize('cls', [ActivityCause, ResourceWatchingCause, ResourceChangingCause])
+@pytest.mark.parametrize('cls', [ActivityCause, WatchingCause, ChangingCause])
 def test_cause_with_no_args(cls):
     with pytest.raises(TypeError):
         cls()
@@ -29,7 +29,7 @@ def test_activity_cause(mocker):
     assert cause.memo is memo
 
 
-def test_resource_watching_cause(mocker):
+def test_watching_cause(mocker):
     logger = mocker.Mock()
     indices = mocker.Mock()
     resource = mocker.Mock()
@@ -38,7 +38,7 @@ def test_resource_watching_cause(mocker):
     memo = mocker.Mock()
     type = mocker.Mock()
     event = mocker.Mock()
-    cause = ResourceWatchingCause(
+    cause = WatchingCause(
         resource=resource,
         indices=indices,
         logger=logger,
@@ -58,7 +58,7 @@ def test_resource_watching_cause(mocker):
     assert cause.event is event
 
 
-def test_resource_changing_cause_with_all_args(mocker):
+def test_changing_cause_with_all_args(mocker):
     logger = mocker.Mock()
     indices = mocker.Mock()
     resource = mocker.Mock()
@@ -70,7 +70,7 @@ def test_resource_changing_cause_with_all_args(mocker):
     diff = mocker.Mock()
     old = mocker.Mock()
     new = mocker.Mock()
-    cause = ResourceChangingCause(
+    cause = ChangingCause(
         resource=resource,
         indices=indices,
         logger=logger,
@@ -96,7 +96,7 @@ def test_resource_changing_cause_with_all_args(mocker):
     assert cause.new is new
 
 
-def test_resource_changing_cause_with_only_required_args(mocker):
+def test_changing_cause_with_only_required_args(mocker):
     logger = mocker.Mock()
     indices = mocker.Mock()
     resource = mocker.Mock()
@@ -105,7 +105,7 @@ def test_resource_changing_cause_with_only_required_args(mocker):
     body = mocker.Mock()
     patch = mocker.Mock()
     memo = mocker.Mock()
-    cause = ResourceChangingCause(
+    cause = ChangingCause(
         resource=resource,
         indices=indices,
         logger=logger,

--- a/tests/basic-structs/test_handlers.py
+++ b/tests/basic-structs/test_handlers.py
@@ -1,9 +1,9 @@
 import pytest
 
-from kopf.structs.handlers import ActivityHandler, ResourceChangingHandler
+from kopf.structs.handlers import ActivityHandler, ChangingHandler
 
 
-@pytest.mark.parametrize('cls', [ActivityHandler, ResourceChangingHandler])
+@pytest.mark.parametrize('cls', [ActivityHandler, ChangingHandler])
 def test_handler_with_no_args(cls):
     with pytest.raises(TypeError):
         cls()
@@ -59,7 +59,7 @@ def test_resource_handler_with_all_args(mocker):
     new = mocker.Mock()
     field_needs_change = mocker.Mock()
     requires_finalizer = mocker.Mock()
-    handler = ResourceChangingHandler(
+    handler = ChangingHandler(
         fn=fn,
         id=id,
         param=param,

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from kopf.reactor.causation import detect_resource_changing_cause
+from kopf.reactor.causation import detect_changing_cause
 from kopf.structs.bodies import Body
 from kopf.structs.handlers import Reason
 
@@ -146,7 +146,7 @@ def test_for_gone(
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_resource_changing_cause(
+    cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
         **kwargs)
@@ -163,7 +163,7 @@ def test_for_free(
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_resource_changing_cause(
+    cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
         **kwargs)
@@ -180,7 +180,7 @@ def test_for_delete(
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_resource_changing_cause(
+    cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
         **kwargs)
@@ -200,7 +200,7 @@ def test_for_create(
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_resource_changing_cause(
+    cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
         old=old,
@@ -218,7 +218,7 @@ def test_for_create_skip_acquire(
     event = {'type': event, 'object': {'metadata': {}}}
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
-    cause = detect_resource_changing_cause(
+    cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
         **kwargs)
@@ -238,7 +238,7 @@ def test_for_no_op(
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_resource_changing_cause(
+    cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
         old=old,
@@ -259,7 +259,7 @@ def test_for_update(
     event['object']['metadata'].update(finalizers)
     event['object']['metadata'].update(deletion_ts)
     event['object']['metadata'].update(annotations)
-    cause = detect_resource_changing_cause(
+    cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
         diff=True,

--- a/tests/causation/test_kwargs.py
+++ b/tests/causation/test_kwargs.py
@@ -5,10 +5,9 @@ from unittest.mock import Mock
 
 import pytest
 
-from kopf.reactor.causation import ActivityCause, BaseCause, DaemonCause, \
-                                   ResourceCause, ResourceChangingCause, \
-                                   ResourceIndexingCause, ResourceSpawningCause, \
-                                   ResourceWatchingCause, ResourceWebhookCause
+from kopf.reactor.causation import ActivityCause, BaseCause, ChangingCause, \
+                                   DaemonCause, IndexingCause, ResourceCause, \
+                                   SpawningCause, WatchingCause, WebhookCause
 from kopf.reactor.indexing import OperatorIndexer, OperatorIndexers
 from kopf.structs.bodies import Body, BodyEssence
 from kopf.structs.configuration import OperatorSettings
@@ -20,9 +19,9 @@ from kopf.structs.primitives import DaemonStopper
 
 ALL_CAUSES = [
     BaseCause, ActivityCause, ResourceCause,
-    ResourceWatchingCause, ResourceSpawningCause,
-    ResourceChangingCause, ResourceIndexingCause,
-    ResourceWebhookCause, DaemonCause,
+    WatchingCause, SpawningCause,
+    ChangingCause, IndexingCause,
+    WebhookCause, DaemonCause,
 ]
 ALL_FIELDS = {
     field.name
@@ -66,12 +65,12 @@ def test_activity_kwargs(resource, activity, attr):
 
 
 @pytest.mark.parametrize('attr', ['kwargs', 'sync_kwargs', 'async_kwargs'])
-def test_resource_admission_kwargs(resource, attr):
+def test_admission_kwargs(resource, attr):
     body = {'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1',
                          'labels': {'l1': 'v1'}, 'annotations': {'a1': 'v1'}},
             'spec': {'field': 'value'},
             'status': {'info': 'payload'}}
-    cause = ResourceWebhookCause(
+    cause = WebhookCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
         indices=OperatorIndexers().indices,
         resource=resource,
@@ -114,12 +113,12 @@ def test_resource_admission_kwargs(resource, attr):
 
 
 @pytest.mark.parametrize('attr', ['kwargs', 'sync_kwargs', 'async_kwargs'])
-def test_resource_watching_kwargs(resource, attr):
+def test_watching_kwargs(resource, attr):
     body = {'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1',
                          'labels': {'l1': 'v1'}, 'annotations': {'a1': 'v1'}},
             'spec': {'field': 'value'},
             'status': {'info': 'payload'}}
-    cause = ResourceWatchingCause(
+    cause = WatchingCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
         indices=OperatorIndexers().indices,
         resource=resource,
@@ -152,12 +151,12 @@ def test_resource_watching_kwargs(resource, attr):
 
 
 @pytest.mark.parametrize('attr', ['kwargs', 'sync_kwargs', 'async_kwargs'])
-def test_resource_changing_kwargs(resource, attr):
+def test_changing_kwargs(resource, attr):
     body = {'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1',
                          'labels': {'l1': 'v1'}, 'annotations': {'a1': 'v1'}},
             'spec': {'field': 'value'},
             'status': {'info': 'payload'}}
-    cause = ResourceChangingCause(
+    cause = ChangingCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
         indices=OperatorIndexers().indices,
         resource=resource,
@@ -195,12 +194,12 @@ def test_resource_changing_kwargs(resource, attr):
 
 
 @pytest.mark.parametrize('attr', ['kwargs', 'sync_kwargs', 'async_kwargs'])
-def test_resource_spawning_kwargs(resource, attr):
+def test_spawning_kwargs(resource, attr):
     body = {'metadata': {'uid': 'uid1', 'name': 'name1', 'namespace': 'ns1',
                          'labels': {'l1': 'v1'}, 'annotations': {'a1': 'v1'}},
             'spec': {'field': 'value'},
             'status': {'info': 'payload'}}
-    cause = ResourceSpawningCause(
+    cause = SpawningCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
         indices=OperatorIndexers().indices,
         resource=resource,

--- a/tests/cli/test_preloading.py
+++ b/tests/cli/test_preloading.py
@@ -6,7 +6,7 @@ def test_nothing(invoke, real_run):
     assert result.exit_code == 0
 
     registry = kopf.get_default_registry()
-    handlers = registry._resource_changing.get_all_handlers()
+    handlers = registry._changing.get_all_handlers()
     assert len(handlers) == 0
 
 
@@ -15,7 +15,7 @@ def test_one_file(invoke, real_run):
     assert result.exit_code == 0
 
     registry = kopf.get_default_registry()
-    handlers = registry._resource_changing.get_all_handlers()
+    handlers = registry._changing.get_all_handlers()
     assert len(handlers) == 1
     assert handlers[0].id == 'create_fn'
 
@@ -25,7 +25,7 @@ def test_two_files(invoke, real_run):
     assert result.exit_code == 0
 
     registry = kopf.get_default_registry()
-    handlers = registry._resource_changing.get_all_handlers()
+    handlers = registry._changing.get_all_handlers()
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'
@@ -36,7 +36,7 @@ def test_one_module(invoke, real_run):
     assert result.exit_code == 0
 
     registry = kopf.get_default_registry()
-    handlers = registry._resource_changing.get_all_handlers()
+    handlers = registry._changing.get_all_handlers()
     assert len(handlers) == 1
     assert handlers[0].id == 'create_fn'
 
@@ -46,7 +46,7 @@ def test_two_modules(invoke, real_run):
     assert result.exit_code == 0
 
     registry = kopf.get_default_registry()
-    handlers = registry._resource_changing.get_all_handlers()
+    handlers = registry._changing.get_all_handlers()
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'
@@ -57,7 +57,7 @@ def test_mixed_sources(invoke, real_run):
     assert result.exit_code == 0
 
     registry = kopf.get_default_registry()
-    handlers = registry._resource_changing.get_all_handlers()
+    handlers = registry._changing.get_all_handlers()
     assert len(handlers) == 2
     assert handlers[0].id == 'create_fn'
     assert handlers[1].id == 'update_fn'

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -40,7 +40,7 @@ from unittest.mock import Mock
 import pytest
 
 import kopf
-from kopf.reactor.causation import ResourceChangingCause
+from kopf.reactor.causation import ChangingCause
 
 
 @dataclasses.dataclass(frozen=True, eq=False)
@@ -202,7 +202,7 @@ def cause_mock(mocker, settings):
 
         # Pass through kwargs: resource, logger, patch, diff, old, new.
         # I.e. everything except what we mock -- for them, use the mocked values (if not None).
-        return ResourceChangingCause(
+        return ChangingCause(
             reason=mock.reason,
             diff=mock.diff if mock.diff is not None else diff,
             new=mock.new if mock.new is not None else new,
@@ -210,7 +210,7 @@ def cause_mock(mocker, settings):
             **kwargs)
 
     # Substitute the real cause detector with out own mock-based one.
-    mocker.patch('kopf.reactor.causation.detect_resource_changing_cause', new=new_detect_fn)
+    mocker.patch('kopf.reactor.causation.detect_changing_cause', new=new_detect_fn)
 
     # The mock object stores some values later used by the factory substitute.
     # Note: ONLY those fields we mock in the tests. Other kwargs should be passed through.

--- a/tests/handling/daemons/test_daemon_filtration.py
+++ b/tests/handling/daemons/test_daemon_filtration.py
@@ -43,7 +43,7 @@ async def test_daemon_filtration_mismatched(
         settings, resource, mocker, labels, annotations,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
-    spawn_resource_daemons = mocker.patch('kopf.reactor.daemons.spawn_resource_daemons')
+    spawn_daemons = mocker.patch('kopf.reactor.daemons.spawn_daemons')
 
     @kopf.daemon(*resource, id='fn',
                  labels={'a': 'value', 'b': kopf.PRESENT, 'c': kopf.ABSENT},
@@ -57,5 +57,5 @@ async def test_daemon_filtration_mismatched(
                                'finalizers': [finalizer]}}
     await simulate_cycle(event_body)
 
-    assert spawn_resource_daemons.called
-    assert spawn_resource_daemons.call_args_list[0][1]['handlers'] == []
+    assert spawn_daemons.called
+    assert spawn_daemons.call_args_list[0][1]['handlers'] == []

--- a/tests/handling/daemons/test_timer_filtration.py
+++ b/tests/handling/daemons/test_timer_filtration.py
@@ -42,7 +42,7 @@ async def test_timer_filtration_mismatched(
         settings, resource, mocker, labels, annotations,
         caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
-    spawn_resource_daemons = mocker.patch('kopf.reactor.daemons.spawn_resource_daemons')
+    spawn_daemons = mocker.patch('kopf.reactor.daemons.spawn_daemons')
 
     @kopf.timer(*resource, id='fn',
                 labels={'a': 'value', 'b': kopf.PRESENT, 'c': kopf.ABSENT},
@@ -55,5 +55,5 @@ async def test_timer_filtration_mismatched(
                                'finalizers': [settings.persistence.finalizer]}}
     await simulate_cycle(event_body)
 
-    assert spawn_resource_daemons.called
-    assert spawn_resource_daemons.call_args_list[0][1]['handlers'] == []
+    assert spawn_daemons.called
+    assert spawn_daemons.call_args_list[0][1]['handlers'] == []

--- a/tests/handling/indexing/test_index_population.py
+++ b/tests/handling/indexing/test_index_population.py
@@ -111,7 +111,7 @@ async def test_removed_on_filters_mismatch(
         resource, settings, registry, indexers, index, caplog, event_type, handlers, mocker):
 
     # Simulate the indexing handler is gone out of scope (this is only one of the ways to do it):
-    mocker.patch.object(registry._resource_indexing, 'get_handlers', return_value=[])
+    mocker.patch.object(registry._indexing, 'get_handlers', return_value=[])
 
     caplog.set_level(logging.DEBUG)
     body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -8,7 +8,7 @@ from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import HANDLER_REASONS, ResourceChangingHandler
+from kopf.structs.handlers import HANDLER_REASONS, ChangingHandler
 
 LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 
@@ -23,8 +23,8 @@ async def test_skipped_with_no_handlers(
     event_body = {'metadata': {'finalizers': []}}
     cause_mock.reason = cause_type
 
-    assert not registry._resource_changing.has_handlers(resource=resource)  # prerequisite
-    registry._resource_changing.append(ResourceChangingHandler(
+    assert not registry._changing.has_handlers(resource=resource)  # prerequisite
+    registry._changing.append(ChangingHandler(
         reason='a-non-existent-cause-type',
         fn=lambda **_: None, id='id', param=None,
         errors=None, timeout=None, retries=None, backoff=None,
@@ -79,8 +79,8 @@ async def test_stealth_mode_with_mismatching_handlers(
     event_body = {'metadata': {'finalizers': []}}
     cause_mock.reason = cause_type
 
-    assert not registry._resource_changing.has_handlers(resource=resource)  # prerequisite
-    registry._resource_changing.append(ResourceChangingHandler(
+    assert not registry._changing.has_handlers(resource=resource)  # prerequisite
+    registry._changing.append(ChangingHandler(
         reason=None,
         fn=lambda **_: None, id='id', param=None,
         errors=None, timeout=None, retries=None, backoff=None,

--- a/tests/handling/test_timing_consistency.py
+++ b/tests/handling/test_timing_consistency.py
@@ -54,7 +54,7 @@ async def test_consistent_awakening(registry, settings, resource, k8s_mocked, mo
     body = {'status': {'kopf': {'progress': {'some-id': {'delayed': ts0_scheduled}}}}}
 
     # Simulate the call as if the event has just arrived on the watch-stream.
-    # Another way (same effect): handle_resource_changing_cause() and its result.
+    # Another way (the same effect): process_changing_cause() and its result.
     with freezegun.freeze_time(tsA_triggered) as frozen_dt:
         assert datetime.datetime.utcnow() < ts0  # extra precaution
         await process_resource_event(

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -4,7 +4,7 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import ResourceChangingCause, ResourceWatchingCause
+from kopf.reactor.causation import ChangingCause, WatchingCause
 from kopf.reactor.handling import cause_var
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.invocation import context
@@ -35,7 +35,7 @@ OWNER = RawBody(
 def owner(request, resource):
     body = Body(copy.deepcopy(OWNER))
     if request.param == 'state-changing-cause':
-        cause = ResourceChangingCause(
+        cause = ChangingCause(
             logger=logging.getLogger('kopf.test.fake.logger'),
             indices=OperatorIndexers().indices,
             resource=resource,
@@ -48,7 +48,7 @@ def owner(request, resource):
         with context([(cause_var, cause)]):
             yield body
     elif request.param == 'event-watching-cause':
-        cause = ResourceWatchingCause(
+        cause = WatchingCause(
             logger=logging.getLogger('kopf.test.fake.logger'),
             indices=OperatorIndexers().indices,
             resource=resource,

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -5,7 +5,7 @@ import traceback
 import pytest
 from asynctest import MagicMock
 
-from kopf.reactor.causation import ResourceChangingCause
+from kopf.reactor.causation import ChangingCause
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.invocation import invoke, is_async_fn
 from kopf.structs.bodies import Body
@@ -167,7 +167,7 @@ async def test_special_kwargs_added(fn, resource):
             'status': {'info': 'payload'}}
 
     # Values can be any.
-    cause = ResourceChangingCause(
+    cause = ChangingCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
         indices=OperatorIndexers().indices,
         resource=resource,

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import ResourceChangingCause
+from kopf.reactor.causation import ChangingCause
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.storage.states import State
 from kopf.structs.bodies import Body
@@ -26,7 +26,7 @@ async def test_protocol_invocation(lifecycle, resource):
     """
     # The values are irrelevant, they can be anything.
     state = State.from_scratch()
-    cause = ResourceChangingCause(
+    cause = ChangingCause(
         logger=logging.getLogger('kopf.test.fake.logger'),
         indices=OperatorIndexers().indices,
         resource=resource,

--- a/tests/registries/conftest.py
+++ b/tests/registries/conftest.py
@@ -2,25 +2,24 @@ import logging
 
 import pytest
 
-from kopf.reactor.causation import ActivityCause, ResourceCause, \
-                                   ResourceChangingCause, ResourceSpawningCause, \
-                                   ResourceWatchingCause, ResourceWebhookCause
+from kopf.reactor.causation import ActivityCause, ChangingCause, ResourceCause, \
+                                   SpawningCause, WatchingCause, WebhookCause
 from kopf.reactor.indexing import OperatorIndexers
-from kopf.reactor.registries import ActivityRegistry, OperatorRegistry, ResourceChangingRegistry, \
-                                    ResourceRegistry, ResourceSpawningRegistry, \
-                                    ResourceWatchingRegistry, ResourceWebhooksRegistry
+from kopf.reactor.registries import ActivityRegistry, ChangingRegistry, OperatorRegistry, \
+                                    ResourceRegistry, SpawningRegistry, WatchingRegistry, \
+                                    WebhooksRegistry
 from kopf.structs.bodies import Body
 from kopf.structs.diffs import Diff, DiffItem
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import ResourceChangingHandler
+from kopf.structs.handlers import ChangingHandler
 from kopf.structs.ids import HandlerId
 from kopf.structs.patches import Patch
 
 
 @pytest.fixture(params=[
     pytest.param(ActivityRegistry, id='activity-registry'),
-    pytest.param(ResourceWatchingRegistry, id='resource-watching-registry'),
-    pytest.param(ResourceChangingRegistry, id='resource-changing-registry'),
+    pytest.param(WatchingRegistry, id='watching-registry'),
+    pytest.param(ChangingRegistry, id='changing-registry'),
 ])
 def generic_registry_cls(request):
     return request.param
@@ -34,8 +33,8 @@ def activity_registry_cls(request):
 
 
 @pytest.fixture(params=[
-    pytest.param(ResourceWatchingRegistry, id='resource-watching-registry'),
-    pytest.param(ResourceChangingRegistry, id='resource-changing-registry'),
+    pytest.param(WatchingRegistry, id='watching-registry'),
+    pytest.param(ChangingRegistry, id='changing-registry'),
 ])
 def resource_registry_cls(request):
     return request.param
@@ -54,7 +53,7 @@ def parent_handler(selector):
     def parent_fn(**_):
         pass
 
-    return ResourceChangingHandler(
+    return ChangingHandler(
         fn=parent_fn, id=HandlerId('parent_fn'), param=None,
         errors=None, retries=None, timeout=None, backoff=None,
         selector=selector, labels=None, annotations=None, when=None,
@@ -83,7 +82,7 @@ def cause_factory(resource):
     is not available to the users.
     """
     def make_cause(
-            cls=ResourceChangingCause,
+            cls=ChangingCause,
             *,
             resource=resource,
             event=None,
@@ -114,8 +113,8 @@ def cause_factory(resource):
                 memo=Memo(),
                 body=Body(body if body is not None else {}),
             )
-        if cls is ResourceWatchingCause or cls is ResourceWatchingRegistry:
-            return ResourceWatchingCause(
+        if cls is WatchingCause or cls is WatchingRegistry:
+            return WatchingCause(
                 logger=logging.getLogger('kopf.test.fake.logger'),
                 indices=OperatorIndexers().indices,
                 resource=resource,
@@ -125,8 +124,8 @@ def cause_factory(resource):
                 type=type,
                 event=event,
             )
-        if cls is ResourceChangingCause or cls is ResourceChangingRegistry:
-            return ResourceChangingCause(
+        if cls is ChangingCause or cls is ChangingRegistry:
+            return ChangingCause(
                 logger=logging.getLogger('kopf.test.fake.logger'),
                 indices=OperatorIndexers().indices,
                 resource=resource,
@@ -139,8 +138,8 @@ def cause_factory(resource):
                 initial=initial,
                 reason=reason,
             )
-        if cls is ResourceSpawningCause or cls is ResourceSpawningRegistry:
-            return ResourceSpawningCause(
+        if cls is SpawningCause or cls is SpawningRegistry:
+            return SpawningCause(
                 logger=logging.getLogger('kopf.test.fake.logger'),
                 indices=OperatorIndexers().indices,
                 resource=resource,
@@ -149,8 +148,8 @@ def cause_factory(resource):
                 body=Body(body if body is not None else {}),
                 reset=False,
             )
-        if cls is ResourceWebhookCause or cls is ResourceWebhooksRegistry:
-            return ResourceWebhookCause(
+        if cls is WebhookCause or cls is WebhooksRegistry:
+            return WebhookCause(
                 logger=logging.getLogger('kopf.test.fake.logger'),
                 indices=OperatorIndexers().indices,
                 resource=resource,

--- a/tests/registries/test_handler_getting.py
+++ b/tests/registries/test_handler_getting.py
@@ -2,7 +2,7 @@ import collections.abc
 
 import pytest
 
-from kopf.reactor.causation import ResourceChangingCause, ResourceWatchingCause
+from kopf.reactor.causation import ChangingCause, WatchingCause
 from kopf.structs.handlers import Activity
 
 
@@ -56,12 +56,12 @@ def test_operator_registry_with_activity_via_iter(
     assert not handlers
 
 
-def test_operator_registry_with_resource_watching_via_iter(
+def test_operator_registry_watching_handlers_via_iter(
         operator_registry_cls, cause_factory):
 
-    cause = cause_factory(ResourceWatchingCause)
+    cause = cause_factory(WatchingCause)
     registry = operator_registry_cls()
-    iterator = registry._resource_watching.iter_handlers(cause)
+    iterator = registry._watching.iter_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
     assert not isinstance(iterator, collections.abc.Collection)
@@ -72,12 +72,12 @@ def test_operator_registry_with_resource_watching_via_iter(
     assert not handlers
 
 
-def test_operator_registry_with_resource_changing_via_iter(
+def test_operator_registry_changing_handlers_via_iter(
         operator_registry_cls, cause_factory):
 
-    cause = cause_factory(ResourceChangingCause)
+    cause = cause_factory(ChangingCause)
     registry = operator_registry_cls()
-    iterator = registry._resource_changing.iter_handlers(cause)
+    iterator = registry._changing.iter_handlers(cause)
 
     assert isinstance(iterator, collections.abc.Iterator)
     assert not isinstance(iterator, collections.abc.Collection)
@@ -101,12 +101,12 @@ def test_operator_registry_with_activity_via_list(
     assert not handlers
 
 
-def test_operator_registry_with_resource_watching_via_list(
+def test_operator_registry_watching_handlers_via_list(
         operator_registry_cls, cause_factory):
 
-    cause = cause_factory(ResourceWatchingCause)
+    cause = cause_factory(WatchingCause)
     registry = operator_registry_cls()
-    handlers = registry._resource_watching.get_handlers(cause)
+    handlers = registry._watching.get_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
     assert isinstance(handlers, collections.abc.Container)
@@ -114,12 +114,12 @@ def test_operator_registry_with_resource_watching_via_list(
     assert not handlers
 
 
-def test_operator_registry_with_resource_changing_via_list(
+def test_operator_registry_changing_handlers_via_list(
         operator_registry_cls, cause_factory):
 
-    cause = cause_factory(ResourceChangingCause)
+    cause = cause_factory(ChangingCause)
     registry = operator_registry_cls()
-    handlers = registry._resource_changing.get_handlers(cause)
+    handlers = registry._changing.get_handlers(cause)
 
     assert isinstance(handlers, collections.abc.Iterable)
     assert isinstance(handlers, collections.abc.Container)

--- a/tests/registries/test_matching_for_indexing.py
+++ b/tests/registries/test_matching_for_indexing.py
@@ -3,10 +3,10 @@ import copy
 import pytest
 
 import kopf
-from kopf.reactor.causation import ResourceWatchingCause
+from kopf.reactor.causation import WatchingCause
 from kopf.structs.dicts import parse_field
 from kopf.structs.filters import ABSENT, PRESENT
-from kopf.structs.handlers import ResourceIndexingHandler
+from kopf.structs.handlers import IndexingHandler
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.
@@ -25,13 +25,13 @@ def _always(*_, **__):
 @pytest.fixture()
 def handler_factory(registry, selector):
     def factory(**kwargs):
-        handler = ResourceIndexingHandler(**dict(dict(
+        handler = IndexingHandler(**dict(dict(
             fn=some_fn, id='a', param=None,
             errors=None, timeout=None, retries=None, backoff=None,
             selector=selector, annotations=None, labels=None, when=None,
             field=None, value=None,
         ), **kwargs))
-        registry._resource_indexing.append(handler)
+        registry._indexing.append(handler)
         return handler
     return factory
 
@@ -43,7 +43,7 @@ def cause_no_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
     kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
                                         'annotations': {'known': 'value'}}})
-    cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
+    cause = cause_factory(cls=WatchingCause, **kwargs)
     return cause
 
 
@@ -54,7 +54,7 @@ def cause_with_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
     kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
                                         'annotations': {'known': 'value'}}})
-    cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
+    cause = cause_factory(cls=WatchingCause, **kwargs)
     return cause
 
 
@@ -67,7 +67,7 @@ def cause_any_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
     kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
                                         'annotations': {'known': 'value'}}})
-    cause = cause_factory(cls=ResourceWatchingCause, **kwargs)
+    cause = cause_factory(cls=WatchingCause, **kwargs)
     return cause
 
 
@@ -79,7 +79,7 @@ def test_catchall_handlers_without_field_found(
         cause_any_field, registry, handler_factory):
     cause = cause_any_field
     handler_factory(field=None)
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -87,7 +87,7 @@ def test_catchall_handlers_with_field_found(
         cause_with_field, registry, handler_factory):
     cause = cause_with_field
     handler_factory(field=parse_field('known-field'))
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -95,7 +95,7 @@ def test_catchall_handlers_with_field_ignored(
         cause_no_field, registry, handler_factory):
     cause = cause_no_field
     handler_factory(field=parse_field('known-field'))
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -107,7 +107,7 @@ def test_catchall_handlers_with_exact_labels_satisfied(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'known': 'value'})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -120,7 +120,7 @@ def test_catchall_handlers_with_exact_labels_not_satisfied(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'known': 'value'})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -132,7 +132,7 @@ def test_catchall_handlers_with_desired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'known': PRESENT})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -144,7 +144,7 @@ def test_catchall_handlers_with_desired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'known': PRESENT})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -156,7 +156,7 @@ def test_catchall_handlers_with_undesired_labels_present(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'known': ABSENT})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -168,7 +168,7 @@ def test_catchall_handlers_with_undesired_labels_absent(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'known': ABSENT})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -181,7 +181,7 @@ def test_catchall_handlers_with_labels_callback_says_true(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'known': _always})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -194,7 +194,7 @@ def test_catchall_handlers_with_labels_callback_says_false(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'known': _never})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -209,7 +209,7 @@ def test_catchall_handlers_without_labels(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels=None)
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -221,7 +221,7 @@ def test_catchall_handlers_with_exact_annotations_satisfied(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'known': 'value'})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -234,7 +234,7 @@ def test_catchall_handlers_with_exact_annotations_not_satisfied(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'known': 'value'})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -246,7 +246,7 @@ def test_catchall_handlers_with_desired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'known': PRESENT})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -258,7 +258,7 @@ def test_catchall_handlers_with_desired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'known': PRESENT})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -270,7 +270,7 @@ def test_catchall_handlers_with_undesired_annotations_present(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'known': ABSENT})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -282,7 +282,7 @@ def test_catchall_handlers_with_undesired_annotations_absent(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'known': ABSENT})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -295,7 +295,7 @@ def test_catchall_handlers_with_annotations_callback_says_true(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'known': _always})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -308,7 +308,7 @@ def test_catchall_handlers_with_annotations_callback_says_false(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory(annotations={'known': _never})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -323,7 +323,7 @@ def test_catchall_handlers_without_annotations(
         cause_factory, registry, handler_factory, annotations):
     cause = cause_factory(body={'metadata': {'annotations': annotations}})
     handler_factory()
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -337,7 +337,7 @@ def test_catchall_handlers_with_labels_and_annotations_satisfied(
         cause_factory, registry, handler_factory, labels, annotations):
     cause = cause_factory(body={'metadata': {'labels': labels, 'annotations': annotations}})
     handler_factory(labels={'known': 'value'}, annotations={'known': 'value'})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -352,7 +352,7 @@ def test_catchall_handlers_with_labels_and_annotations_not_satisfied(
         cause_factory, registry, handler_factory, labels):
     cause = cause_factory(body={'metadata': {'labels': labels}})
     handler_factory(labels={'known': 'value'}, annotations={'known': 'value'})
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -365,7 +365,7 @@ def test_catchall_handlers_with_when_callback_matching(
         cause_factory, registry, handler_factory, when):
     cause = cause_factory(body={'spec': {'name': 'test'}})
     handler_factory(when=when)
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -377,7 +377,7 @@ def test_catchall_handlers_with_when_callback_mismatching(
         cause_factory, registry, handler_factory, when):
     cause = cause_factory(body={'spec': {'name': 'test'}})
     handler_factory(when=when)
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -388,7 +388,7 @@ def test_decorator_without_field_found(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -399,7 +399,7 @@ def test_decorator_with_field_found(
     def some_fn(**_): ...
 
     cause = cause_with_field
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -410,7 +410,7 @@ def test_decorator_with_field_ignored(
     def some_fn(**_): ...
 
     cause = cause_no_field
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -421,7 +421,7 @@ def test_decorator_with_labels_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -432,7 +432,7 @@ def test_decorator_with_labels_not_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -443,7 +443,7 @@ def test_decorator_with_annotations_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -454,7 +454,7 @@ def test_decorator_with_annotations_not_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers
 
 
@@ -465,7 +465,7 @@ def test_decorator_with_filter_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert handlers
 
 
@@ -476,5 +476,5 @@ def test_decorator_with_filter_not_satisfied(
     def some_fn(**_): ...
 
     cause = cause_any_field
-    handlers = registry._resource_indexing.get_handlers(cause)
+    handlers = registry._indexing.get_handlers(cause)
     assert not handlers

--- a/tests/registries/test_matching_of_callbacks.py
+++ b/tests/registries/test_matching_of_callbacks.py
@@ -3,11 +3,11 @@ from unittest.mock import Mock
 
 import pytest
 
-from kopf.reactor.causation import ResourceWatchingCause
+from kopf.reactor.causation import WatchingCause
 from kopf.reactor.registries import match, prematch
 from kopf.structs.bodies import Body
 from kopf.structs.dicts import parse_field
-from kopf.structs.handlers import ResourceWatchingHandler
+from kopf.structs.handlers import WatchingHandler
 from kopf.structs.references import Resource
 
 
@@ -25,7 +25,7 @@ def callback():
 
 @pytest.fixture(params=['annotations', 'labels', 'value', 'when'])
 def handler(request, callback, selector):
-    handler = ResourceWatchingHandler(
+    handler = WatchingHandler(
         selector=selector,
         annotations={'known': 'value'},
         labels={'known': 'value'},
@@ -44,7 +44,7 @@ def handler(request, callback, selector):
 @pytest.fixture()
 def cause(cause_factory, callback):
     return cause_factory(
-        cls=ResourceWatchingCause,
+        cls=WatchingCause,
         body=Body(dict(
             metadata=dict(
                 labels={'known': 'value'},

--- a/tests/registries/test_requires_finalizer.py
+++ b/tests/registries/test_requires_finalizer.py
@@ -30,7 +30,7 @@ def test_requires_finalizer_deletion_handler(
     def fn(**_):
         pass
 
-    requires_finalizer = registry._resource_changing.requires_finalizer(cause)
+    requires_finalizer = registry._changing.requires_finalizer(cause)
     assert requires_finalizer == expected
 
 
@@ -50,7 +50,7 @@ def test_requires_finalizer_multiple_handlers(
     def fn2(**_):
         pass
 
-    requires_finalizer = registry._resource_changing.requires_finalizer(cause)
+    requires_finalizer = registry._changing.requires_finalizer(cause)
     assert requires_finalizer == expected
 
 
@@ -62,7 +62,7 @@ def test_requires_finalizer_no_deletion_handler(
     def fn1(**_):
         pass
 
-    requires_finalizer = registry._resource_changing.requires_finalizer(cause)
+    requires_finalizer = registry._changing.requires_finalizer(cause)
     assert requires_finalizer is False
 
 
@@ -82,7 +82,7 @@ def test_requires_finalizer_deletion_handler_matches_labels(
     def fn(**_):
         pass
 
-    requires_finalizer = registry._resource_changing.requires_finalizer(cause)
+    requires_finalizer = registry._changing.requires_finalizer(cause)
     assert requires_finalizer == expected
 
 
@@ -102,7 +102,7 @@ def test_requires_finalizer_deletion_handler_mismatches_labels(
     def fn(**_):
         pass
 
-    requires_finalizer = registry._resource_changing.requires_finalizer(cause)
+    requires_finalizer = registry._changing.requires_finalizer(cause)
     assert requires_finalizer == expected
 
 
@@ -122,7 +122,7 @@ def test_requires_finalizer_deletion_handler_matches_annotations(
     def fn(**_):
         pass
 
-    requires_finalizer = registry._resource_changing.requires_finalizer(cause)
+    requires_finalizer = registry._changing.requires_finalizer(cause)
     assert requires_finalizer == expected
 
 
@@ -142,5 +142,5 @@ def test_requires_finalizer_deletion_handler_mismatches_annotations(
     def fn(**_):
         pass
 
-    requires_finalizer = registry._resource_changing.requires_finalizer(cause)
+    requires_finalizer = registry._changing.requires_finalizer(cause)
     assert requires_finalizer == expected

--- a/tests/registries/test_resumes_mixed_in.py
+++ b/tests/registries/test_resumes_mixed_in.py
@@ -17,7 +17,7 @@ def test_resumes_ignored_for_non_initial_causes(
     def fn(**_):
         pass
 
-    handlers = registry._resource_changing.get_handlers(cause)
+    handlers = registry._changing.get_handlers(cause)
     assert len(handlers) == 0
 
 
@@ -32,7 +32,7 @@ def test_resumes_selected_for_initial_non_deletions(
     def fn(**_):
         pass
 
-    handlers = registry._resource_changing.get_handlers(cause)
+    handlers = registry._changing.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn
 
@@ -49,7 +49,7 @@ def test_resumes_ignored_for_initial_deletions_by_default(
     def fn(**_):
         pass
 
-    handlers = registry._resource_changing.get_handlers(cause)
+    handlers = registry._changing.get_handlers(cause)
     assert len(handlers) == 0
 
 
@@ -65,6 +65,6 @@ def test_resumes_selected_for_initial_deletions_when_explicitly_marked(
     def fn(**_):
         pass
 
-    handlers = registry._resource_changing.get_handlers(cause)
+    handlers = registry._changing.get_handlers(cause)
     assert len(handlers) == 1
     assert handlers[0].fn is fn


### PR DESCRIPTION
Everything in Kubernetes operators is about resources anyway — there is no need to highlight it. Originally, this "resource" prefix was added to distinguish from "activities". Over time, it became clear that "activities" is the only non-resource entity.

This change is intended to simplify the codebase and clean up the code visually.
