### PR TITLE
Lint the source code with pre-commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,11 +20,7 @@ jobs:
         with:
           python-version: "3.9"
       - run: pip install -r requirements.txt
-      - run: lint-imports
-      - run: isort . --check --diff
-        continue-on-error: true
-      - run: isort examples --settings=examples --check --diff
-        continue-on-error: true
+      - run: pre-commit run --all-files
 
   unit-tests:
     strategy:

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -24,11 +24,7 @@ jobs:
         with:
           python-version: "3.9"
       - run: pip install -r requirements.txt
-      - run: lint-imports
-      - run: isort . --check --diff
-        continue-on-error: true
-      - run: isort examples --settings=examples --check --diff
-        continue-on-error: true
+      - run: pre-commit run --all-files
 
   unit-tests:
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,91 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+exclude: |
+  (?x)^(
+    docs/.*\.xml|
+    docs/.*\.png
+  )
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-ast
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: check-xml
+      - id: check-toml
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: check-json
+      - id: pretty-format-json
+      - id: check-added-large-files
+      - id: check-builtin-literals
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-vcs-permalinks
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      - id: debug-statements
+      - id: detect-aws-credentials
+        args: [--allow-missing-credentials]
+      - id: detect-private-key
+        exclude: ^tests/authentication/test_credentials.py$
+      - id: fix-encoding-pragma
+        args: [--remove]
+      - id: forbid-new-submodules
+      - id: mixed-line-ending
+        args: [--fix=auto]
+      - id: name-tests-test
+        args: [--django]
+      - id: no-commit-to-branch
+        args: [--branch, main, --pattern, release/.*]
+      - id: requirements-txt-fixer
+
+      # Intentionally disabled:
+      # - id: double-quote-string-fixer
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.8.0
+    hooks:
+      - id: python-check-blanket-noqa
+      - id: python-check-mock-methods
+      - id: python-no-eval
+      - id: python-use-type-annotations
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+      - id: text-unicode-replacement-char
+
+      # Intentionally disabled:
+      # - id: python-no-log-warn  # overreacts to `kopf.warn()`.
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.812
+    hooks:
+      - id: mypy
+        args: [--strict, --pretty]
+        files: ^kopf/
+
+  - repo: https://github.com/seddonym/import-linter
+    rev: v1.2.1
+    hooks:
+      - id: import-linter
+        additional_dependencies:
+          - astpath[xpath]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+        name: isort-source-code
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.8.0
+    hooks:
+      - id: isort
+        name: isort-examples
+        args: [--settings=examples]
+        files: '^examples/'

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/nolar/kopf/badge.svg?branch=main)](https://coveralls.io/github/nolar/kopf?branch=main)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/nolar/kopf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nolar/kopf/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/nolar/kopf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/nolar/kopf/context:python)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 **Kopf** —Kubernetes Operator Pythonic Framework— is a framework and a library
 to make Kubernetes operators development easier, just in a few lines of Python code.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -10,6 +10,8 @@ In a nutshell, to contribute, follow this scenario:
 * Clone the fork.
 * Check out a feature branch.
 * **Implement the changes.**
+  * Lint with ``pre-commit run``.
+  * Test with ``pytest``.
 * Sign-off your commits.
 * Create a pull request.
 * Ensure all required checks are passed.
@@ -99,14 +101,15 @@ Blend your code into the surrounding code style.
 
 Kopf does not use and will never use strict code formatters
 (at least until they acquire common sense and context awareness).
-In case of doubt, adhere to PEP-8 and [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
-
-For imports, use [isort](https://github.com/PyCQA/isort)::
-
-    isort .
+In case of doubt, adhere to PEP-8 and
+[Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
 
 The line length is 100 characters for code, 80 for docstrings and RsT files.
 Long URLs can exceed this length.
+
+For linting, minor code styling, import sorting, layered modules checks, run::
+
+    pre-commit run
 
 
 Tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ import-linter
 isort>=5.5.0
 lxml
 mypy==0.800
+pre-commit
 pyngrok
 pytest>=6.0.0
 pytest-aiohttp

--- a/tests/posting/test_poster.py
+++ b/tests/posting/test_poster.py
@@ -49,10 +49,10 @@ async def test_poster_polls_and_posts(mocker):
 
     assert post_event.call_count == 2
     assert post_event.await_count == 2
-    assert post_event.called_with(
-        call(ref=REF1, type='type1', reason='reason1', message='message1'),
-        call(ref=REF2, type='type2', reason='reason2', message='message2'),
-    )
+    assert post_event.call_args_list == [
+        call(ref=REF1, type='type1', reason='reason1', message='message1', resource=EVENTS),
+        call(ref=REF2, type='type2', reason='reason2', message='message2', resource=EVENTS),
+    ]
 
 
 def test_queueing_fails_with_no_queue(event_queue_loop):


### PR DESCRIPTION
The time has come: there are 3+ linters & checkers in the CI and in local development — mypy, isort (code & examples separately), lint-imports — which are easier to execute at once with pre-commit.

Tests are not included in the pre-commit hooks — they take quite some time (2 mins), which can be too slow for every commit and even for every push. This can be reconsidered later.

Related: #775 for the code style fixes, #773 for documentation fixes.