### PR TITLE
Upgrade to mypy 0.910 and fix the issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,14 +41,14 @@ jobs:
       - run: pip install -e .[${{ matrix.install-extras }}]
         if: ${{ matrix.install-extras }}
 
-      - run: mypy kopf --strict --pretty
+      - run: mypy kopf --strict
       - run: |
           # Mypying the examples
           exit_codes=0
           for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
           do
             echo "Checking ${d}"
-            mypy $d --pretty
+            mypy $d
             exit_codes=$[${exit_codes} + $?]
           done
           exit ${exit_codes}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,16 @@ jobs:
           python-version: "3.9"
       - run: pip install -r requirements.txt
       - run: pre-commit run --all-files
+      - run: |
+          # Mypying the examples
+          exit_codes=0
+          for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
+          do
+            echo "Checking ${d}"
+            mypy $d
+            exit_codes=$[${exit_codes} + $?]
+          done
+          exit ${exit_codes}
 
   unit-tests:
     strategy:
@@ -40,18 +50,6 @@ jobs:
       - run: pip install -r requirements.txt
       - run: pip install -e .[${{ matrix.install-extras }}]
         if: ${{ matrix.install-extras }}
-
-      - run: mypy kopf --strict
-      - run: |
-          # Mypying the examples
-          exit_codes=0
-          for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
-          do
-            echo "Checking ${d}"
-            mypy $d
-            exit_codes=$[${exit_codes} + $?]
-          done
-          exit ${exit_codes}
       - run: pytest --color=yes --cov=kopf --cov-branch
 
       - name: Publish coverage to Coveralls.io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
           python-version: "3.9"
       - run: pip install -r requirements.txt
       - run: pre-commit run --all-files
+      - run: mypy kopf --strict
       - run: |
           # Mypying the examples
           exit_codes=0

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -25,6 +25,7 @@ jobs:
           python-version: "3.9"
       - run: pip install -r requirements.txt
       - run: pre-commit run --all-files
+      - run: mypy kopf --strict
       - run: |
           # Mypying the examples
           exit_codes=0

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -45,14 +45,14 @@ jobs:
       - run: pip install -e .[${{ matrix.install-extras }}]
         if: ${{ matrix.install-extras }}
 
-      - run: mypy kopf --strict --pretty
+      - run: mypy kopf --strict
       - run: |
           # Mypying the examples
           exit_codes=0
           for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
           do
             echo "Checking ${d}"
-            mypy $d --pretty
+            mypy $d
             exit_codes=$[${exit_codes} + $?]
           done
           exit ${exit_codes}

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -25,6 +25,16 @@ jobs:
           python-version: "3.9"
       - run: pip install -r requirements.txt
       - run: pre-commit run --all-files
+      - run: |
+          # Mypying the examples
+          exit_codes=0
+          for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
+          do
+            echo "Checking ${d}"
+            mypy $d
+            exit_codes=$[${exit_codes} + $?]
+          done
+          exit ${exit_codes}
 
   unit-tests:
     strategy:
@@ -44,18 +54,6 @@ jobs:
       - run: pip install -r requirements.txt
       - run: pip install -e .[${{ matrix.install-extras }}]
         if: ${{ matrix.install-extras }}
-
-      - run: mypy kopf --strict
-      - run: |
-          # Mypying the examples
-          exit_codes=0
-          for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
-          do
-            echo "Checking ${d}"
-            mypy $d
-            exit_codes=$[${exit_codes} + $?]
-          done
-          exit ${exit_codes}
       - run: pytest --color=yes --cov=kopf --cov-branch
 
       - name: Publish coverage to Coveralls.io

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,13 +60,6 @@ repos:
       # Intentionally disabled:
       # - id: python-no-log-warn  # overreacts to `kopf.warn()`.
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
-    hooks:
-      - id: mypy
-        args: [--strict, --pretty]
-        files: ^kopf/
-
   - repo: https://github.com/seddonym/import-linter
     rev: v1.2.1
     hooks:

--- a/kopf/_cogs/aiokits/aiotasks.py
+++ b/kopf/_cogs/aiokits/aiotasks.py
@@ -13,7 +13,7 @@ import asyncio
 import logging
 import sys
 from typing import TYPE_CHECKING, Any, Awaitable, Collection, Coroutine, \
-                   Generator, Optional, Set, Tuple, TypeVar, Union, cast
+                   Generator, Optional, Set, Tuple, TypeVar, Union
 
 _T = TypeVar('_T')
 
@@ -117,7 +117,7 @@ async def wait(
     if not tasks:
         return set(), set()
     done, pending = await asyncio.wait(tasks, timeout=timeout, return_when=return_when)
-    return cast(Set[Task], done), cast(Set[Task], pending)
+    return done, pending
 
 
 async def stop(

--- a/kopf/_kits/runner.py
+++ b/kopf/_kits/runner.py
@@ -101,16 +101,18 @@ class KopfRunner(_AbstractKopfRunner):
             raise Exception("The operator didn't stop, still running.")
 
         # Re-raise the exceptions of the threading & invocation logic.
-        if self._future.exception() is not None:
+        e = self._future.exception()
+        if e is not None:
             if exc_val is None:
-                raise self._future.exception()  # type: ignore
+                raise e
             else:
-                raise self._future.exception() from exc_val  # type: ignore
-        if self._future.result().exception is not None and self.reraise:
+                raise e from exc_val
+        e = self._future.result().exception
+        if e is not None and self.reraise:
             if exc_val is None:
-                raise self._future.result().exception
+                raise e
             else:
-                raise self._future.result().exception from exc_val
+                raise e from exc_val
 
         return False
 
@@ -169,7 +171,7 @@ class KopfRunner(_AbstractKopfRunner):
 
     @property
     def stderr_bytes(self) -> bytes:
-        return self.future.result().stderr_bytes
+        return self.future.result().stderr_bytes or b''
 
     @property
     def exit_code(self) -> int:

--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -59,10 +59,10 @@ def logging_options(fn: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-@click.version_option(prog_name='kopf')
 @click.group(name='kopf', context_settings=dict(
     auto_envvar_prefix='KOPF',
 ))
+@click.version_option(prog_name='kopf')
 def main() -> None:
     pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ freezegun
 import-linter
 isort>=5.5.0
 lxml
-mypy==0.800
+mypy==0.910
 pre-commit
 pyngrok
 pytest>=6.0.0
@@ -22,3 +22,5 @@ pytest-aiohttp
 pytest-asyncio
 pytest-cov
 pytest-mock
+types-pkg_resources
+types-PyYAML


### PR DESCRIPTION
Upgrade mypy to 0.900. The main change is the extraction of stubs from mypy to separate libraries.

**On  mypy exclusion from pre-commit:**

Pre-commit is conceptually broken with mypy>=0.900. Mypy 0.900 has extracted some typed stubs from its own repo into separate libraries. Besides, Click 8.0.0 got its own type annotations instead of the mypy-embedded stubs.

Pre-commit uses its own isolated virtualenvs per hook. As a result, it cannot access the installed dependencies of the project's virtualenv. Which, in turn, breaks the mypy checks when executed in pre-commit's virtualenv. The decision not to fix this seems final: https://github.com/pre-commit/pre-commit/issues/730#issuecomment-835856309

This can be "solved" by adding `additional_dependencies: [...]` and listing all the dependencies which are already present in `requirements.txt` & `setup.py` (the hook also does not install the library itself; "-r" does not work due to wrong working dir). But this will be a code duplication and makes the dependencies harder to manage.

Instead, together with the upgrade, mypy is excluded from pre-commit and is executed on its own. Pre-commit remains only for small code-formatting things, e.g. whitespaces & co.
