### PR TITLE
Unify the publicly exported sync/async daemon-stopping flag

### DIFF
--- a/docs/kwargs.rst
+++ b/docs/kwargs.rst
@@ -251,8 +251,8 @@ Resource daemon kwargs
 Stop-flag
 ---------
 
-The daemons also have ``stopped``. It is a flag object for sync daemons
-to check if they should stop. See also: `DaemonStopperChecker`.
+Daemons also have ``stopped``. It is a flag object for sync & async daemons
+(mostly, sync) to check if they should stop. See also: `DaemonStopped`.
 
 To check, ``.is_set()`` method can be called, or the object itself can be used
 as a boolean expression: e.g. ``while not stopped: ...``.

--- a/examples/11-filtering-handlers/example.py
+++ b/examples/11-filtering-handlers/example.py
@@ -86,7 +86,7 @@ def update_with_field_change_satisfied(logger, **kwargs):
 
 
 @kopf.daemon('kopfexamples', field='spec.field', value='value')
-def daemon_with_field(stopped, logger, **kwargs):
+def daemon_with_field(stopped: kopf.DaemonStopped, logger, **kwargs):
     while not stopped:
         logger.info("Field daemon is satisfied.")
         stopped.wait(1)

--- a/examples/14-daemons/example.py
+++ b/examples/14-daemons/example.py
@@ -7,7 +7,7 @@ import kopf
 # Sync daemons in threads are non-interruptable, they must check for the `stopped` flag.
 # This daemon exits after 3 attempts and then 30 seconds of running (unless stopped).
 @kopf.daemon('kopfexamples', backoff=3)
-def background_sync(spec, stopped, logger, retry, patch, **_):
+def background_sync(stopped: kopf.DaemonStopped, spec, logger, retry, patch, **_):
     if retry < 3:
         patch.status['message'] = f"Failed {retry+1} times."
         raise kopf.TemporaryError("Simulated failure.", delay=1)

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -130,9 +130,10 @@ from kopf.structs.patches import (
     Patch,
 )
 from kopf.structs.primitives import (
+    DaemonStopped,
     DaemonStoppingReason,
-    SyncDaemonStopperChecker,
-    AsyncDaemonStopperChecker,
+    SyncDaemonStopperChecker,  # deprecated
+    AsyncDaemonStopperChecker,  # deprecated
 )
 from kopf.structs.references import (
     Resource,
@@ -218,7 +219,6 @@ __all__ = [
     'StatusProgressStorage',
     'MultiProgressStorage',
     'SmartProgressStorage',
-    'DaemonStoppingReason',
     'RawEventType',
     'RawEvent',
     'RawBody',
@@ -243,7 +243,9 @@ __all__ = [
     'HandlerId',
     'Reason',
     'Patch',
-    'SyncDaemonStopperChecker',
-    'AsyncDaemonStopperChecker',
+    'DaemonStopped',
+    'DaemonStoppingReason',
+    'SyncDaemonStopperChecker',  # deprecated
+    'AsyncDaemonStopperChecker',  # deprecated
     'Resource', 'EVERYTHING',
 ]

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -200,11 +200,11 @@ class DaemonCause(ResourceCause):
 
     @property
     def _sync_kwargs(self) -> Mapping[str, Any]:
-        return dict(super()._sync_kwargs, stopped=self.stopper.sync_checker)
+        return dict(super()._sync_kwargs, stopped=self.stopper.sync_waiter)
 
     @property
     def _async_kwargs(self) -> Mapping[str, Any]:
-        return dict(super()._async_kwargs, stopped=self.stopper.async_checker)
+        return dict(super()._async_kwargs, stopped=self.stopper.async_waiter)
 
 
 def detect_watching_cause(

--- a/kopf/reactor/daemons.py
+++ b/kopf/reactor/daemons.py
@@ -380,7 +380,7 @@ async def _runner(
 
         # Prevent future re-spawns for those exited on their own, for no reason.
         # Only the filter-mismatching or peering-pausing daemons can be re-spawned.
-        if stopper.reason == primitives.DaemonStoppingReason.NONE:
+        if stopper.reason is None:
             memory.forever_stopped.add(handler.id)
 
         # Save the memory by not remembering the exited daemons (they may be never re-spawned).

--- a/kopf/reactor/effects.py
+++ b/kopf/reactor/effects.py
@@ -139,7 +139,7 @@ async def throttled(
         *,
         throttler: containers.Throttler,
         delays: Iterable[float],
-        wakeup: Optional[Union[asyncio.Event, primitives.DaemonStopper]] = None,
+        wakeup: Optional[asyncio.Event] = None,
         logger: Union[logging.Logger, logging.LoggerAdapter],
         errors: Union[Type[BaseException], Tuple[Type[BaseException], ...]] = Exception,
 ) -> AsyncGenerator[bool, None]:

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -156,7 +156,7 @@ else:
 
     DaemonFn = Callable[
         [
-            NamedArg(primitives.SyncAsyncDaemonStopperChecker, "stopped"),
+            NamedArg(primitives.DaemonStopped, "stopped"),
             NamedArg(int, "retry"),
             NamedArg(datetime.datetime, "started"),
             NamedArg(datetime.timedelta, "runtime"),

--- a/kopf/structs/primitives.py
+++ b/kopf/structs/primitives.py
@@ -7,8 +7,8 @@ import concurrent.futures
 import enum
 import threading
 import time
-from typing import Any, AsyncIterator, Callable, Collection, Generic, \
-                   Iterable, Iterator, Optional, Set, TypeVar, Union
+from typing import Any, AsyncIterator, Awaitable, Callable, Collection, Generator, \
+                   Generic, Iterable, Iterator, Optional, Set, TypeVar, Union
 
 from kopf.utilities import aiotasks
 
@@ -291,42 +291,21 @@ class ToggleSet(Collection[Toggle]):
             self._condition.notify_all()
 
 
-class DaemonStoppingReason(enum.Flag):
-    """
-    A reason or reasons of daemon being terminated.
-
-    Daemons are signalled to exit usually for two reasons: the operator itself
-    is exiting or restarting, so all daemons of all resources must stop;
-    or the individual resource was deleted, but the operator continues running.
-
-    No matter the reason, the daemons must exit, so one and only one stop-flag
-    is used. Some daemons can check the reason of exiting if it is important.
-
-    There can be multiple reasons combined (in rare cases, all of them).
-    """
-    NONE = 0
-    DONE = enum.auto()  # whatever the reason and the status, the asyncio task has exited.
-    FILTERS_MISMATCH = enum.auto()  # the resource does not match the filters anymore.
-    RESOURCE_DELETED = enum.auto()  # the resource was deleted, the asyncio task is still awaited.
-    OPERATOR_PAUSING = enum.auto()  # the operator is pausing, the asyncio task is still awaited.
-    OPERATOR_EXITING = enum.auto()  # the operator is exiting, the asyncio task is still awaited.
-    DAEMON_SIGNALLED = enum.auto()  # the stopper flag was set, the asyncio task is still awaited.
-    DAEMON_CANCELLED = enum.auto()  # the asyncio task was cancelled, the thread can be running.
-    DAEMON_ABANDONED = enum.auto()  # we gave up on the asyncio task, the thread can be running.
+FlagReasonT = TypeVar('FlagReasonT', bound=enum.Flag)
 
 
-class DaemonStopper:
+class FlagSetter(Generic[FlagReasonT]):
     """
     A boolean flag indicating that the daemon should stop and exit.
 
-    Every daemon gets a ``stopper`` kwarg, which is an event-like object.
-    The stopper is raised in two cases:
+    Every daemon gets a ``stopped`` kwarg, which is an event-like object.
+    The stopped flag is raised in two cases:
 
     * The corresponding k8s object is deleted, so the daemon should stop.
     * The whole operator is stopping, so all the daemons should stop too.
 
-    The stopper flag is a graceful way of a daemon termination.
-    If the daemons do not react to their stoppers, and continue running,
+    The stopped flag is a graceful way of a daemon termination.
+    If the daemons do not react to their stoppers and continue running,
     their tasks are cancelled by raising a `asyncio.CancelledError`.
 
     .. warning::
@@ -341,38 +320,37 @@ class DaemonStopper:
     def __init__(self) -> None:
         super().__init__()
         self.when: Optional[float] = None
-        self.reason = DaemonStoppingReason.NONE
-        self.sync_checker = SyncDaemonStopperChecker(self)
-        self.async_checker = AsyncDaemonStopperChecker(self)
+        self.reason: Optional[FlagReasonT] = None
         self.sync_event = threading.Event()
         self.async_event = asyncio.Event()
+        self.sync_waiter: SyncFlagWaiter[FlagReasonT] = SyncFlagWaiter(self)
+        self.async_waiter: AsyncFlagWaiter[FlagReasonT] = AsyncFlagWaiter(self)
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__}: {self.is_set()}, reason={self.reason}>'
 
-    def is_set(self, reason: Optional[DaemonStoppingReason] = None) -> bool:
+    def is_set(self, reason: Optional[FlagReasonT] = None) -> bool:
         """
-        Check if the daemon stopper is set: at all or for specific reason.
+        Check if the daemon stopper is set: at all or for a specific reason.
         """
-        return ((reason is None or reason in self.reason) and self.sync_event.is_set())
+        matching_reason = reason is None or (self.reason is not None and reason in self.reason)
+        return matching_reason and self.sync_event.is_set()
 
-    def set(self, *, reason: DaemonStoppingReason) -> None:
+    def set(self, reason: Optional[FlagReasonT] = None) -> None:
         self.when = self.when if self.when is not None else time.monotonic()
-        self.reason |= reason
+        self.reason = reason if self.reason is None or reason is None else self.reason | reason
         self.sync_event.set()
         self.async_event.set()  # it is thread-safe: always called in operator's event loop.
 
 
-class DaemonStopperChecker:
-
+class FlagWaiter(Generic[FlagReasonT]):
     """
     A minimalistic read-only checker for the daemons from the user side.
 
     This object is fed into the :kwarg:`stopped` kwarg for the handlers.
 
-    The actual stopper is hidden from the users, and is an internal class.
-    The users should not be able to trigger the stopping activities or
-    check the reasons of stopping (or know about them at all).
+    The flag setter is hidden from the users, and is an internal class.
+    The users should not be able to trigger the stopping activities.
 
     Usage::
 
@@ -383,42 +361,132 @@ class DaemonStopperChecker:
                 stopped.wait(60)
     """
 
-    def __init__(self, stopper: DaemonStopper) -> None:
+    def __init__(self, setter: FlagSetter[FlagReasonT]) -> None:
         super().__init__()
-        self._stopper = stopper
+        self._setter = setter
 
     def __repr__(self) -> str:
-        return repr(self._stopper)
+        return repr(self._setter)
 
     def __bool__(self) -> bool:
-        return self._stopper.is_set()
+        return self._setter.is_set()
 
     def is_set(self) -> bool:
-        return self._stopper.is_set()
+        return self._setter.is_set()
 
     @property
-    def reason(self) -> DaemonStoppingReason:
-        return self._stopper.reason
+    def reason(self) -> Optional[FlagReasonT]:
+        return self._setter.reason
+
+    # See the docstring for AsyncFlagPromise for explanation.
+    def wait(self, timeout: Optional[float] = None) -> "FlagWaiter[FlagReasonT]":
+        # Presumably, `await stopped.wait(n).wait(m)` in async mode.
+        raise NotImplementedError("Please report the use-case in the issue tracker if needed.")
+
+    # See the docstring for AsyncFlagPromise for explanation.
+    def __await__(self) -> Generator[None, None, "FlagWaiter[FlagReasonT]"]:
+        # Presumably, `await stopped` in either sync or async mode.
+        raise NotImplementedError("Daemon stoppers should not be awaited directly. "
+                                  "Use `await stopped.wait()`.")
 
 
-class SyncDaemonStopperChecker(DaemonStopperChecker):
-    def wait(self, timeout: Optional[float] = None) -> bool:
-        self._stopper.sync_event.wait(timeout=timeout)
-        return bool(self)
+class SyncFlagWaiter(FlagWaiter[FlagReasonT], Generic[FlagReasonT]):
+    def wait(self, timeout: Optional[float] = None) -> "SyncFlagWaiter[FlagReasonT]":
+        self._setter.sync_event.wait(timeout=timeout)
+        return self
 
 
-class AsyncDaemonStopperChecker(DaemonStopperChecker):
-    async def wait(self, timeout: Optional[float] = None) -> bool:
+class AsyncFlagWaiter(FlagWaiter[FlagReasonT], Generic[FlagReasonT]):
+    def wait(self, timeout: Optional[float] = None) -> "AsyncFlagPromise[FlagReasonT]":
+        # A new checker instance, which is awaitable and returns the original checker in the end.
+        return AsyncFlagPromise(self, timeout=timeout)
+
+
+class AsyncFlagPromise(FlagWaiter[FlagReasonT],
+                       Awaitable[AsyncFlagWaiter[FlagReasonT]],
+                       Generic[FlagReasonT]):
+    """
+    An artificial future-like promise for ``await stopped.wait(...)``.
+
+    This is a low-level "clean hack" to simplify the publicly faced types.
+    As a trade-off, the complexity moves to the implementation side.
+
+    The only goal is to accept one and only one type for the ``stopped`` kwarg
+    in ``@kopf.daemon()`` handlers (protocol `callbacks.ResourceDaemonFn`)
+    regardless of whether they are sync or async, but still usable for both.
+
+    For this, the kwarg is announced with the base type `DaemonStoppingFlag`,
+    not as a union of sync or async, or any other double-typed approach.
+
+    The challenge is to support ``stopped.wait()`` in both sync & async modes:
+
+    * sync: ``stopped.wait(float) -> bool``.
+    * async: ``await stopped.wait(float) -> bool``.
+
+    The sync case is the primary case as there are no alternatives to it.
+    The async case is secondary because such use is discouraged (but supported);
+    it is recommended to rely on regular task cancellations in async daemons.
+
+    To solve it, instead of returning a ``bool``, a ``bool``-evaluable object
+    is returned --- the checker itself. This solves the primary (sync) use-case:
+    just sleep for the requested duration and return bool-evaluable self.
+
+    To follow the established signatures of the primary (sync) use-case,
+    the secondary (async) use-case also returns an instance of the checker:
+    but not "self"! Instead, it creates a new time-limited & awaitable checker
+    for every call to ``stopped.wait(n)``, limiting its life by ``n`` seconds.
+
+    Extra checker instances add some tiny memory overhead, but this is fine
+    since the use-case is discouraged and there is a better native alternative.
+
+    Then, going back through the class hierarchy, all classes are made awaitable
+    so that this functionality becomes exposed via the declared base class.
+    But all checkers except the time-limited one prohibit waiting for them.
+    """
+
+    def __init__(self, waiter: AsyncFlagWaiter[FlagReasonT], *, timeout: Optional[float]) -> None:
+        super().__init__(waiter._setter)
+        self._timeout = timeout
+        self._waiter = waiter
+
+    def __await__(self) -> Generator[None, None, AsyncFlagWaiter[FlagReasonT]]:
+        name = f"time-limited waiting for the daemon stopper {self._setter!r}"
+        coro = asyncio.wait_for(self._setter.async_event.wait(), timeout=self._timeout)
+        task = aiotasks.create_task(coro, name=name)
         try:
-            await asyncio.wait_for(self._stopper.async_event.wait(), timeout=timeout)
+            yield from task
         except asyncio.TimeoutError:
             pass
-        return bool(self)
+        return self._waiter  # the original checker! not the time-limited one!
 
 
-# Having this union allows both sync & async checkers in the same protocol,
-# while not restricting the use of `wait()` as if the base class would be used.
-SyncAsyncDaemonStopperChecker = Union[SyncDaemonStopperChecker, AsyncDaemonStopperChecker]
+class DaemonStoppingReason(enum.Flag):
+    """
+    A reason or reasons of daemon being terminated.
+
+    Daemons are signalled to exit usually for two reasons: the operator itself
+    is exiting or restarting, so all daemons of all resources must stop;
+    or the individual resource was deleted, but the operator continues running.
+
+    No matter the reason, the daemons must exit, so one and only one stop-flag
+    is used. Some daemons can check the reason of exiting if it is important.
+
+    There can be multiple reasons combined (in rare cases, all of them).
+    """
+    DONE = enum.auto()  # whatever the reason and the status, the asyncio task has exited.
+    FILTERS_MISMATCH = enum.auto()  # the resource does not match the filters anymore.
+    RESOURCE_DELETED = enum.auto()  # the resource was deleted, the asyncio task is still awaited.
+    OPERATOR_PAUSING = enum.auto()  # the operator is pausing, the asyncio task is still awaited.
+    OPERATOR_EXITING = enum.auto()  # the operator is exiting, the asyncio task is still awaited.
+    DAEMON_SIGNALLED = enum.auto()  # the stopper flag was set, the asyncio task is still awaited.
+    DAEMON_CANCELLED = enum.auto()  # the asyncio task was cancelled, the thread can be running.
+    DAEMON_ABANDONED = enum.auto()  # we gave up on the asyncio task, the thread can be running.
+
+
+DaemonStopper = FlagSetter[DaemonStoppingReason]
+DaemonStopped = FlagWaiter[DaemonStoppingReason]
+SyncDaemonStopperChecker = SyncFlagWaiter[DaemonStoppingReason]  # deprecated
+AsyncDaemonStopperChecker = AsyncFlagWaiter[DaemonStoppingReason]  # deprecated
 
 
 async def sleep_or_wait(

--- a/kopf/structs/primitives.py
+++ b/kopf/structs/primitives.py
@@ -423,7 +423,7 @@ SyncAsyncDaemonStopperChecker = Union[SyncDaemonStopperChecker, AsyncDaemonStopp
 
 async def sleep_or_wait(
         delays: Union[None, float, Collection[Union[None, float]]],
-        wakeup: Optional[Union[asyncio.Event, DaemonStopper]] = None,
+        wakeup: Optional[asyncio.Event] = None,
 ) -> Optional[float]:
     """
     Measure the sleep time: either until the timeout, or until the event is set.
@@ -441,11 +441,7 @@ async def sleep_or_wait(
     if minimal_delay <= 0:
         return None
 
-    awakening_event = (
-        wakeup.async_event if isinstance(wakeup, DaemonStopper) else
-        wakeup if wakeup is not None else
-        asyncio.Event())
-
+    awakening_event = wakeup if wakeup is not None else asyncio.Event()
     loop = asyncio.get_running_loop()
     try:
         start_time = loop.time()

--- a/tests/causation/test_kwargs.py
+++ b/tests/causation/test_kwargs.py
@@ -276,7 +276,7 @@ def test_daemon_sync_stopper(resource, attr):
     )
     kwargs = getattr(cause, attr)  # cause.sync_kwargs
     assert 'stopper' not in kwargs
-    assert kwargs['stopped'] is cause.stopper.sync_checker
+    assert kwargs['stopped'] is cause.stopper.sync_waiter
 
 
 @pytest.mark.parametrize('attr', ['async_kwargs'])
@@ -292,4 +292,4 @@ def test_daemon_async_stopper(resource, attr):
     )
     kwargs = getattr(cause, attr)  # cause.async_kwargs
     assert 'stopper' not in kwargs
-    assert kwargs['stopped'] is cause.stopper.async_checker
+    assert kwargs['stopped'] is cause.stopper.async_waiter

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -10,7 +10,6 @@ from kopf.reactor.daemons import daemon_killer
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.bodies import RawBody
-from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
 from kopf.structs.primitives import ToggleSet
 
@@ -30,7 +29,7 @@ class DaemonDummy:
     async def wait_for_daemon_done(self):
         stopped = self.kwargs['stopped']
         await stopped.wait()
-        while not stopped._stopper.reason & stopped._stopper.reason.DONE:
+        while not stopped.reason & stopped.reason.DONE:
             await asyncio.sleep(0)  # give control back to asyncio event loop
 
 

--- a/tests/handling/daemons/test_timer_errors.py
+++ b/tests/handling/daemons/test_timer_errors.py
@@ -14,7 +14,7 @@ async def test_timer_stopped_on_permanent_error(
         dummy.mock()
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
-        kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
+        kwargs['stopped']._setter.set()  # to exit the cycle
         raise PermanentError("boo!")
 
     event_object = {'metadata': {'finalizers': [settings.persistence.finalizer]}}
@@ -43,7 +43,7 @@ async def test_timer_stopped_on_arbitrary_errors_with_mode_permanent(
         dummy.mock()
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
-        kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
+        kwargs['stopped']._setter.set()  # to exit the cycle
         raise Exception("boo!")
 
     event_object = {'metadata': {'finalizers': [settings.persistence.finalizer]}}
@@ -76,7 +76,7 @@ async def test_timer_retried_on_temporary_error(
         if not retry:
             raise TemporaryError("boo!", delay=1.0)
         else:
-            kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
+            kwargs['stopped']._setter.set()  # to exit the cycle
             dummy.steps['finish'].set()
 
     event_object = {'metadata': {'finalizers': [settings.persistence.finalizer]}}
@@ -108,7 +108,7 @@ async def test_timer_retried_on_arbitrary_error_with_mode_temporary(
         if not retry:
             raise Exception("boo!")
         else:
-            kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
+            kwargs['stopped']._setter.set()  # to exit the cycle
             dummy.steps['finish'].set()
 
     event_object = {'metadata': {'finalizers': [settings.persistence.finalizer]}}
@@ -138,7 +138,7 @@ async def test_timer_retried_until_retries_limit(
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
         if dummy.mock.call_count >= 5:
-            kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
+            kwargs['stopped']._setter.set()  # to exit the cycle
         raise TemporaryError("boo!", delay=1.0)
 
     await simulate_cycle({})
@@ -162,7 +162,7 @@ async def test_timer_retried_until_timeout(
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
         if dummy.mock.call_count >= 5:
-            kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
+            kwargs['stopped']._setter.set()  # to exit the cycle
         raise TemporaryError("boo!", delay=1.0)
 
     await simulate_cycle({})

--- a/tests/handling/daemons/test_timer_intervals.py
+++ b/tests/handling/daemons/test_timer_intervals.py
@@ -17,7 +17,7 @@ async def test_timer_regular_interval(
         frozen_time.tick(0.3)
         if dummy.mock.call_count >= 2:
             dummy.steps['finish'].set()
-            kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
+            kwargs['stopped']._setter.set()  # to exit the cycle
 
     await simulate_cycle({})
     await dummy.steps['called'].wait()
@@ -41,7 +41,7 @@ async def test_timer_sharp_interval(
         frozen_time.tick(0.3)
         if dummy.mock.call_count >= 2:
             dummy.steps['finish'].set()
-            kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
+            kwargs['stopped']._setter.set()  # to exit the cycle
 
     await simulate_cycle({})
     await dummy.steps['called'].wait()

--- a/tests/handling/daemons/test_timer_triggering.py
+++ b/tests/handling/daemons/test_timer_triggering.py
@@ -12,7 +12,7 @@ async def test_timer_is_spawned_at_least_once(
         dummy.mock()
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
-        kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
+        kwargs['stopped']._setter.set()  # to exit the cycle
 
     await simulate_cycle({})
     await dummy.steps['called'].wait()
@@ -34,7 +34,7 @@ async def test_timer_initial_delay_obeyed(
         dummy.mock()
         dummy.kwargs = kwargs
         dummy.steps['called'].set()
-        kwargs['stopped']._stopper.set(reason=kopf.DaemonStoppingReason.NONE)  # to exit the cycle
+        kwargs['stopped']._setter.set()  # to exit the cycle
 
     await simulate_cycle({})
     await dummy.steps['called'].wait()


### PR DESCRIPTION
Previously, `Union` of sync & async checkers was used in the daemon protocol. As a result, it forced the operator developers to accept both types and do proper handling of both cases — when in fact only one checker was passed according to the daemon type (sync/async).

To simplify type-checking of operators, both sync & async checkers are now downgraded to _implementation details_ (but remain exported for backwards compatibility), while only the base class is exposed for type annotations of the `stopped` kwarg. To achieve this, some "clean" (as in, "not dirty") trickery was implemented — see the docstring of the new “promise” class.

All public interfaces should remain supported without breaking them. Even evaluating the results of `stopped.wait()` as booleans remain there: the returned value is the flag/checker itself, but it is bool-evaluable (unless `x is True`/`x is False` conditions were used).

Related #747. Fixes #746. Replaces #748.
