### PR TITLE
Fix an issue with Click 8.0.0 for custom type double-conversion

### DIFF
--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -31,8 +31,11 @@ class LogFormatParamType(click.Choice):
         super().__init__(choices=[v.name.lower() for v in loggers.LogFormat])
 
     def convert(self, value: Any, param: Any, ctx: Any) -> loggers.LogFormat:
-        name: str = super().convert(value, param, ctx)
-        return loggers.LogFormat[name.upper()]
+        if isinstance(value, loggers.LogFormat):
+            return value
+        else:
+            name: str = super().convert(value, param, ctx)
+            return loggers.LogFormat[name.upper()]
 
 
 def logging_options(fn: Callable[..., Any]) -> Callable[..., Any]:


### PR DESCRIPTION
Presumably caused by this change in Click:

* https://github.com/pallets/click/commit/e79c2b47aa5b456e6c70f980ecf0f883447eb340
* https://github.com/pallets/click/pull/1687

> … This ensures the default value is processed like other values. Some type converters were adjusted to accept values that are already the correct type. …

Previously, the default string was converted to the default value of the parameter only once. With Click 8.0.0, first, the default string ("full") is converted to its typed (enum), and then its enum is converted again as a regular value.

According to the docs (from a quote below), this is a violation of the conversion contract from Click's side — i.e. not only a string is passed:

> … To implement a custom type, you need to subclass the ParamType class. Override the convert() method to convert the value **from a string to the correct type**. … https://click.palletsprojects.com/en/7.x/parameters/#implementing-custom-types

With this fix, if a value is already of the proper type, do not convert it and use it "as is".

**As an immediate workaround for bleeding cases when Kopf upgrade is not possible and older versions are required, restrict `click<8.0.0` in your requirements.**

Fixes #767. Replaces #768.