### PR TITLE
Expose Kopf's version in user-agent & in logs

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -34,6 +34,9 @@ from kopf._cogs.configs.progress import (
     MultiProgressStorage,
     SmartProgressStorage,
 )
+from kopf._cogs.helpers.versions import (
+    version as __version__,
+)
 from kopf._cogs.structs.bodies import (
     RawEventType,
     RawEvent,

--- a/kopf/_cogs/clients/auth.py
+++ b/kopf/_cogs/clients/auth.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, Iterator, Mapping, Optional, TypeVar, ca
 import aiohttp
 
 from kopf._cogs.clients import errors
+from kopf._cogs.helpers import versions
 from kopf._cogs.structs import credentials
 
 # Per-operator storage and exchange point for authentication methods.
@@ -186,7 +187,7 @@ class APIContext:
             auth = None
 
         # It is a good practice to self-identify a bit.
-        headers['User-Agent'] = f'kopf/unknown'  # TODO: add version someday
+        headers['User-Agent'] = f'kopf/{versions.version or "unknown"}'
 
         # Generic aiohttp session based on the constructed credentials.
         self.session = aiohttp.ClientSession(

--- a/kopf/_cogs/helpers/versions.py
+++ b/kopf/_cogs/helpers/versions.py
@@ -1,0 +1,25 @@
+"""
+Detecting the framework's own version.
+
+The codebase does not contain the version directly, as it would require
+code changes on every release. Kopf's releases depend on tagging rather
+than in-code version bumps (Kopf's authour believes that versions belong
+to the versioning system, not to the codebase).
+
+The version is determined only once at startup when the code is loaded.
+"""
+from typing import Optional
+
+version: Optional[str] = None
+
+try:
+    import pkg_resources
+except ImportError:
+    pass
+else:
+    try:
+        name, *_ = __name__.split('.')  # usually "kopf", unless renamed/forked.
+        dist: pkg_resources.Distribution = pkg_resources.get_distribution(name)
+        version = dist.version
+    except Exception:
+        pass  # installed as an egg, from git, etc.

--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -9,6 +9,7 @@ from typing import Collection, Coroutine, MutableSequence, Optional, Sequence
 from kopf._cogs.aiokits import aioadapters, aiobindings, aiotasks, aiotoggles, aiovalues
 from kopf._cogs.clients import auth
 from kopf._cogs.configs import configuration
+from kopf._cogs.helpers import versions
 from kopf._cogs.structs import credentials, ephemera, references, reviews
 from kopf._core.actions import execution, lifecycles
 from kopf._core.engines import activities, admission, daemons, indexing, peering, posting, probing
@@ -488,6 +489,7 @@ async def _startup_cleanup_activities(
     Beside calling the startup/cleanup handlers, it performs few operator-scoped
     cleanups too (those that cannot be handled by garbage collection).
     """
+    logger.debug(f"Starting Kopf {versions.version or '(unknown version)'}.")
 
     # Execute the startup activity before any root task starts running (due to readiness flag).
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -411,6 +411,7 @@ def fake_vault(mocker, hostname):
     try:
         yield vault
     finally:
+        # await vault.close()  # TODO: but it runs in a different loop, w/ wrong contextvar.
         auth.vault_var.reset(token)
 
 #

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,0 +1,38 @@
+import json
+from typing import Any, Dict
+
+import pytest
+
+from kopf._cogs.clients.auth import APIContext, reauthenticated_request
+
+
+def test_package_version():
+    import kopf
+    assert hasattr(kopf, '__version__')
+    assert kopf.__version__  # not empty, not null
+
+
+@pytest.mark.parametrize('version, useragent', [
+    ('1.2.3', 'kopf/1.2.3'),
+    ('1.2rc', 'kopf/1.2rc'),
+    (None, 'kopf/unknown'),
+])
+async def test_http_user_agent_version(
+        aresponses, hostname, fake_vault, mocker, version, useragent):
+
+    mocker.patch('kopf._cogs.helpers.versions.version', version)
+
+    @reauthenticated_request
+    async def get_it(url: str, *, context: APIContext) -> Dict[str, Any]:
+        response = await context.session.get(url)
+        return await response.json()
+
+    async def responder(request):
+        return aresponses.Response(
+            content_type='application/json',
+            text=json.dumps(dict(request.headers)))
+
+    aresponses.add(hostname, '/', 'get', responder)
+    returned_headers = await get_it(f"http://{hostname}/")
+    assert returned_headers['User-Agent'] == useragent
+    await fake_vault.close()  # to prevent ResourceWarnings for unclosed connectors


### PR DESCRIPTION
Show the version in logs on startup:

```
[2021-05-14 15:06:23,079] kopf._core.reactor.r [DEBUG   ] Starting Kopf 1.32rc1.
[2021-05-14 15:06:23,080] kopf._core.engines.a [INFO    ] Initial authentication has been initiated.
[2021-05-14 15:06:23,080] kopf.activities.auth [DEBUG   ] Activity 'login_via_pykube' is invoked.
………
```

And in the API request as `User-Agent`:

```
User-Agent: kopf/1.32rc1
```

If a dev-mode version is installed, the version will look like this:

```
[2021-05-14 15:08:30,213] kopf._core.reactor.r [DEBUG   ] Starting Kopf 1.32rc2.dev22+ga97ef9eb.
```

All in all, the version is retrieved from the virtualenv — as python/pip/pkg_resources see it. The source code does not store the hard-coded version anywhere.
