### PR TITLE
Retry all K8s API operations on networking/server-side errors

### DIFF
--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -1,4 +1,6 @@
 import asyncio
+import collections.abc
+import itertools
 import json
 import logging
 import ssl
@@ -62,15 +64,39 @@ async def request(
             sock_connect=settings.networking.connect_timeout,
         )
 
-    response = await context.session.request(
-        method=method,
-        url=url,
-        json=payload,
-        headers=headers,
-        timeout=timeout,
-    )
-    await errors.check_response(response)  # but do not parse it!
-    return response
+    backoffs = settings.networking.error_backoffs
+    backoffs = backoffs if isinstance(backoffs, collections.abc.Iterable) else [backoffs]
+    count = len(backoffs) + 1 if isinstance(backoffs, collections.abc.Sized) else None
+    backoff: Optional[float]
+    for retry, backoff in enumerate(itertools.chain(backoffs, [None]), start=1):
+        idx = f"#{retry}/{count}" if count is not None else f"#{retry}"
+        what = f"{method.upper()} {url}"
+        try:
+            if retry > 1:
+                logger.debug(f"Request attempt {idx}: {what}")
+
+            response = await context.session.request(
+                method=method,
+                url=url,
+                json=payload,
+                headers=headers,
+                timeout=timeout,
+            )
+            await errors.check_response(response)  # but do not parse it!
+
+        except (aiohttp.ClientConnectionError, errors.APIServerError) as e:
+            if backoff is None:  # i.e. the last or the only attempt.
+                logger.error(f"Request attempt {idx} failed; escalating: {what} -> {e!r}")
+                raise
+            else:
+                logger.error(f"Request attempt {idx} failed; will retry: {what} -> {e!r}")
+                await asyncio.sleep(backoff)  # non-awakable! but still cancellable.
+        else:
+            if retry > 1:
+                logger.debug(f"Request attempt {idx} succeeded: {what}")
+            return response
+
+    raise RuntimeError("Broken retryable routine.")  # impossible, but needed for type-checking.
 
 
 async def get(

--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -1,8 +1,9 @@
 import asyncio
 import json
+import logging
 import ssl
 import urllib.parse
-from typing import Any, AsyncIterator, Mapping, Optional, Tuple
+from typing import Any, AsyncIterator, Mapping, Optional, Tuple, Union
 
 import aiohttp
 
@@ -47,6 +48,7 @@ async def request(
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
         context: Optional[auth.APIContext] = None,  # injected by the decorator
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> aiohttp.ClientResponse:
     if context is None:  # for type-checking!
         raise RuntimeError("API instance is not injected by the decorator.")
@@ -78,6 +80,7 @@ async def get(
         payload: Optional[object] = None,
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> Any:
     response = await request(
         method='get',
@@ -86,6 +89,7 @@ async def get(
         headers=headers,
         timeout=timeout,
         settings=settings,
+        logger=logger,
     )
     async with response:
         return await response.json()
@@ -98,6 +102,7 @@ async def post(
         payload: Optional[object] = None,
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> Any:
     response = await request(
         method='post',
@@ -106,6 +111,7 @@ async def post(
         headers=headers,
         timeout=timeout,
         settings=settings,
+        logger=logger,
     )
     async with response:
         return await response.json()
@@ -118,6 +124,7 @@ async def patch(
         payload: Optional[object] = None,
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> Any:
     response = await request(
         method='patch',
@@ -126,6 +133,7 @@ async def patch(
         headers=headers,
         timeout=timeout,
         settings=settings,
+        logger=logger,
     )
     async with response:
         return await response.json()
@@ -138,6 +146,7 @@ async def delete(
         payload: Optional[object] = None,
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> Any:
     response = await request(
         method='delete',
@@ -146,6 +155,7 @@ async def delete(
         headers=headers,
         timeout=timeout,
         settings=settings,
+        logger=logger,
     )
     async with response:
         return await response.json()
@@ -159,6 +169,7 @@ async def stream(
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
         stopper: Optional[aiotasks.Future] = None,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> AsyncIterator[Any]:
     response = await request(
         method='get',
@@ -167,6 +178,7 @@ async def stream(
         headers=headers,
         timeout=timeout,
         settings=settings,
+        logger=logger,
     )
     response_close_callback = lambda _: response.close()  # to remove the positional arg.
     if stopper is not None:

--- a/kopf/_cogs/clients/creating.py
+++ b/kopf/_cogs/clients/creating.py
@@ -1,4 +1,5 @@
-from typing import Optional, cast
+import logging
+from typing import Optional, Union, cast
 
 from kopf._cogs.clients import api
 from kopf._cogs.configs import configuration
@@ -12,6 +13,7 @@ async def create_obj(
         namespace: references.Namespace = None,
         name: Optional[str] = None,
         body: Optional[bodies.RawBody] = None,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> Optional[bodies.RawBody]:
     """
     Create a resource.
@@ -26,6 +28,7 @@ async def create_obj(
     created_body: bodies.RawBody = await api.post(
         url=resource.get_url(namespace=namespace),
         payload=body,
+        logger=logger,
         settings=settings,
     )
     return created_body

--- a/kopf/_cogs/clients/errors.py
+++ b/kopf/_cogs/clients/errors.py
@@ -89,19 +89,27 @@ class APIError(Exception):
         return self._payload.get('details') if self._payload else None
 
 
-class APIUnauthorizedError(APIError):
+class APIClientError(APIError):  # all 4xx
     pass
 
 
-class APIForbiddenError(APIError):
+class APIServerError(APIError):  # all 5xx
     pass
 
 
-class APINotFoundError(APIError):
+class APIUnauthorizedError(APIClientError):
     pass
 
 
-class APIConflictError(APIError):
+class APIForbiddenError(APIClientError):
+    pass
+
+
+class APINotFoundError(APIClientError):
+    pass
+
+
+class APIConflictError(APIClientError):
     pass
 
 
@@ -129,6 +137,8 @@ async def check_response(
             APIForbiddenError if response.status == 403 else
             APINotFoundError if response.status == 404 else
             APIConflictError if response.status == 409 else
+            APIClientError if 400 <= response.status < 500 else
+            APIServerError if 500 <= response.status < 600 else
             APIError
         )
 

--- a/kopf/_cogs/clients/events.py
+++ b/kopf/_cogs/clients/events.py
@@ -1,14 +1,13 @@
 import copy
 import datetime
 import logging
+from typing import Union
 
 import aiohttp
 
 from kopf._cogs.clients import api, errors
 from kopf._cogs.configs import configuration
 from kopf._cogs.structs import bodies, references
-
-logger = logging.getLogger(__name__)
 
 MAX_MESSAGE_LENGTH = 1024
 CUT_MESSAGE_INFIX = '...'
@@ -22,6 +21,7 @@ async def post_event(
         message: str = '',
         resource: references.Resource,
         settings: configuration.OperatorSettings,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> None:
     """
     Issue an event for the object.
@@ -78,6 +78,7 @@ async def post_event(
             url=resource.get_url(namespace=namespace),
             headers={'Content-Type': 'application/json'},
             payload=body,
+            logger=logger,
             settings=settings,
         )
 

--- a/kopf/_cogs/clients/fetching.py
+++ b/kopf/_cogs/clients/fetching.py
@@ -1,4 +1,5 @@
-from typing import Collection, List, Tuple
+import logging
+from typing import Collection, List, Tuple, Union
 
 from kopf._cogs.clients import api
 from kopf._cogs.configs import configuration
@@ -10,6 +11,7 @@ async def list_objs(
         settings: configuration.OperatorSettings,
         resource: references.Resource,
         namespace: references.Namespace,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> Tuple[Collection[bodies.RawBody], str]:
     """
     List the objects of specific resource type.
@@ -25,6 +27,7 @@ async def list_objs(
     """
     rsp = await api.get(
         url=resource.get_url(namespace=namespace),
+        logger=logger,
         settings=settings,
     )
 

--- a/kopf/_cogs/clients/patching.py
+++ b/kopf/_cogs/clients/patching.py
@@ -1,4 +1,5 @@
-from typing import Optional
+import logging
+from typing import Optional, Union
 
 from kopf._cogs.clients import api, errors
 from kopf._cogs.configs import configuration
@@ -12,6 +13,7 @@ async def patch_obj(
         namespace: references.Namespace,
         name: Optional[str],
         patch: patches.Patch,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> Optional[bodies.RawBody]:
     """
     Patch a resource of specific kind.
@@ -47,6 +49,7 @@ async def patch_obj(
                 headers={'Content-Type': 'application/merge-patch+json'},
                 payload=body_patch,
                 settings=settings,
+                logger=logger,
             )
 
         if status_patch:
@@ -56,6 +59,7 @@ async def patch_obj(
                 headers={'Content-Type': 'application/merge-patch+json'},
                 payload={'status': status_patch},
                 settings=settings,
+                logger=logger,
             )
             patched_body['status'] = response.get('status')
 

--- a/kopf/_cogs/clients/scanning.py
+++ b/kopf/_cogs/clients/scanning.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Collection, Mapping, Optional, Set
+import logging
+from typing import Collection, Mapping, Optional, Set, Union
 
 from kopf._cogs.clients import api, errors
 from kopf._cogs.configs import configuration
@@ -9,19 +10,21 @@ from kopf._cogs.structs import references
 async def read_version(
         *,
         settings: configuration.OperatorSettings,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> Mapping[str, str]:
-    rsp: Mapping[str, str] = await api.get('/version', settings=settings)
+    rsp: Mapping[str, str] = await api.get('/version', settings=settings, logger=logger)
     return rsp
 
 
 async def scan_resources(
         *,
         settings: configuration.OperatorSettings,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
         groups: Optional[Collection[str]] = None,
 ) -> Collection[references.Resource]:
     coros = {
-        _read_old_api(groups=groups, settings=settings),
-        _read_new_apis(groups=groups, settings=settings),
+        _read_old_api(groups=groups, settings=settings, logger=logger),
+        _read_new_apis(groups=groups, settings=settings, logger=logger),
     }
     resources: Set[references.Resource] = set()
     for coro in asyncio.as_completed(coros):
@@ -32,11 +35,12 @@ async def scan_resources(
 async def _read_old_api(
         *,
         settings: configuration.OperatorSettings,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
         groups: Optional[Collection[str]],
 ) -> Collection[references.Resource]:
     resources: Set[references.Resource] = set()
     if groups is None or '' in groups:
-        rsp = await api.get('/api', settings=settings)
+        rsp = await api.get('/api', settings=settings, logger=logger)
         coros = {
             _read_version(
                 url=f'/api/{version_name}',
@@ -44,6 +48,7 @@ async def _read_old_api(
                 version=version_name,
                 preferred=True,
                 settings=settings,
+                logger=logger,
             )
             for version_name in rsp['versions']
         }
@@ -55,11 +60,12 @@ async def _read_old_api(
 async def _read_new_apis(
         *,
         settings: configuration.OperatorSettings,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
         groups: Optional[Collection[str]],
 ) -> Collection[references.Resource]:
     resources: Set[references.Resource] = set()
     if groups is None or set(groups or {}) - {''}:
-        rsp = await api.get('/apis', settings=settings)
+        rsp = await api.get('/apis', settings=settings, logger=logger)
         items = [d for d in rsp['groups'] if groups is None or d['name'] in groups]
         coros = {
             _read_version(
@@ -68,6 +74,7 @@ async def _read_new_apis(
                 version=version['version'],
                 preferred=version['version'] == group_dat['preferredVersion']['version'],
                 settings=settings,
+                logger=logger,
             )
             for group_dat in items
             for version in group_dat['versions']
@@ -84,9 +91,10 @@ async def _read_version(
         version: str,
         preferred: bool,
         settings: configuration.OperatorSettings,
+        logger: Union[logging.Logger, logging.LoggerAdapter],
 ) -> Collection[references.Resource]:
     try:
-        rsp = await api.get(url, settings=settings)
+        rsp = await api.get(url, settings=settings, logger=logger)
     except errors.APINotFoundError:
         # This happens when the last and the only resource of a group/version
         # has been deleted, the whole group/version is gone, and we rescan it.

--- a/kopf/_cogs/clients/watching.py
+++ b/kopf/_cogs/clients/watching.py
@@ -156,6 +156,7 @@ async def continuous_watch(
     # First, list the resources regularly, and get the list's resource version.
     # Simulate the events with type "None" event - used in detection of causes.
     objs, resource_version = await fetching.list_objs(
+        logger=logger,
         settings=settings,
         resource=resource,
         namespace=namespace,
@@ -245,6 +246,7 @@ async def watch_objs(
     try:
         async for raw_input in api.stream(
             url=resource.get_url(namespace=namespace, params=params),
+            logger=logger,
             settings=settings,
             stopper=operator_pause_waiter,
             timeout=aiohttp.ClientTimeout(

--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -28,7 +28,7 @@ the root object, while keeping the legacy names for backward compatibility.
 import concurrent.futures
 import dataclasses
 import logging
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Union
 
 from kopf._cogs.configs import diffbase, progress
 from kopf._cogs.structs import reviews
@@ -218,19 +218,9 @@ class BatchingSettings:
 
     error_delays: Iterable[float] = (1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610)
     """
-    Backoff intervals in case of unexpected errors in the framework (not the handlers).
+    Backoff intervals in case of unexpected errors in the framework.
 
-    Per-resource workers freeze all activities for this number of seconds in case of errors.
-    Once they are back to work, they process only the latest event seen (due to event batching).
-
-    Every further error leads to the next, even bigger delay (10m is enough for a default maximum).
-    Every success resets the backoff intervals, and it goes from the beginning on the next error.
-
-    If needed, this value can be an arbitrary collection/iterator/object:
-    only ``iter()`` is called on every new throttling cycle, no other protocols
-    are required; but make sure that it is re-iterable for multiple uses.
-
-    To disable throttling (on your own risk), set it to ``[]`` or ``()``.
+    For more information on error throttling, see :ref:`error-throttling`.
     """
 
 
@@ -353,6 +343,13 @@ class NetworkingSettings:
     connect_timeout: Optional[float] = None
     """
     A timeout for the connection & handshake of an API request (in seconds).
+    """
+
+    error_backoffs: Union[float, Iterable[float]] = (1, 1, 2, 3, 5, 8, 13, 21)
+    """
+    How many times and with which delays (seconds) to retry the API errors.
+
+    For more information on the API errors retrying, see :doc:`api-retrying`.
     """
 
 

--- a/kopf/_core/actions/application.py
+++ b/kopf/_core/actions/application.py
@@ -134,6 +134,7 @@ async def patch_and_check(
             namespace=body.metadata.namespace,
             name=body.metadata.name,
             patch=patch,
+            logger=logger,
         )
         inconsistencies = diffs.diff(patch, resulting_body, scope=diffs.DiffScope.LEFT)
         inconsistencies = diffs.Diff(

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -334,6 +334,7 @@ async def configuration_manager(
         await creating.create_obj(
             settings=settings,
             resource=resource,
+            logger=logger,
             name=settings.admission.managed,
         )
     except errors.APIConflictError:
@@ -360,6 +361,7 @@ async def configuration_manager(
                 namespace=None,
                 name=settings.admission.managed,
                 patch=patches.Patch({'webhooks': webhooks}),
+                logger=logger,
             )
     finally:
         # Attempt to remove all managed webhooks, except for the strict ones.
@@ -377,6 +379,7 @@ async def configuration_manager(
                 namespace=None,
                 name=settings.admission.managed,
                 patch=patches.Patch({'webhooks': webhooks}),
+                logger=logger,
             )
 
 

--- a/kopf/_core/engines/peering.py
+++ b/kopf/_core/engines/peering.py
@@ -224,6 +224,7 @@ async def touch(
         namespace=namespace,
         name=name,
         patch=patch,
+        logger=logger,
     )
 
     if not settings.peering.stealth or rsp is None:
@@ -248,6 +249,7 @@ async def clean(
         namespace=namespace,
         name=name,
         patch=patch,
+        logger=logger,
     )
 
 

--- a/kopf/_core/engines/posting.py
+++ b/kopf/_core/engines/posting.py
@@ -25,6 +25,8 @@ from kopf._cogs.configs import configuration
 from kopf._cogs.structs import bodies, dicts, references
 from kopf._core.actions import loggers
 
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
     K8sEventQueue = asyncio.Queue["K8sEvent"]
 else:
@@ -173,6 +175,7 @@ async def poster(
             message=posted_event.message,
             resource=resource,
             settings=settings,
+            logger=logger,
         )
 
 

--- a/kopf/_core/reactor/observation.py
+++ b/kopf/_core/reactor/observation.py
@@ -48,7 +48,12 @@ async def namespace_observer(
     # Populate the namespaces atomically (instead of notifying on every item from the watch-stream).
     if not settings.scanning.disabled and not clusterwide:
         try:
-            objs, _ = await fetching.list_objs(settings=settings, resource=resource, namespace=None)
+            objs, _ = await fetching.list_objs(
+                settings=settings,
+                resource=resource,
+                namespace=None,
+                logger=logger,
+            )
             async with insights.revised:
                 revise_namespaces(raw_bodies=objs, insights=insights, namespaces=namespaces)
                 insights.revised.notify_all()
@@ -105,7 +110,7 @@ async def resource_observer(
     # Prepopulate the resources before the dimension watchers start, so that each initially listed
     # namespace would start a watcher, and each initially listed CRD is already on the list.
     group_filter = None if None in groups else {group for group in groups if group is not None}
-    resources = await scanning.scan_resources(groups=group_filter, settings=settings)
+    resources = await scanning.scan_resources(groups=group_filter, settings=settings, logger=logger)
     async with insights.revised:
         revise_resources(resources=resources, insights=insights, registry=registry, group=None)
         await insights.backbone.fill(resources=resources)
@@ -175,7 +180,7 @@ async def process_discovered_resource_event(
     # instead of mimicking K8s in interpreting them ourselves (a probable source of bugs).
     # As long as it is atomic (for asyncio, i.e. sync), the existing tasks will not be affected.
     group = raw_event['object']['spec']['group']
-    resources = await scanning.scan_resources(groups={group}, settings=settings)
+    resources = await scanning.scan_resources(groups={group}, settings=settings, logger=logger)
     async with insights.revised:
         revise_resources(resources=resources, insights=insights, registry=registry, group=group)
         await insights.backbone.fill(resources=resources)

--- a/kopf/_kits/webhooks.py
+++ b/kopf/_kits/webhooks.py
@@ -584,7 +584,7 @@ class ClusterDetector:
             # the version in observation routines and pass it via contextvars,
             # but this is too overcomplicated for a dev-mode helping utility.
             settings = configuration.OperatorSettings()
-            versioninfo = await scanning.read_version(settings=settings)
+            versioninfo = await scanning.read_version(settings=settings, logger=logger)
             if '+k3s' in versioninfo.get('gitVersion', ''):
                 return WebhookK3dServer.DEFAULT_HOST
         return None

--- a/tests/apis/test_error_retries.py
+++ b/tests/apis/test_error_retries.py
@@ -1,0 +1,200 @@
+import aiohttp.web
+import pytest
+
+from kopf._cogs.clients.api import request
+from kopf._cogs.clients.errors import APIError
+
+
+@pytest.fixture(autouse=True)
+def sleep(mocker):
+    """Do not let it actually sleep, even if it is a 0-sleep."""
+    return mocker.patch('asyncio.sleep')
+
+
+@pytest.fixture()
+def request_fn(mocker):
+    return mocker.patch('aiohttp.ClientSession.request')
+
+
+async def test_regular_errors_escalate_without_retries(
+        caplog, assert_logs, settings, logger, resp_mocker, aresponses, hostname, request_fn):
+    caplog.set_level(0)
+
+    request_fn.side_effect = Exception("boo")
+
+    settings.networking.error_backoffs = [1, 2, 3]
+    with pytest.raises(Exception) as err:
+        await request('get', '/url', settings=settings, logger=logger)
+
+    assert str(err.value) == "boo"
+    assert request_fn.call_count == 1
+    assert_logs([], prohibited=["attempt", "escalating", "retry"])
+
+
+@pytest.mark.parametrize('status', [400, 403, 404, 499, 666, 999])
+async def test_client_errors_escalate_without_retries(
+        caplog, assert_logs, settings, logger, resp_mocker, aresponses, hostname, status):
+    caplog.set_level(0)
+
+    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
+    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response({}, status=status))
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+
+    settings.networking.error_backoffs = [1, 2, 3]
+    with pytest.raises(APIError) as err:
+        await request('get', '/url', settings=settings, logger=logger)
+
+    assert err.value.status == status
+    assert mock.call_count == 1
+    assert_logs([], prohibited=["attempt", "escalating", "retry"])
+
+
+@pytest.mark.parametrize('status', [500, 503, 599])
+async def test_server_errors_escalate_with_retries(
+        caplog, assert_logs, settings, logger, resp_mocker, aresponses, hostname, status):
+    caplog.set_level(0)
+
+    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
+    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response({}, status=status))
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+
+    settings.networking.error_backoffs = [0, 0, 0]
+    with pytest.raises(APIError) as err:
+        await request('get', '/url', settings=settings, logger=logger)
+
+    assert err.value.status == status
+    assert mock.call_count == 4
+    assert_logs([
+        "attempt #1/4 failed; will retry",
+        "attempt #2/4 failed; will retry",
+        "attempt #3/4 failed; will retry",
+        "attempt #4/4 failed; escalating",
+    ])
+
+
+async def test_connection_errors_escalate_with_retries(
+        caplog, assert_logs, settings, logger, resp_mocker, aresponses, hostname, request_fn):
+    caplog.set_level(0)
+
+    request_fn.side_effect = aiohttp.ClientConnectionError()
+
+    settings.networking.error_backoffs = [0, 0, 0]
+    with pytest.raises(aiohttp.ClientConnectionError):
+        await request('get', '/url', settings=settings, logger=logger)
+
+    assert request_fn.call_count == 4
+    assert_logs([
+        "attempt #1/4 failed; will retry",
+        "attempt #2/4 failed; will retry",
+        "attempt #3/4 failed; will retry",
+        "attempt #4/4 failed; escalating",
+    ])
+
+
+async def test_retried_until_succeeded(
+        caplog, assert_logs, settings, logger, resp_mocker, aresponses, hostname):
+    caplog.set_level(0)
+
+    mock = resp_mocker(side_effect=[
+        aiohttp.web.json_response({}, status=505),
+        aiohttp.web.json_response({}, status=505),
+        aiohttp.web.json_response({}),
+    ])
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+
+    settings.networking.error_backoffs = [0, 0, 0]
+    await request('get', '/url', settings=settings, logger=logger)
+
+    assert mock.call_count == 3  # 2 failures, 1 success; limited to 4 attempts.
+    assert_logs([
+        "attempt #1/4 failed; will retry",
+        "attempt #2/4 failed; will retry",
+        "attempt #3/4 succeeded",
+    ], prohibited=[
+        "attempt #4/4",
+    ])
+
+
+@pytest.mark.parametrize('backoffs, exp_calls', [
+    ([], 1),
+    ([0], 2),
+    ([1], 2),
+    ([0, 0], 3),
+    ([1, 2], 3),
+])
+async def test_backoffs_as_lists(
+        caplog, assert_logs, settings, logger, resp_mocker, aresponses, hostname, sleep,
+        backoffs, exp_calls):
+    caplog.set_level(0)
+
+    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
+    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response({}, status=500))
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+
+    settings.networking.error_backoffs = backoffs
+    with pytest.raises(APIError):
+        await request('get', '/url', settings=settings, logger=logger)
+
+    assert mock.call_count == exp_calls
+    all_sleeps = [call[0][0] for call in sleep.call_args_list]
+    assert all_sleeps == backoffs
+
+
+async def test_backoffs_as_floats(
+        caplog, assert_logs, settings, logger, resp_mocker, aresponses, hostname, sleep):
+    caplog.set_level(0)
+
+    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
+    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response({}, status=500))
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+
+    settings.networking.error_backoffs = 5.0
+    with pytest.raises(APIError):
+        await request('get', '/url', settings=settings, logger=logger)
+
+    assert mock.call_count == 2
+    all_sleeps = [call[0][0] for call in sleep.call_args_list]
+    assert all_sleeps == [5.0]
+
+
+async def test_backoffs_as_iterables(
+        caplog, assert_logs, settings, logger, resp_mocker, aresponses, hostname, sleep):
+    caplog.set_level(0)
+
+    class Itr:
+        def __iter__(self):
+            return iter([1, 2, 3])
+
+    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
+    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response({}, status=500))
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+
+    settings.networking.error_backoffs = Itr()  # to be reused on every attempt
+    with pytest.raises(APIError):
+        await request('get', '/url', settings=settings, logger=logger)
+    with pytest.raises(APIError):
+        await request('get', '/url', settings=settings, logger=logger)
+
+    assert mock.call_count == 8
+    all_sleeps = [call[0][0] for call in sleep.call_args_list]
+    assert all_sleeps == [1, 2, 3, 1, 2, 3]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,6 +163,11 @@ def memories():
 
 
 @pytest.fixture()
+def logger():
+    return logging.getLogger('fake-logger')
+
+
+@pytest.fixture()
 def settings_via_contextvar(settings):
     token = settings_var.set(settings)
     try:

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -4,3 +4,8 @@ import pytest
 @pytest.fixture(autouse=True)
 def _autouse_resp_mocker(resp_mocker, version_api):
     pass
+
+
+@pytest.fixture(autouse=True)
+def _prevent_retries_in_api_tests(settings):
+    settings.networking.error_backoffs = []

--- a/tests/k8s/test_creating.py
+++ b/tests/k8s/test_creating.py
@@ -6,13 +6,14 @@ from kopf._cogs.clients.errors import APIError
 
 
 async def test_simple_body_with_arguments(
-        resp_mocker, aresponses, hostname, settings, resource, namespace, caplog):
+        resp_mocker, aresponses, hostname, settings, resource, namespace, logger, caplog):
 
     post_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
     aresponses.add(hostname, resource.get_url(namespace=namespace), 'post', post_mock)
 
     body = {'x': 'y'}
     await create_obj(
+        logger=logger,
         settings=settings,
         resource=resource,
         namespace=namespace,
@@ -31,13 +32,14 @@ async def test_simple_body_with_arguments(
 
 
 async def test_full_body_with_identifiers(
-        resp_mocker, aresponses, hostname, settings, resource, namespace, caplog):
+        resp_mocker, aresponses, hostname, settings, resource, namespace, caplog, logger):
 
     post_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
     aresponses.add(hostname, resource.get_url(namespace=namespace), 'post', post_mock)
 
     body = {'x': 'y', 'metadata': {'name': 'name1', 'namespace': namespace}}
     await create_obj(
+        logger=logger,
         settings=settings,
         resource=resource,
         body=body,
@@ -53,7 +55,7 @@ async def test_full_body_with_identifiers(
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.
 @pytest.mark.parametrize('status', [400, 403, 404, 409, 500, 666])
 async def test_raises_api_errors(
-        resp_mocker, aresponses, hostname, settings, status, resource, namespace,
+        resp_mocker, aresponses, hostname, settings, status, resource, namespace, logger,
         cluster_resource, namespaced_resource):
 
     post_mock = resp_mocker(return_value=aresponses.Response(status=status))
@@ -65,6 +67,7 @@ async def test_raises_api_errors(
     body = {'x': 'y'}
     with pytest.raises(APIError) as e:
         await create_obj(
+            logger=logger,
             settings=settings,
             resource=resource,
             namespace=namespace,

--- a/tests/k8s/test_errors.py
+++ b/tests/k8s/test_errors.py
@@ -2,8 +2,9 @@ import aiohttp
 import pytest
 
 from kopf._cogs.clients.auth import APIContext, authenticated
-from kopf._cogs.clients.errors import APIConflictError, APIError, APIForbiddenError, \
-                                      APINotFoundError, check_response
+from kopf._cogs.clients.errors import APIClientError, APIConflictError, APIError, \
+                                      APIForbiddenError, APINotFoundError, \
+                                      APIServerError, check_response
 
 
 @authenticated
@@ -49,10 +50,15 @@ async def test_no_error_on_success(
 
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.
 @pytest.mark.parametrize('status, exctype', [
-    (400, APIError),
     (403, APIForbiddenError),
     (404, APINotFoundError),
     (409, APIConflictError),
+    (400, APIClientError),
+    (403, APIClientError),
+    (404, APIClientError),
+    (500, APIServerError),
+    (503, APIServerError),
+    (400, APIError),
     (500, APIError),
     (666, APIError),
 ])

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -7,7 +7,7 @@ from kopf._cogs.structs.credentials import LoginError
 
 
 async def test_listing_works(
-        resp_mocker, aresponses, hostname, settings, resource, namespace,
+        resp_mocker, aresponses, hostname, settings, logger, resource, namespace,
         cluster_resource, namespaced_resource):
 
     result = {'items': [{}, {}]}
@@ -18,6 +18,7 @@ async def test_listing_works(
     aresponses.add(hostname, namespaced_url, 'get', list_mock)
 
     items, resource_version = await list_objs(
+        logger=logger,
         settings=settings,
         resource=resource,
         namespace=namespace,
@@ -31,7 +32,7 @@ async def test_listing_works(
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.
 @pytest.mark.parametrize('status', [400, 403, 500, 666])
 async def test_raises_direct_api_errors(
-        resp_mocker, aresponses, hostname, settings, status, resource, namespace,
+        resp_mocker, aresponses, hostname, settings, logger, status, resource, namespace,
         cluster_resource, namespaced_resource):
 
     list_mock = resp_mocker(return_value=aresponses.Response(status=status))
@@ -42,6 +43,7 @@ async def test_raises_direct_api_errors(
 
     with pytest.raises(APIError) as e:
         await list_objs(
+            logger=logger,
             settings=settings,
             resource=resource,
             namespace=namespace,

--- a/tests/k8s/test_patching.py
+++ b/tests/k8s/test_patching.py
@@ -9,13 +9,14 @@ from kopf._cogs.structs.patches import Patch
 
 
 async def test_without_subresources(
-        resp_mocker, aresponses, hostname, settings, resource, namespace):
+        resp_mocker, aresponses, hostname, settings, resource, namespace, logger):
 
     patch_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
     aresponses.add(hostname, resource.get_url(namespace=namespace, name='name1'), 'patch', patch_mock)
 
     patch = Patch({'x': 'y'})
     await patch_obj(
+        logger=logger,
         settings=settings,
         resource=resource,
         namespace=namespace,
@@ -31,7 +32,7 @@ async def test_without_subresources(
 
 
 async def test_status_as_subresource_with_combined_payload(
-        resp_mocker, aresponses, hostname, settings, resource, namespace):
+        resp_mocker, aresponses, hostname, settings, resource, namespace, logger):
     resource = dataclasses.replace(resource, subresources=['status'])
 
     # Simulate Kopf's initial state and intention.
@@ -51,6 +52,7 @@ async def test_status_as_subresource_with_combined_payload(
     aresponses.add(hostname, status_url, 'patch', status_patch_mock)
 
     reconstructed = await patch_obj(
+        logger=logger,
         settings=settings,
         resource=resource,
         namespace=namespace,
@@ -74,7 +76,7 @@ async def test_status_as_subresource_with_combined_payload(
 
 
 async def test_status_as_subresource_with_object_fields_only(
-        resp_mocker, aresponses, hostname, settings, resource, namespace):
+        resp_mocker, aresponses, hostname, settings, resource, namespace, logger):
     resource = dataclasses.replace(resource, subresources=['status'])
 
     # Simulate Kopf's initial state and intention.
@@ -94,6 +96,7 @@ async def test_status_as_subresource_with_object_fields_only(
     aresponses.add(hostname, status_url, 'patch', status_patch_mock)
 
     reconstructed = await patch_obj(
+        logger=logger,
         settings=settings,
         resource=resource,
         namespace=namespace,
@@ -114,7 +117,7 @@ async def test_status_as_subresource_with_object_fields_only(
 
 
 async def test_status_as_subresource_with_status_fields_only(
-        resp_mocker, aresponses, hostname, settings, resource, namespace):
+        resp_mocker, aresponses, hostname, settings, resource, namespace, logger):
     resource = dataclasses.replace(resource, subresources=['status'])
 
     # Simulate Kopf's initial state and intention.
@@ -134,6 +137,7 @@ async def test_status_as_subresource_with_status_fields_only(
     aresponses.add(hostname, status_url, 'patch', status_patch_mock)
 
     reconstructed = await patch_obj(
+        logger=logger,
         settings=settings,
         resource=resource,
         namespace=namespace,
@@ -152,7 +156,7 @@ async def test_status_as_subresource_with_status_fields_only(
 
 
 async def test_status_as_body_field_with_combined_payload(
-        resp_mocker, aresponses, hostname, settings, resource, namespace):
+        resp_mocker, aresponses, hostname, settings, resource, namespace, logger):
 
     # Simulate Kopf's initial state and intention.
     patch = Patch({'spec': {'x': 'y'}, 'status': {'s': 't'}})
@@ -171,6 +175,7 @@ async def test_status_as_body_field_with_combined_payload(
     aresponses.add(hostname, status_url, 'patch', status_patch_mock)
 
     reconstructed = await patch_obj(
+        logger=logger,
         settings=settings,
         resource=resource,
         namespace=namespace,
@@ -192,7 +197,7 @@ async def test_status_as_body_field_with_combined_payload(
 
 @pytest.mark.parametrize('status', [404])
 async def test_ignores_absent_objects(
-        resp_mocker, aresponses, hostname, settings, status, resource, namespace,
+        resp_mocker, aresponses, hostname, settings, status, resource, namespace, logger,
         cluster_resource, namespaced_resource):
 
     patch_mock = resp_mocker(return_value=aresponses.Response(status=status))
@@ -203,6 +208,7 @@ async def test_ignores_absent_objects(
 
     patch = {'x': 'y'}
     result = await patch_obj(
+        logger=logger,
         settings=settings,
         resource=resource,
         namespace=namespace,
@@ -216,7 +222,7 @@ async def test_ignores_absent_objects(
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.
 @pytest.mark.parametrize('status', [400, 403, 500, 666])
 async def test_raises_api_errors(
-        resp_mocker, aresponses, hostname, settings, status, resource, namespace,
+        resp_mocker, aresponses, hostname, settings, status, resource, namespace, logger,
         cluster_resource, namespaced_resource):
 
     patch_mock = resp_mocker(return_value=aresponses.Response(status=status))
@@ -228,6 +234,7 @@ async def test_raises_api_errors(
     patch = {'x': 'y'}
     with pytest.raises(APIError) as e:
         await patch_obj(
+            logger=logger,
             settings=settings,
             resource=resource,
             namespace=namespace,


### PR DESCRIPTION
## What do these changes do?

When a server-side or networking error happens in an API call, retry a limited number of times with a backoff interval between attempts. This should help to stabilise Kopf-based operators in unreliable networks (between the operator and the cluster).


## Description

<!-- What was the previous behaviour before the PR is merged? -->

<!-- What will be the new behaviour after the PR is merged? -->

<!-- A code snippet showing the new features added (if any)? -->

<!-- Does the change affect the end users or is it internal? -->

<!-- Why have you decided to solve the problem this way? What were the trade-offs? (If appropriate.) -->

<!-- Are there any breaking or risky changes? -->


## Issues/PRs

<!-- Cross-referencing is highly useful in hindsight. Put the main issue, and all the related/affected/causing/preceding issues and PRs related to this change. -->

> Issues: #738 #787

> Related:


## Type of changes

<!-- Remove the irrelevant items. Keep only those that reflect the main purpose of the change. -->

- New feature (non-breaking change which adds functionality)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

<!-- Are there any questions or uncertainties left?
     Any tasks that have to be done to complete the PR? -->
