### PR TITLE
Fix tests with namespaces mismatching the resource scopes

### DIFF
--- a/kopf/_core/reactor/orchestration.py
+++ b/kopf/_core/reactor/orchestration.py
@@ -180,6 +180,7 @@ async def spawn_missing_peerings(
         ensemble: Ensemble,
 ) -> None:
     for resource, namespace in itertools.product(resources, namespaces):
+        namespace = namespace if resource.namespaced else None
         dkey = EnsembleKey(resource=resource, namespace=namespace)
         if dkey not in ensemble.peering_tasks:
             what = f"{settings.peering.name}@{namespace}"

--- a/tests/admission/conftest.py
+++ b/tests/admission/conftest.py
@@ -72,7 +72,7 @@ def pkeyfile(tmpdir, certpkey):
 
 
 @pytest.fixture()
-def adm_request(resource):
+def adm_request(resource, namespace):
     return Request(
         apiVersion='admission.k8s.io/v1',
         kind='AdmissionReview',
@@ -84,7 +84,7 @@ def adm_request(resource):
             requestResource=RequestResource(group=resource.group, version=resource.version, resource=resource.plural),
             userInfo=UserInfo(username='user1', uid='useruid1', groups=['group1']),
             name='name1',
-            namespace='ns1',
+            namespace=namespace,
             operation='CREATE',
             options=CreateOptions(apiVersion='meta.k8s.io/v1', kind='CreateOptions'),
             object={'spec': {'field': 'value'}},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,19 +93,19 @@ def enforce_asyncio_mocker(pytestconfig):
 
 
 @pytest.fixture(params=[
-    ('kopf.dev', 'v1', 'clusterkopfpeerings'),
-    ('zalando.org', 'v1', 'clusterkopfpeerings'),
+    ('kopf.dev', 'v1', 'kopfpeerings', True),
+    ('zalando.org', 'v1', 'kopfpeerings', True),
 ], ids=['kopf-dev-namespaced', 'zalando-org-namespaced'])
 def namespaced_peering_resource(request):
-    return Resource(*request.param[:3], namespaced=True)
+    return Resource(*request.param[:3], namespaced=request.param[3])
 
 
 @pytest.fixture(params=[
-    ('kopf.dev', 'v1', 'kopfpeerings'),
-    ('zalando.org', 'v1', 'kopfpeerings'),
+    ('kopf.dev', 'v1', 'clusterkopfpeerings', False),
+    ('zalando.org', 'v1', 'clusterkopfpeerings', False),
 ], ids=['kopf-dev-cluster', 'zalando-org-cluster'])
 def cluster_peering_resource(request):
-    return Resource(*request.param[:3], namespaced=False)
+    return Resource(*request.param[:3], namespaced=request.param[3])
 
 
 @pytest.fixture(params=[

--- a/tests/handling/indexing/conftest.py
+++ b/tests/handling/indexing/conftest.py
@@ -17,8 +17,8 @@ def index(indexers):
 
 
 @pytest.fixture()
-async def indexed_123(indexers, index):
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+async def indexed_123(indexers, index, namespace):
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     key = indexers.make_key(Body(body))
     indexers['index_fn'].replace(key, 123)
     assert set(index) == {None}

--- a/tests/handling/indexing/test_index_exclusion.py
+++ b/tests/handling/indexing/test_index_exclusion.py
@@ -26,9 +26,9 @@ EVENT_TYPES = EVENT_TYPES_WHEN_EXISTS + EVENT_TYPES_WHEN_GONE
 
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_successes_are_removed_from_the_indexing_state(
-        resource, settings, registry, memories, indexers, caplog, event_type, handlers):
+        resource, namespace, settings, registry, memories, indexers, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     memory = await memories.recall(raw_body=body)
     memory.indexing_memory.indexing_state = State({'unrelated': HandlerState(success=True)})
     handlers.index_mock.side_effect = 123
@@ -50,9 +50,9 @@ async def test_successes_are_removed_from_the_indexing_state(
 
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_temporary_failures_with_no_delays_are_reindexed(
-        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers):
+        resource, namespace, settings, registry, memories, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     memory = await memories.recall(raw_body=body)
     memory.indexing_memory.indexing_state = State({'index_fn': HandlerState(delayed=None)})
     await process_resource_event(
@@ -73,9 +73,9 @@ async def test_temporary_failures_with_no_delays_are_reindexed(
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_temporary_failures_with_expired_delays_are_reindexed(
-        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers):
+        resource, namespace, settings, registry, memories, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     delayed = datetime.datetime(2020, 12, 31, 23, 59, 59, 0)
     memory = await memories.recall(raw_body=body)
     memory.indexing_memory.indexing_state = State({'index_fn': HandlerState(delayed=delayed)})
@@ -96,9 +96,9 @@ async def test_temporary_failures_with_expired_delays_are_reindexed(
 
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_permanent_failures_are_not_reindexed(
-        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers):
+        resource, namespace, settings, registry, memories, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     memory = await memories.recall(raw_body=body)
     memory.indexing_memory.indexing_state = State({'index_fn': HandlerState(failure=True)})
     await process_resource_event(
@@ -126,9 +126,9 @@ async def test_permanent_failures_are_not_reindexed(
 @pytest.mark.usefixtures('indexed_123')
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_removed_and_remembered_on_permanent_errors(
-        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers):
+        resource, namespace, settings, registry, memories, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     memory = await memories.recall(raw_body=body)
     handlers.index_mock.side_effect = PermanentError("boo!")
     await process_resource_event(
@@ -161,10 +161,10 @@ async def test_removed_and_remembered_on_permanent_errors(
 @pytest.mark.usefixtures('indexed_123')
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_removed_and_remembered_on_temporary_errors(
-        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers,
-        delay_kwargs, expected_delayed):
+        resource, namespace, settings, registry, memories, indexers, index, handlers,
+        caplog, event_type, delay_kwargs, expected_delayed):
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     memory = await memories.recall(raw_body=body)
     handlers.index_mock.side_effect = TemporaryError("boo!", **delay_kwargs)
     await process_resource_event(
@@ -190,9 +190,9 @@ async def test_removed_and_remembered_on_temporary_errors(
 @pytest.mark.usefixtures('indexed_123')
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_preserved_on_ignored_errors(
-        resource, settings, registry, memories, indexers, index, caplog, event_type, handlers):
+        resource, namespace, settings, registry, memories, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     memory = await memories.recall(raw_body=body)
     handlers.index_mock.side_effect = Exception("boo!")
     await process_resource_event(

--- a/tests/handling/indexing/test_index_population.py
+++ b/tests/handling/indexing/test_index_population.py
@@ -16,9 +16,9 @@ EVENT_TYPES = EVENT_TYPES_WHEN_EXISTS + EVENT_TYPES_WHEN_GONE
 
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_initially_stored(
-        resource, settings, registry, indexers, index, caplog, event_type, handlers):
+        resource, namespace, settings, registry, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     handlers.index_mock.return_value = 123
     await process_resource_event(
         lifecycle=all_at_once,
@@ -39,9 +39,9 @@ async def test_initially_stored(
 @pytest.mark.usefixtures('indexed_123')
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_overwritten(
-        resource, settings, registry, indexers, index, caplog, event_type, handlers):
+        resource, namespace, settings, registry, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     handlers.index_mock.return_value = 456
     await process_resource_event(
         lifecycle=all_at_once,
@@ -62,9 +62,9 @@ async def test_overwritten(
 @pytest.mark.usefixtures('indexed_123')
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_preserved_on_logical_deletion(
-        resource, settings, registry, indexers, index, caplog, event_type, handlers):
+        resource, namespace, settings, registry, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1',
+    body = {'metadata': {'namespace': namespace, 'name': 'name1',
                          'deletionTimestamp': '...'}}
     handlers.index_mock.return_value = 456
     await process_resource_event(
@@ -86,9 +86,9 @@ async def test_preserved_on_logical_deletion(
 @pytest.mark.usefixtures('indexed_123')
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_GONE)
 async def test_removed_on_physical_deletion(
-        resource, settings, registry, indexers, index, caplog, event_type, handlers):
+        resource, namespace, settings, registry, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     handlers.index_mock.return_value = 456
     await process_resource_event(
         lifecycle=all_at_once,
@@ -108,13 +108,14 @@ async def test_removed_on_physical_deletion(
 @pytest.mark.usefixtures('indexed_123')
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_removed_on_filters_mismatch(
-        resource, settings, registry, indexers, index, caplog, event_type, handlers, mocker):
+        resource, namespace, settings, registry, indexers, index,
+        caplog, event_type, handlers, mocker):
 
     # Simulate the indexing handler is gone out of scope (this is only one of the ways to do it):
     mocker.patch.object(registry._indexing, 'get_handlers', return_value=[])
 
     caplog.set_level(logging.DEBUG)
-    body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     handlers.index_mock.return_value = 123
     await process_resource_event(
         lifecycle=all_at_once,

--- a/tests/handling/test_cause_logging.py
+++ b/tests/handling/test_cause_logging.py
@@ -15,10 +15,10 @@ from kopf._core.reactor.processing import process_resource_event
 
 
 @pytest.mark.parametrize('cause_type', ALL_REASONS)
-async def test_all_logs_are_prefixed(registry, settings, resource, handlers,
+async def test_all_logs_are_prefixed(registry, settings, resource, namespace, handlers,
                                      logstream, cause_type, cause_mock):
     event_type = None if cause_type == Reason.RESUME else 'irrelevant'
-    event_body = {'metadata': {'namespace': 'ns1', 'name': 'name1'}}
+    event_body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     cause_mock.reason = cause_type
 
     await process_resource_event(
@@ -35,7 +35,10 @@ async def test_all_logs_are_prefixed(registry, settings, resource, handlers,
 
     lines = logstream.getvalue().splitlines()
     assert lines  # no messages means that we cannot test it
-    assert all(line.startswith('prefix [ns1/name1] ') for line in lines)
+    if namespace:
+        assert all(line.startswith(f'prefix [{namespace}/name1] ') for line in lines)
+    else:
+        assert all(line.startswith('prefix [name1] ') for line in lines)
 
 
 @pytest.mark.parametrize('diff', [

--- a/tests/orchestration/test_task_adjustments.py
+++ b/tests/orchestration/test_task_adjustments.py
@@ -89,8 +89,9 @@ async def test_new_resources_and_namespaces_spawn_new_tasks(
     r1ns2 = EnsembleKey(resource=r1, namespace='ns2')
     r2ns1 = EnsembleKey(resource=r2, namespace='ns1')
     r2ns2 = EnsembleKey(resource=r2, namespace='ns2')
-    peer1 = EnsembleKey(resource=peering_resource, namespace='ns1')
-    peer2 = EnsembleKey(resource=peering_resource, namespace='ns2')
+    peerns = peering_resource.namespaced
+    peer1 = EnsembleKey(resource=peering_resource, namespace='ns1' if peerns else None)
+    peer2 = EnsembleKey(resource=peering_resource, namespace='ns2' if peerns else None)
 
     await adjust_tasks(
         processor=processor,
@@ -120,7 +121,8 @@ async def test_gone_resources_and_namespaces_stop_running_tasks(
     r1ns2 = EnsembleKey(resource=r1, namespace='ns2')
     r2ns1 = EnsembleKey(resource=r2, namespace='ns1')
     r2ns2 = EnsembleKey(resource=r2, namespace='ns2')
-    peer1 = EnsembleKey(resource=peering_resource, namespace='ns1')
+    peerns = peering_resource.namespaced
+    peer1 = EnsembleKey(resource=peering_resource, namespace='ns1' if peerns else None)
 
     await adjust_tasks(  # initialisation
         processor=processor,


### PR DESCRIPTION
Fix some tests with improperly used resources & namespaces. In particular, specific hard-coded namespaces were used with cluster-scoped resources (incl. peering resources), while such resources cannot form a URL — it is an error. However, the errors were silenced because the URL construction happens in the API client routines which were mocked. With #792, the mocked routines were shifted down the stack, and the errors became visible.

This change does not affect the code itself (almost) — only the tests.