### PR TITLE
Adapt logging defaults to click 8.0

### DIFF
--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -40,7 +40,7 @@ def logging_options(fn: Callable[..., Any]) -> Callable[..., Any]:
     @click.option('-v', '--verbose', is_flag=True)
     @click.option('-d', '--debug', is_flag=True)
     @click.option('-q', '--quiet', is_flag=True)
-    @click.option('--log-format', type=LogFormatParamType(), default='full')
+    @click.option('--log-format', type=LogFormatParamType(), default=loggers.LogFormat.FULL)
     @click.option('--log-refkey', type=str)
     @click.option('--log-prefix/--no-log-prefix', default=None)
     @functools.wraps(fn)  # to preserve other opts/args

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'typing_extensions',    # 0.20 MB
         'python-json-logger',   # 0.05 MB
         'iso8601',              # 0.07 MB
-        'click',                # 0.60 MB
+        'click>=8.0.0',         # 0.60 MB
         'aiojobs',              # 0.07 MB
         'aiohttp<4.0.0',        # 7.80 MB
     ],


### PR DESCRIPTION
also require at least this version of click

Fixes issue #767

## What do these changes do?

adapt logging to the new release of click

## Description

w/o this patch `kopf run` fails to start with click 8.0 without explicitly specifying `--log-format`

As kopf does not pin/cap click version, all users of already released versions will have to either cap `click<8.0.0` themselves or add explicit `--log-format full` to their `kopf run` arguments.

## Issues/PRs

<!-- Cross-referencing is highly useful in hindsight. Put the main issue, and all the related/affected/causing/preceding issues and PRs related to this change. --> 

> Issues: #767 

> Related:


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left? 
     Any tasks that have to be done to complete the PR? -->
