### PR TITLE
Use only pure f-strings for logs, avoid %s/%r formatting

### DIFF
--- a/docs/walkthrough/creation.rst
+++ b/docs/walkthrough/creation.rst
@@ -76,7 +76,7 @@ We will use the official Kubernetes client library (``pip install kubernetes``):
             body=data,
         )
 
-        logger.info(f"PVC child is created: %s", obj)
+        logger.info(f"PVC child is created: {obj}")
 
 And let us try it in action (assuming the operator is running in the background):
 

--- a/docs/walkthrough/deletion.rst
+++ b/docs/walkthrough/deletion.rst
@@ -60,7 +60,7 @@ Let's extend the creation handler:
             body=data,
         )
 
-        logger.info(f"PVC child is created: %s", obj)
+        logger.info(f"PVC child is created: {obj}")
 
         return {'pvc-name': obj.metadata.name}
 

--- a/docs/walkthrough/updates.rst
+++ b/docs/walkthrough/updates.rst
@@ -45,7 +45,7 @@ with one additional line:
             body=data,
         )
 
-        logger.info(f"PVC child is created: %s", obj)
+        logger.info(f"PVC child is created: {obj}")
 
         return {'pvc-name': obj.metadata.name}
 
@@ -98,7 +98,7 @@ and patches the PVC with the new size from the EVC::
             body=pvc_patch,
         )
 
-        logger.info(f"PVC child is updated: %s", obj)
+        logger.info(f"PVC child is updated: {obj}")
 
 Now, let's change the EVC's size:
 

--- a/kopf/_cogs/aiokits/aiotasks.py
+++ b/kopf/_cogs/aiokits/aiotasks.py
@@ -73,7 +73,7 @@ async def guard(
         raise
     except Exception as e:
         if logger is not None:
-            logger.exception(f"{capname} has failed: %s", e)
+            logger.exception(f"{capname} has failed: {e}")
         raise
     else:
         if logger is not None and not finishable:

--- a/kopf/_cogs/clients/watching.py
+++ b/kopf/_cogs/clients/watching.py
@@ -194,7 +194,7 @@ async def continuous_watch(
 
             # Ensure that the event is something we understand and can handle.
             if raw_type not in ['ADDED', 'MODIFIED', 'DELETED']:
-                logger.warning("Ignoring an unsupported event type: %r", raw_input)
+                logger.warning(f"Ignoring an unsupported event type: {raw_input!r}")
                 continue
 
             # Keep the latest seen resource version for continuation of the stream on disconnects.

--- a/kopf/_core/actions/execution.py
+++ b/kopf/_core/actions/execution.py
@@ -304,18 +304,18 @@ async def execute_handler_once(
 
     # Definitely a temporary error, regardless of the error strictness.
     except TemporaryError as e:
-        logger.error(f"{handler} failed temporarily: %s", str(e) or repr(e))
+        logger.error(f"{handler} failed temporarily: {str(e) or repr(e)}")
         return Outcome(final=False, exception=e, delay=e.delay, subrefs=subrefs)
 
     # Same as permanent errors below, but with better logging for our internal cases.
     except HandlerTimeoutError as e:
-        logger.error(f"%s", str(e) or repr(e))  # already formatted
+        logger.error(f"{str(e) or repr(e)}")  # already formatted
         return Outcome(final=True, exception=e, subrefs=subrefs)
         # TODO: report the handling failure somehow (beside logs/events). persistent status?
 
     # Definitely a permanent error, regardless of the error strictness.
     except PermanentError as e:
-        logger.error(f"{handler} failed permanently: %s", str(e) or repr(e))
+        logger.error(f"{handler} failed permanently: {str(e) or repr(e)}")
         return Outcome(final=True, exception=e, subrefs=subrefs)
         # TODO: report the handling failure somehow (beside logs/events). persistent status?
 

--- a/kopf/_core/engines/probing.py
+++ b/kopf/_core/engines/probing.py
@@ -87,7 +87,7 @@ async def health_reporter(
 
     # Log with the actual URL: normalised, with hostname/port set.
     url = urllib.parse.urlunsplit([parts.scheme, f'{host}:{port}', path, '', ''])
-    logger.debug("Serving health status at %s", url)
+    logger.debug(f"Serving health status at {url}")
     if ready_flag is not None:
         ready_flag.set()
 

--- a/kopf/_core/reactor/processing.py
+++ b/kopf/_core/reactor/processing.py
@@ -406,9 +406,9 @@ async def process_changing_cause(
 
         # Inform on the current cause/event on every processing cycle. Even if there are
         # no handlers -- to show what has happened and why the diff-base is patched.
-        logger.debug(f"{title.capitalize()} is in progress: %r", body)
+        logger.debug(f"{title.capitalize()} is in progress: {body!r}")
         if cause.diff and cause.old is not None and cause.new is not None:
-            logger.debug(f"{title.capitalize()} diff: %r", cause.diff)
+            logger.debug(f"{title.capitalize()} diff: {cause.diff!r}")
 
         if cause_handlers:
             outcomes = await execution.execute_handlers_once(

--- a/kopf/_core/reactor/queueing.py
+++ b/kopf/_core/reactor/queueing.py
@@ -363,4 +363,4 @@ async def _wait_for_depletion(
 
     # The last check if the termination is going to be graceful or not.
     if streams:
-        logger.warning("Unprocessed streams left for %r.", list(streams.keys()))
+        logger.warning(f"Unprocessed streams left for {list(streams.keys())!r}.")

--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -436,9 +436,9 @@ async def _stop_flag_checker(
         if result is None:
             logger.info("Stop-flag is raised. Operator is stopping.")
         elif isinstance(result, signal.Signals):
-            logger.info("Signal %s is received. Operator is stopping.", result.name)
+            logger.info(f"Signal {result.name!s} is received. Operator is stopping.")
         else:
-            logger.info("Stop-flag is set to %r. Operator is stopping.", result)
+            logger.info(f"Stop-flag is set to {result!r}. Operator is stopping.")
 
 
 async def _ultimate_termination(


### PR DESCRIPTION
This is secure, as Python checks for the existence of args/kwargs in `logging` before doing the printf-style formatting — see `logging.LogRecord.getMessage()`:

```python
msg = str(self.msg)
if self.args:
    msg = msg % self.args
```

If we do not pass the args/kwargs, the formatting will not be invoked, so injections of format specifiers via user-side resource fields are not possible — they will be logged "as is".
