### PR TITLE
Decouple specialised memories from generic memories

### DIFF
--- a/kopf/reactor/admission.py
+++ b/kopf/reactor/admission.py
@@ -77,7 +77,7 @@ class MemoGetter(metaclass=abc.ABCMeta):
             self,
             raw_body: bodies.RawBody,
             *,
-            memo: Optional[ephemera.AnyMemo] = None,
+            memobase: Optional[ephemera.AnyMemo] = None,
             ephemeral: bool = False,
     ) -> ephemera.AnyMemo:
         raise NotImplementedError
@@ -123,7 +123,7 @@ async def serve_admission_request(
     if raw_body is None:
         raise MissingDataError("Either old or new object is missing from the admission request.")
 
-    memo = await memories.recall_memo(raw_body, memo=memobase, ephemeral=operation=='CREATE')
+    memo = await memories.recall_memo(raw_body, memobase=memobase, ephemeral=operation=='CREATE')
     body = bodies.Body(raw_body)
     patch = patches.Patch()
     warnings: List[str] = []

--- a/kopf/reactor/effects.py
+++ b/kopf/reactor/effects.py
@@ -19,16 +19,13 @@ It is used from in :mod:`processing`, :mod:`actitivies`, and :mod:`daemons` --
 all the modules, of which the reactor's core consists.
 """
 import asyncio
-import contextlib
 import datetime
 import logging
-import time
-from typing import AsyncGenerator, Collection, Iterable, Optional, Tuple, Type, Union
+from typing import Collection, Optional, Union
 
 from kopf.clients import patching
 from kopf.engines import loggers
-from kopf.structs import bodies, configuration, containers, dicts, \
-                         diffs, patches, primitives, references
+from kopf.structs import bodies, configuration, dicts, diffs, patches, primitives, references
 
 # How often to wake up from the long sleep, to show liveness in the logs.
 WAITING_KEEPALIVE_INTERVAL = 10 * 60
@@ -132,71 +129,3 @@ async def patch_and_check(
             logger.debug(f"Patching was skipped: the object does not exist anymore.")
         elif inconsistencies:
             logger.warning(f"Patching failed with inconsistencies: {inconsistencies}")
-
-
-@contextlib.asynccontextmanager
-async def throttled(
-        *,
-        throttler: containers.Throttler,
-        delays: Iterable[float],
-        wakeup: Optional[asyncio.Event] = None,
-        logger: Union[logging.Logger, logging.LoggerAdapter],
-        errors: Union[Type[BaseException], Tuple[Type[BaseException], ...]] = Exception,
-) -> AsyncGenerator[bool, None]:
-    """
-    A helper to throttle any arbitrary operation.
-    """
-
-    # The 1st sleep: if throttling is already active, but was interrupted by a queue replenishment.
-    # It is needed to properly process the latest known event after the successful sleep.
-    if throttler.active_until is not None:
-        remaining_time = throttler.active_until - time.monotonic()
-        unslept_time = await primitives.sleep_or_wait(remaining_time, wakeup=wakeup)
-        if unslept_time is None:
-            logger.info("Throttling is over. Switching back to normal operations.")
-            throttler.active_until = None
-
-    # Run only if throttling either is not active initially, or has just finished sleeping.
-    should_run = throttler.active_until is None
-    try:
-        yield should_run
-
-    except asyncio.CancelledError:
-        # CancelledError is a BaseException in 3.8 & 3.9, but a regular Exception in 3.7.
-        # Behave as if it is a BaseException -- to enabled tests with async-timeout.
-        raise
-
-    except Exception as e:
-
-        # If it is not an error-of-interest, escalate normally. BaseExceptions are escalated always.
-        if not isinstance(e, errors):
-            raise
-
-        # If the code does not follow the recommendation to not run, escalate.
-        if not should_run:
-            raise
-
-        # Activate throttling if not yet active, or reuse the active sequence of delays.
-        if throttler.source_of_delays is None:
-            throttler.source_of_delays = iter(delays)
-
-        # Choose a delay. If there are none, avoid throttling at all.
-        delay = next(throttler.source_of_delays, throttler.last_used_delay)
-        if delay is not None:
-            throttler.last_used_delay = delay
-            throttler.active_until = time.monotonic() + delay
-            logger.exception(f"Throttling for {delay} seconds due to an unexpected error: {e!r}")
-
-    else:
-        # Reset the throttling. Release the iterator to keep the memory free during normal run.
-        if should_run:
-            throttler.source_of_delays = throttler.last_used_delay = None
-
-    # The 2nd sleep: if throttling has been just activated (i.e. there was a fresh error).
-    # It is needed to have better logging/sleeping without workers exiting for "no events".
-    if throttler.active_until is not None and should_run:
-        remaining_time = throttler.active_until - time.monotonic()
-        unslept_time = await primitives.sleep_or_wait(remaining_time, wakeup=wakeup)
-        if unslept_time is None:
-            throttler.active_until = None
-            logger.info("Throttling is over. Switching back to normal operations.")

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -21,8 +21,8 @@ from kopf.engines import loggers, posting
 from kopf.reactor import causation, daemons, effects, handling, \
                          indexing, lifecycles, registries, subhandling
 from kopf.storage import finalizers, states
-from kopf.structs import bodies, configuration, containers, diffs, \
-                         ephemera, patches, primitives, references
+from kopf.structs import bodies, configuration, containers, diffs, ephemera, \
+                         patches, primitives, references, throttlers
 
 
 async def process_resource_event(
@@ -72,7 +72,7 @@ async def process_resource_event(
     # to prevent queue overfilling, but the processing is skipped (events are ignored).
     # Choice of place: late enough to have a per-resource memory for a throttler; also, a logger.
     # But early enough to catch environment errors from K8s API, and from most of the complex code.
-    async with effects.throttled(
+    async with throttlers.throttled(
         throttler=memory.error_throttler,
         logger=local_logger,
         delays=settings.batching.error_delays,

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -49,7 +49,7 @@ async def process_resource_event(
     # Recall what is stored about that object. Share it in little portions with the consumers.
     # And immediately forget it if the object is deleted from the cluster (but keep in memory).
     raw_type, raw_body = raw_event['type'], raw_event['object']
-    memory = await memories.recall(raw_body, noticed_by_listing=raw_type is None, memo=memobase)
+    memory = await memories.recall(raw_body, noticed_by_listing=raw_type is None, memobase=memobase)
     if memory.daemons_memory.live_fresh_body is not None:
         memory.daemons_memory.live_fresh_body._replace_with(raw_body)
     if raw_type == 'DELETED':

--- a/kopf/reactor/processing.py
+++ b/kopf/reactor/processing.py
@@ -92,7 +92,8 @@ async def process_resource_event(
                 resource=resource,
                 raw_event=raw_event,
                 body=body,
-                memory=memory,
+                memo=memory.memo,
+                memory=memory.indexing_memory,
                 logger=terse_logger,
             )
 

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -1,11 +1,21 @@
 """
-A in-memory storage of arbitrary information per resource/object.
+An internal in-memory storage of structured records about resource objects.
 
+Each object gets at most one record in the inventory of an operator's memories.
 The information is stored strictly in-memory and is not persistent.
 On the operator restart, all the memories are lost.
+The information is not exposed to the operator developers (except for memos).
 
 It is used internally to track allocated system resources for each Kubernetes
 object, even if that object does not show up in the event streams for long time.
+
+In the future, additional never-ending tasks can be running to maintain
+the operator's memories and inventory and garbage-collect all outdated records.
+
+The inventory memories are data structures, but they are a part of the reactor
+because they store specialised data structures of specialised reactor modules
+(e.g. daemons, admission, indexing, etc). For cohesion, these data structures
+must be kept together with their owning modules rather than mirrored in structs.
 """
 import copy
 import dataclasses

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -13,7 +13,7 @@ import logging
 import time
 from typing import Dict, Iterator, MutableMapping, Optional, Set, Union
 
-from kopf.storage import states
+from kopf.reactor import indexing
 from kopf.structs import bodies, ephemera, handlers, ids, primitives, throttlers
 from kopf.utilities import aiotasks
 
@@ -31,6 +31,7 @@ class ResourceMemory:
     """ A system memo about a single resource/object. Usually stored in `Memories`. """
     memo: ephemera.AnyMemo = dataclasses.field(default_factory=lambda: ephemera.AnyMemo(ephemera.Memo()))
     error_throttler: throttlers.Throttler = dataclasses.field(default_factory=throttlers.Throttler)
+    indexing_memory: indexing.IndexingMemory = dataclasses.field(default_factory=indexing.IndexingMemory)
 
     # For resuming handlers tracking and deciding on should they be called or not.
     noticed_by_listing: bool = False
@@ -41,9 +42,6 @@ class ResourceMemory:
     idle_reset_time: float = dataclasses.field(default_factory=time.monotonic)
     forever_stopped: Set[ids.HandlerId] = dataclasses.field(default_factory=set)
     running_daemons: Dict[ids.HandlerId, Daemon] = dataclasses.field(default_factory=dict)
-
-    # For indexing errors backoffs/retries/timeouts. It is None when successfully indexed.
-    indexing_state: Optional[states.State] = None
 
 
 class ResourceMemories:

--- a/kopf/structs/containers.py
+++ b/kopf/structs/containers.py
@@ -64,17 +64,17 @@ class ResourceMemories(admission.MemoGetter, daemons.DaemonsMemoriesIterator):
             self,
             raw_body: bodies.RawBody,
             *,
-            memo: Optional[ephemera.AnyMemo] = None,
+            memobase: Optional[ephemera.AnyMemo] = None,
             ephemeral: bool = False,
     ) -> ephemera.AnyMemo:
-        memory = await self.recall(raw_body=raw_body, memo=memo, ephemeral=ephemeral)
+        memory = await self.recall(raw_body=raw_body, memobase=memobase, ephemeral=ephemeral)
         return memory.memo
 
     async def recall(
             self,
             raw_body: bodies.RawBody,
             *,
-            memo: Optional[ephemera.AnyMemo] = None,
+            memobase: Optional[ephemera.AnyMemo] = None,
             noticed_by_listing: bool = False,
             ephemeral: bool = False,
     ) -> ResourceMemory:
@@ -93,10 +93,11 @@ class ResourceMemories(admission.MemoGetter, daemons.DaemonsMemoriesIterator):
         if key in self._items:
             memory = self._items[key]
         else:
-            if memo is None:
+            if memobase is None:
                 memory = ResourceMemory(noticed_by_listing=noticed_by_listing)
             else:
-                memory = ResourceMemory(noticed_by_listing=noticed_by_listing, memo=copy.copy(memo))
+                memo = copy.copy(memobase)
+                memory = ResourceMemory(noticed_by_listing=noticed_by_listing, memo=memo)
             if not ephemeral:
                 self._items[key] = memory
         return memory

--- a/kopf/structs/throttlers.py
+++ b/kopf/structs/throttlers.py
@@ -1,0 +1,84 @@
+import asyncio
+import contextlib
+import dataclasses
+import logging
+import time
+from typing import AsyncGenerator, Iterable, Iterator, Optional, Tuple, Type, Union
+
+from kopf.structs import primitives
+
+
+@dataclasses.dataclass(frozen=False)
+class Throttler:
+    """ A state of throttling for one specific purpose (there can be a few). """
+    source_of_delays: Optional[Iterator[float]] = None
+    last_used_delay: Optional[float] = None
+    active_until: Optional[float] = None  # internal clock
+
+
+@contextlib.asynccontextmanager
+async def throttled(
+        *,
+        throttler: Throttler,
+        delays: Iterable[float],
+        wakeup: Optional[asyncio.Event] = None,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
+        errors: Union[Type[BaseException], Tuple[Type[BaseException], ...]] = Exception,
+) -> AsyncGenerator[bool, None]:
+    """
+    A helper to throttle any arbitrary operation.
+    """
+
+    # The 1st sleep: if throttling is already active, but was interrupted by a queue replenishment.
+    # It is needed to properly process the latest known event after the successful sleep.
+    if throttler.active_until is not None:
+        remaining_time = throttler.active_until - time.monotonic()
+        unslept_time = await primitives.sleep_or_wait(remaining_time, wakeup=wakeup)
+        if unslept_time is None:
+            logger.info("Throttling is over. Switching back to normal operations.")
+            throttler.active_until = None
+
+    # Run only if throttling either is not active initially, or has just finished sleeping.
+    should_run = throttler.active_until is None
+    try:
+        yield should_run
+
+    except asyncio.CancelledError:
+        # CancelledError is a BaseException in 3.8 & 3.9, but a regular Exception in 3.7.
+        # Behave as if it is a BaseException -- to enabled tests with async-timeout.
+        raise
+
+    except Exception as e:
+
+        # If it is not an error-of-interest, escalate normally. BaseExceptions are escalated always.
+        if not isinstance(e, errors):
+            raise
+
+        # If the code does not follow the recommendation to not run, escalate.
+        if not should_run:
+            raise
+
+        # Activate throttling if not yet active, or reuse the active sequence of delays.
+        if throttler.source_of_delays is None:
+            throttler.source_of_delays = iter(delays)
+
+        # Choose a delay. If there are none, avoid throttling at all.
+        delay = next(throttler.source_of_delays, throttler.last_used_delay)
+        if delay is not None:
+            throttler.last_used_delay = delay
+            throttler.active_until = time.monotonic() + delay
+            logger.exception(f"Throttling for {delay} seconds due to an unexpected error: {e!r}")
+
+    else:
+        # Reset the throttling. Release the iterator to keep the memory free during normal run.
+        if should_run:
+            throttler.source_of_delays = throttler.last_used_delay = None
+
+    # The 2nd sleep: if throttling has been just activated (i.e. there was a fresh error).
+    # It is needed to have better logging/sleeping without workers exiting for "no events".
+    if throttler.active_until is not None and should_run:
+        remaining_time = throttler.active_until - time.monotonic()
+        unslept_time = await primitives.sleep_or_wait(remaining_time, wakeup=wakeup)
+        if unslept_time is None:
+            throttler.active_until = None
+            logger.info("Throttling is over. Switching back to normal operations.")

--- a/tests/basic-structs/test_memories.py
+++ b/tests/basic-structs/test_memories.py
@@ -57,8 +57,8 @@ async def test_memo_is_shallow_copied():
             return MyMemo()
 
     mock = Mock()
-    memo = MyMemo()
+    memobase = MyMemo()
     memories = ResourceMemories()
-    memory = await memories.recall(BODY, memo=memo)
+    memory = await memories.recall(BODY, memobase=memobase)
     assert mock.call_count == 1
-    assert memory.memo is not memo
+    assert memory.memo is not memobase

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -71,7 +71,7 @@ async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing(
     # which are tested by the paused operators elsewhere (test_daemon_spawning.py).
     # We only test that it is capable for respawning (not forever-stopped):
     memory = await memories.recall(event_object)
-    assert not memory.forever_stopped
+    assert not memory.daemons_memory.forever_stopped
 
 
 async def test_daemon_exits_instantly_via_cancellation_with_backoff(

--- a/tests/timing/test_throttling.py
+++ b/tests/timing/test_throttling.py
@@ -4,8 +4,7 @@ from unittest.mock import call
 
 import pytest
 
-from kopf.reactor.effects import throttled
-from kopf.structs.containers import Throttler
+from kopf.structs.throttlers import Throttler, throttled
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
As preparation for the layered layout of the codebase (#765), decouple specialised memories from the generic memories. As a result, the generic memories can be shifted to the lower levels of the module-/class-dependency tree.

As of now, memories are unified, so they have to depend on specialised aspects (e.g. on `daemons` to keep running daemons, on `indexing` to keep the intermediate indexing state, etc). Those specialised modules, in turn, have to depend on the memories to access their specialised parts.

The separation is done by splitting the implementations from the specialised interfaces.

**The are no changes in the external behaviour or public interfaces.**