### PR TITLE
Fall back to rudimentary login handlers if the clients are absent

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -6,9 +6,18 @@ To access a Kubernetes cluster, an endpoint and some credentials are needed.
 They are usually taken either from the environment (environment variables),
 or from the ``~/.kube/config`` file, or from external authentication services.
 
+Kopf provides rudimentary authentication out of the box: it can authenticate
+with the Kubernetes API either via the service account or raw kubeconfig data
+(with no additional interpretation or parsing of those).
+
+But this can be not enough in some setups and environments.
 Kopf does not try to maintain all the authentication methods possible.
 Instead, it allows the operator developers to implement their custom
-authentication methods and piggybacks the existing Kubernetes clients.
+authentication methods and "piggybacks" the existing Kubernetes clients.
+
+The latter ones can implement some advanced authentication techniques,
+such as the temporary token retrieval via the authentication services,
+token rotation, etc.
 
 
 Custom authentication
@@ -129,8 +138,18 @@ until succeeded, returned nothing, or explicitly failed)::
     def login_fn(**kwargs):
         return kopf.login_via_pykube(**kwargs)
 
+Similarly, if the libraries are installed and needed, but their credentials
+are not desired, the rudimentary login functions can be used directly::
+
+    import kopf
+
+    @kopf.on.login()
+    def login_fn(**kwargs):
+        return kopf.login_with_service_account(**kwargs) or kopf.login_with_kubeconfig(**kwargs)
+
 .. seealso::
-    `kopf.login_via_pykube`, `kopf.login_via_client`.
+    `kopf.login_via_pykube`, `kopf.login_via_client`,
+    `kopf.login_with_kubeconfig`, `kopf.login_with_service_account`.
 
 
 Credentials lifecycle

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -145,6 +145,8 @@ from kopf._core.intents.stoppers import (
 from kopf._core.intents.piggybacking import (
     login_via_pykube,
     login_via_client,
+    login_with_kubeconfig,
+    login_with_service_account,
 )
 from kopf._core.reactor.running import (
     spawn_tasks,
@@ -175,7 +177,12 @@ from kopf._kits.webhooks import (
 __all__ = [
     'on', 'lifecycles', 'register', 'execute', 'daemon', 'timer', 'index',
     'configure', 'LogFormat',
-    'login_via_pykube', 'login_via_client', 'LoginError', 'ConnectionInfo',
+    'login_via_pykube',
+    'login_via_client',
+    'login_with_kubeconfig',
+    'login_with_service_account',
+    'LoginError',
+    'ConnectionInfo',
     'event', 'info', 'warn', 'exception',
     'spawn_tasks', 'run_tasks', 'operator', 'run',
     'adopt', 'label',

--- a/kopf/_core/intents/piggybacking.py
+++ b/kopf/_core/intents/piggybacking.py
@@ -10,7 +10,10 @@ in them, and extracts the basic credentials for its own use.
 .. seealso::
     :mod:`credentials` and :func:`authentication`.
 """
-from typing import Any, Optional, Sequence
+import os
+from typing import Any, Dict, Optional, Sequence
+
+import yaml
 
 from kopf._cogs.structs import credentials
 from kopf._core.actions import execution
@@ -18,6 +21,10 @@ from kopf._core.actions import execution
 # Keep as constants to make them patchable. Higher priority is more preferred.
 PRIORITY_OF_CLIENT: int = 10
 PRIORITY_OF_PYKUBE: int = 20
+
+# Rudimentary logins are added only if the clients are absent, so the priorities can overlap.
+PRIORITY_OF_KUBECONFIG: int = 10
+PRIORITY_OF_SERVICE_ACCOUNT: int = 20
 
 
 def has_client() -> bool:
@@ -142,4 +149,121 @@ def login_via_pykube(
         private_key_path=pkey.filename() if pkey else None,  # can be a temporary file
         default_namespace=config.namespace,
         priority=PRIORITY_OF_PYKUBE,
+    )
+
+
+def has_service_account() -> bool:
+    return os.path.exists('/var/run/secrets/kubernetes.io/serviceaccount/token')
+
+
+def login_with_service_account(**_: Any) -> Optional[credentials.ConnectionInfo]:
+    """
+    A minimalistic login handler that can get raw data from a service account.
+
+    Authentication capabilities can be limited to keep the code short & simple.
+    No parsing or sophisticated multi-step token retrieval is performed.
+
+    This login function is intended to make Kopf runnable in trivial cases
+    when neither pykube-ng nor the official client library are installed.
+    """
+
+    # As per https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/
+    token_path = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+    ns_path = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+    ca_path = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+
+    if os.path.exists(token_path):
+        with open(token_path, 'rt', encoding='utf-8') as f:
+            token = f.read().strip()
+
+        namespace: Optional[str] = None
+        if os.path.exists(ns_path):
+            with open(ns_path, 'rt', encoding='utf-8') as f:
+                namespace = f.read().strip()
+
+        return credentials.ConnectionInfo(
+            server='https://kubernetes.default.svc',
+            ca_path=ca_path if os.path.exists(ca_path) else None,
+            token=token or None,
+            default_namespace=namespace or None,
+            priority=PRIORITY_OF_SERVICE_ACCOUNT,
+        )
+    else:
+        return None
+
+
+def has_kubeconfig() -> bool:
+    env_var_set = bool(os.environ.get('KUBECONFIG'))
+    file_exists = os.path.exists(os.path.expanduser('~/.kube/config'))
+    return env_var_set or file_exists
+
+
+def login_with_kubeconfig(**_: Any) -> Optional[credentials.ConnectionInfo]:
+    """
+    A minimalistic login handler that can get raw data from a kubeconfig file.
+
+    Authentication capabilities can be limited to keep the code short & simple.
+    No parsing or sophisticated multi-step token retrieval is performed.
+
+    This login function is intended to make Kopf runnable in trivial cases
+    when neither pykube-ng nor the official client library are installed.
+    """
+
+    # As per https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+    kubeconfig = os.environ.get('KUBECONFIG')
+    if not kubeconfig and os.path.exists(os.path.expanduser('~/.kube/config')):
+        kubeconfig = '~/.kube/config'
+    if not kubeconfig:
+        return None
+
+    paths = [path.strip() for path in kubeconfig.split(os.pathsep)]
+    paths = [os.path.expanduser(path) for path in paths if path]
+
+    # As prescribed: if the file is absent or non-deserialisable, then fail. The first value wins.
+    current_context: Optional[str] = None
+    contexts: Dict[Any, Any] = {}
+    clusters: Dict[Any, Any] = {}
+    users: Dict[Any, Any] = {}
+    for path in paths:
+
+        with open(path, 'rt', encoding='utf-8') as f:
+            config = yaml.safe_load(f.read()) or {}
+
+        if current_context is None:
+            current_context = config.get('current-context')
+        for item in config.get('contexts', []):
+            if item['name'] not in contexts:
+                contexts[item['name']] = item.get('context') or {}
+        for item in config.get('clusters', []):
+            if item['name'] not in clusters:
+                clusters[item['name']] = item.get('cluster') or {}
+        for item in config.get('users', []):
+            if item['name'] not in users:
+                users[item['name']] = item.get('user') or {}
+
+    # Once fully parsed, use the current context only.
+    if current_context is None:
+        raise credentials.LoginError('Current context is not set in kubeconfigs.')
+    context = contexts[current_context]
+    cluster = clusters[context['cluster']]
+    user = users[context['user']]
+
+    # Unlike pykube's login, we do not make a fake API request to refresh the token.
+    provider_token = user.get('auth-provider', {}).get('config', {}).get('access-token')
+
+    # Map the retrieved fields into the credentials object.
+    return credentials.ConnectionInfo(
+        server=cluster.get('server'),
+        ca_path=cluster.get('certificate-authority'),
+        ca_data=cluster.get('certificate-authority-data'),
+        insecure=cluster.get('insecure-skip-tls-verify'),
+        certificate_path=user.get('client-certificate'),
+        certificate_data=user.get('client-certificate-data'),
+        private_key_path=user.get('client-key'),
+        private_key_data=user.get('client-key-data'),
+        username=user.get('username'),
+        password=user.get('password'),
+        token=user.get('token') or provider_token,
+        default_namespace=context.get('namespace'),
+        priority=PRIORITY_OF_KUBECONFIG,
     )

--- a/kopf/_core/intents/piggybacking.py
+++ b/kopf/_core/intents/piggybacking.py
@@ -10,10 +10,10 @@ in them, and extracts the basic credentials for its own use.
 .. seealso::
     :mod:`credentials` and :func:`authentication`.
 """
-import logging
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Optional, Sequence
 
 from kopf._cogs.structs import credentials
+from kopf._core.actions import execution
 
 # Keep as constants to make them patchable. Higher priority is more preferred.
 PRIORITY_OF_CLIENT: int = 10
@@ -41,9 +41,9 @@ def has_pykube() -> bool:
 # We keep the official client library auto-login only because it was
 # an implied behavior before switching to pykube -- to keep it so (implied).
 def login_via_client(
-        *args: Any,
-        logger: Union[logging.Logger, logging.LoggerAdapter],
-        **kwargs: Any,
+        *,
+        logger: execution.Logger,
+        **_: Any,
 ) -> Optional[credentials.ConnectionInfo]:
 
     # Keep imports in the function, as module imports are mocked in some tests.
@@ -95,11 +95,10 @@ def login_via_client(
     )
 
 
-# Pykube login is mandatory. If it fails, the framework will not run at all.
 def login_via_pykube(
-        *args: Any,
-        logger: Union[logging.Logger, logging.LoggerAdapter],
-        **kwargs: Any,
+        *,
+        logger: execution.Logger,
+        **_: Any,
 ) -> Optional[credentials.ConnectionInfo]:
 
     # Keep imports in the function, as module imports are mocked in some tests.

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'click',                # 0.60 MB
         'aiojobs',              # 0.07 MB
         'aiohttp<4.0.0',        # 7.80 MB
+        'pyyaml',               # 0.90 MB
     ],
     extras_require={
         'full-auth': [

--- a/tests/authentication/test_login_kubeconfig.py
+++ b/tests/authentication/test_login_kubeconfig.py
@@ -1,0 +1,321 @@
+import os
+
+import pytest
+import yaml
+
+from kopf._cogs.structs.credentials import LoginError
+from kopf._core.intents.piggybacking import has_kubeconfig, login_with_kubeconfig
+
+MINICONFIG = '''
+    kind: Config
+    current-context: ctx
+    contexts:
+      - name: ctx
+        context:
+          cluster: clstr
+          user: usr
+    clusters:
+      - name: clstr
+    users:
+      - name: usr
+'''
+
+
+@pytest.mark.parametrize('envs', [{}, {'KUBECONFIG': ''}], ids=['absent', 'empty'])
+def test_has_no_kubeconfig_when_nothing_is_provided(mocker, envs):
+    exists_mock = mocker.patch('os.path.exists', return_value=False)
+    mocker.patch.dict(os.environ, envs, clear=True)
+    result = has_kubeconfig()
+    assert result is False
+    assert exists_mock.call_count == 1
+    assert exists_mock.call_args_list[0][0][0].endswith('/.kube/config')
+
+
+@pytest.mark.parametrize('envs', [{'KUBECONFIG': 'x'}], ids=['set'])
+def test_has_kubeconfig_when_envvar_is_set_but_no_homedir(mocker, envs):
+    exists_mock = mocker.patch('os.path.exists', return_value=False)
+    mocker.patch.dict(os.environ, envs, clear=True)
+    result = has_kubeconfig()
+    assert result is True
+    assert exists_mock.call_count == 1
+    assert exists_mock.call_args_list[0][0][0].endswith('/.kube/config')
+
+
+@pytest.mark.parametrize('envs', [{}, {'KUBECONFIG': ''}], ids=['absent', 'empty'])
+def test_has_kubeconfig_when_homedir_exists_but_no_envvar(mocker, envs):
+    exists_mock = mocker.patch('os.path.exists', return_value=True)
+    mocker.patch.dict(os.environ, envs, clear=True)
+    result = has_kubeconfig()
+    assert result is True
+    assert exists_mock.call_count == 1
+    assert exists_mock.call_args_list[0][0][0].endswith('/.kube/config')
+
+
+@pytest.mark.parametrize('envs', [{}, {'KUBECONFIG': ''}], ids=['absent', 'empty'])
+def test_homedir_is_used_if_it_exists(tmpdir, mocker, envs):
+    exists_mock = mocker.patch('os.path.exists', return_value=True)
+    open_mock = mocker.patch('kopf._core.intents.piggybacking.open')
+    open_mock.return_value.__enter__.return_value.read.return_value = MINICONFIG
+    mocker.patch.dict(os.environ, envs, clear=True)
+    credentials = login_with_kubeconfig()
+    assert exists_mock.call_count == 1
+    assert exists_mock.call_args_list[0][0][0].endswith('/.kube/config')
+    assert open_mock.call_count == 1
+    assert open_mock.call_args_list[0][0][0].endswith('/.kube/config')
+    assert credentials is not None
+
+
+@pytest.mark.parametrize('envs', [{}, {'KUBECONFIG': ''}], ids=['absent', 'empty'])
+def test_homedir_is_ignored_if_it_is_absent(tmpdir, mocker, envs):
+    exists_mock = mocker.patch('os.path.exists', return_value=False)
+    open_mock = mocker.patch('kopf._core.intents.piggybacking.open')
+    open_mock.return_value.__enter__.return_value.read.return_value = ''
+    mocker.patch.dict(os.environ, envs, clear=True)
+    credentials = login_with_kubeconfig()
+    assert exists_mock.call_count == 1
+    assert exists_mock.call_args_list[0][0][0].endswith('/.kube/config')
+    assert open_mock.call_count == 0
+    assert credentials is None
+
+
+def test_absent_kubeconfig_fails(tmpdir, mocker):
+    kubeconfig = tmpdir.join('config')
+    mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
+    with pytest.raises(IOError):
+        login_with_kubeconfig()
+
+
+def test_corrupted_kubeconfig_fails(tmpdir, mocker):
+    kubeconfig = tmpdir.join('config')
+    kubeconfig.write("""!!acb!.-//:""")  # invalid yaml
+    mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
+    with pytest.raises(yaml.YAMLError):
+        login_with_kubeconfig()
+
+
+def test_empty_kubeconfig_fails(tmpdir, mocker):
+    kubeconfig = tmpdir.join('config')
+    kubeconfig.write('')
+    mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
+    with pytest.raises(LoginError) as err:
+        login_with_kubeconfig()
+    assert "context is not set" in str(err.value)
+
+
+def test_mini_kubeconfig_reading(tmpdir, mocker):
+    kubeconfig = tmpdir.join('config')
+    kubeconfig.write(MINICONFIG)
+
+    mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
+    credentials = login_with_kubeconfig()
+
+    assert credentials is not None
+    assert credentials.server is None
+    assert credentials.insecure is None
+    assert credentials.scheme is None
+    assert credentials.token is None
+    assert credentials.certificate_path is None
+    assert credentials.certificate_data is None
+    assert credentials.private_key_path is None
+    assert credentials.private_key_data is None
+    assert credentials.ca_path is None
+    assert credentials.ca_data is None
+    assert credentials.password is None
+    assert credentials.username is None
+    assert credentials.default_namespace is None
+
+
+def test_full_kubeconfig_reading(tmpdir, mocker):
+    kubeconfig = tmpdir.join('config')
+    kubeconfig.write('''
+        kind: Config
+        current-context: ctx
+        contexts:
+          - name: ctx
+            context:
+              cluster: clstr
+              user: usr
+              namespace: ns
+          - name: def
+        clusters:
+          - name: clstr
+            cluster:
+              server: https://hostname:1234/
+              certificate-authority-data: base64dataA
+              certificate-authority: /pathA
+              insecure-skip-tls-verify: true
+          - name: hij            
+        users:
+          - name: usr
+            user:
+              username: uname
+              password: passw
+              client-certificate-data: base64dataC
+              client-certificate: /pathC
+              client-key-data: base64dataK
+              client-key: /pathK
+              token: tkn
+          - name: klm
+    ''')
+
+    mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
+    credentials = login_with_kubeconfig()
+
+    assert credentials is not None
+    assert credentials.server == 'https://hostname:1234/'
+    assert credentials.insecure == True
+    assert credentials.scheme is None
+    assert credentials.token == 'tkn'
+    assert credentials.certificate_path == '/pathC'
+    assert credentials.certificate_data == 'base64dataC'
+    assert credentials.private_key_path == '/pathK'
+    assert credentials.private_key_data == 'base64dataK'
+    assert credentials.ca_path == '/pathA'
+    assert credentials.ca_data == 'base64dataA'
+    assert credentials.password == 'passw'
+    assert credentials.username == 'uname'
+    assert credentials.default_namespace == 'ns'
+
+
+def test_kubeconfig_with_provider_token(tmpdir, mocker):
+    kubeconfig = tmpdir.join('config')
+    kubeconfig.write('''
+        kind: Config
+        current-context: ctx
+        contexts:
+          - name: ctx
+            context:
+              cluster: clstr
+              user: usr
+        clusters:
+          - name: clstr
+        users:
+          - name: usr
+            user:
+              auth-provider:
+                config:
+                  access-token: provtkn
+    ''')
+
+    mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
+    credentials = login_with_kubeconfig()
+
+    assert credentials is not None
+    assert credentials.token == 'provtkn'
+
+
+def test_merged_kubeconfigs_across_currentcontext(tmpdir, mocker):
+    kubeconfig1 = tmpdir.join('config1')
+    kubeconfig1.write('''
+        kind: Config
+        current-context: ctx
+    ''')
+    kubeconfig2 = tmpdir.join('config2')
+    kubeconfig2.write('''
+        kind: Config
+        contexts:
+          - name: ctx
+            context:
+              cluster: clstr
+              user: usr
+              namespace: ns
+        clusters:
+          - name: clstr
+            cluster:
+              server: srv
+        users:
+          - name: usr
+            user:
+              token: tkn
+    ''')
+
+    mocker.patch.dict(os.environ, clear=True, KUBECONFIG=f'{kubeconfig1}{os.pathsep}{kubeconfig2}')
+    credentials = login_with_kubeconfig()
+
+    assert credentials is not None
+    assert credentials.default_namespace == 'ns'
+    assert credentials.server == 'srv'
+    assert credentials.token == 'tkn'
+
+
+def test_merged_kubeconfigs_across_contexts(tmpdir, mocker):
+    kubeconfig1 = tmpdir.join('config1')
+    kubeconfig1.write('''
+        kind: Config
+        current-context: ctx
+        contexts:
+          - name: ctx
+            context:
+              cluster: clstr
+              user: usr
+              namespace: ns
+    ''')
+    kubeconfig2 = tmpdir.join('config2')
+    kubeconfig2.write('''
+        kind: Config
+        clusters:
+          - name: clstr
+            cluster:
+              server: srv
+        users:
+          - name: usr
+            user:
+              token: tkn
+    ''')
+
+    mocker.patch.dict(os.environ, clear=True, KUBECONFIG=f'{kubeconfig1}{os.pathsep}{kubeconfig2}')
+    credentials = login_with_kubeconfig()
+
+    assert credentials is not None
+    assert credentials.default_namespace == 'ns'
+    assert credentials.server == 'srv'
+    assert credentials.token == 'tkn'
+
+
+def test_merged_kubeconfigs_first_wins(tmpdir, mocker):
+    kubeconfig1 = tmpdir.join('config1')
+    kubeconfig1.write('''
+        kind: Config
+        current-context: ctx
+        contexts:
+          - name: ctx
+            context:
+              cluster: clstr
+              user: usr
+              namespace: ns1
+        clusters:
+          - name: clstr
+            cluster:
+              server: srv1
+        users:
+          - name: usr
+            user:
+              token: tkn1
+    ''')
+    kubeconfig2 = tmpdir.join('config2')
+    kubeconfig2.write('''
+        kind: Config
+        current-context: ctx
+        contexts:
+          - name: ctx
+            context:
+              cluster: clstr
+              user: usr
+              namespace: ns2
+        clusters:
+          - name: clstr
+            cluster:
+              server: srv2
+        users:
+          - name: usr
+            user:
+              token: tkn2
+    ''')
+
+    mocker.patch.dict(os.environ, clear=True, KUBECONFIG=f'{kubeconfig1}{os.pathsep}{kubeconfig2}')
+    credentials = login_with_kubeconfig()
+
+    assert credentials is not None
+    assert credentials.default_namespace == 'ns1'
+    assert credentials.server == 'srv1'
+    assert credentials.token == 'tkn1'

--- a/tests/authentication/test_login_serviceaccount.py
+++ b/tests/authentication/test_login_serviceaccount.py
@@ -1,0 +1,72 @@
+from kopf._core.intents.piggybacking import has_service_account, login_with_service_account
+
+# As per https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/
+NAMESPACE_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+SA_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+CA_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+
+
+def test_has_no_serviceaccount_when_special_file_is_absent(mocker):
+    exists_mock = mocker.patch('os.path.exists', return_value=False)
+    result = has_service_account()
+    assert result is False
+    assert exists_mock.call_count == 1
+    assert exists_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
+
+
+def test_has_serviceaccount_when_special_file_exists(mocker):
+    exists_mock = mocker.patch('os.path.exists', return_value=True)
+    result = has_service_account()
+    assert result is True
+    assert exists_mock.call_count == 1
+    assert exists_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
+
+
+def test_serviceaccount_with_all_absent_files(mocker):
+    exists_mock = mocker.patch('os.path.exists', return_value=False)  # all 3 of them.
+    open_mock = mocker.patch('kopf._core.intents.piggybacking.open')
+    open_mock.return_value.__enter__.return_value.read.return_value = ''
+    credentials = login_with_service_account()
+    assert credentials is None
+    assert exists_mock.call_count == 1
+    assert exists_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
+    assert not open_mock.called
+
+
+def test_serviceaccount_with_all_present_files(mocker):
+    exists_mock = mocker.patch('os.path.exists', return_value=True)  # all 3 of them.
+    open_mock = mocker.patch('kopf._core.intents.piggybacking.open')
+    open_mock.return_value.__enter__.return_value.read.side_effect=[' tkn ', ' ns ', RuntimeError]
+    credentials = login_with_service_account()
+    assert credentials is not None
+    assert credentials.server == 'https://kubernetes.default.svc'
+    assert credentials.default_namespace == 'ns'
+    assert credentials.token == 'tkn'
+    assert credentials.ca_path == CA_PATH
+    assert exists_mock.call_count == 3
+    assert exists_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
+    assert exists_mock.call_args_list[1][0][0] == NAMESPACE_PATH
+    assert exists_mock.call_args_list[2][0][0] == CA_PATH
+    assert open_mock.call_count == 2
+    assert open_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
+    assert open_mock.call_args_list[1][0][0] == NAMESPACE_PATH
+    # NB: the order is irrelevant and can be changed if needed.
+
+
+def test_serviceaccount_with_only_the_token_file(mocker):
+    # NB: the order is irrelevant and can be changed if needed.
+    exists_mock = mocker.patch('os.path.exists', side_effect=[True, False, False])
+    open_mock = mocker.patch('kopf._core.intents.piggybacking.open')
+    open_mock.return_value.__enter__.return_value.read.side_effect=[' tkn ', RuntimeError]
+    credentials = login_with_service_account()
+    assert credentials is not None
+    assert credentials.server == 'https://kubernetes.default.svc'
+    assert credentials.default_namespace is None
+    assert credentials.token == 'tkn'
+    assert credentials.ca_path is None
+    assert exists_mock.call_count == 3
+    assert exists_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
+    assert exists_mock.call_args_list[1][0][0] == NAMESPACE_PATH
+    assert exists_mock.call_args_list[2][0][0] == CA_PATH
+    assert open_mock.call_count == 1
+    assert open_mock.call_args_list[0][0][0] == SA_TOKEN_PATH


### PR DESCRIPTION
This will make Kopf runnable in the majority of cases even with no `pykube-ng` and `kubernetes` client libraries installed. This was not a problem till recently, but then `pykube-ng` was removed from the implicit dependencies (#655), so users get frustrated by "unauthenticated" or "ran out of credentials" errors (#349 #187, partially solved in #770).

Two extra functions are added to the public interface:

* `kopf.login_with_kubeconfig()`
* `kopf.login_with_service_account()`

They can only read the rudimentary (but usually sufficient) data and pass them to the API requests "as is", with no post-processing or interpretation (or token rotation, or whatever the client libraries can provide).

To avoid running too many login handlers at startup, the rudimentary login handlers are added strictly when the client libraries are absent, not always. This can be overridden with custom login handlers calling these functions (as documented).

TODOs:

* [x] Tests.
