### PR TITLE
Hint a possible action when API authentication errors occur

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -14,6 +14,12 @@ authentication methods and piggybacks the existing Kubernetes clients.
 Custom authentication
 =====================
 
+In most setups, the normal authentication from one of the API client libraries
+is enough --- it works out of the box if those clients are installed
+(see :ref:`auth-piggybacking` below). Custom authentication is only needed
+if the normal authentication methods do not work for some reason, such as if
+you have a specific and unusual cluster setup (e.g. your own auth tokens).
+
 To implement a custom authentication method, one or a few login-handlers
 can be added. The login handlers should either return nothing (``None``)
 or an instance of `kopf.ConnectionInfo`::

--- a/kopf/_core/intents/piggybacking.py
+++ b/kopf/_core/intents/piggybacking.py
@@ -46,6 +46,7 @@ def login_via_client(
         **kwargs: Any,
 ) -> Optional[credentials.ConnectionInfo]:
 
+    # Keep imports in the function, as module imports are mocked in some tests.
     try:
         import kubernetes.config
     except ImportError:
@@ -59,7 +60,8 @@ def login_via_client(
             kubernetes.config.load_kube_config()  # developer's config files
             logger.debug("Client is configured via kubeconfig file.")
         except kubernetes.config.ConfigException as e2:
-            raise credentials.LoginError(f"Cannot authenticate client neither in-cluster, nor via kubeconfig.")
+            raise credentials.LoginError("Cannot authenticate the client library "
+                                         "neither in-cluster, nor via kubeconfig.")
 
     # We do not even try to understand how it works and why. Just load it, and extract the results.
     # For kubernetes client >= 12.0.0 use the new 'get_default_copy' method
@@ -100,6 +102,7 @@ def login_via_pykube(
         **kwargs: Any,
 ) -> Optional[credentials.ConnectionInfo]:
 
+    # Keep imports in the function, as module imports are mocked in some tests.
     try:
         import pykube
     except ImportError:
@@ -115,8 +118,8 @@ def login_via_pykube(
             config = pykube.KubeConfig.from_file()
             logger.debug("Pykube is configured via kubeconfig file.")
         except (pykube.PyKubeError, FileNotFoundError):
-            raise credentials.LoginError(f"Cannot authenticate pykube "
-                                         f"neither in-cluster, nor via kubeconfig.")
+            raise credentials.LoginError("Cannot authenticate pykube "
+                                         "neither in-cluster, nor via kubeconfig.")
 
     # We don't know how this token will be retrieved, we just get it afterwards.
     provider_token = None

--- a/tests/authentication/test_vault.py
+++ b/tests/authentication/test_vault.py
@@ -55,7 +55,8 @@ async def test_invalidation_reraises_if_nothing_is_left_with_exception(mocker):
     with pytest.raises(Exception) as e:
         await vault.invalidate(key1, exc=exc)
 
-    assert e.value is exc
+    assert isinstance(e.value, LoginError)
+    assert e.value.__cause__ is exc
     assert vault._ready.wait_for.await_args_list == [((True,),)]
 
 

--- a/tests/k8s/test_creating.py
+++ b/tests/k8s/test_creating.py
@@ -40,7 +40,8 @@ async def test_full_body_with_identifiers(
     assert data == {'x': 'y', 'metadata': {'name': 'name1', 'namespace': namespace}}
 
 
-@pytest.mark.parametrize('status', [400, 401, 403, 404, 409, 500, 666])
+# Note: 401 is wrapped into a LoginError and is tested elsewhere.
+@pytest.mark.parametrize('status', [400, 403, 404, 409, 500, 666])
 async def test_raises_api_errors(
         resp_mocker, aresponses, hostname, status, resource, namespace,
         cluster_resource, namespaced_resource):

--- a/tests/k8s/test_errors.py
+++ b/tests/k8s/test_errors.py
@@ -3,7 +3,7 @@ import pytest
 
 from kopf._cogs.clients.auth import APIContext, reauthenticated_request
 from kopf._cogs.clients.errors import APIConflictError, APIError, APIForbiddenError, \
-                                      APINotFoundError, APIUnauthorizedError, check_response
+                                      APINotFoundError, check_response
 
 
 @reauthenticated_request
@@ -47,9 +47,9 @@ async def test_no_error_on_success(
     await get_it(f"http://{hostname}/")
 
 
+# Note: 401 is wrapped into a LoginError and is tested elsewhere.
 @pytest.mark.parametrize('status, exctype', [
     (400, APIError),
-    (401, APIUnauthorizedError),
     (403, APIForbiddenError),
     (404, APINotFoundError),
     (409, APIConflictError),

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -3,6 +3,7 @@ import pytest
 
 from kopf._cogs.clients.errors import APIError
 from kopf._cogs.clients.fetching import list_objs_rv
+from kopf._cogs.structs.credentials import LoginError
 
 
 async def test_listing_works(
@@ -23,8 +24,9 @@ async def test_listing_works(
     assert list_mock.call_count == 1
 
 
-@pytest.mark.parametrize('status', [400, 401, 403, 500, 666])
-async def test_raises_api_error(
+# Note: 401 is wrapped into a LoginError and is tested elsewhere.
+@pytest.mark.parametrize('status', [400, 403, 500, 666])
+async def test_raises_direct_api_errors(
         resp_mocker, aresponses, hostname, status, resource, namespace,
         cluster_resource, namespaced_resource):
 

--- a/tests/k8s/test_patching.py
+++ b/tests/k8s/test_patching.py
@@ -177,7 +177,8 @@ async def test_ignores_absent_objects(
     assert result is None
 
 
-@pytest.mark.parametrize('status', [400, 401, 403, 500, 666])
+# Note: 401 is wrapped into a LoginError and is tested elsewhere.
+@pytest.mark.parametrize('status', [400, 403, 500, 666])
 async def test_raises_api_errors(
         resp_mocker, aresponses, hostname, status, resource, namespace,
         cluster_resource, namespaced_resource):


### PR DESCRIPTION
It has become a common issue with "no credentials available" errors after Kopf was detached from Pykube-ng by default, especially if used with complicated authentication providers (e.g. Google Cloud).

With the new error messages, it will be more clear what to do and where to read more — without being frustrated by an error message.

Note: some errors are reclassified from login errors to a broken (and theoretically impossible) state — to keep the exceptions there as safeguards "just in case".

Was before:

```
[2021-05-13 17:55:38,353] kopf._core.reactor.r [ERROR   ] Resource observer has failed: ('Unauthorized', {'kind': 'Status', 'apiVersion': 'v1', 'metadata': {}, 'status': 'Failure', 'message': 'Unauthorized', 'reason': 'Unauthorized', 'code': 401})

Traceback (most recent call last):
………
aiohttp.client_exceptions.ClientResponseError: 401, message='Unauthorized', url=URL('https://0.0.0.0:64952/api')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
………
kopf._cogs.clients.errors.APIUnauthorizedError: ('Unauthorized', {'kind': 'Status', 'apiVersion': 'v1', 'metadata': {}, 'status': 'Failure', 'message': 'Unauthorized', 'reason': 'Unauthorized', 'code': 401})
```

Now it looks like this:

```
[2021-05-13 17:51:56,195] kopf._core.reactor.r [ERROR   ] Resource observer has failed: Ran out of valid credentials. Consider installing an API client library or adding a login handler. See more: https://kopf.readthedocs.io/en/stable/authentication/

Traceback (most recent call last):
………
aiohttp.client_exceptions.ClientResponseError: 401, message='Unauthorized', url=URL('https://0.0.0.0:64952/apis')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
………
kopf._cogs.clients.errors.APIUnauthorizedError: ('Unauthorized', {'kind': 'Status', 'apiVersion': 'v1', 'metadata': {}, 'status': 'Failure', 'message': 'Unauthorized', 'reason': 'Unauthorized', 'code': 401})

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
………
kopf._cogs.structs.credentials.LoginError: Ran out of valid credentials. Consider installing an API client library or adding a login handler. See more: https://kopf.readthedocs.io/en/stable/authentication/
```

Addresses #349 #187 in retrospection, closes #633. 