### PR TITLE
Decouple & isolate handling from specialised causes & handlers

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -121,6 +121,8 @@ from kopf.structs.filters import (
 )
 from kopf.structs.handlers import (
     ErrorsMode,
+)
+from kopf.reactor.causation import (
     Reason,
 )
 from kopf.structs.ids import (

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -36,6 +36,8 @@ from kopf.reactor.admission import (
     AdmissionError,
 )
 from kopf.reactor.handling import (
+    Logger,
+    ErrorsMode,
     TemporaryError,
     PermanentError,
     HandlerTimeoutError,
@@ -90,7 +92,6 @@ from kopf.structs.bodies import (
     build_owner_reference,
 )
 from kopf.structs.callbacks import (
-    Logger,
     not_,
     all_,
     any_,
@@ -120,9 +121,6 @@ from kopf.structs.ephemera import (
 from kopf.structs.filters import (
     ABSENT,
     PRESENT,
-)
-from kopf.structs.handlers import (
-    ErrorsMode,
 )
 from kopf.reactor.causation import (
     Reason,

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -40,6 +40,8 @@ from kopf.reactor.handling import (
     PermanentError,
     HandlerTimeoutError,
     HandlerRetriesError,
+)
+from kopf.reactor.subhandling import (
     execute,
 )
 from kopf.reactor.lifecycles import (

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -6,8 +6,8 @@ from typing import MutableMapping, Optional, Tuple
 
 import aiohttp.web
 
-from kopf.reactor import activities, lifecycles, registries
-from kopf.structs import callbacks, configuration, ephemera, handlers, ids
+from kopf.reactor import activities, causation, lifecycles, registries
+from kopf.structs import callbacks, configuration, ephemera, ids
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ async def health_reporter(
                         lifecycle=lifecycles.all_at_once,
                         registry=registry,
                         settings=settings,
-                        activity=handlers.Activity.PROBE,
+                        activity=causation.Activity.PROBE,
                         indices=indices,
                         memo=memo,
                     )

--- a/kopf/engines/probing.py
+++ b/kopf/engines/probing.py
@@ -6,8 +6,8 @@ from typing import MutableMapping, Optional, Tuple
 
 import aiohttp.web
 
-from kopf.reactor import activities, causation, lifecycles, registries
-from kopf.structs import callbacks, configuration, ephemera, ids
+from kopf.reactor import activities, causation, handling, lifecycles, registries
+from kopf.structs import configuration, ephemera, ids
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ async def health_reporter(
     is cancelled or failed). Once it will stop responding for any reason,
     Kubernetes will assume the pod is not alive anymore, and will restart it.
     """
-    probing_container: MutableMapping[ids.HandlerId, callbacks.Result] = {}
+    probing_container: MutableMapping[ids.HandlerId, handling.Result] = {}
     probing_timestamp: Optional[datetime.datetime] = None
     probing_max_age = datetime.timedelta(seconds=10.0)
     probing_lock = asyncio.Lock()

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -30,7 +30,7 @@ def startup(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -57,7 +57,7 @@ def cleanup(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -84,7 +84,7 @@ def login(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -112,7 +112,7 @@ def probe(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -263,7 +263,7 @@ def resume(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -320,7 +320,7 @@ def create(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -376,7 +376,7 @@ def update(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -434,7 +434,7 @@ def delete(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -491,7 +491,7 @@ def field(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -549,7 +549,7 @@ def index(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -653,7 +653,7 @@ def daemon(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -715,7 +715,7 @@ def timer(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -764,7 +764,7 @@ def subhandler(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -838,7 +838,7 @@ def register(  # lgtm[py/similar-function]
         # Handler's behaviour specification:
         id: Optional[str] = None,
         param: Optional[Any] = None,
-        errors: Optional[handlers.ErrorsMode] = None,
+        errors: Optional[handling.ErrorsMode] = None,
         timeout: Optional[float] = None,
         retries: Optional[int] = None,
         backoff: Optional[float] = None,
@@ -908,7 +908,7 @@ def _warn_conflicting_values(
 
 
 def _warn_incompatible_parent_with_oldnew(
-        handler: handlers.BaseHandler,
+        handler: handling.Handler,
         old: Any,
         new: Any,
 ) -> None:

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -13,7 +13,7 @@ This module is a part of the framework's public interface.
 # TODO: add cluster=True support (different API methods)
 from typing import Any, Callable, Optional, Union
 
-from kopf.reactor import causation, handling, registries
+from kopf.reactor import causation, handling, registries, subhandling
 from kopf.structs import callbacks, dicts, filters, handlers, references, reviews
 
 ActivityDecorator = Callable[[callbacks.ActivityFn], callbacks.ActivityFn]
@@ -814,7 +814,7 @@ def subhandler(  # lgtm[py/similar-function]
         _warn_incompatible_parent_with_oldnew(parent_handler, old, new)
         _warn_conflicting_values(field, value, old, new)
         _verify_filters(labels, annotations)
-        real_registry = handling.subregistry_var.get()
+        real_registry = subhandling.subregistry_var.get()
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id,
                                          prefix=parent_handler.id if parent_handler else None)

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -13,7 +13,7 @@ This module is a part of the framework's public interface.
 # TODO: add cluster=True support (different API methods)
 from typing import Any, Callable, Optional, Union
 
-from kopf.reactor import handling, registries
+from kopf.reactor import causation, handling, registries
 from kopf.structs import callbacks, dicts, filters, handlers, references, reviews
 
 ActivityDecorator = Callable[[callbacks.ActivityFn], callbacks.ActivityFn]
@@ -45,7 +45,7 @@ def startup(  # lgtm[py/similar-function]
         handler = handlers.ActivityHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
-            activity=handlers.Activity.STARTUP,
+            activity=causation.Activity.STARTUP,
         )
         real_registry._activities.append(handler)
         return fn
@@ -72,7 +72,7 @@ def cleanup(  # lgtm[py/similar-function]
         handler = handlers.ActivityHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
-            activity=handlers.Activity.CLEANUP,
+            activity=causation.Activity.CLEANUP,
         )
         real_registry._activities.append(handler)
         return fn
@@ -100,7 +100,7 @@ def login(  # lgtm[py/similar-function]
         handler = handlers.ActivityHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
-            activity=handlers.Activity.AUTHENTICATION,
+            activity=causation.Activity.AUTHENTICATION,
         )
         real_registry._activities.append(handler)
         return fn
@@ -128,7 +128,7 @@ def probe(  # lgtm[py/similar-function]
         handler = handlers.ActivityHandler(
             fn=fn, id=real_id, param=param,
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
-            activity=handlers.Activity.PROBE,
+            activity=causation.Activity.PROBE,
         )
         real_registry._activities.append(handler)
         return fn
@@ -183,7 +183,7 @@ def validate(  # lgtm[py/similar-function]
             errors=None, timeout=None, retries=None, backoff=None,  # TODO: add some meaning later
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value,
-            reason=handlers.WebhookType.VALIDATING, operation=operation,
+            reason=causation.WebhookType.VALIDATING, operation=operation,
             persistent=persistent, side_effects=side_effects, ignore_failures=ignore_failures,
         )
         real_registry._webhooks.append(handler)
@@ -239,7 +239,7 @@ def mutate(  # lgtm[py/similar-function]
             errors=None, timeout=None, retries=None, backoff=None,  # TODO: add some meaning later
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value,
-            reason=handlers.WebhookType.MUTATING, operation=operation,
+            reason=causation.WebhookType.MUTATING, operation=operation,
             persistent=persistent, side_effects=side_effects, ignore_failures=ignore_failures,
         )
         real_registry._webhooks.append(handler)
@@ -353,7 +353,7 @@ def create(  # lgtm[py/similar-function]
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=None, new=None, field_needs_change=False,
             initial=None, deleted=None, requires_finalizer=None,
-            reason=handlers.Reason.CREATE,
+            reason=causation.Reason.CREATE,
         )
         real_registry._changing.append(handler)
         return fn
@@ -411,7 +411,7 @@ def update(  # lgtm[py/similar-function]
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=old, new=new, field_needs_change=True,
             initial=None, deleted=None, requires_finalizer=None,
-            reason=handlers.Reason.UPDATE,
+            reason=causation.Reason.UPDATE,
         )
         real_registry._changing.append(handler)
         return fn
@@ -468,7 +468,7 @@ def delete(  # lgtm[py/similar-function]
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value, old=None, new=None, field_needs_change=False,
             initial=None, deleted=None, requires_finalizer=bool(not optional),
-            reason=handlers.Reason.DELETE,
+            reason=causation.Reason.DELETE,
         )
         real_registry._changing.append(handler)
         return fn
@@ -914,7 +914,7 @@ def _warn_incompatible_parent_with_oldnew(
 ) -> None:
     if old is not None or new is not None:
         if isinstance(handler, handlers.ChangingHandler):
-            is_on_update = handler.reason == handlers.Reason.UPDATE
+            is_on_update = handler.reason == causation.Reason.UPDATE
             is_on_field = handler.reason is None and not handler.initial
             if not is_on_update and not is_on_field:
                 raise TypeError("Filters old=/new= can only be used in update handlers.")

--- a/kopf/reactor/activities.py
+++ b/kopf/reactor/activities.py
@@ -83,7 +83,7 @@ async def authenticate(
         lifecycle=lifecycles.all_at_once,
         registry=registry,
         settings=settings,
-        activity=handlers_.Activity.AUTHENTICATION,
+        activity=causation.Activity.AUTHENTICATION,
         indices=indices,
         memo=memo,
     )
@@ -103,7 +103,7 @@ async def run_activity(
         lifecycle: lifecycles.LifeCycleFn,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
-        activity: handlers_.Activity,
+        activity: causation.Activity,
         indices: ephemera.Indices,
         memo: ephemera.AnyMemo,
 ) -> Mapping[ids.HandlerId, callbacks.Result]:

--- a/kopf/reactor/admission.py
+++ b/kopf/reactor/admission.py
@@ -66,7 +66,7 @@ async def serve_admission_request(
         headers: Optional[Mapping[str, str]] = None,
         sslpeer: Optional[Mapping[str, Any]] = None,
         webhook: Optional[ids.HandlerId] = None,
-        reason: Optional[handlers.WebhookType] = None,  # TODO: undocumented: requires typing clarity!
+        reason: Optional[causation.WebhookType] = None,  # TODO: undocumented: requires typing clarity!
         # Injected by partial() from spawn_tasks():
         settings: configuration.OperatorSettings,
         memories: containers.ResourceMemories,
@@ -243,7 +243,7 @@ async def validating_configuration_manager(
         container: primitives.Container[reviews.WebhookClientConfig],
 ) -> None:
     await configuration_manager(
-        reason=handlers.WebhookType.VALIDATING,
+        reason=causation.WebhookType.VALIDATING,
         selector=references.VALIDATING_WEBHOOK,
         registry=registry, settings=settings,
         insights=insights, container=container,
@@ -258,7 +258,7 @@ async def mutating_configuration_manager(
         container: primitives.Container[reviews.WebhookClientConfig],
 ) -> None:
     await configuration_manager(
-        reason=handlers.WebhookType.MUTATING,
+        reason=causation.WebhookType.MUTATING,
         selector=references.MUTATING_WEBHOOK,
         registry=registry, settings=settings,
         insights=insights, container=container,
@@ -267,7 +267,7 @@ async def mutating_configuration_manager(
 
 async def configuration_manager(
         *,
-        reason: handlers.WebhookType,
+        reason: causation.WebhookType,
         selector: references.Selector,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,

--- a/kopf/reactor/admission.py
+++ b/kopf/reactor/admission.py
@@ -128,7 +128,7 @@ async def serve_admission_request(
         handlers=handlers_,
         cause=cause,
         state=state,
-        default_errors=handlers.ErrorsMode.PERMANENT,
+        default_errors=handling.ErrorsMode.PERMANENT,
     )
 
     # Construct the response as per Kubernetes's conventions and expectations.
@@ -168,7 +168,7 @@ def find_resource(
 def build_response(
         *,
         request: reviews.Request,
-        outcomes: Mapping[ids.HandlerId, states.HandlerOutcome],
+        outcomes: Mapping[ids.HandlerId, handling.Outcome],
         warnings: Collection[str],
         jsonpatch: patches.JSONPatch,
 ) -> reviews.Response:

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -77,10 +77,10 @@ ALL_REASONS = HANDLER_REASONS + REACTOR_REASONS
 
 # The human-readable names of these causes. Will be capitalised when needed.
 TITLES = {
-    Reason.CREATE: 'creation',
-    Reason.UPDATE: 'updating',
-    Reason.DELETE: 'deletion',
-    Reason.RESUME: 'resuming',
+    Reason.CREATE.value: 'creation',
+    Reason.UPDATE.value: 'updating',
+    Reason.DELETE.value: 'deletion',
+    Reason.RESUME.value: 'resuming',
 }
 
 

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -22,7 +22,7 @@ could execute on the yet-existing object (and its children, if created).
 import dataclasses
 import enum
 import logging
-from typing import Any, List, Mapping, Optional, TypeVar, Union
+from typing import Any, List, Mapping, Optional, Union
 
 from kopf.reactor import invocation
 from kopf.storage import finalizers
@@ -342,19 +342,3 @@ def detect_changing_cause(
 
     # And what is left, is the update operation on one of the useful fields of the existing object.
     return ChangingCause(reason=Reason.UPDATE, **kwargs)
-
-
-_CT = TypeVar('_CT', bound=BaseCause)
-
-
-def enrich_cause(
-        cause: _CT,
-        **kwargs: Any,
-) -> _CT:
-    """
-    Produce a new derived cause with some fields modified ().
-
-    Usually, those are the old/new/diff fields, and used when a field-handler
-    is invoked (the old/new/diff refer to the field's values only).
-    """
-    return dataclasses.replace(cause, **kwargs)

--- a/kopf/reactor/causation.py
+++ b/kopf/reactor/causation.py
@@ -21,10 +21,9 @@ could execute on the yet-existing object (and its children, if created).
 """
 import dataclasses
 import enum
-import logging
-from typing import Any, List, Mapping, Optional, Union
+from typing import Any, List, Mapping, Optional
 
-from kopf.reactor import invocation
+from kopf.reactor import handling
 from kopf.storage import finalizers
 from kopf.structs import bodies, configuration, diffs, ephemera, ids, \
                          patches, primitives, references, reviews
@@ -85,7 +84,7 @@ TITLES = {
 
 
 @dataclasses.dataclass
-class BaseCause(invocation.Kwargable):
+class BaseCause(handling.Cause):
     """
     Base non-specific cause as used in the framework's reactor in most cases.
 
@@ -102,13 +101,11 @@ class BaseCause(invocation.Kwargable):
     harms only the developers who do so, so this is considered safe.
     """
     indices: ephemera.Indices
-    logger: Union[logging.Logger, logging.LoggerAdapter]
     memo: ephemera.AnyMemo
 
     @property
     def _kwargs(self) -> Mapping[str, Any]:
-        # Similar to `dataclasses.asdict()`, but not recursive for other dataclasses.
-        kwargs = {field.name: getattr(self, field.name) for field in dataclasses.fields(self)}
+        kwargs = dict(super()._kwargs)
         del kwargs['indices']
         return kwargs
 

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -15,7 +15,7 @@ from typing import Collection, Iterable, Mapping, MutableMapping, Optional, Set,
 
 from kopf.reactor import causation, invocation, lifecycles, registries
 from kopf.storage import states
-from kopf.structs import callbacks, configuration, dicts, diffs, handlers as handlers_, ids
+from kopf.structs import callbacks, configuration, handlers as handlers_, ids
 
 DEFAULT_RETRY_DELAY = 1 * 60
 """ The default delay duration for the regular exception in retry-mode. """
@@ -337,14 +337,7 @@ async def invoke_handler(
     """
 
     # For the field-handlers, the old/new/diff values must match the field, not the whole object.
-    if (True and  # for readable indenting
-            isinstance(cause, causation.ChangingCause) and
-            isinstance(handler, handlers_.ChangingHandler) and
-            handler.field is not None):
-        old = dicts.resolve(cause.old, handler.field, None)
-        new = dicts.resolve(cause.new, handler.field, None)
-        diff = diffs.reduce(cause.diff, handler.field)
-        cause = causation.enrich_cause(cause=cause, old=old, new=new, diff=diff)
+    cause = handler.adjust_cause(cause)
 
     # Store the context of the current handler, to be used in `@kopf.subhandler`,
     # and maybe other places, and consumed in the recursive `execute()` calls for the children.

--- a/kopf/reactor/handling.py
+++ b/kopf/reactor/handling.py
@@ -10,11 +10,9 @@ activities, when there is no underlying Kubernetes object to patch'n'watch.
 import asyncio
 import collections.abc
 import datetime
-import logging
 from contextvars import ContextVar
 from typing import Collection, Iterable, Mapping, MutableMapping, Optional, Set, Union
 
-from kopf.engines import loggers
 from kopf.reactor import causation, invocation, lifecycles, registries
 from kopf.storage import states
 from kopf.structs import callbacks, configuration, dicts, diffs, handlers as handlers_, ids
@@ -243,13 +241,7 @@ async def execute_handler_once(
     """
     errors_mode = handler.errors if handler.errors is not None else default_errors
     backoff = handler.backoff if handler.backoff is not None else DEFAULT_RETRY_DELAY
-
-    # Prevent successes/failures from posting k8s-events for resource-watching causes.
-    logger: Union[logging.Logger, logging.LoggerAdapter]
-    if isinstance(cause, causation.WatchingCause):
-        logger = loggers.LocalObjectLogger(body=cause.body, settings=settings)
-    else:
-        logger = cause.logger
+    logger = cause.logger
 
     # Mutable accumulator for all the sub-handlers of any level deep; populated in `kopf.execute`.
     subrefs: Set[ids.HandlerId] = set()

--- a/kopf/reactor/indexing.py
+++ b/kopf/reactor/indexing.py
@@ -197,7 +197,7 @@ class OperatorIndexers(Dict[ids.HandlerId, OperatorIndexer]):
     def replace(
             self,
             body: bodies.Body,
-            outcomes: Mapping[ids.HandlerId, states.HandlerOutcome],
+            outcomes: Mapping[ids.HandlerId, handling.Outcome],
     ) -> None:
         """ Interpret the indexing results and apply them to the indices. """
         key = self.make_key(body)
@@ -318,7 +318,7 @@ async def index_resource(
             handlers=indexing_handlers,
             cause=cause,
             state=state,
-            default_errors=handlers.ErrorsMode.IGNORED,
+            default_errors=handling.ErrorsMode.IGNORED,
         )
         indexers.replace(body=body, outcomes=outcomes)
 

--- a/kopf/reactor/invocation.py
+++ b/kopf/reactor/invocation.py
@@ -5,7 +5,6 @@ Both sync & async functions are supported, so as their partials.
 Also, decorated wrappers and lambdas are recognized.
 All of this goes via the same invocation logic and protocol.
 """
-import abc
 import asyncio
 import contextlib
 import contextvars
@@ -25,23 +24,22 @@ _R = TypeVar('_R')
 SyncOrAsync = Union[_R, Coroutine[None, None, _R]]
 
 # A generic sync-or-async callable with no args/kwargs checks (unlike in protocols).
-# Used for the BaseHandler and generic invocation methods (which do not care about protocols).
+# Used for the Handler and generic invocation methods (which do not care about protocols).
 Invokable = Callable[..., SyncOrAsync[Optional[object]]]
 
 
-class Kwargable(metaclass=abc.ABCMeta):
+class Kwargable:
     """
     Something that can provide kwargs to the function invocation rotuine.
 
     Technically, there is only one source of kwargs in the framework --
-    ``causes.py`` (`BaseCause` and descendants across the source code).
+    `Cause` and descendants across the source code (e.g. ``causes.py``).
     However, we do not want to introduce a new dependency of a low-level
     function invocation module on the specialised causation logic & structures.
-    For this reason, the `BaseCause` & `Kwargable` classes are split.
+    For this reason, the `Cause` & `Kwargable` classes are split.
     """
 
     @property
-    @abc.abstractmethod
     def _kwargs(self) -> Mapping[str, Any]:
         return {}
 

--- a/kopf/reactor/lifecycles.py
+++ b/kopf/reactor/lifecycles.py
@@ -12,70 +12,50 @@ import logging
 import random
 from typing import Any, Optional, Sequence
 
-from typing_extensions import Protocol
-
-from kopf.storage import states
-from kopf.structs import handlers as handlers_
+from kopf.reactor import handling
 
 logger = logging.getLogger(__name__)
 
-Handlers = Sequence[handlers_.BaseHandler]
+Handlers = Sequence[handling.Handler]
 
 
-class LifeCycleFn(Protocol):
-    """
-    A callback type for handlers selection based on the event/cause.
-
-    It is basically `Invokable` extended with an additional positional parameter
-    and specific return type. But we cannot express it with `typing`.
-    For the names and types of kwargs, see `Invokable`.
-    """
-    def __call__(
-            self,
-            handlers: Handlers,
-            *,
-            state: states.State,
-            **kwargs: Any,
-    ) -> Handlers: ...
-
-
-def all_at_once(handlers: Handlers, **kwargs: Any) -> Handlers:
+def all_at_once(handlers: Handlers, **_: Any) -> Handlers:
     """ Execute all handlers at once, in one event reaction cycle, if possible. """
     return handlers
 
 
-def one_by_one(handlers: Handlers, **kwargs: Any) -> Handlers:
+def one_by_one(handlers: Handlers, **_: Any) -> Handlers:
     """ Execute handlers one at a time, in the order they were registered. """
     return handlers[:1]
 
 
-def randomized(handlers: Handlers, **kwargs: Any) -> Handlers:
+def randomized(handlers: Handlers, **_: Any) -> Handlers:
     """ Execute one handler at a time, in the random order. """
     return [random.choice(handlers)] if handlers else []
 
 
-def shuffled(handlers: Handlers, **kwargs: Any) -> Handlers:
+def shuffled(handlers: Handlers, **_: Any) -> Handlers:
     """ Execute all handlers at once, but in the random order. """
     return random.sample(handlers, k=len(handlers)) if handlers else []
 
 
-def asap(handlers: Handlers, *, state: states.State, **kwargs: Any) -> Handlers:
+def asap(handlers: Handlers, *, state: handling.State, **_: Any) -> Handlers:
     """ Execute one handler at a time, skip on failure, try the next one, retry after the full cycle. """
 
-    def keyfn(handler: handlers_.BaseHandler) -> int:
+    def keyfn(handler: handling.Handler) -> int:
         return state[handler.id].retries or 0
 
     return sorted(handlers, key=keyfn)[:1]
 
 
-_default_lifecycle: LifeCycleFn = asap
+_default_lifecycle: handling.LifeCycleFn = asap
 
 
-def get_default_lifecycle() -> LifeCycleFn:
+def get_default_lifecycle() -> handling.LifeCycleFn:
     return _default_lifecycle
 
 
-def set_default_lifecycle(lifecycle: Optional[LifeCycleFn]) -> None:
+def set_default_lifecycle(lifecycle: Optional[handling.LifeCycleFn]) -> None:
     global _default_lifecycle
     if _default_lifecycle is not None:
         logger.warning(f"The default lifecycle is already set to {_default_lifecycle}, overriding it to {lifecycle}.")

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -18,7 +18,8 @@ import time
 from typing import Collection, Optional, Tuple
 
 from kopf.engines import loggers, posting
-from kopf.reactor import causation, daemons, effects, handling, indexing, lifecycles, registries
+from kopf.reactor import causation, daemons, effects, handling, \
+                         indexing, lifecycles, registries, subhandling
 from kopf.storage import finalizers, states
 from kopf.structs import bodies, configuration, containers, diffs, ephemera, \
                          handlers as handlers_, patches, primitives, references
@@ -413,6 +414,7 @@ async def process_changing_cause(
                 handlers=cause_handlers,
                 cause=cause,
                 state=state,
+                extra_context=subhandling.subhandling_context,
             )
             state = state.with_outcomes(outcomes)
             state.store(body=cause.body, patch=cause.patch, storage=storage)

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -372,8 +372,8 @@ async def process_changing_cause(
     skip: Optional[bool] = None
 
     # Regular causes invoke the handlers.
-    if cause.reason in handlers_.HANDLER_REASONS:
-        title = handlers_.TITLES.get(cause.reason, repr(cause.reason))
+    if cause.reason in causation.HANDLER_REASONS:
+        title = causation.TITLES.get(cause.reason, repr(cause.reason))
 
         resource_registry = registry._changing
         owned_handlers = resource_registry.get_resource_handlers(resource=cause.resource)
@@ -386,7 +386,7 @@ async def process_changing_cause(
         # The mix-in causes (i.e. resuming) is re-purposed if its handlers are still selected.
         # To the next cycle, all extras are purged or re-purposed, so the message does not repeat.
         for extra_reason, counters in state.extras.items():  # usually 0..1 items, rarely 2+.
-            extra_title = handlers_.TITLES.get(extra_reason, repr(extra_reason))
+            extra_title = causation.TITLES.get(extra_reason, repr(extra_reason))
             logger.info(f"{extra_title.capitalize()} is superseded by {title.lower()}: "
                         f"{counters.success} succeeded; "
                         f"{counters.failure} failed; "
@@ -441,13 +441,13 @@ async def process_changing_cause(
         memory.fully_handled_once = True
 
     # Informational causes just print the log lines.
-    if cause.reason == handlers_.Reason.GONE:
+    if cause.reason == causation.Reason.GONE:
         logger.debug("Deleted, really deleted, and we are notified.")
 
-    if cause.reason == handlers_.Reason.FREE:
+    if cause.reason == causation.Reason.FREE:
         logger.debug("Deletion, but we are done with it, and we do not care.")
 
-    if cause.reason == handlers_.Reason.NOOP:
+    if cause.reason == causation.Reason.NOOP:
         logger.debug("Something has changed, but we are not interested (the essence is the same).")
 
     # The delay is then consumed by the main handling routine (in different ways).

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -373,7 +373,7 @@ async def process_changing_cause(
 
     # Regular causes invoke the handlers.
     if cause.reason in causation.HANDLER_REASONS:
-        title = causation.TITLES.get(cause.reason, repr(cause.reason))
+        title = causation.TITLES.get(cause.reason.value, repr(cause.reason.value))
 
         resource_registry = registry._changing
         owned_handlers = resource_registry.get_resource_handlers(resource=cause.resource)
@@ -385,8 +385,8 @@ async def process_changing_cause(
         # Report the causes that have been superseded (intercepted, overridden) by the current one.
         # The mix-in causes (i.e. resuming) is re-purposed if its handlers are still selected.
         # To the next cycle, all extras are purged or re-purposed, so the message does not repeat.
-        for extra_reason, counters in state.extras.items():  # usually 0..1 items, rarely 2+.
-            extra_title = causation.TITLES.get(extra_reason, repr(extra_reason))
+        for extra_purpose, counters in state.extras.items():  # usually 0..1 items, rarely 2+.
+            extra_title = causation.TITLES.get(extra_purpose, repr(extra_purpose))
             logger.info(f"{extra_title.capitalize()} is superseded by {title.lower()}: "
                         f"{counters.success} succeeded; "
                         f"{counters.failure} failed; "

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -21,12 +21,12 @@ from kopf.engines import loggers, posting
 from kopf.reactor import causation, daemons, effects, handling, \
                          indexing, lifecycles, registries, subhandling
 from kopf.storage import finalizers, states
-from kopf.structs import bodies, configuration, containers, diffs, ephemera, \
-                         handlers as handlers_, patches, primitives, references
+from kopf.structs import bodies, configuration, containers, diffs, \
+                         ephemera, patches, primitives, references
 
 
 async def process_resource_event(
-        lifecycle: lifecycles.LifeCycleFn,
+        lifecycle: handling.LifeCycleFn,
         indexers: indexing.OperatorIndexers,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
@@ -138,7 +138,7 @@ async def process_resource_event(
 
 
 async def process_resource_causes(
-        lifecycle: lifecycles.LifeCycleFn,
+        lifecycle: handling.LifeCycleFn,
         indexers: indexing.OperatorIndexers,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
@@ -273,7 +273,7 @@ async def process_resource_causes(
 
 
 async def process_watching_cause(
-        lifecycle: lifecycles.LifeCycleFn,
+        lifecycle: handling.LifeCycleFn,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         cause: causation.WatchingCause,
@@ -295,7 +295,7 @@ async def process_watching_cause(
         handlers=handlers,
         cause=cause,
         state=states.State.from_scratch().with_handlers(handlers),
-        default_errors=handlers_.ErrorsMode.IGNORED,
+        default_errors=handling.ErrorsMode.IGNORED,
     )
 
     # Store the results, but not the handlers' progress.
@@ -356,7 +356,7 @@ async def process_spawning_cause(
 
 
 async def process_changing_cause(
-        lifecycle: lifecycles.LifeCycleFn,
+        lifecycle: handling.LifeCycleFn,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
         memory: containers.ResourceMemory,

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -47,13 +47,13 @@ class ActivityRegistry(GenericRegistry[handlers.ActivityHandler]):
 
     def get_handlers(
             self,
-            activity: handlers.Activity,
+            activity: causation.Activity,
     ) -> Sequence[handlers.ActivityHandler]:
         return list(_deduplicated(self.iter_handlers(activity=activity)))
 
     def iter_handlers(
             self,
-            activity: handlers.Activity,
+            activity: causation.Activity,
     ) -> Iterator[handlers.ActivityHandler]:
         found: bool = False
 
@@ -232,7 +232,7 @@ class WebhooksRegistry(ResourceRegistry[handlers.WebhookHandler, causation.Webho
                 matching_webhook = cause.webhook is None or cause.webhook == handler.id
                 if matching_reason and matching_webhook:
                     # For deletion, exclude all mutation handlers unless explicitly enabled.
-                    non_mutating = handler.reason != handlers.WebhookType.MUTATING
+                    non_mutating = handler.reason != causation.WebhookType.MUTATING
                     non_deletion = cause.operation != 'DELETE'
                     explicitly_for_deletion = handler.operation == 'DELETE'
                     if non_mutating or non_deletion or explicitly_for_deletion:
@@ -269,7 +269,7 @@ class SmartOperatorRegistry(OperatorRegistry):
             self._activities.append(handlers.ActivityHandler(
                 id=ids.HandlerId('login_via_pykube'),
                 fn=piggybacking.login_via_pykube,
-                activity=handlers.Activity.AUTHENTICATION,
+                activity=causation.Activity.AUTHENTICATION,
                 errors=handlers.ErrorsMode.IGNORED,
                 param=None, timeout=None, retries=None, backoff=None,
                 _fallback=True,
@@ -282,7 +282,7 @@ class SmartOperatorRegistry(OperatorRegistry):
             self._activities.append(handlers.ActivityHandler(
                 id=ids.HandlerId('login_via_client'),
                 fn=piggybacking.login_via_client,
-                activity=handlers.Activity.AUTHENTICATION,
+                activity=causation.Activity.AUTHENTICATION,
                 errors=handlers.ErrorsMode.IGNORED,
                 param=None, timeout=None, retries=None, backoff=None,
                 _fallback=True,

--- a/kopf/reactor/registries.py
+++ b/kopf/reactor/registries.py
@@ -18,13 +18,13 @@ from types import FunctionType, MethodType
 from typing import Any, Callable, Collection, Container, Generic, Iterable, Iterator, List, \
                    Mapping, MutableMapping, Optional, Sequence, Set, Tuple, TypeVar, cast
 
-from kopf.reactor import causation
+from kopf.reactor import causation, handling
 from kopf.structs import dicts, filters, handlers, ids, references
 from kopf.utilities import piggybacking
 
 # We only type-check for known classes of handlers/callbacks, and ignore any custom subclasses.
-CauseT = TypeVar('CauseT', bound=causation.BaseCause)
-HandlerT = TypeVar('HandlerT', bound=handlers.BaseHandler)
+CauseT = TypeVar('CauseT', bound=handling.Cause)
+HandlerT = TypeVar('HandlerT', bound=handling.Handler)
 ResourceHandlerT = TypeVar('ResourceHandlerT', bound=handlers.ResourceHandler)
 
 
@@ -270,7 +270,7 @@ class SmartOperatorRegistry(OperatorRegistry):
                 id=ids.HandlerId('login_via_pykube'),
                 fn=piggybacking.login_via_pykube,
                 activity=causation.Activity.AUTHENTICATION,
-                errors=handlers.ErrorsMode.IGNORED,
+                errors=handling.ErrorsMode.IGNORED,
                 param=None, timeout=None, retries=None, backoff=None,
                 _fallback=True,
             ))
@@ -283,7 +283,7 @@ class SmartOperatorRegistry(OperatorRegistry):
                 id=ids.HandlerId('login_via_client'),
                 fn=piggybacking.login_via_client,
                 activity=causation.Activity.AUTHENTICATION,
-                errors=handlers.ErrorsMode.IGNORED,
+                errors=handling.ErrorsMode.IGNORED,
                 param=None, timeout=None, retries=None, backoff=None,
                 _fallback=True,
             ))

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -8,10 +8,10 @@ from typing import Collection, Coroutine, MutableSequence, Optional, Sequence
 
 from kopf.clients import auth
 from kopf.engines import peering, posting, probing
-from kopf.reactor import activities, admission, daemons, indexing, lifecycles, \
-                         observation, orchestration, processing, registries
-from kopf.structs import configuration, containers, credentials, ephemera, \
-                         handlers, primitives, references, reviews
+from kopf.reactor import activities, admission, causation, daemons, handling, indexing, \
+                         lifecycles, observation, orchestration, processing, registries
+from kopf.structs import configuration, containers, credentials, \
+                         ephemera, primitives, references, reviews
 from kopf.utilities import aiotasks
 
 logger = logging.getLogger(__name__)
@@ -494,7 +494,7 @@ async def _startup_cleanup_activities(
             lifecycle=lifecycles.all_at_once,
             registry=registry,
             settings=settings,
-            activity=handlers.Activity.STARTUP,
+            activity=causation.Activity.STARTUP,
             indices=indices,
             memo=memo,
         )
@@ -528,7 +528,7 @@ async def _startup_cleanup_activities(
             lifecycle=lifecycles.all_at_once,
             registry=registry,
             settings=settings,
-            activity=handlers.Activity.CLEANUP,
+            activity=causation.Activity.CLEANUP,
             indices=indices,
             memo=memo,
         )

--- a/kopf/reactor/running.py
+++ b/kopf/reactor/running.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 def run(
         *,
         loop: Optional[asyncio.AbstractEventLoop] = None,
-        lifecycle: Optional[lifecycles.LifeCycleFn] = None,
+        lifecycle: Optional[handling.LifeCycleFn] = None,
         indexers: Optional[indexing.OperatorIndexers] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         settings: Optional[configuration.OperatorSettings] = None,
@@ -74,7 +74,7 @@ def run(
 
 async def operator(
         *,
-        lifecycle: Optional[lifecycles.LifeCycleFn] = None,
+        lifecycle: Optional[handling.LifeCycleFn] = None,
         indexers: Optional[indexing.OperatorIndexers] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         settings: Optional[configuration.OperatorSettings] = None,
@@ -129,7 +129,7 @@ async def operator(
 
 async def spawn_tasks(
         *,
-        lifecycle: Optional[lifecycles.LifeCycleFn] = None,
+        lifecycle: Optional[handling.LifeCycleFn] = None,
         indexers: Optional[indexing.OperatorIndexers] = None,
         registry: Optional[registries.OperatorRegistry] = None,
         settings: Optional[configuration.OperatorSettings] = None,

--- a/kopf/reactor/subhandling.py
+++ b/kopf/reactor/subhandling.py
@@ -1,0 +1,147 @@
+import collections.abc
+import contextlib
+from contextvars import ContextVar
+from typing import AsyncIterator, Iterable, Optional, Set
+
+from kopf.reactor import causation, handling, invocation, lifecycles, registries
+from kopf.storage import states
+from kopf.structs import callbacks, configuration, handlers as handlers_, ids
+
+# The task-local context; propagated down the stack instead of multiple kwargs.
+# Used in `@kopf.subhandler` and `kopf.execute()` to add/get the sub-handlers.
+subregistry_var: ContextVar[registries.ChangingRegistry] = ContextVar('subregistry_var')
+subexecuted_var: ContextVar[bool] = ContextVar('subexecuted_var')
+
+
+@contextlib.asynccontextmanager
+async def subhandling_context() -> AsyncIterator[None]:
+    with invocation.context([
+        (subregistry_var, registries.ChangingRegistry()),
+        (subexecuted_var, False),
+    ]):
+        # Go for normal handler invocation.
+        yield
+
+        # If the sub-handlers are not called explicitly, run them implicitly
+        # as if it was done inside of the handler (still under the try-finally clause).
+        if not subexecuted_var.get():
+            await execute()
+
+
+async def execute(
+        *,
+        fns: Optional[Iterable[callbacks.ChangingFn]] = None,
+        handlers: Optional[Iterable[handlers_.ChangingHandler]] = None,
+        registry: Optional[registries.ChangingRegistry] = None,
+        lifecycle: Optional[lifecycles.LifeCycleFn] = None,
+        cause: Optional[causation.BaseCause] = None,
+) -> None:
+    """
+    Execute the handlers in an isolated lifecycle.
+
+    This function is just a public wrapper for `execute` with multiple
+    ways to specify the handlers: either as the raw functions, or as the
+    pre-created handlers, or as a registry (as used in the object handling).
+
+    If no explicit functions or handlers or registry are passed,
+    the sub-handlers of the current handler are assumed, as accumulated
+    in the per-handler registry with ``@kopf.subhandler``.
+
+    If the call to this method for the sub-handlers is not done explicitly
+    in the handler, it is done implicitly after the handler is exited.
+    One way or another, it is executed for the sub-handlers.
+    """
+
+    # Restore the current context as set in the handler execution cycle.
+    lifecycle = lifecycle if lifecycle is not None else handling.sublifecycle_var.get()
+    lifecycle = lifecycle if lifecycle is not None else lifecycles.get_default_lifecycle()
+    cause = cause if cause is not None else handling.cause_var.get()
+    parent_handler: handlers_.BaseHandler = handling.handler_var.get()
+    parent_prefix = parent_handler.id if parent_handler is not None else None
+
+    # Validate the inputs; the function signatures cannot put these kind of restrictions, so we do.
+    if len([v for v in [fns, handlers, registry] if v is not None]) > 1:
+        raise TypeError("Only one of the fns, handlers, registry can be passed. Got more.")
+
+    elif fns is not None and isinstance(fns, collections.abc.Mapping):
+        subregistry = registries.ChangingRegistry()
+        for id, fn in fns.items():
+            real_id = registries.generate_id(fn=fn, id=id, prefix=parent_prefix)
+            handler = handlers_.ChangingHandler(
+                fn=fn, id=real_id, param=None,
+                errors=None, timeout=None, retries=None, backoff=None,
+                selector=None, labels=None, annotations=None, when=None,
+                initial=None, deleted=None, requires_finalizer=None,
+                reason=None, field=None, value=None, old=None, new=None,
+                field_needs_change=None,
+            )
+            subregistry.append(handler)
+
+    elif fns is not None and isinstance(fns, collections.abc.Iterable):
+        subregistry = registries.ChangingRegistry()
+        for fn in fns:
+            real_id = registries.generate_id(fn=fn, id=None, prefix=parent_prefix)
+            handler = handlers_.ChangingHandler(
+                fn=fn, id=real_id, param=None,
+                errors=None, timeout=None, retries=None, backoff=None,
+                selector=None, labels=None, annotations=None, when=None,
+                initial=None, deleted=None, requires_finalizer=None,
+                reason=None, field=None, value=None, old=None, new=None,
+                field_needs_change=None,
+            )
+            subregistry.append(handler)
+
+    elif fns is not None:
+        raise ValueError(f"fns must be a mapping or an iterable, got {fns.__class__}.")
+
+    elif handlers is not None:
+        subregistry = registries.ChangingRegistry()
+        for handler in handlers:
+            subregistry.append(handler)
+
+    # Use the registry as is; assume that the caller knows what they do.
+    elif registry is not None:
+        subregistry = registry
+
+    # Prevent double implicit execution.
+    elif subexecuted_var.get():
+        return
+
+    # If no explicit args were passed, use the accumulated handlers from `@kopf.subhandler`.
+    else:
+        subexecuted_var.set(True)
+        subregistry = subregistry_var.get()
+
+    # The sub-handlers are only for upper-level causes, not for lower-level events.
+    if not isinstance(cause, causation.ChangingCause):
+        raise RuntimeError("Sub-handlers of event-handlers are not supported and have "
+                           "no practical use (there are no retries or state tracking).")
+
+    # Execute the real handlers (all or few or one of them, as per the lifecycle).
+    settings: configuration.OperatorSettings = handling.subsettings_var.get()
+    owned_handlers = subregistry.get_resource_handlers(resource=cause.resource)
+    cause_handlers = subregistry.get_handlers(cause=cause)
+    storage = settings.persistence.progress_storage
+    state = states.State.from_storage(body=cause.body, storage=storage, handlers=owned_handlers)
+    state = state.with_purpose(cause.reason).with_handlers(cause_handlers)
+    outcomes = await handling.execute_handlers_once(
+        lifecycle=lifecycle,
+        settings=settings,
+        handlers=cause_handlers,
+        cause=cause,
+        state=state,
+    )
+    state = state.with_outcomes(outcomes)
+    state.store(body=cause.body, patch=cause.patch, storage=storage)
+    states.deliver_results(outcomes=outcomes, patch=cause.patch)
+
+    # Enrich all parents with references to sub-handlers of any level deep (sub-sub-handlers, etc).
+    # There is at least one container, as this function can be called only from a handler.
+    subrefs_containers: Iterable[Set[ids.HandlerId]] = handling.subrefs_var.get()
+    for key in state:
+        for subrefs_container in subrefs_containers:
+            subrefs_container.add(key)
+
+    # Escalate `HandlerChildrenRetry` if the execute should be continued on the next iteration.
+    if not state.done:
+        raise handling.HandlerChildrenRetry(delay=state.delay)

--- a/kopf/reactor/subhandling.py
+++ b/kopf/reactor/subhandling.py
@@ -33,8 +33,8 @@ async def execute(
         fns: Optional[Iterable[callbacks.ChangingFn]] = None,
         handlers: Optional[Iterable[handlers_.ChangingHandler]] = None,
         registry: Optional[registries.ChangingRegistry] = None,
-        lifecycle: Optional[lifecycles.LifeCycleFn] = None,
-        cause: Optional[causation.BaseCause] = None,
+        lifecycle: Optional[handling.LifeCycleFn] = None,
+        cause: Optional[handling.Cause] = None,
 ) -> None:
     """
     Execute the handlers in an isolated lifecycle.
@@ -56,7 +56,7 @@ async def execute(
     lifecycle = lifecycle if lifecycle is not None else handling.sublifecycle_var.get()
     lifecycle = lifecycle if lifecycle is not None else lifecycles.get_default_lifecycle()
     cause = cause if cause is not None else handling.cause_var.get()
-    parent_handler: handlers_.BaseHandler = handling.handler_var.get()
+    parent_handler: handling.Handler = handling.handler_var.get()
     parent_prefix = parent_handler.id if parent_handler is not None else None
 
     # Validate the inputs; the function signatures cannot put these kind of restrictions, so we do.

--- a/kopf/structs/callbacks.py
+++ b/kopf/structs/callbacks.py
@@ -9,20 +9,11 @@ a corresponding type or class ``kopf.Whatever`` with all the typing tricks
 (``Union[...]``, ``Optional[...]``, partial ``Any`` values, etc) included.
 """
 import datetime
-import logging
-from typing import TYPE_CHECKING, Any, Callable, Collection, List, NewType, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Collection, List, Optional, TypeVar, Union
 
-from kopf.reactor import invocation
+from kopf.reactor import handling, invocation
 from kopf.structs import bodies, configuration, diffs, ephemera, \
                          patches, primitives, references, reviews
-
-# As publicly exposed: we only promise that it is based on one of the built-in loggable classes.
-# Mind that these classes have multi-versioned stubs, so we avoid redefining the protocol ourselves.
-Logger = Union[logging.Logger, logging.LoggerAdapter]
-
-# A specialised type to highlight the purpose or origin of the data of type Any,
-# to not be mixed with other arbitrary Any values, where it is indeed "any".
-Result = NewType('Result', object)
 
 if not TYPE_CHECKING:  # pragma: nocover
     # Define unspecified protocols for the runtime annotations -- to avoid "quoting".
@@ -36,7 +27,7 @@ if not TYPE_CHECKING:  # pragma: nocover
     WhenFilterFn = Callable[..., bool]  # strictly sync, no async!
     MetaFilterFn = Callable[..., bool]  # strictly sync, no async!
 else:
-    from mypy_extensions import Arg, DefaultNamedArg, KwArg, NamedArg, VarArg
+    from mypy_extensions import Arg, DefaultNamedArg, KwArg, NamedArg
 
     # TODO:1: Split to specialised LoginFn, ProbeFn, StartupFn, etc. -- with different result types.
     # TODO:2: Try using ParamSpec to support index type checking in callbacks
@@ -48,7 +39,7 @@ else:
             NamedArg(int, "retry"),
             NamedArg(datetime.datetime, "started"),
             NamedArg(datetime.timedelta, "runtime"),
-            NamedArg(Logger, "logger"),
+            NamedArg(handling.Logger, "logger"),
             NamedArg(Any, "memo"),
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
@@ -69,7 +60,7 @@ else:
             NamedArg(Optional[str], "name"),
             NamedArg(Optional[str], "namespace"),
             NamedArg(patches.Patch, "patch"),
-            NamedArg(Logger, "logger"),
+            NamedArg(handling.Logger, "logger"),
             NamedArg(Any, "memo"),
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
@@ -92,7 +83,7 @@ else:
             NamedArg(Optional[str], "name"),
             NamedArg(Optional[str], "namespace"),
             NamedArg(patches.Patch, "patch"),
-            NamedArg(Logger, "logger"),
+            NamedArg(handling.Logger, "logger"),
             NamedArg(Any, "memo"),
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
@@ -120,7 +111,7 @@ else:
             NamedArg(diffs.Diff, "diff"),
             NamedArg(Optional[Union[bodies.BodyEssence, Any]], "old"),
             NamedArg(Optional[Union[bodies.BodyEssence, Any]], "new"),
-            NamedArg(Logger, "logger"),
+            NamedArg(handling.Logger, "logger"),
             NamedArg(Any, "memo"),
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
@@ -146,7 +137,7 @@ else:
             NamedArg(Optional[str], "name"),
             NamedArg(Optional[str], "namespace"),
             NamedArg(patches.Patch, "patch"),
-            NamedArg(Logger, "logger"),
+            NamedArg(handling.Logger, "logger"),
             NamedArg(Any, "memo"),
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
@@ -171,7 +162,7 @@ else:
             NamedArg(Optional[str], "name"),
             NamedArg(Optional[str], "namespace"),
             NamedArg(patches.Patch, "patch"),
-            NamedArg(Logger, "logger"),
+            NamedArg(handling.Logger, "logger"),
             NamedArg(Any, "memo"),
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
@@ -193,7 +184,7 @@ else:
             NamedArg(Optional[str], "name"),
             NamedArg(Optional[str], "namespace"),
             NamedArg(patches.Patch, "patch"),
-            NamedArg(Logger, "logger"),
+            NamedArg(handling.Logger, "logger"),
             NamedArg(Any, "memo"),
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
@@ -219,7 +210,7 @@ else:
             NamedArg(diffs.Diff, "diff"),
             NamedArg(Optional[Union[bodies.BodyEssence, Any]], "old"),
             NamedArg(Optional[Union[bodies.BodyEssence, Any]], "new"),
-            NamedArg(Logger, "logger"),
+            NamedArg(handling.Logger, "logger"),
             NamedArg(Any, "memo"),
             DefaultNamedArg(Any, "param"),
             KwArg(Any),
@@ -242,7 +233,7 @@ else:
             NamedArg(Optional[str], "name"),
             NamedArg(Optional[str], "namespace"),
             NamedArg(patches.Patch, "patch"),
-            NamedArg(Logger, "logger"),
+            NamedArg(handling.Logger, "logger"),
             NamedArg(Any, "memo"),
             DefaultNamedArg(Any, "param"),
             KwArg(Any),

--- a/kopf/structs/handlers.py
+++ b/kopf/structs/handlers.py
@@ -2,7 +2,7 @@ import dataclasses
 import enum
 from typing import Any, Optional
 
-from kopf.reactor import invocation
+from kopf.reactor import causation, invocation
 from kopf.structs import callbacks, dicts, filters, ids, references
 
 
@@ -11,60 +11,6 @@ class ErrorsMode(enum.Enum):
     IGNORED = enum.auto()
     TEMPORARY = enum.auto()
     PERMANENT = enum.auto()
-
-
-class Activity(str, enum.Enum):
-    STARTUP = 'startup'
-    CLEANUP = 'cleanup'
-    AUTHENTICATION = 'authentication'
-    PROBE = 'probe'
-
-
-class WebhookType(str, enum.Enum):
-    VALIDATING = 'validating'
-    MUTATING = 'mutating'
-
-    def __str__(self) -> str:
-        return str(self.value)
-
-
-# Constants for cause types, to prevent a direct usage of strings, and typos.
-# They are not exposed by the framework, but are used internally. See also: `kopf.on`.
-class Reason(str, enum.Enum):
-    CREATE = 'create'
-    UPDATE = 'update'
-    DELETE = 'delete'
-    RESUME = 'resume'
-    NOOP = 'noop'
-    FREE = 'free'
-    GONE = 'gone'
-
-    def __str__(self) -> str:
-        return str(self.value)
-
-
-# These sets are checked in few places, so we keep them centralised:
-# the user-facing causes (for handlers) and internally facing (for the reactor).
-HANDLER_REASONS = (
-    Reason.CREATE,
-    Reason.UPDATE,
-    Reason.DELETE,
-    Reason.RESUME,
-)
-REACTOR_REASONS = (
-    Reason.NOOP,
-    Reason.FREE,
-    Reason.GONE,
-)
-ALL_REASONS = HANDLER_REASONS + REACTOR_REASONS
-
-# The human-readable names of these causes. Will be capitalised when needed.
-TITLES = {
-    Reason.CREATE: 'creation',
-    Reason.UPDATE: 'updating',
-    Reason.DELETE: 'deletion',
-    Reason.RESUME: 'resuming',
-}
 
 
 # A registered handler (function + meta info).
@@ -89,7 +35,7 @@ class BaseHandler:
 @dataclasses.dataclass
 class ActivityHandler(BaseHandler):
     fn: callbacks.ActivityFn  # type clarification
-    activity: Optional[Activity]
+    activity: Optional[causation.Activity]
     _fallback: bool = False  # non-public!
 
     def __str__(self) -> str:
@@ -113,7 +59,7 @@ class ResourceHandler(BaseHandler):
 @dataclasses.dataclass
 class WebhookHandler(ResourceHandler):
     fn: callbacks.WebhookFn  # type clarification
-    reason: WebhookType
+    reason: causation.WebhookType
     operation: Optional[str]
     persistent: Optional[bool]
     side_effects: Optional[bool]
@@ -151,7 +97,7 @@ class WatchingHandler(ResourceHandler):
 @dataclasses.dataclass
 class ChangingHandler(ResourceHandler):
     fn: callbacks.ChangingFn  # type clarification
-    reason: Optional[Reason]
+    reason: Optional[causation.Reason]
     initial: Optional[bool]
     deleted: Optional[bool]  # used for mixed-in (initial==True) @on.resume handlers only.
     requires_finalizer: Optional[bool]

--- a/tests/admission/test_admission_manager.py
+++ b/tests/admission/test_admission_manager.py
@@ -3,7 +3,7 @@ import pytest
 import kopf
 from kopf.clients.errors import APIConflictError, APIError, APIForbiddenError, APIUnauthorizedError
 from kopf.reactor.admission import configuration_manager
-from kopf.structs.handlers import WebhookType
+from kopf.reactor.causation import WebhookType
 from kopf.structs.primitives import Container
 from kopf.structs.references import MUTATING_WEBHOOK, VALIDATING_WEBHOOK
 

--- a/tests/admission/test_serving_handler_selection.py
+++ b/tests/admission/test_serving_handler_selection.py
@@ -4,7 +4,7 @@ import pytest
 
 import kopf
 from kopf.reactor.admission import serve_admission_request
-from kopf.structs.handlers import WebhookType
+from kopf.reactor.causation import WebhookType
 from kopf.structs.ids import HandlerId
 
 

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -1,11 +1,12 @@
 import pytest
 
 from kopf.reactor.activities import authenticate
+from kopf.reactor.causation import Activity
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.credentials import ConnectionInfo, LoginError, Vault
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import Activity, ActivityHandler
+from kopf.structs.handlers import ActivityHandler
 
 
 async def test_empty_registry_produces_no_credentials(settings):

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -3,9 +3,8 @@ import json
 
 import pytest
 
-from kopf.reactor.causation import detect_changing_cause
+from kopf.reactor.causation import Reason, detect_changing_cause
 from kopf.structs.bodies import Body
-from kopf.structs.handlers import Reason
 
 LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 FINALIZER = 'fin'

--- a/tests/causation/test_kwargs.py
+++ b/tests/causation/test_kwargs.py
@@ -5,15 +5,14 @@ from unittest.mock import Mock
 
 import pytest
 
-from kopf.reactor.causation import ActivityCause, BaseCause, ChangingCause, \
-                                   DaemonCause, IndexingCause, ResourceCause, \
+from kopf.reactor.causation import Activity, ActivityCause, BaseCause, ChangingCause, \
+                                   DaemonCause, IndexingCause, Reason, ResourceCause, \
                                    SpawningCause, WatchingCause, WebhookCause
 from kopf.reactor.indexing import OperatorIndexer, OperatorIndexers
 from kopf.structs.bodies import Body, BodyEssence
 from kopf.structs.configuration import OperatorSettings
 from kopf.structs.diffs import Diff
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import Activity, Reason
 from kopf.structs.patches import Patch
 from kopf.structs.primitives import DaemonStopper
 

--- a/tests/handling/daemons/test_daemon_errors.py
+++ b/tests/handling/daemons/test_daemon_errors.py
@@ -1,8 +1,7 @@
 import logging
 
 import kopf
-from kopf.reactor.handling import PermanentError, TemporaryError
-from kopf.structs.handlers import ErrorsMode
+from kopf.reactor.handling import ErrorsMode, PermanentError, TemporaryError
 
 
 async def test_daemon_stopped_on_permanent_error(

--- a/tests/handling/daemons/test_timer_errors.py
+++ b/tests/handling/daemons/test_timer_errors.py
@@ -1,8 +1,7 @@
 import logging
 
 import kopf
-from kopf.reactor.handling import PermanentError, TemporaryError
-from kopf.structs.handlers import ErrorsMode
+from kopf.reactor.handling import ErrorsMode, PermanentError, TemporaryError
 
 
 async def test_timer_stopped_on_permanent_error(

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -5,19 +5,18 @@ import pytest
 
 from kopf.reactor.activities import ActivityError, run_activity
 from kopf.reactor.causation import Activity
-from kopf.reactor.handling import PermanentError, TemporaryError
+from kopf.reactor.handling import Outcome, PermanentError, TemporaryError
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.lifecycles import all_at_once
 from kopf.reactor.registries import OperatorRegistry
-from kopf.storage.states import HandlerOutcome
 from kopf.structs.ephemera import Memo
 from kopf.structs.handlers import ActivityHandler
 from kopf.structs.ids import HandlerId
 
 
 def test_activity_error_exception():
-    outcome = HandlerOutcome(final=True)
-    outcomes: Mapping[HandlerId, HandlerOutcome]
+    outcome = Outcome(final=True)
+    outcomes: Mapping[HandlerId, Outcome]
     outcomes = {HandlerId('id'): outcome}
     error = ActivityError("message", outcomes=outcomes)
     assert str(error) == "message"

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -4,13 +4,14 @@ import freezegun
 import pytest
 
 from kopf.reactor.activities import ActivityError, run_activity
+from kopf.reactor.causation import Activity
 from kopf.reactor.handling import PermanentError, TemporaryError
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.lifecycles import all_at_once
 from kopf.reactor.registries import OperatorRegistry
 from kopf.storage.states import HandlerOutcome
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import Activity, ActivityHandler
+from kopf.structs.handlers import ActivityHandler
 from kopf.structs.ids import HandlerId
 
 

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -4,11 +4,11 @@ import logging
 import pytest
 
 import kopf
+from kopf.reactor.causation import Reason
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import Reason
 
 LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -6,12 +6,12 @@ import freezegun
 import pytest
 
 import kopf
+from kopf.reactor.causation import ALL_REASONS, HANDLER_REASONS, Reason
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.storage.progress import StatusProgressStorage
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import ALL_REASONS, HANDLER_REASONS, Reason
 
 
 @pytest.mark.parametrize('cause_type', ALL_REASONS)

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -6,6 +6,7 @@ import freezegun
 import pytest
 
 import kopf
+from kopf.reactor.causation import HANDLER_REASONS, Reason
 from kopf.reactor.effects import WAITING_KEEPALIVE_INTERVAL
 from kopf.reactor.handling import TemporaryError
 from kopf.reactor.indexing import OperatorIndexers
@@ -13,7 +14,6 @@ from kopf.reactor.processing import process_resource_event
 from kopf.storage.states import HandlerState
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import HANDLER_REASONS, Reason
 
 
 @pytest.mark.parametrize('cause_reason', HANDLER_REASONS)

--- a/tests/handling/test_error_handling.py
+++ b/tests/handling/test_error_handling.py
@@ -4,12 +4,12 @@ import logging
 import pytest
 
 import kopf
+from kopf.reactor.causation import HANDLER_REASONS, Reason
 from kopf.reactor.handling import PermanentError, TemporaryError
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import HANDLER_REASONS, Reason
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -4,11 +4,11 @@ import logging
 import pytest
 
 import kopf
+from kopf.reactor.causation import ALL_REASONS
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import ALL_REASONS
 
 
 @pytest.mark.parametrize('cause_type', ALL_REASONS)

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -3,11 +3,11 @@ import asyncio
 import pytest
 
 import kopf
+from kopf.reactor.causation import HANDLER_REASONS, Reason
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import HANDLER_REASONS, Reason
 
 
 @pytest.mark.parametrize('deletion_ts', [

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -4,11 +4,12 @@ import logging
 import pytest
 
 import kopf
+from kopf.reactor.causation import HANDLER_REASONS
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import HANDLER_REASONS, ChangingHandler
+from kopf.structs.handlers import ChangingHandler
 
 LAST_SEEN_ANNOTATION = 'kopf.zalando.org/last-handled-configuration'
 

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -5,11 +5,11 @@ import freezegun
 import pytest
 
 import kopf
+from kopf.reactor.causation import HANDLER_REASONS, Reason
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.processing import process_resource_event
 from kopf.structs.containers import ResourceMemories
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import HANDLER_REASONS, Reason
 
 
 # The timeout is hard-coded in conftest.py:handlers().

--- a/tests/hierarchies/test_contextual_owner.py
+++ b/tests/hierarchies/test_contextual_owner.py
@@ -4,13 +4,12 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import ChangingCause, WatchingCause
+from kopf.reactor.causation import ChangingCause, Reason, WatchingCause
 from kopf.reactor.handling import cause_var
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.invocation import context
 from kopf.structs.bodies import Body, RawBody, RawEvent, RawMeta
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import Reason
 from kopf.structs.patches import Patch
 
 OWNER_API_VERSION = 'owner-api-version'

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -5,11 +5,10 @@ import traceback
 import pytest
 from asynctest import MagicMock
 
-from kopf.reactor.causation import ChangingCause
+from kopf.reactor.causation import ChangingCause, Reason
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.invocation import invoke, is_async_fn
 from kopf.structs.bodies import Body
-from kopf.structs.handlers import Reason
 from kopf.structs.patches import Patch
 
 STACK_TRACE_MARKER = object()

--- a/tests/lifecycles/test_handler_selection.py
+++ b/tests/lifecycles/test_handler_selection.py
@@ -1,7 +1,8 @@
 import pytest
 
 import kopf
-from kopf.storage.states import HandlerOutcome, State
+from kopf.reactor.handling import Outcome
+from kopf.storage.states import State
 
 
 @pytest.mark.parametrize('lifecycle', [
@@ -98,9 +99,9 @@ def test_asap_takes_the_least_retried(mocker):
 
     # Set the pre-existing state, and verify that it was set properly.
     state = State.from_scratch().with_handlers([handler1, handler2, handler3])
-    state = state.with_outcomes({handler1.id: HandlerOutcome(final=False)})
-    state = state.with_outcomes({handler1.id: HandlerOutcome(final=False)})
-    state = state.with_outcomes({handler3.id: HandlerOutcome(final=False)})
+    state = state.with_outcomes({handler1.id: Outcome(final=False)})
+    state = state.with_outcomes({handler1.id: Outcome(final=False)})
+    state = state.with_outcomes({handler3.id: Outcome(final=False)})
     assert state[handler1.id].retries == 2
     assert state[handler2.id].retries == 0
     assert state[handler3.id].retries == 1

--- a/tests/lifecycles/test_real_invocation.py
+++ b/tests/lifecycles/test_real_invocation.py
@@ -3,12 +3,11 @@ import logging
 import pytest
 
 import kopf
-from kopf.reactor.causation import ChangingCause
+from kopf.reactor.causation import ChangingCause, Reason
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.storage.states import State
 from kopf.structs.bodies import Body
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import Reason
 from kopf.structs.patches import Patch
 
 

--- a/tests/persistence/test_outcomes.py
+++ b/tests/persistence/test_outcomes.py
@@ -1,9 +1,8 @@
-from kopf.storage.states import HandlerOutcome
-from kopf.structs.callbacks import Result
+from kopf.reactor.handling import Outcome, Result
 
 
 def test_creation_for_ignored_handlers():
-    outcome = HandlerOutcome(final=True)
+    outcome = Outcome(final=True)
     assert outcome.final
     assert outcome.delay is None
     assert outcome.result is None
@@ -13,7 +12,7 @@ def test_creation_for_ignored_handlers():
 
 def test_creation_for_results():
     result = Result(object())
-    outcome = HandlerOutcome(final=True, result=result)
+    outcome = Outcome(final=True, result=result)
     assert outcome.final
     assert outcome.delay is None
     assert outcome.result is result
@@ -23,7 +22,7 @@ def test_creation_for_results():
 
 def test_creation_for_permanent_errors():
     error = Exception()
-    outcome = HandlerOutcome(final=True, exception=error)
+    outcome = Outcome(final=True, exception=error)
     assert outcome.final
     assert outcome.delay is None
     assert outcome.result is None
@@ -33,7 +32,7 @@ def test_creation_for_permanent_errors():
 
 def test_creation_for_temporary_errors():
     error = Exception()
-    outcome = HandlerOutcome(final=False, exception=error, delay=123)
+    outcome = Outcome(final=False, exception=error, delay=123)
     assert not outcome.final
     assert outcome.delay == 123
     assert outcome.result is None
@@ -42,5 +41,5 @@ def test_creation_for_temporary_errors():
 
 
 def test_creation_with_subrefs():
-    outcome = HandlerOutcome(final=True, subrefs=['sub1', 'sub2'])
+    outcome = Outcome(final=True, subrefs=['sub1', 'sub2'])
     assert outcome.subrefs == ['sub1', 'sub2']

--- a/tests/persistence/test_states.py
+++ b/tests/persistence/test_states.py
@@ -4,10 +4,10 @@ from unittest.mock import Mock
 import freezegun
 import pytest
 
+from kopf.reactor.causation import HANDLER_REASONS, Reason
 from kopf.storage.progress import SmartProgressStorage, StatusProgressStorage
 from kopf.storage.states import HandlerOutcome, State, StateCounters, deliver_results
 from kopf.structs.bodies import Body
-from kopf.structs.handlers import HANDLER_REASONS, Reason
 from kopf.structs.patches import Patch
 
 # Timestamps: time zero (0), before (B), after (A), and time zero+1s (1).

--- a/tests/persistence/test_states.py
+++ b/tests/persistence/test_states.py
@@ -177,7 +177,7 @@ def test_created_from_purposeful_storage(storage, handler, reason):
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
     assert len(state) == 1
     assert state.purpose is None
-    assert state['some-id'].purpose is reason
+    assert state['some-id'].purpose == reason
 
 
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
@@ -185,7 +185,7 @@ def test_enriched_with_handlers_keeps_the_original_purpose(handler, reason):
     state = State.from_scratch()
     state = state.with_purpose(reason)
     state = state.with_handlers([handler])
-    assert state.purpose is reason
+    assert state.purpose == reason
 
 
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
@@ -193,7 +193,7 @@ def test_enriched_with_outcomes_keeps_the_original_purpose(reason):
     state = State.from_scratch()
     state = state.with_purpose(reason)
     state = state.with_outcomes({})
-    assert state.purpose is reason
+    assert state.purpose == reason
 
 
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
@@ -201,8 +201,8 @@ def test_repurposed_before_handlers(handler, reason):
     state = State.from_scratch()
     state = state.with_purpose(reason).with_handlers([handler])
     assert len(state) == 1
-    assert state.purpose is reason
-    assert state['some-id'].purpose is reason
+    assert state.purpose == reason
+    assert state['some-id'].purpose == reason
 
 
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
@@ -210,7 +210,7 @@ def test_repurposed_after_handlers(handler, reason):
     state = State.from_scratch()
     state = state.with_handlers([handler]).with_purpose(reason)
     assert len(state) == 1
-    assert state.purpose is reason
+    assert state.purpose == reason
     assert state['some-id'].purpose is None
 
 
@@ -219,8 +219,8 @@ def test_repurposed_with_handlers(handler, reason):
     state = State.from_scratch()
     state = state.with_handlers([handler]).with_purpose(reason, handlers=[handler])
     assert len(state) == 1
-    assert state.purpose is reason
-    assert state['some-id'].purpose is reason
+    assert state.purpose == reason
+    assert state['some-id'].purpose == reason
 
 
 @pytest.mark.parametrize('reason', HANDLER_REASONS)
@@ -228,7 +228,7 @@ def test_repurposed_not_affecting_the_existing_handlers_from_scratch(handler, re
     state = State.from_scratch()
     state = state.with_handlers([handler]).with_purpose(reason).with_handlers([handler])
     assert len(state) == 1
-    assert state.purpose is reason
+    assert state.purpose == reason
     assert state['some-id'].purpose is None
 
 
@@ -238,7 +238,7 @@ def test_repurposed_not_affecting_the_existing_handlers_from_storage(storage, ha
     state = State.from_storage(body=Body(body), handlers=[handler], storage=storage)
     state = state.with_handlers([handler]).with_purpose(reason).with_handlers([handler])
     assert len(state) == 1
-    assert state.purpose is reason
+    assert state.purpose == reason
     assert state['some-id'].purpose is None
 
 

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -1,11 +1,11 @@
 import pytest
 
 import kopf
-from kopf.reactor.causation import WebhookCause
+from kopf.reactor.causation import HANDLER_REASONS, Activity, Reason, WebhookCause
 from kopf.reactor.handling import handler_var, subregistry_var
 from kopf.reactor.invocation import context
 from kopf.reactor.registries import ChangingRegistry, OperatorRegistry
-from kopf.structs.handlers import HANDLER_REASONS, Activity, ErrorsMode, Reason
+from kopf.structs.handlers import ErrorsMode
 
 
 def test_on_startup_minimal():

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -2,11 +2,10 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import HANDLER_REASONS, Activity, Reason, WebhookCause
-from kopf.reactor.handling import handler_var
+from kopf.reactor.handling import ErrorsMode, handler_var
 from kopf.reactor.invocation import context
 from kopf.reactor.registries import ChangingRegistry, OperatorRegistry
 from kopf.reactor.subhandling import subregistry_var
-from kopf.structs.handlers import ErrorsMode
 
 
 def test_on_startup_minimal():

--- a/tests/registries/test_decorators.py
+++ b/tests/registries/test_decorators.py
@@ -2,9 +2,10 @@ import pytest
 
 import kopf
 from kopf.reactor.causation import HANDLER_REASONS, Activity, Reason, WebhookCause
-from kopf.reactor.handling import handler_var, subregistry_var
+from kopf.reactor.handling import handler_var
 from kopf.reactor.invocation import context
 from kopf.reactor.registries import ChangingRegistry, OperatorRegistry
+from kopf.reactor.subhandling import subregistry_var
 from kopf.structs.handlers import ErrorsMode
 
 

--- a/tests/registries/test_handler_getting.py
+++ b/tests/registries/test_handler_getting.py
@@ -2,8 +2,7 @@ import collections.abc
 
 import pytest
 
-from kopf.reactor.causation import ChangingCause, WatchingCause
-from kopf.structs.handlers import Activity
+from kopf.reactor.causation import Activity, ChangingCause, WatchingCause
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.

--- a/tests/registries/test_matching_for_changing.py
+++ b/tests/registries/test_matching_for_changing.py
@@ -3,10 +3,11 @@ import copy
 import pytest
 
 import kopf
+from kopf.reactor.causation import ALL_REASONS, Reason
 from kopf.structs.bodies import Body
 from kopf.structs.dicts import parse_field
 from kopf.structs.filters import ABSENT, PRESENT
-from kopf.structs.handlers import ALL_REASONS, ChangingHandler, Reason
+from kopf.structs.handlers import ChangingHandler
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.

--- a/tests/registries/test_resumes_mixed_in.py
+++ b/tests/registries/test_resumes_mixed_in.py
@@ -1,7 +1,7 @@
 import pytest
 
 import kopf
-from kopf.structs.handlers import HANDLER_REASONS, Reason
+from kopf.reactor.causation import HANDLER_REASONS, Reason
 
 
 @pytest.mark.parametrize('deleted', [True, False, None])

--- a/tests/registries/test_subhandlers_ids.py
+++ b/tests/registries/test_subhandlers_ids.py
@@ -1,6 +1,7 @@
 import kopf
-from kopf.reactor.handling import handler_var, subregistry_var
+from kopf.reactor.handling import handler_var
 from kopf.reactor.invocation import context
+from kopf.reactor.subhandling import subregistry_var
 
 
 # Used in the tests. Must be global-scoped, or its qualname will be affected.

--- a/tests/test_liveness.py
+++ b/tests/test_liveness.py
@@ -4,10 +4,11 @@ import aiohttp
 import pytest
 
 from kopf.engines.probing import health_reporter
+from kopf.reactor.causation import Activity
 from kopf.reactor.indexing import OperatorIndexers
 from kopf.reactor.registries import OperatorRegistry
 from kopf.structs.ephemera import Memo
-from kopf.structs.handlers import Activity, ActivityHandler
+from kopf.structs.handlers import ActivityHandler
 
 
 @pytest.fixture()


### PR DESCRIPTION
The goal is to make "handling" fully isolated so that it could be moved to the lower levels of the reactor/core.

For this, rudimentary base classes (almost interfaces) are extracted from causes, handlers, and states — while the specialised modules extend them as needed: e.g. states are needed only in read-only mode for handling, while the actual states are capable of producing derived/modified states.

More details can be found in separate commits.