### PR TITLE
Disable branch checks for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,6 @@ repos:
         args: [--fix=auto]
       - id: name-tests-test
         args: [--django]
-      - id: no-commit-to-branch
-        args: [--branch, main, --pattern, release/.*]
       - id: requirements-txt-fixer
 
       # Intentionally disabled:


### PR DESCRIPTION
This check fails the Thorough Tests in CI — those executed on the main branch after the merged and nightly.

Related: #776 