### PR TITLE
Extract API sessions & HTTP requests as lower-level client routines

### DIFF
--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -1,0 +1,221 @@
+import asyncio
+import json
+import ssl
+import urllib.parse
+from typing import Any, AsyncIterator, Mapping, Optional, Tuple
+
+import aiohttp
+
+from kopf._cogs.aiokits import aiotasks
+from kopf._cogs.clients import auth, errors
+
+
+@auth.authenticated
+async def get_default_namespace(
+        *,
+        context: Optional[auth.APIContext] = None,
+) -> Optional[str]:
+    if context is None:
+        raise RuntimeError("API instance is not injected by the decorator.")
+    return context.default_namespace
+
+
+@auth.authenticated
+async def read_sslcert(
+        *,
+        context: Optional[auth.APIContext] = None,
+) -> Tuple[str, bytes]:
+    if context is None:
+        raise RuntimeError("API instance is not injected by the decorator.")
+
+    parsed = urllib.parse.urlparse(context.server)
+    host = parsed.hostname or ''  # NB: it cannot be None/empty in our case.
+    port = parsed.port or 443
+    loop = asyncio.get_running_loop()
+    cert = await loop.run_in_executor(None, ssl.get_server_certificate, (host, port))
+    return host, cert.encode('ascii')
+
+
+@auth.authenticated
+async def request(
+        method: str,
+        url: str,  # relative to the server/api root.
+        *,
+        payload: Optional[object] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        timeout: Optional[aiohttp.ClientTimeout] = None,
+        context: Optional[auth.APIContext] = None,  # injected by the decorator
+) -> aiohttp.ClientResponse:
+    if context is None:  # for type-checking!
+        raise RuntimeError("API instance is not injected by the decorator.")
+
+    if '://' not in url:
+        url = context.server.rstrip('/') + '/' + url.lstrip('/')
+
+    # NB: aiohttp uses an internal sentinel for default timeout; None has a different meaning.
+    # TODO: Replace this kwargs hack with our own timeout object.
+    timeout_kwarg = {'timeout': timeout} if timeout is not None else {}
+    response = await context.session.request(
+        method=method,
+        url=url,
+        json=payload,
+        headers=headers,
+        **timeout_kwarg,
+    )
+    await errors.check_response(response)  # but do not parse it!
+    return response
+
+
+async def get(
+        url: str,  # relative to the server/api root.
+        *,
+        payload: Optional[object] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        timeout: Optional[aiohttp.ClientTimeout] = None,
+) -> Any:
+    response = await request(
+        method='get',
+        url=url,
+        payload=payload,
+        headers=headers,
+        timeout=timeout,
+    )
+    return await response.json()
+
+
+async def post(
+        url: str,  # relative to the server/api root.
+        *,
+        payload: Optional[object] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        timeout: Optional[aiohttp.ClientTimeout] = None,
+) -> Any:
+    response = await request(
+        method='post',
+        url=url,
+        payload=payload,
+        headers=headers,
+        timeout=timeout,
+    )
+    return await response.json()
+
+
+async def patch(
+        url: str,  # relative to the server/api root.
+        *,
+        payload: Optional[object] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        timeout: Optional[aiohttp.ClientTimeout] = None,
+) -> Any:
+    response = await request(
+        method='patch',
+        url=url,
+        payload=payload,
+        headers=headers,
+        timeout=timeout,
+    )
+    return await response.json()
+
+
+async def delete(
+        url: str,  # relative to the server/api root.
+        *,
+        payload: Optional[object] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        timeout: Optional[aiohttp.ClientTimeout] = None,
+) -> Any:
+    response = await request(
+        method='delete',
+        url=url,
+        payload=payload,
+        headers=headers,
+        timeout=timeout,
+    )
+    return await response.json()
+
+
+async def stream(
+        url: str,  # relative to the server/api root.
+        *,
+        payload: Optional[object] = None,
+        headers: Optional[Mapping[str, str]] = None,
+        timeout: Optional[aiohttp.ClientTimeout] = None,
+        stopper: Optional[aiotasks.Future] = None,
+) -> AsyncIterator[Any]:
+    response = await request(
+        method='get',
+        url=url,
+        payload=payload,
+        headers=headers,
+        timeout=timeout,
+    )
+    response_close_callback = lambda _: response.close()  # to remove the positional arg.
+    if stopper is not None:
+        stopper.add_done_callback(response_close_callback)
+    try:
+        async with response:
+            async for line in iter_jsonlines(response.content):
+                yield json.loads(line.decode('utf-8'))
+    except aiohttp.ClientConnectionError:
+        if stopper is not None and stopper.done():
+            pass
+        else:
+            raise
+    finally:
+        if stopper is not None:
+            stopper.remove_done_callback(response_close_callback)
+
+
+async def iter_jsonlines(
+        content: aiohttp.StreamReader,
+        chunk_size: int = 1024 * 1024,
+) -> AsyncIterator[bytes]:
+    """
+    Iterate line by line over the response's content.
+
+    Usage::
+
+        async for line in _iter_lines(response.content):
+            pass
+
+    This is an equivalent of::
+
+        async for line in response.content:
+            pass
+
+    Except that the aiohttp's line iteration fails if the accumulated buffer
+    length is above 2**17 bytes, i.e. 128 KB (`aiohttp.streams.DEFAULT_LIMIT`
+    for the buffer's low-watermark, multiplied by 2 for the high-watermark).
+    Kubernetes secrets and other fields can be much longer, up to MBs in length.
+
+    The chunk size of 1MB is an empirical guess for keeping the memory footprint
+    reasonably low on huge amount of small lines (limited to 1 MB in total),
+    while ensuring the near-instant reads of the huge lines (can be a problem
+    with a small chunk size due to too many iterations).
+
+    .. seealso::
+        https://github.com/zalando-incubator/kopf/issues/275
+    """
+
+    # Minimize the memory footprint by keeping at most 2 copies of a yielded line in memory
+    # (in the buffer and as a yielded value), and at most 1 copy of other lines (in the buffer).
+    buffer = b''
+    async for data in content.iter_chunked(chunk_size):
+        buffer += data
+        del data
+
+        start = 0
+        index = buffer.find(b'\n', start)
+        while index >= 0:
+            line = buffer[start:index]
+            if line:
+                yield line
+            del line
+            start = index + 1
+            index = buffer.find(b'\n', start)
+
+        if start > 0:
+            buffer = buffer[start:]
+
+    if buffer:
+        yield buffer

--- a/kopf/_cogs/clients/creating.py
+++ b/kopf/_cogs/clients/creating.py
@@ -1,24 +1,19 @@
 from typing import Optional, cast
 
-from kopf._cogs.clients import auth, errors
+from kopf._cogs.clients import api
 from kopf._cogs.structs import bodies, references
 
 
-@auth.reauthenticated_request
 async def create_obj(
         *,
         resource: references.Resource,
         namespace: references.Namespace = None,
         name: Optional[str] = None,
         body: Optional[bodies.RawBody] = None,
-        context: Optional[auth.APIContext] = None,  # injected by the decorator
 ) -> Optional[bodies.RawBody]:
     """
     Create a resource.
     """
-    if context is None:
-        raise RuntimeError("API instance is not injected by the decorator.")
-
     body = body if body is not None else {}
     if namespace is not None:
         body.setdefault('metadata', {}).setdefault('namespace', namespace)
@@ -26,9 +21,8 @@ async def create_obj(
         body.setdefault('metadata', {}).setdefault('name', name)
 
     namespace = cast(references.Namespace, body.get('metadata', {}).get('namespace'))
-    response = await context.session.post(
-        url=resource.get_url(server=context.server, namespace=namespace),
-        json=body,
+    created_body: bodies.RawBody = await api.post(
+        url=resource.get_url(namespace=namespace),
+        payload=body,
     )
-    created_body: bodies.RawBody = await errors.parse_response(response)
     return created_body

--- a/kopf/_cogs/clients/errors.py
+++ b/kopf/_cogs/clients/errors.py
@@ -27,7 +27,7 @@ as the reasons of failures. However, the errors are exposed to other packages.
 """
 import collections.abc
 import json
-from typing import Any, Collection, Optional
+from typing import Collection, Optional
 
 import aiohttp
 from typing_extensions import Literal, TypedDict
@@ -138,14 +138,3 @@ async def check_response(
             response.raise_for_status()
         except aiohttp.ClientResponseError as e:
             raise cls(payload, status=response.status) from e
-
-
-async def parse_response(
-        response: aiohttp.ClientResponse,
-) -> Any:
-    """
-    Check the response for errors, and either raise or returned the parsed data.
-    """
-    await check_response(response)
-    payload = await response.json()
-    return payload

--- a/kopf/_cogs/clients/fetching.py
+++ b/kopf/_cogs/clients/fetching.py
@@ -5,7 +5,7 @@ from kopf._cogs.structs import bodies, references
 
 
 @auth.reauthenticated_request
-async def list_objs_rv(
+async def list_objs(
         *,
         resource: references.Resource,
         namespace: references.Namespace,

--- a/kopf/_cogs/clients/watching.py
+++ b/kopf/_cogs/clients/watching.py
@@ -156,9 +156,12 @@ async def continuous_watch(
 
     # First, list the resources regularly, and get the list's resource version.
     # Simulate the events with type "None" event - used in detection of causes.
-    items, resource_version = await fetching.list_objs_rv(resource=resource, namespace=namespace)
-    for item in items:
-        yield {'type': None, 'object': item}
+    objs, resource_version = await fetching.list_objs(
+        resource=resource,
+        namespace=namespace,
+    )
+    for obj in objs:
+        yield {'type': None, 'object': obj}
 
     # Notify the watcher that the initial listing is over, even if there was nothing yielded.
     yield Bookmark.LISTED

--- a/kopf/_cogs/structs/credentials.py
+++ b/kopf/_cogs/structs/credentials.py
@@ -103,8 +103,7 @@ class Vault(AsyncIterable[Tuple[VaultKey, ConnectionInfo]]):
     * Populated by the authenticator background task when and if needed.
 
     .. seealso::
-        :func:`reauthenticated_request`/:func:`reauthenticated_stream`
-        and :func:`authentication`.
+        :func:`auth.authenticated` and :func:`authentication`.
     """
     _current: Dict[VaultKey, VaultItem]
     _invalid: Dict[VaultKey, List[VaultItem]]

--- a/kopf/_core/reactor/observation.py
+++ b/kopf/_core/reactor/observation.py
@@ -48,7 +48,7 @@ async def namespace_observer(
     # Populate the namespaces atomically (instead of notifying on every item from the watch-stream).
     if not settings.scanning.disabled and not clusterwide:
         try:
-            objs, _ = await fetching.list_objs_rv(resource=resource, namespace=None)
+            objs, _ = await fetching.list_objs(resource=resource, namespace=None)
             async with insights.revised:
                 revise_namespaces(raw_bodies=objs, insights=insights, namespaces=namespaces)
                 insights.revised.notify_all()

--- a/kopf/_kits/webhooks.py
+++ b/kopf/_kits/webhooks.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, AsyncIterator, Collection, Dict, Iterable, Opt
 
 import aiohttp.web
 
-from kopf._cogs.clients import scanning
+from kopf._cogs.clients import api, scanning
 from kopf._cogs.structs import reviews
 from kopf._core.engines import admission
 
@@ -564,7 +564,7 @@ class ClusterDetector:
                 "run `pip install certvalidator` or `pip install kopf[dev]`. "
                 "More: https://kopf.readthedocs.io/en/stable/admission/")
 
-        hostname, cert = await scanning.read_sslcert()
+        hostname, cert = await api.read_sslcert()
         valcontext = certvalidator.ValidationContext(extra_trust_roots=[cert])
         validator = certvalidator.CertificateValidator(cert, validation_context=valcontext)
         certpath = validator.validate_tls(hostname)

--- a/tests/admission/conftest.py
+++ b/tests/admission/conftest.py
@@ -1,7 +1,6 @@
 import asyncio
 import dataclasses
 import warnings
-from unittest.mock import Mock
 
 import pyngrok.conf
 import pyngrok.ngrok
@@ -122,25 +121,6 @@ async def insights(settings, resource):
 def indices():
     indexers = OperatorIndexers()
     return indexers.indices
-
-
-@dataclasses.dataclass(frozen=True, eq=False)
-class K8sMocks:
-    patch_obj: Mock
-    create_obj: Mock
-    post_event: Mock
-    sleep: Mock
-
-
-@pytest.fixture(autouse=True)
-def k8s_mocked(mocker):
-    # We mock on the level of our own K8s API wrappers, not the K8s client.
-    return K8sMocks(
-        patch_obj=mocker.patch('kopf._cogs.clients.patching.patch_obj', return_value={}),
-        create_obj=mocker.patch('kopf._cogs.clients.creating.create_obj', return_value={}),
-        post_event=mocker.patch('kopf._cogs.clients.events.post_event'),
-        sleep=mocker.patch('kopf._cogs.aiokits.aiotime.sleep', return_value=None),
-    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/apis/test_api_requests.py
+++ b/tests/apis/test_api_requests.py
@@ -1,0 +1,176 @@
+import asyncio
+import textwrap
+import time
+
+import aiohttp.web
+import pytest
+
+from kopf._cogs.clients.api import delete, get, patch, post, request, stream
+from kopf._cogs.clients.errors import APIError
+
+
+@pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
+async def test_raw_requests_work(resp_mocker, aresponses, hostname, method):
+    mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    aresponses.add(hostname, '/url', method, mock)
+    response = await request(
+        method=method,
+        url='/url',
+        payload={'fake': 'payload'},
+        headers={'fake': 'headers'},
+    )
+    assert isinstance(response, aiohttp.ClientResponse)  # unparsed!
+    assert mock.call_count == 1
+    assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
+    assert mock.call_args[0][0].method.lower() == method
+    assert mock.call_args[0][0].path == '/url'
+    assert mock.call_args[0][0].data == {'fake': 'payload'}
+    assert mock.call_args[0][0].headers['fake'] == 'headers'  # and other system headers
+
+
+@pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
+async def test_raw_requests_are_not_parsed(resp_mocker, aresponses, hostname, method):
+    mock = resp_mocker(return_value=aresponses.Response(text='BAD JSON!'))
+    aresponses.add(hostname, '/url', method, mock)
+    response = await request(method, '/url')
+    assert isinstance(response, aiohttp.ClientResponse)
+
+
+@pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
+async def test_server_errors_escalate(resp_mocker, aresponses, hostname, method):
+    mock = resp_mocker(return_value=aiohttp.web.json_response({}, status=666))
+    aresponses.add(hostname, '/url', method, mock)
+    with pytest.raises(APIError) as err:
+        await request(method, '/url')
+    assert err.value.status == 666
+
+
+@pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
+async def test_relative_urls_are_prepended_with_server(resp_mocker, aresponses, hostname, method):
+    mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    aresponses.add(hostname, '/url', method, mock)
+    await request(method, '/url')
+    assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
+    assert str(mock.call_args[0][0].url) == f'http://{hostname}/url'
+
+
+@pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
+async def test_absolute_urls_are_passed_through(resp_mocker, aresponses, hostname, method):
+    mock = resp_mocker(return_value=aiohttp.web.json_response({}))
+    aresponses.add(hostname, '/url', method, mock)
+    aresponses.add('fakehost.localdomain', '/url', method, mock)
+    await request(method, 'http://fakehost.localdomain/url')
+    assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
+    assert str(mock.call_args[0][0].url) == 'http://fakehost.localdomain/url'
+
+
+@pytest.mark.parametrize('fn, method', [
+    (get, 'get'),
+    (post, 'post'),
+    (patch, 'patch'),
+    (delete, 'delete'),
+])
+async def test_parsing_in_requests(resp_mocker, aresponses, hostname, fn, method):
+    mock = resp_mocker(return_value=aiohttp.web.json_response({'fake': 'result'}))
+    aresponses.add(hostname, '/url', method, mock)
+    response = await fn(
+        url='/url',
+        payload={'fake': 'payload'},
+        headers={'fake': 'headers'},
+    )
+    assert response == {'fake': 'result'}  # parsed!
+    assert mock.call_count == 1
+    assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
+    assert mock.call_args[0][0].method.lower() == method
+    assert mock.call_args[0][0].path == '/url'
+    assert mock.call_args[0][0].data == {'fake': 'payload'}
+    assert mock.call_args[0][0].headers['fake'] == 'headers'  # and other system headers
+
+
+@pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
+async def test_parsing_in_streams(resp_mocker, aresponses, hostname, method):
+    mock = resp_mocker(return_value=aresponses.Response(text=textwrap.dedent("""
+        {"fake": "result1"}
+        {"fake": "result2"}
+    """)))
+    aresponses.add(hostname, '/url', method, mock)
+
+    items = []
+    async for item in stream(
+        url='/url',
+        payload={'fake': 'payload'},
+        headers={'fake': 'headers'},
+    ):
+        items.append(item)
+
+    assert items == [{'fake': 'result1'}, {'fake': 'result2'}]
+    assert mock.call_count == 1
+    assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
+    assert mock.call_args[0][0].method.lower() == method
+    assert mock.call_args[0][0].path == '/url'
+    assert mock.call_args[0][0].data == {'fake': 'payload'}
+    assert mock.call_args[0][0].headers['fake'] == 'headers'  # and other system headers
+
+
+@pytest.mark.parametrize('fn, method', [
+    (get, 'get'),
+    (post, 'post'),
+    (patch, 'patch'),
+    (delete, 'delete'),
+])
+async def test_timeout_in_requests(resp_mocker, aresponses, hostname, fn, method):
+
+    def serve_slowly():
+        time.sleep(0.2)
+        return aiohttp.web.json_response({})
+
+    mock = resp_mocker(side_effect=serve_slowly)
+    aresponses.add(hostname, '/url', method, mock)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await fn('/url', timeout=aiohttp.ClientTimeout(total=0.1))
+
+
+@pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
+async def test_timeout_in_streams(resp_mocker, aresponses, hostname, method):
+
+    def serve_slowly():
+        time.sleep(0.2)
+        return "{}"
+
+    mock = resp_mocker(side_effect=serve_slowly)
+    aresponses.add(hostname, '/url', method, mock)
+
+    with pytest.raises(asyncio.TimeoutError):
+        async for _ in stream('/url', timeout=aiohttp.ClientTimeout(total=0.1)):
+            pass
+
+
+@pytest.mark.parametrize('delay, expected', [
+    pytest.param(0.0, [], id='instant-none'),
+    pytest.param(0.1, [{'fake': 'result1'}], id='fast-single'),
+    pytest.param(9.9, [{'fake': 'result1'}, {'fake': 'result2'}], id='inf-double'),
+])
+@pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
+async def test_stopper_in_streams(resp_mocker, aresponses, hostname, method, delay, expected):
+
+    async def stream_slowly(request: aiohttp.ClientRequest):
+        response = aiohttp.web.StreamResponse()
+        await response.prepare(request)
+        await asyncio.sleep(0.05)
+        await response.write(b'{"fake": "result1"}\n')
+        await asyncio.sleep(0.15)
+        await response.write(b'{"fake": "result2"}\n')
+        await response.write_eof()
+        return response
+
+    aresponses.add(hostname, '/url', method, stream_slowly)
+
+    stopper = asyncio.Future()
+    asyncio.get_running_loop().call_later(delay, stopper.set_result, None)
+
+    items = []
+    async for item in stream('/url', stopper=stopper):
+        items.append(item)
+
+    assert items == expected

--- a/tests/apis/test_default_namespace.py
+++ b/tests/apis/test_default_namespace.py
@@ -1,0 +1,13 @@
+from kopf._cogs.clients.api import get_default_namespace
+
+
+async def test_default_namespace_when_unset(mocker, enforced_context):
+    mocker.patch.object(enforced_context, 'default_namespace', None)
+    ns = await get_default_namespace()
+    assert ns is None
+
+
+async def test_default_namespace_when_set(mocker, enforced_context):
+    mocker.patch.object(enforced_context, 'default_namespace', 'xyz')
+    ns = await get_default_namespace()
+    assert ns == 'xyz'

--- a/tests/apis/test_iterjsonlines.py
+++ b/tests/apis/test_iterjsonlines.py
@@ -1,6 +1,6 @@
 import asynctest
 
-from kopf._cogs.clients.watching import _iter_jsonlines
+from kopf._cogs.clients.api import iter_jsonlines
 
 
 async def test_empty_content():
@@ -10,7 +10,7 @@ async def test_empty_content():
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_jsonlines(content):
+    async for line in iter_jsonlines(content):
         lines.append(line)
 
     assert lines == []
@@ -22,7 +22,7 @@ async def test_empty_chunk():
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_jsonlines(content):
+    async for line in iter_jsonlines(content):
         lines.append(line)
 
     assert lines == []
@@ -34,7 +34,7 @@ async def test_one_chunk_one_line():
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_jsonlines(content):
+    async for line in iter_jsonlines(content):
         lines.append(line)
 
     assert lines == [b'hello']
@@ -46,7 +46,7 @@ async def test_one_chunk_two_lines():
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_jsonlines(content):
+    async for line in iter_jsonlines(content):
         lines.append(line)
 
     assert lines == [b'hello', b'world']
@@ -58,7 +58,7 @@ async def test_one_chunk_empty_lines():
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_jsonlines(content):
+    async for line in iter_jsonlines(content):
         lines.append(line)
 
     assert lines == [b'hello', b'world']
@@ -72,7 +72,7 @@ async def test_few_chunks_split():
 
     content = asynctest.Mock(iter_chunked=iter_chunked)
     lines = []
-    async for line in _iter_jsonlines(content):
+    async for line in iter_jsonlines(content):
         lines.append(line)
 
     assert lines == [b'hello', b'world']

--- a/tests/authentication/test_credentials.py
+++ b/tests/authentication/test_credentials.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from kopf._cogs.clients.auth import APIContext, reauthenticated_request, vault_var
+from kopf._cogs.clients.auth import APIContext, authenticated, vault_var
 from kopf._cogs.structs.credentials import ConnectionInfo, Vault
 
 # These are Minikube's locally geenrated certificates (CN=minikubeCA).
@@ -83,7 +83,7 @@ lUXVsCYgw8yNCm10xGCelpJ4nxxPhf5apbz4F3nGORGfsv5C+x++
 ''').strip()
 
 
-@reauthenticated_request
+@authenticated
 async def fn(context: APIContext):
     return context.session
 

--- a/tests/authentication/test_reauthentication.py
+++ b/tests/authentication/test_reauthentication.py
@@ -1,13 +1,13 @@
-from typing import AsyncIterator, Optional, Tuple
+from typing import Optional, Tuple
 
 import aiohttp.web
 
-from kopf._cogs.clients.auth import APIContext, reauthenticated_request, reauthenticated_stream
+from kopf._cogs.clients.auth import APIContext, authenticated
 from kopf._cogs.structs.credentials import ConnectionInfo
 
 
-@reauthenticated_request
-async def request_fn(
+@authenticated
+async def fn(
         x: int,
         *,
         context: Optional[APIContext],
@@ -15,48 +15,21 @@ async def request_fn(
     return context, x + 100
 
 
-@reauthenticated_stream
-async def stream_fn(
-        x: int,
-        *,
-        context: Optional[APIContext],
-) -> AsyncIterator[Tuple[APIContext, int]]:
-    yield context, x + 100
-
-
-async def test_session_is_injected_to_request(
+async def test_session_is_injected(
         fake_vault, resp_mocker, aresponses, hostname, resource, namespace):
 
     result = {}
     get_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
     aresponses.add(hostname, resource.get_url(namespace=namespace, name='xyz'), 'get', get_mock)
 
-    context, result = await request_fn(1)
+    context, result = await fn(1)
 
     async with context.session:
         assert context is not None
         assert result == 101
 
 
-async def test_session_is_injected_to_stream(
-        fake_vault, resp_mocker, aresponses, hostname, resource, namespace):
-
-    result = {}
-    get_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
-    aresponses.add(hostname, resource.get_url(namespace=namespace, name='xyz'), 'get', get_mock)
-
-    context = None
-    counter = 0
-    async for context, result in stream_fn(1):
-        counter += 1
-
-    async with context.session:
-        assert context is not None
-        assert result == 101
-        assert counter == 1
-
-
-async def test_session_is_passed_through_to_request(
+async def test_session_is_passed_through(
         fake_vault, resp_mocker, aresponses, hostname, resource, namespace):
 
     result = {}
@@ -64,26 +37,8 @@ async def test_session_is_passed_through_to_request(
     aresponses.add(hostname, resource.get_url(namespace=namespace, name='xyz'), 'get', get_mock)
 
     explicit_context = APIContext(ConnectionInfo(server='http://irrelevant/'))
-    context, result = await request_fn(1, context=explicit_context)
+    context, result = await fn(1, context=explicit_context)
 
     async with context.session:
         assert context is explicit_context
         assert result == 101
-
-
-async def test_session_is_passed_through_to_stream(
-        fake_vault, resp_mocker, aresponses, hostname, resource, namespace):
-
-    result = {}
-    get_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
-    aresponses.add(hostname, resource.get_url(namespace=namespace, name='xyz'), 'get', get_mock)
-
-    explicit_context = APIContext(ConnectionInfo(server='http://irrelevant/'))
-    counter = 0
-    async for context, result in stream_fn(1, context=explicit_context):
-        counter += 1
-
-    async with context.session:
-        assert context is explicit_context
-        assert result == 101
-        assert counter == 1

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -43,21 +43,9 @@ import kopf
 from kopf._core.intents.causes import ChangingCause
 
 
-@dataclasses.dataclass(frozen=True, eq=False)
-class K8sMocks:
-    patch_obj: Mock
-    post_event: Mock
-    sleep: Mock
-
-
 @pytest.fixture(autouse=True)
-def k8s_mocked(mocker, resp_mocker):
-    # We mock on the level of our own K8s API wrappers, not the K8s client.
-    return K8sMocks(
-        patch_obj=mocker.patch('kopf._cogs.clients.patching.patch_obj', return_value={}),
-        post_event=mocker.patch('kopf._cogs.clients.events.post_event'),
-        sleep=mocker.patch('kopf._cogs.aiokits.aiotime.sleep', return_value=None),
-    )
+def _auto_mocked(k8s_mocked):
+    pass
 
 
 @dataclasses.dataclass(frozen=True, eq=False, order=False)

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -67,8 +67,8 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
         )
 
         # Do the same as k8s does: merge the patches into the object.
-        for call in k8s_mocked.patch_obj.call_args_list:
-            _merge_dicts(call[1]['patch'], event_object)
+        for call in k8s_mocked.patch.call_args_list:
+            _merge_dicts(call[1]['payload'], event_object)
 
     return _simulate_cycle
 

--- a/tests/handling/daemons/test_daemon_errors.py
+++ b/tests/handling/daemons/test_daemon_errors.py
@@ -23,7 +23,7 @@ async def test_daemon_stopped_on_permanent_error(
     await dummy.wait_for_daemon_done()
 
     assert dummy.mock.call_count == 1
-    assert k8s_mocked.patch_obj.call_count == 0
+    assert k8s_mocked.patch.call_count == 0
     assert k8s_mocked.sleep.call_count == 0
 
     assert_logs([

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -35,8 +35,8 @@ async def test_daemon_exits_gracefully_and_instantly_on_termination_request(
 
     assert timer.seconds < 0.01  # near-instantly
     assert k8s_mocked.sleep.call_count == 0
-    assert k8s_mocked.patch_obj.call_count == 1
-    assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_count == 1
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
 
 
 @pytest.mark.usefixtures('background_daemon_killer')
@@ -103,8 +103,8 @@ async def test_daemon_exits_instantly_via_cancellation_with_backoff(
 
     assert k8s_mocked.sleep.call_count == 1
     assert k8s_mocked.sleep.call_args_list[0][0][0] == 5.0
-    assert k8s_mocked.patch_obj.call_count == 1
-    assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_count == 1
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
 
     # 2nd cycle: cancelling after the backoff is reached. Wait for cancellation timeout.
     mocker.resetall()
@@ -112,8 +112,8 @@ async def test_daemon_exits_instantly_via_cancellation_with_backoff(
     await simulate_cycle(event_object)
 
     assert k8s_mocked.sleep.call_count == 0
-    assert k8s_mocked.patch_obj.call_count == 1
-    assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_count == 1
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
 
     # Cleanup.
     await dummy.wait_for_daemon_done()
@@ -147,8 +147,8 @@ async def test_daemon_exits_slowly_via_cancellation_with_backoff(
 
     assert k8s_mocked.sleep.call_count == 1
     assert k8s_mocked.sleep.call_args_list[0][0][0] == 5.0
-    assert k8s_mocked.patch_obj.call_count == 1
-    assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_count == 1
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
 
     # 2nd cycle: cancelling after the backoff is reached. Wait for cancellation timeout.
     mocker.resetall()
@@ -157,8 +157,8 @@ async def test_daemon_exits_slowly_via_cancellation_with_backoff(
 
     assert k8s_mocked.sleep.call_count == 1
     assert k8s_mocked.sleep.call_args_list[0][0][0] == 10.0
-    assert k8s_mocked.patch_obj.call_count == 1
-    assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_count == 1
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
 
     # 3rd cycle: the daemon has exited, the resource should be unblocked from actual deletion.
     mocker.resetall()
@@ -169,8 +169,8 @@ async def test_daemon_exits_slowly_via_cancellation_with_backoff(
     await dummy.wait_for_daemon_done()
 
     assert k8s_mocked.sleep.call_count == 0
-    assert k8s_mocked.patch_obj.call_count == 1
-    assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_count == 1
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
 
 
 async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
@@ -201,8 +201,8 @@ async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
 
     assert k8s_mocked.sleep.call_count == 1
     assert k8s_mocked.sleep.call_args_list[0][0][0] == 10.0
-    assert k8s_mocked.patch_obj.call_count == 1
-    assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_count == 1
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
 
     # 2rd cycle: the daemon has exited, the resource should be unblocked from actual deletion.
     mocker.resetall()
@@ -211,8 +211,8 @@ async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
         await simulate_cycle(event_object)
 
     assert k8s_mocked.sleep.call_count == 0
-    assert k8s_mocked.patch_obj.call_count == 1
-    assert k8s_mocked.patch_obj.call_args_list[0][1]['patch']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_count == 1
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
     assert_logs(["Daemon 'fn' did not exit in time. Leaving it orphaned."])
 
     # Cleanup.

--- a/tests/handling/subhandling/test_subhandling.py
+++ b/tests/handling/subhandling/test_subhandling.py
@@ -58,7 +58,7 @@ async def test_1st_level(registry, settings, resource, cause_mock, event_type,
     assert sub1b_mock.call_count == 1
 
     assert k8s_mocked.sleep.call_count == 0
-    assert k8s_mocked.patch_obj.call_count == 1
+    assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 
     assert_logs([
@@ -138,7 +138,7 @@ async def test_2nd_level(registry, settings, resource, cause_mock, event_type,
     assert sub1b2b_mock.call_count == 1
 
     assert k8s_mocked.sleep.call_count == 0
-    assert k8s_mocked.patch_obj.call_count == 1
+    assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 
     assert_logs([

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -40,10 +40,10 @@ async def test_create(registry, settings, handlers, resource, cause_mock, event_
     assert not handlers.delete_mock.called
 
     assert k8s_mocked.sleep.call_count == 0
-    assert k8s_mocked.patch_obj.call_count == 1
+    assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
     assert 'metadata' in patch
     assert 'annotations' in patch['metadata']
     assert LAST_SEEN_ANNOTATION in patch['metadata']['annotations']
@@ -81,10 +81,10 @@ async def test_update(registry, settings, handlers, resource, cause_mock, event_
     assert not handlers.delete_mock.called
 
     assert k8s_mocked.sleep.call_count == 0
-    assert k8s_mocked.patch_obj.call_count == 1
+    assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
     assert 'metadata' in patch
     assert 'annotations' in patch['metadata']
     assert LAST_SEEN_ANNOTATION in patch['metadata']['annotations']
@@ -124,7 +124,7 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
     assert handlers.delete_mock.call_count == 1
 
     assert k8s_mocked.sleep.call_count == 0
-    assert k8s_mocked.patch_obj.call_count == 1
+    assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 
     assert_logs([
@@ -164,7 +164,7 @@ async def test_gone(registry, settings, handlers, resource, cause_mock, event_ty
     assert not handlers.update_mock.called
     assert not handlers.delete_mock.called
 
-    assert not k8s_mocked.patch_obj.called
+    assert not k8s_mocked.patch.called
     assert event_queue.empty()
 
     assert_logs([
@@ -196,7 +196,7 @@ async def test_free(registry, settings, handlers, resource, cause_mock, event_ty
     assert not handlers.delete_mock.called
 
     assert not k8s_mocked.sleep.called
-    assert not k8s_mocked.patch_obj.called
+    assert not k8s_mocked.patch.called
     assert event_queue.empty()
 
     assert_logs([
@@ -228,7 +228,7 @@ async def test_noop(registry, settings, handlers, resource, cause_mock, event_ty
     assert not handlers.delete_mock.called
 
     assert not k8s_mocked.sleep.called
-    assert not k8s_mocked.patch_obj.called
+    assert not k8s_mocked.patch.called
     assert event_queue.empty()
 
     assert_logs([

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -52,10 +52,10 @@ async def test_delayed_handlers_progress(
     assert handlers.resume_mock.call_count == (1 if cause_reason == Reason.RESUME else 0)
 
     assert not k8s_mocked.sleep.called
-    assert k8s_mocked.patch_obj.called
+    assert k8s_mocked.patch.called
 
     fname = f'{cause_reason}_fn'
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
     assert patch['status']['kopf']['progress'][fname]['delayed'] == delayed_iso
 
     assert_logs([
@@ -109,8 +109,8 @@ async def test_delayed_handlers_sleep(
     assert not handlers.resume_mock.called
 
     # The dummy patch is needed to trigger the further changes. The value is irrelevant.
-    assert k8s_mocked.patch_obj.called
-    assert 'dummy' in k8s_mocked.patch_obj.call_args_list[-1][1]['patch']['status']['kopf']
+    assert k8s_mocked.patch.called
+    assert 'dummy' in k8s_mocked.patch.call_args_list[-1][1]['payload']['status']['kopf']
 
     # The duration of sleep should be as expected.
     assert k8s_mocked.sleep.called

--- a/tests/handling/test_error_handling.py
+++ b/tests/handling/test_error_handling.py
@@ -45,9 +45,9 @@ async def test_fatal_error_stops_handler(
     assert handlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
     assert not k8s_mocked.sleep.called
-    assert k8s_mocked.patch_obj.called
+    assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
     assert patch['status']['kopf']['progress'] is not None
     assert patch['status']['kopf']['progress'][name1]['failure'] is True
     assert patch['status']['kopf']['progress'][name1]['message'] == 'oops'
@@ -90,9 +90,9 @@ async def test_retry_error_delays_handler(
     assert handlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
     assert not k8s_mocked.sleep.called
-    assert k8s_mocked.patch_obj.called
+    assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
     assert patch['status']['kopf']['progress'] is not None
     assert patch['status']['kopf']['progress'][name1]['failure'] is False
     assert patch['status']['kopf']['progress'][name1]['success'] is False
@@ -136,9 +136,9 @@ async def test_arbitrary_error_delays_handler(
     assert handlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
     assert not k8s_mocked.sleep.called
-    assert k8s_mocked.patch_obj.called
+    assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
     assert patch['status']['kopf']['progress'] is not None
     assert patch['status']['kopf']['progress'][name1]['failure'] is False
     assert patch['status']['kopf']['progress'][name1]['success'] is False

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -47,9 +47,9 @@ async def test_1st_step_stores_progress_by_patching(
     assert handlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
     assert not k8s_mocked.sleep.called
-    assert k8s_mocked.patch_obj.called
+    assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
     assert patch['status']['kopf']['progress'] is not None
 
     assert patch['status']['kopf']['progress'][name1]['retries'] == 1
@@ -107,9 +107,9 @@ async def test_2nd_step_finishes_the_handlers(caplog,
     assert extrahandlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
     assert not k8s_mocked.sleep.called
-    assert k8s_mocked.patch_obj.called
+    assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
     assert patch['status']['kopf']['progress'] == {name1: None, name2: None}
 
     # Finalizers could be removed for resources being deleted on the 2nd step.

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -47,10 +47,10 @@ async def test_skipped_with_no_handlers(
     )
 
     assert not k8s_mocked.sleep.called
-    assert k8s_mocked.patch_obj.called
+    assert k8s_mocked.patch.called
 
     # The patch must contain ONLY the last-seen update, and nothing else.
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
     assert set(patch.keys()) == {'metadata'}
     assert set(patch['metadata'].keys()) == {'annotations'}
     assert set(patch['metadata']['annotations'].keys()) == {LAST_SEEN_ANNOTATION}
@@ -103,5 +103,5 @@ async def test_stealth_mode_with_mismatching_handlers(
     )
 
     assert not k8s_mocked.sleep.called
-    assert not k8s_mocked.patch_obj.called
+    assert not k8s_mocked.patch.called
     assert not caplog.messages  # total stealth mode!

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -55,9 +55,9 @@ async def test_timed_out_handler_fails(
 
     # Progress is reset, as the handler is not going to retry.
     assert not k8s_mocked.sleep.called
-    assert k8s_mocked.patch_obj.called
+    assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
     assert patch['status']['kopf']['progress'] is not None
     assert patch['status']['kopf']['progress'][name1]['failure'] is True
 
@@ -105,9 +105,9 @@ async def test_retries_limited_handler_fails(
 
     # Progress is reset, as the handler is not going to retry.
     assert not k8s_mocked.sleep.called
-    assert k8s_mocked.patch_obj.called
+    assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch_obj.call_args_list[0][1]['patch']
+    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
     assert patch['status']['kopf']['progress'] is not None
     assert patch['status']['kopf']['progress'][name1]['failure'] is True
 

--- a/tests/handling/test_timing_consistency.py
+++ b/tests/handling/test_timing_consistency.py
@@ -74,5 +74,5 @@ async def test_consistent_awakening(registry, settings, resource, k8s_mocked, mo
 
     # Without "now"-time consistency, neither sleep() would be called, nor a patch applied.
     # Verify that the patch was actually applied, so that the reaction cycle continues.
-    assert k8s_mocked.patch_obj.called
-    assert 'dummy' in k8s_mocked.patch_obj.call_args_list[-1][1]['patch']['status']['kopf']
+    assert k8s_mocked.patch.called
+    assert 'dummy' in k8s_mocked.patch.call_args_list[-1][1]['payload']['status']['kopf']

--- a/tests/k8s/test_errors.py
+++ b/tests/k8s/test_errors.py
@@ -1,12 +1,12 @@
 import aiohttp
 import pytest
 
-from kopf._cogs.clients.auth import APIContext, reauthenticated_request
+from kopf._cogs.clients.auth import APIContext, authenticated
 from kopf._cogs.clients.errors import APIConflictError, APIError, APIForbiddenError, \
                                       APINotFoundError, check_response
 
 
-@reauthenticated_request
+@authenticated
 async def get_it(url: str, *, context: APIContext) -> None:
     response = await context.session.get(url)
     await check_response(response)

--- a/tests/k8s/test_events.py
+++ b/tests/k8s/test_events.py
@@ -79,7 +79,7 @@ async def test_regular_errors_escalate(
         resp_mocker, enforced_session, mocker):
 
     error = Exception('boo!')
-    enforced_session.post = mocker.Mock(side_effect=error)
+    enforced_session.request = mocker.Mock(side_effect=error)
 
     obj = {'apiVersion': 'group/version',
            'kind': 'kind',
@@ -116,7 +116,8 @@ async def test_message_is_cut_to_max_length(
     assert data['message'].endswith('end')
 
 
-@pytest.mark.parametrize('status', [555, 500, 404, 403, 401])
+# 401 causes LoginError from the vault, and this is out of scope of API testing.
+@pytest.mark.parametrize('status', [555, 500, 404, 403])
 async def test_headers_are_not_leaked(
         resp_mocker, aresponses, hostname, assert_logs, status):
 

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -2,7 +2,7 @@ import aiohttp.web
 import pytest
 
 from kopf._cogs.clients.errors import APIError
-from kopf._cogs.clients.fetching import list_objs_rv
+from kopf._cogs.clients.fetching import list_objs
 from kopf._cogs.structs.credentials import LoginError
 
 
@@ -17,7 +17,7 @@ async def test_listing_works(
     aresponses.add(hostname, cluster_url, 'get', list_mock)
     aresponses.add(hostname, namespaced_url, 'get', list_mock)
 
-    items, resource_version = await list_objs_rv(resource=resource, namespace=namespace)
+    items, resource_version = await list_objs(resource=resource, namespace=namespace)
     assert items == result['items']
 
     assert list_mock.called
@@ -37,5 +37,5 @@ async def test_raises_direct_api_errors(
     aresponses.add(hostname, namespaced_url, 'get', list_mock)
 
     with pytest.raises(APIError) as e:
-        await list_objs_rv(resource=resource, namespace=namespace)
+        await list_objs(resource=resource, namespace=namespace)
     assert e.value.status == status

--- a/tests/k8s/test_watching_continuously.py
+++ b/tests/k8s/test_watching_continuously.py
@@ -141,7 +141,7 @@ async def test_unknown_error_raises_exception(
 async def test_exception_escalates(
         settings, resource, stream, namespace, enforced_session, mocker):
 
-    enforced_session.get = mocker.Mock(side_effect=SampleException())
+    enforced_session.request = mocker.Mock(side_effect=SampleException())
     stream.feed([], namespace=namespace)
     stream.close(namespace=namespace)
 

--- a/tests/k8s/test_watching_infinitely.py
+++ b/tests/k8s/test_watching_infinitely.py
@@ -22,7 +22,7 @@ class SampleException(Exception):
 async def test_exception_escalates(
         settings, resource, stream, namespace, enforced_session, mocker):
 
-    enforced_session.get = mocker.Mock(side_effect=SampleException())
+    enforced_session.request = mocker.Mock(side_effect=SampleException())
     stream.feed([], namespace=namespace)
     stream.close(namespace=namespace)
 

--- a/tests/orchestration/test_task_adjustments.py
+++ b/tests/orchestration/test_task_adjustments.py
@@ -1,7 +1,5 @@
 import asyncio
-import dataclasses
 from typing import Optional
-from unittest.mock import Mock
 
 import pytest
 
@@ -16,17 +14,9 @@ async def processor(*, raw_event: bodies.RawEvent, stream_pressure: Optional[asy
     pass
 
 
-@dataclasses.dataclass(frozen=True, eq=False)
-class K8sMocks:
-    patch_obj: Mock
-
-
 @pytest.fixture(autouse=True)
-def k8s_mocked(mocker, resp_mocker):
-    # We mock on the level of our own K8s API wrappers, not the K8s client.
-    return K8sMocks(
-        patch_obj=mocker.patch('kopf._cogs.clients.patching.patch_obj', return_value={}),
-    )
+def _auto_mocked(k8s_mocked):
+    pass
 
 
 @pytest.fixture()

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 
 import pytest
 
-from kopf._cogs.clients.auth import APIContext, reauthenticated_request
+from kopf._cogs.clients.auth import APIContext, authenticated
 
 
 def test_package_version():
@@ -22,7 +22,7 @@ async def test_http_user_agent_version(
 
     mocker.patch('kopf._cogs.helpers.versions.version', version)
 
-    @reauthenticated_request
+    @authenticated
     async def get_it(url: str, *, context: APIContext) -> Dict[str, Any]:
         response = await context.session.get(url)
         return await response.json()


### PR DESCRIPTION
We need to prepare the API client routines for the coming feature of retrying all API requests on server-side/networking errors. It is easier to implement such logic in one place rather than to apply it with decorators and/or composing objects in several places.

As such, the lower-level routines are extracted and all the API session management (authentication, response checking, etc) is shifted down the stack. The lower-level routines only do the generic API requests (GET/POST/PATCH/DELETE/etc) without knowing their purpose. The higher-level routines do additional object manipulation before sending anything to the lower-level API requests.

For convenience and code simplicity, most lower-level methods return a parsed object; all of them implicitly verify the response status.

_Extracted from #788 to reduce the diff size and remove unrelated changes._