### PR TITLE
Configure networking timeouts for API clients

### DIFF
--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -54,15 +54,18 @@ async def request(
     if '://' not in url:
         url = context.server.rstrip('/') + '/' + url.lstrip('/')
 
-    # NB: aiohttp uses an internal sentinel for default timeout; None has a different meaning.
-    # TODO: Replace this kwargs hack with our own timeout object.
-    timeout_kwarg = {'timeout': timeout} if timeout is not None else {}
+    if timeout is None:
+        timeout = aiohttp.ClientTimeout(
+            total=settings.networking.request_timeout,
+            sock_connect=settings.networking.connect_timeout,
+        )
+
     response = await context.session.request(
         method=method,
         url=url,
         json=payload,
         headers=headers,
-        **timeout_kwarg,
+        timeout=timeout,
     )
     await errors.check_response(response)  # but do not parse it!
     return response

--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -8,6 +8,7 @@ import aiohttp
 
 from kopf._cogs.aiokits import aiotasks
 from kopf._cogs.clients import auth, errors
+from kopf._cogs.configs import configuration
 
 
 @auth.authenticated
@@ -41,6 +42,7 @@ async def request(
         method: str,
         url: str,  # relative to the server/api root.
         *,
+        settings: configuration.OperatorSettings,
         payload: Optional[object] = None,
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
@@ -69,6 +71,7 @@ async def request(
 async def get(
         url: str,  # relative to the server/api root.
         *,
+        settings: configuration.OperatorSettings,
         payload: Optional[object] = None,
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
@@ -79,6 +82,7 @@ async def get(
         payload=payload,
         headers=headers,
         timeout=timeout,
+        settings=settings,
     )
     return await response.json()
 
@@ -86,6 +90,7 @@ async def get(
 async def post(
         url: str,  # relative to the server/api root.
         *,
+        settings: configuration.OperatorSettings,
         payload: Optional[object] = None,
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
@@ -96,6 +101,7 @@ async def post(
         payload=payload,
         headers=headers,
         timeout=timeout,
+        settings=settings,
     )
     return await response.json()
 
@@ -103,6 +109,7 @@ async def post(
 async def patch(
         url: str,  # relative to the server/api root.
         *,
+        settings: configuration.OperatorSettings,
         payload: Optional[object] = None,
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
@@ -113,6 +120,7 @@ async def patch(
         payload=payload,
         headers=headers,
         timeout=timeout,
+        settings=settings,
     )
     return await response.json()
 
@@ -120,6 +128,7 @@ async def patch(
 async def delete(
         url: str,  # relative to the server/api root.
         *,
+        settings: configuration.OperatorSettings,
         payload: Optional[object] = None,
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
@@ -130,6 +139,7 @@ async def delete(
         payload=payload,
         headers=headers,
         timeout=timeout,
+        settings=settings,
     )
     return await response.json()
 
@@ -137,6 +147,7 @@ async def delete(
 async def stream(
         url: str,  # relative to the server/api root.
         *,
+        settings: configuration.OperatorSettings,
         payload: Optional[object] = None,
         headers: Optional[Mapping[str, str]] = None,
         timeout: Optional[aiohttp.ClientTimeout] = None,
@@ -148,6 +159,7 @@ async def stream(
         payload=payload,
         headers=headers,
         timeout=timeout,
+        settings=settings,
     )
     response_close_callback = lambda _: response.close()  # to remove the positional arg.
     if stopper is not None:

--- a/kopf/_cogs/clients/creating.py
+++ b/kopf/_cogs/clients/creating.py
@@ -1,11 +1,13 @@
 from typing import Optional, cast
 
 from kopf._cogs.clients import api
+from kopf._cogs.configs import configuration
 from kopf._cogs.structs import bodies, references
 
 
 async def create_obj(
         *,
+        settings: configuration.OperatorSettings,
         resource: references.Resource,
         namespace: references.Namespace = None,
         name: Optional[str] = None,
@@ -24,5 +26,6 @@ async def create_obj(
     created_body: bodies.RawBody = await api.post(
         url=resource.get_url(namespace=namespace),
         payload=body,
+        settings=settings,
     )
     return created_body

--- a/kopf/_cogs/clients/events.py
+++ b/kopf/_cogs/clients/events.py
@@ -5,6 +5,7 @@ import logging
 import aiohttp
 
 from kopf._cogs.clients import api, errors
+from kopf._cogs.configs import configuration
 from kopf._cogs.structs import bodies, references
 
 logger = logging.getLogger(__name__)
@@ -20,6 +21,7 @@ async def post_event(
         reason: str,
         message: str = '',
         resource: references.Resource,
+        settings: configuration.OperatorSettings,
 ) -> None:
     """
     Issue an event for the object.
@@ -76,6 +78,7 @@ async def post_event(
             url=resource.get_url(namespace=namespace),
             headers={'Content-Type': 'application/json'},
             payload=body,
+            settings=settings,
         )
 
     # Events are helpful but auxiliary, they should not fail the handling cycle.

--- a/kopf/_cogs/clients/fetching.py
+++ b/kopf/_cogs/clients/fetching.py
@@ -1,11 +1,13 @@
 from typing import Collection, List, Tuple
 
 from kopf._cogs.clients import api
+from kopf._cogs.configs import configuration
 from kopf._cogs.structs import bodies, references
 
 
 async def list_objs(
         *,
+        settings: configuration.OperatorSettings,
         resource: references.Resource,
         namespace: references.Namespace,
 ) -> Tuple[Collection[bodies.RawBody], str]:
@@ -21,8 +23,10 @@ async def list_objs(
 
     * The resource is namespace-scoped AND operator is namespaced-restricted.
     """
-    url = resource.get_url(namespace=namespace)
-    rsp = await api.get(url)
+    rsp = await api.get(
+        url=resource.get_url(namespace=namespace),
+        settings=settings,
+    )
 
     items: List[bodies.RawBody] = []
     resource_version = rsp.get('metadata', {}).get('resourceVersion', None)

--- a/kopf/_cogs/clients/patching.py
+++ b/kopf/_cogs/clients/patching.py
@@ -1,11 +1,13 @@
 from typing import Optional
 
 from kopf._cogs.clients import api, errors
+from kopf._cogs.configs import configuration
 from kopf._cogs.structs import bodies, patches, references
 
 
 async def patch_obj(
         *,
+        settings: configuration.OperatorSettings,
         resource: references.Resource,
         namespace: references.Namespace,
         name: Optional[str],
@@ -44,6 +46,7 @@ async def patch_obj(
                 url=resource.get_url(namespace=namespace, name=name),
                 headers={'Content-Type': 'application/merge-patch+json'},
                 payload=body_patch,
+                settings=settings,
             )
 
         if status_patch:
@@ -52,6 +55,7 @@ async def patch_obj(
                                      subresource='status' if as_subresource else None),
                 headers={'Content-Type': 'application/merge-patch+json'},
                 payload={'status': status_patch},
+                settings=settings,
             )
             patched_body['status'] = response.get('status')
 

--- a/kopf/_cogs/clients/watching.py
+++ b/kopf/_cogs/clients/watching.py
@@ -156,6 +156,7 @@ async def continuous_watch(
     # First, list the resources regularly, and get the list's resource version.
     # Simulate the events with type "None" event - used in detection of causes.
     objs, resource_version = await fetching.list_objs(
+        settings=settings,
         resource=resource,
         namespace=namespace,
     )
@@ -240,6 +241,7 @@ async def watch_objs(
     try:
         async for raw_input in api.stream(
             url=resource.get_url(namespace=namespace, params=params),
+            settings=settings,
             stopper=operator_pause_waiter,
             timeout=aiohttp.ClientTimeout(
                 total=settings.watching.client_timeout,

--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -339,6 +339,24 @@ class ExecutionSettings:
 
 
 @dataclasses.dataclass
+class NetworkingSettings:
+
+    request_timeout: Optional[float] = 5 * 60  # == aiohttp.client.DEFAULT_TIMEOUT
+    """
+    A timeout for the entire duration of an API request (in seconds).
+
+    The timeout is only applied to all short atomic requests.
+    For watch-streams, use one of ``settings.watching.client_timeout``
+    or ``settings.watching.server_timeout``.
+    """
+
+    connect_timeout: Optional[float] = None
+    """
+    A timeout for the connection & handshake of an API request (in seconds).
+    """
+
+
+@dataclasses.dataclass
 class PersistenceSettings:
 
     finalizer: str = 'kopf.zalando.org/KopfFinalizerMarker'
@@ -430,4 +448,5 @@ class OperatorSettings:
     admission: AdmissionSettings =dataclasses.field(default_factory=AdmissionSettings)
     execution: ExecutionSettings = dataclasses.field(default_factory=ExecutionSettings)
     background: BackgroundSettings = dataclasses.field(default_factory=BackgroundSettings)
+    networking: NetworkingSettings = dataclasses.field(default_factory=NetworkingSettings)
     persistence: PersistenceSettings = dataclasses.field(default_factory=PersistenceSettings)

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -331,7 +331,11 @@ async def configuration_manager(
     # Optionally (if configured), pre-create the configuration objects if they are absent.
     # Use the try-or-fail strategy instead of check-and-do -- to reduce the RBAC requirements.
     try:
-        await creating.create_obj(resource=resource, name=settings.admission.managed)
+        await creating.create_obj(
+            settings=settings,
+            resource=resource,
+            name=settings.admission.managed,
+        )
     except errors.APIConflictError:
         pass  # exists already
     except errors.APIForbiddenError:
@@ -351,6 +355,7 @@ async def configuration_manager(
                 name_suffix=settings.admission.managed,
                 client_config=client_config)
             await patching.patch_obj(
+                settings=settings,
                 resource=resource,
                 namespace=None,
                 name=settings.admission.managed,
@@ -367,6 +372,7 @@ async def configuration_manager(
                 client_config=client_config,
                 persistent_only=True)
             await patching.patch_obj(
+                settings=settings,
                 resource=resource,
                 namespace=None,
                 name=settings.admission.managed,

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -463,7 +463,13 @@ async def _daemon(
         )
         state = state.with_outcomes(outcomes)
         progression.deliver_results(outcomes=outcomes, patch=patch)
-        await application.patch_and_check(resource=resource, patch=patch, body=body, logger=logger)
+        await application.patch_and_check(
+            settings=settings,
+            resource=resource,
+            logger=logger,
+            patch=patch,
+            body=body,
+        )
         patch.clear()
 
         # The in-memory sleep does not react to resource changes, but only to stopping.
@@ -544,7 +550,13 @@ async def _timer(
         )
         state = state.with_outcomes(outcomes)
         progression.deliver_results(outcomes=outcomes, patch=patch)
-        await application.patch_and_check(resource=resource, patch=patch, body=body, logger=logger)
+        await application.patch_and_check(
+            settings=settings,
+            resource=resource,
+            logger=logger,
+            patch=patch,
+            body=body,
+        )
         patch.clear()
 
         # For temporary errors, override the schedule by the one provided by errors themselves.

--- a/kopf/_core/engines/peering.py
+++ b/kopf/_core/engines/peering.py
@@ -218,7 +218,13 @@ async def touch(
 
     patch = patches.Patch()
     patch.update({'status': {identity: None if peer.is_dead else peer.as_dict()}})
-    rsp = await patching.patch_obj(resource=resource, namespace=namespace, name=name, patch=patch)
+    rsp = await patching.patch_obj(
+        settings=settings,
+        resource=resource,
+        namespace=namespace,
+        name=name,
+        patch=patch,
+    )
 
     if not settings.peering.stealth or rsp is None:
         where = f"in {namespace!r}" if namespace else "cluster-wide"
@@ -236,7 +242,13 @@ async def clean(
     name = settings.peering.name
     patch = patches.Patch()
     patch.update({'status': {peer.identity: None for peer in peers}})
-    await patching.patch_obj(resource=resource, namespace=namespace, name=name, patch=patch)
+    await patching.patch_obj(
+        settings=settings,
+        resource=resource,
+        namespace=namespace,
+        name=name,
+        patch=patch,
+    )
 
 
 def detect_own_id(*, manual: bool) -> Identity:

--- a/kopf/_core/engines/posting.py
+++ b/kopf/_core/engines/posting.py
@@ -146,6 +146,7 @@ async def poster(
         *,
         event_queue: K8sEventQueue,
         backbone: references.Backbone,
+        settings: configuration.OperatorSettings,
 ) -> NoReturn:
     """
     Post events in the background as they are queued.
@@ -170,7 +171,9 @@ async def poster(
             type=posted_event.type,
             reason=posted_event.reason,
             message=posted_event.message,
-            resource=resource)
+            resource=resource,
+            settings=settings,
+        )
 
 
 class K8sPoster(logging.Handler):

--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -255,6 +255,7 @@ async def spawn_tasks(
     tasks.append(aiotasks.create_guarded_task(
         name="poster of events", flag=started_flag, logger=logger,
         coro=posting.poster(
+            settings=settings,
             backbone=insights.backbone,
             event_queue=event_queue)))
 

--- a/tests/apis/test_api_requests.py
+++ b/tests/apis/test_api_requests.py
@@ -10,7 +10,9 @@ from kopf._cogs.clients.errors import APIError
 
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
-async def test_raw_requests_work(resp_mocker, aresponses, hostname, method):
+async def test_raw_requests_work(
+        resp_mocker, aresponses, hostname, method, settings):
+
     mock = resp_mocker(return_value=aiohttp.web.json_response({}))
     aresponses.add(hostname, '/url', method, mock)
     response = await request(
@@ -18,6 +20,7 @@ async def test_raw_requests_work(resp_mocker, aresponses, hostname, method):
         url='/url',
         payload={'fake': 'payload'},
         headers={'fake': 'headers'},
+        settings=settings,
     )
     assert isinstance(response, aiohttp.ClientResponse)  # unparsed!
     assert mock.call_count == 1
@@ -29,37 +32,45 @@ async def test_raw_requests_work(resp_mocker, aresponses, hostname, method):
 
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
-async def test_raw_requests_are_not_parsed(resp_mocker, aresponses, hostname, method):
+async def test_raw_requests_are_not_parsed(
+        resp_mocker, aresponses, hostname, method, settings):
+
     mock = resp_mocker(return_value=aresponses.Response(text='BAD JSON!'))
     aresponses.add(hostname, '/url', method, mock)
-    response = await request(method, '/url')
+    response = await request(method, '/url', settings=settings)
     assert isinstance(response, aiohttp.ClientResponse)
 
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
-async def test_server_errors_escalate(resp_mocker, aresponses, hostname, method):
+async def test_server_errors_escalate(
+        resp_mocker, aresponses, hostname, method, settings):
+
     mock = resp_mocker(return_value=aiohttp.web.json_response({}, status=666))
     aresponses.add(hostname, '/url', method, mock)
     with pytest.raises(APIError) as err:
-        await request(method, '/url')
+        await request(method, '/url', settings=settings)
     assert err.value.status == 666
 
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
-async def test_relative_urls_are_prepended_with_server(resp_mocker, aresponses, hostname, method):
+async def test_relative_urls_are_prepended_with_server(
+        resp_mocker, aresponses, hostname, method, settings):
+
     mock = resp_mocker(return_value=aiohttp.web.json_response({}))
     aresponses.add(hostname, '/url', method, mock)
-    await request(method, '/url')
+    await request(method, '/url', settings=settings)
     assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
     assert str(mock.call_args[0][0].url) == f'http://{hostname}/url'
 
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
-async def test_absolute_urls_are_passed_through(resp_mocker, aresponses, hostname, method):
+async def test_absolute_urls_are_passed_through(
+        resp_mocker, aresponses, hostname, method, settings):
+
     mock = resp_mocker(return_value=aiohttp.web.json_response({}))
     aresponses.add(hostname, '/url', method, mock)
     aresponses.add('fakehost.localdomain', '/url', method, mock)
-    await request(method, 'http://fakehost.localdomain/url')
+    await request(method, 'http://fakehost.localdomain/url', settings=settings)
     assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
     assert str(mock.call_args[0][0].url) == 'http://fakehost.localdomain/url'
 
@@ -70,13 +81,16 @@ async def test_absolute_urls_are_passed_through(resp_mocker, aresponses, hostnam
     (patch, 'patch'),
     (delete, 'delete'),
 ])
-async def test_parsing_in_requests(resp_mocker, aresponses, hostname, fn, method):
+async def test_parsing_in_requests(
+        resp_mocker, aresponses, hostname, fn, method, settings):
+
     mock = resp_mocker(return_value=aiohttp.web.json_response({'fake': 'result'}))
     aresponses.add(hostname, '/url', method, mock)
     response = await fn(
         url='/url',
         payload={'fake': 'payload'},
         headers={'fake': 'headers'},
+        settings=settings,
     )
     assert response == {'fake': 'result'}  # parsed!
     assert mock.call_count == 1
@@ -88,7 +102,9 @@ async def test_parsing_in_requests(resp_mocker, aresponses, hostname, fn, method
 
 
 @pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
-async def test_parsing_in_streams(resp_mocker, aresponses, hostname, method):
+async def test_parsing_in_streams(
+        resp_mocker, aresponses, hostname, method, settings):
+
     mock = resp_mocker(return_value=aresponses.Response(text=textwrap.dedent("""
         {"fake": "result1"}
         {"fake": "result2"}
@@ -100,6 +116,7 @@ async def test_parsing_in_streams(resp_mocker, aresponses, hostname, method):
         url='/url',
         payload={'fake': 'payload'},
         headers={'fake': 'headers'},
+        settings=settings,
     ):
         items.append(item)
 
@@ -118,7 +135,8 @@ async def test_parsing_in_streams(resp_mocker, aresponses, hostname, method):
     (patch, 'patch'),
     (delete, 'delete'),
 ])
-async def test_timeout_in_requests(resp_mocker, aresponses, hostname, fn, method):
+async def test_timeout_in_requests(
+        resp_mocker, aresponses, hostname, fn, method, settings):
 
     def serve_slowly():
         time.sleep(0.2)
@@ -128,11 +146,12 @@ async def test_timeout_in_requests(resp_mocker, aresponses, hostname, fn, method
     aresponses.add(hostname, '/url', method, mock)
 
     with pytest.raises(asyncio.TimeoutError):
-        await fn('/url', timeout=aiohttp.ClientTimeout(total=0.1))
+        await fn('/url', timeout=aiohttp.ClientTimeout(total=0.1), settings=settings)
 
 
 @pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
-async def test_timeout_in_streams(resp_mocker, aresponses, hostname, method):
+async def test_timeout_in_streams(
+        resp_mocker, aresponses, hostname, method, settings):
 
     def serve_slowly():
         time.sleep(0.2)
@@ -142,7 +161,7 @@ async def test_timeout_in_streams(resp_mocker, aresponses, hostname, method):
     aresponses.add(hostname, '/url', method, mock)
 
     with pytest.raises(asyncio.TimeoutError):
-        async for _ in stream('/url', timeout=aiohttp.ClientTimeout(total=0.1)):
+        async for _ in stream('/url', timeout=aiohttp.ClientTimeout(total=0.1), settings=settings):
             pass
 
 
@@ -152,7 +171,8 @@ async def test_timeout_in_streams(resp_mocker, aresponses, hostname, method):
     pytest.param(9.9, [{'fake': 'result1'}, {'fake': 'result2'}], id='inf-double'),
 ])
 @pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
-async def test_stopper_in_streams(resp_mocker, aresponses, hostname, method, delay, expected):
+async def test_stopper_in_streams(
+        resp_mocker, aresponses, hostname, method, delay, expected, settings):
 
     async def stream_slowly(request: aiohttp.ClientRequest):
         response = aiohttp.web.StreamResponse()
@@ -170,7 +190,7 @@ async def test_stopper_in_streams(resp_mocker, aresponses, hostname, method, del
     asyncio.get_running_loop().call_later(delay, stopper.set_result, None)
 
     items = []
-    async for item in stream('/url', stopper=stopper):
+    async for item in stream('/url', stopper=stopper, settings=settings):
         items.append(item)
 
     assert items == expected

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,6 +299,8 @@ def resp_mocker(fake_vault, enforced_session, aresponses):
 
             # Get a response/error as it was intended (via return_value/side_effect).
             response = actual_response()
+            if asyncio.iscoroutine(response):
+                response = await response
             return response
 
         return asynctest.CoroutineMock(side_effect=resp_mock_effect)

--- a/tests/k8s/test_creating.py
+++ b/tests/k8s/test_creating.py
@@ -6,13 +6,19 @@ from kopf._cogs.clients.errors import APIError
 
 
 async def test_simple_body_with_arguments(
-        resp_mocker, aresponses, hostname, resource, namespace, caplog):
+        resp_mocker, aresponses, hostname, settings, resource, namespace, caplog):
 
     post_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
     aresponses.add(hostname, resource.get_url(namespace=namespace), 'post', post_mock)
 
     body = {'x': 'y'}
-    await create_obj(resource=resource, namespace=namespace, name='name1', body=body)
+    await create_obj(
+        settings=settings,
+        resource=resource,
+        namespace=namespace,
+        name='name1',
+        body=body,
+    )
 
     assert post_mock.called
     assert post_mock.call_count == 1
@@ -25,13 +31,17 @@ async def test_simple_body_with_arguments(
 
 
 async def test_full_body_with_identifiers(
-        resp_mocker, aresponses, hostname, resource, namespace, caplog):
+        resp_mocker, aresponses, hostname, settings, resource, namespace, caplog):
 
     post_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
     aresponses.add(hostname, resource.get_url(namespace=namespace), 'post', post_mock)
 
     body = {'x': 'y', 'metadata': {'name': 'name1', 'namespace': namespace}}
-    await create_obj(resource=resource, body=body)
+    await create_obj(
+        settings=settings,
+        resource=resource,
+        body=body,
+    )
 
     assert post_mock.called
     assert post_mock.call_count == 1
@@ -43,7 +53,7 @@ async def test_full_body_with_identifiers(
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.
 @pytest.mark.parametrize('status', [400, 403, 404, 409, 500, 666])
 async def test_raises_api_errors(
-        resp_mocker, aresponses, hostname, status, resource, namespace,
+        resp_mocker, aresponses, hostname, settings, status, resource, namespace,
         cluster_resource, namespaced_resource):
 
     post_mock = resp_mocker(return_value=aresponses.Response(status=status))
@@ -54,5 +64,11 @@ async def test_raises_api_errors(
 
     body = {'x': 'y'}
     with pytest.raises(APIError) as e:
-        await create_obj(resource=resource, namespace=namespace, name='name1', body=body)
+        await create_obj(
+            settings=settings,
+            resource=resource,
+            namespace=namespace,
+            name='name1',
+            body=body,
+        )
     assert e.value.status == status

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -7,7 +7,7 @@ from kopf._cogs.structs.credentials import LoginError
 
 
 async def test_listing_works(
-        resp_mocker, aresponses, hostname, resource, namespace,
+        resp_mocker, aresponses, hostname, settings, resource, namespace,
         cluster_resource, namespaced_resource):
 
     result = {'items': [{}, {}]}
@@ -17,7 +17,11 @@ async def test_listing_works(
     aresponses.add(hostname, cluster_url, 'get', list_mock)
     aresponses.add(hostname, namespaced_url, 'get', list_mock)
 
-    items, resource_version = await list_objs(resource=resource, namespace=namespace)
+    items, resource_version = await list_objs(
+        settings=settings,
+        resource=resource,
+        namespace=namespace,
+    )
     assert items == result['items']
 
     assert list_mock.called
@@ -27,7 +31,7 @@ async def test_listing_works(
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.
 @pytest.mark.parametrize('status', [400, 403, 500, 666])
 async def test_raises_direct_api_errors(
-        resp_mocker, aresponses, hostname, status, resource, namespace,
+        resp_mocker, aresponses, hostname, settings, status, resource, namespace,
         cluster_resource, namespaced_resource):
 
     list_mock = resp_mocker(return_value=aresponses.Response(status=status))
@@ -37,5 +41,9 @@ async def test_raises_direct_api_errors(
     aresponses.add(hostname, namespaced_url, 'get', list_mock)
 
     with pytest.raises(APIError) as e:
-        await list_objs(resource=resource, namespace=namespace)
+        await list_objs(
+            settings=settings,
+            resource=resource,
+            namespace=namespace,
+        )
     assert e.value.status == status

--- a/tests/k8s/test_scanning.py
+++ b/tests/k8s/test_scanning.py
@@ -6,7 +6,7 @@ from kopf._cogs.clients.scanning import scan_resources
 
 
 async def test_no_resources_in_empty_apis(
-        resp_mocker, aresponses, hostname):
+        resp_mocker, aresponses, hostname, settings):
 
     core_mock = resp_mocker(return_value=aiohttp.web.json_response({'versions': []}))
     apis_mock = resp_mocker(return_value=aiohttp.web.json_response({'groups': []}))
@@ -14,7 +14,7 @@ async def test_no_resources_in_empty_apis(
     aresponses.add(hostname, '/api', 'get', core_mock)
     aresponses.add(hostname, '/apis', 'get', apis_mock)
 
-    resources = await scan_resources()
+    resources = await scan_resources(settings=settings)
     assert len(resources) == 0
 
     assert core_mock.call_count == 1
@@ -23,7 +23,7 @@ async def test_no_resources_in_empty_apis(
 
 @pytest.mark.parametrize('namespaced', [True, False])
 async def test_resources_in_old_apis(
-        resp_mocker, aresponses, hostname, namespaced):
+        resp_mocker, aresponses, hostname, settings, namespaced):
 
 
     core_mock = resp_mocker(return_value=aiohttp.web.json_response({'versions': ['v1']}))
@@ -43,7 +43,7 @@ async def test_resources_in_old_apis(
     aresponses.add(hostname, '/apis', 'get', apis_mock)
     aresponses.add(hostname, '/api/v1', 'get', scan_mock)
 
-    resources = await scan_resources()
+    resources = await scan_resources(settings=settings)
     assert len(resources) == 1
 
     resource1 = list(resources)[0]
@@ -70,7 +70,7 @@ async def test_resources_in_old_apis(
     ('versionX', False),
 ])
 async def test_resources_in_new_apis(
-        resp_mocker, aresponses, hostname, namespaced,
+        resp_mocker, aresponses, hostname, settings, namespaced,
         preferred_version, expected_preferred):
 
     core_mock = resp_mocker(return_value=aiohttp.web.json_response({'versions': []}))
@@ -96,7 +96,7 @@ async def test_resources_in_new_apis(
     aresponses.add(hostname, '/apis', 'get', apis_mock)
     aresponses.add(hostname, '/apis/group1/version1', 'get', g1v1_mock)
 
-    resources = await scan_resources()
+    resources = await scan_resources(settings=settings)
     assert len(resources) == 1
 
     resource1 = list(resources)[0]
@@ -118,7 +118,7 @@ async def test_resources_in_new_apis(
 
 
 async def test_subresources_in_old_apis(
-        resp_mocker, aresponses, hostname):
+        resp_mocker, aresponses, hostname, settings):
 
     core_mock = resp_mocker(return_value=aiohttp.web.json_response({'versions': ['v1']}))
     apis_mock = resp_mocker(return_value=aiohttp.web.json_response({'groups': []}))
@@ -146,14 +146,14 @@ async def test_subresources_in_old_apis(
     aresponses.add(hostname, '/apis', 'get', apis_mock)
     aresponses.add(hostname, '/api/v1', 'get', v1v1_mock)
 
-    resources = await scan_resources()
+    resources = await scan_resources(settings=settings)
     assert len(resources) == 1
     resource1 = list(resources)[0]
     assert resource1.subresources == {'sub1', 'sub2'}
 
 
 async def test_subresources_in_new_apis(
-        resp_mocker, aresponses, hostname):
+        resp_mocker, aresponses, hostname, settings):
 
     core_mock = resp_mocker(return_value=aiohttp.web.json_response({'versions': []}))
     apis_mock = resp_mocker(return_value=aiohttp.web.json_response({'groups': [
@@ -187,7 +187,7 @@ async def test_subresources_in_new_apis(
     aresponses.add(hostname, '/apis', 'get', apis_mock)
     aresponses.add(hostname, '/apis/group1/version1', 'get', g1v1_mock)
 
-    resources = await scan_resources()
+    resources = await scan_resources(settings=settings)
     assert len(resources) == 1
     resource1 = list(resources)[0]
     assert resource1.subresources == {'sub1', 'sub2'}
@@ -206,7 +206,7 @@ async def test_subresources_in_new_apis(
     pytest.param(None, 1, 1, 1, 1, 1, id='unfiltered'),
 ])
 async def test_group_filtering(
-        resp_mocker, aresponses, hostname,
+        resp_mocker, aresponses, hostname, settings,
         group_filter, exp_core, exp_apis, exp_crv1, exp_g1v1, exp_g2v1):
 
     core_mock = resp_mocker(return_value=aiohttp.web.json_response({'versions': ['v1']}))
@@ -223,7 +223,7 @@ async def test_group_filtering(
     aresponses.add(hostname, '/apis/g1/g1v1', 'get', g1v1_mock)
     aresponses.add(hostname, '/apis/g2/g2v1', 'get', g2v1_mock)
 
-    await scan_resources(groups=group_filter)
+    await scan_resources(groups=group_filter, settings=settings)
 
     assert core_mock.call_count == exp_core
     assert apis_mock.call_count == exp_apis
@@ -236,7 +236,7 @@ async def test_group_filtering(
 
 @pytest.mark.parametrize('status', [404])
 async def test_http404_returns_no_resources_from_old_apis(
-        resp_mocker, aresponses, hostname, status):
+        resp_mocker, aresponses, hostname, settings, status):
 
     core_mock = resp_mocker(return_value=aiohttp.web.json_response({'versions': ['v1']}))
     apis_mock = resp_mocker(return_value=aiohttp.web.json_response({'groups': []}))
@@ -245,7 +245,7 @@ async def test_http404_returns_no_resources_from_old_apis(
     aresponses.add(hostname, '/apis', 'get', apis_mock)
     aresponses.add(hostname, '/api/v1', 'get', status_mock)
 
-    resources = await scan_resources()
+    resources = await scan_resources(settings=settings)
 
     assert not resources
     assert status_mock.call_count == 1
@@ -253,7 +253,7 @@ async def test_http404_returns_no_resources_from_old_apis(
 
 @pytest.mark.parametrize('status', [404])
 async def test_http404_returns_no_resources_from_new_apis(
-        resp_mocker, aresponses, hostname, status):
+        resp_mocker, aresponses, hostname, settings, status):
 
     core_mock = resp_mocker(return_value=aiohttp.web.json_response({'versions': []}))
     apis_mock = resp_mocker(return_value=aiohttp.web.json_response({'groups': [
@@ -264,7 +264,7 @@ async def test_http404_returns_no_resources_from_new_apis(
     aresponses.add(hostname, '/apis', 'get', apis_mock)
     aresponses.add(hostname, '/apis/g1/g1v1', 'get', status_mock)
 
-    resources = await scan_resources()
+    resources = await scan_resources(settings=settings)
 
     assert not resources
     assert status_mock.call_count == 1
@@ -272,7 +272,7 @@ async def test_http404_returns_no_resources_from_new_apis(
 
 @pytest.mark.parametrize('status', [403, 500, 666])
 async def test_unknown_api_statuses_escalate_from_old_apis(
-        resp_mocker, aresponses, hostname, status):
+        resp_mocker, aresponses, hostname, settings, status):
 
     core_mock = resp_mocker(return_value=aiohttp.web.json_response({'versions': ['v1']}))
     apis_mock = resp_mocker(return_value=aiohttp.web.json_response({'groups': []}))
@@ -282,7 +282,7 @@ async def test_unknown_api_statuses_escalate_from_old_apis(
     aresponses.add(hostname, '/api/v1', 'get', status_mock)
 
     with pytest.raises(APIError) as err:
-        await scan_resources()
+        await scan_resources(settings=settings)
 
     assert err.value.status == status
     assert status_mock.call_count == 1
@@ -290,7 +290,7 @@ async def test_unknown_api_statuses_escalate_from_old_apis(
 
 @pytest.mark.parametrize('status', [403, 500, 666])
 async def test_unknown_api_statuses_escalate_from_new_apis(
-        resp_mocker, aresponses, hostname, status):
+        resp_mocker, aresponses, hostname, settings, status):
 
     core_mock = resp_mocker(return_value=aiohttp.web.json_response({'versions': []}))
     apis_mock = resp_mocker(return_value=aiohttp.web.json_response({'groups': [
@@ -302,14 +302,14 @@ async def test_unknown_api_statuses_escalate_from_new_apis(
     aresponses.add(hostname, '/apis/g1/g1v1', 'get', status_mock)
 
     with pytest.raises(APIError) as err:
-        await scan_resources()
+        await scan_resources(settings=settings)
 
     assert err.value.status == status
     assert status_mock.call_count == 1
 
 
 async def test_empty_singulars_fall_back_to_kinds(
-        resp_mocker, aresponses, hostname):
+        resp_mocker, aresponses, hostname, settings):
 
     # Only one endpoint is enough, core v1 is easier to mock:
     core_mock = resp_mocker(return_value=aiohttp.web.json_response({'versions': ['v1']}))
@@ -329,7 +329,7 @@ async def test_empty_singulars_fall_back_to_kinds(
     aresponses.add(hostname, '/apis', 'get', apis_mock)
     aresponses.add(hostname, '/api/v1', 'get', scan_mock)
 
-    resources = await scan_resources(groups=[''])
+    resources = await scan_resources(groups=[''], settings=settings)
     assert len(resources) == 1
 
     resource1 = list(resources)[0]

--- a/tests/observation/test_processing_of_resources.py
+++ b/tests/observation/test_processing_of_resources.py
@@ -94,14 +94,16 @@ def handlers(request, registry):
 
 
 
-async def test_initial_listing_is_ignored(registry, apis_mock, group1_mock):
+async def test_initial_listing_is_ignored(
+        settings, registry, apis_mock, group1_mock):
+
     insights = Insights()
     e1 = RawEvent(type=None, object=RawBody(spec={'group': 'group1'}))
 
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry)
+            insights=insights, raw_event=e1, registry=registry, settings=settings)
 
     task = asyncio.create_task(delayed_injection(0))
     with pytest.raises(asyncio.TimeoutError):
@@ -117,7 +119,9 @@ async def test_initial_listing_is_ignored(registry, apis_mock, group1_mock):
 
 @pytest.mark.usefixtures('handlers')
 @pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED'])
-async def test_followups_for_addition(registry, apis_mock, group1_mock, timer, etype):
+async def test_followups_for_addition(
+        settings, registry, apis_mock, group1_mock, timer, etype):
+
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
     r1 = Resource(group='group1', version='version1', plural='plural1')
     insights = Insights()
@@ -125,7 +129,7 @@ async def test_followups_for_addition(registry, apis_mock, group1_mock, timer, e
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry)
+            insights=insights, raw_event=e1, registry=registry, settings=settings)
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1.0):
@@ -140,7 +144,9 @@ async def test_followups_for_addition(registry, apis_mock, group1_mock, timer, e
 
 @pytest.mark.usefixtures('handlers')
 @pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED', 'DELETED'])
-async def test_followups_for_deletion_of_resource(registry, apis_mock, group1_empty_mock, timer, etype):
+async def test_followups_for_deletion_of_resource(
+        settings, registry, apis_mock, group1_empty_mock, timer, etype):
+
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
     r1 = Resource(group='group1', version='version1', plural='plural1')
     insights = Insights()
@@ -149,7 +155,7 @@ async def test_followups_for_deletion_of_resource(registry, apis_mock, group1_em
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry)
+            insights=insights, raw_event=e1, registry=registry, settings=settings)
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1.0):
@@ -164,7 +170,9 @@ async def test_followups_for_deletion_of_resource(registry, apis_mock, group1_em
 
 @pytest.mark.usefixtures('handlers')
 @pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED', 'DELETED'])
-async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mock, timer, etype):
+async def test_followups_for_deletion_of_group(
+        settings, registry, apis_mock, group1_404mock, timer, etype):
+
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
     r1 = Resource(group='group1', version='version1', plural='plural1')
     insights = Insights()
@@ -173,7 +181,7 @@ async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mo
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry)
+            insights=insights, raw_event=e1, registry=registry, settings=settings)
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1.0):
@@ -188,7 +196,9 @@ async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mo
 
 @pytest.mark.usefixtures('handlers')
 @pytest.mark.parametrize('etype', ['DELETED'])
-async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mock, timer, etype):
+async def test_followups_for_deletion_of_group(
+        settings, registry, apis_mock, group1_404mock, timer, etype):
+
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
     r1 = Resource(group='group1', version='version1', plural='plural1')
     insights = Insights()
@@ -197,7 +207,7 @@ async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mo
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry)
+            insights=insights, raw_event=e1, registry=registry, settings=settings)
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1.0):
@@ -211,14 +221,16 @@ async def test_followups_for_deletion_of_group(registry, apis_mock, group1_404mo
 
 
 @pytest.mark.parametrize('etype', ['DELETED'])
-async def test_backbone_is_filled(registry, core_mock, corev1_mock, timer, etype):
+async def test_backbone_is_filled(
+        settings, registry, core_mock, corev1_mock, timer, etype):
+
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': ''}))
     insights = Insights()
 
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
         await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry)
+            insights=insights, raw_event=e1, registry=registry, settings=settings)
 
     task = asyncio.create_task(delayed_injection(0.1))
     async with timer, async_timeout.timeout(1.0):

--- a/tests/posting/test_poster.py
+++ b/tests/posting/test_poster.py
@@ -26,7 +26,8 @@ def _settings_via_contextvar(settings_via_contextvar):
     pass
 
 
-async def test_poster_polls_and_posts(mocker):
+async def test_poster_polls_and_posts(mocker, settings):
+
     event1 = K8sEvent(type='type1', reason='reason1', message='message1', ref=REF1)
     event2 = K8sEvent(type='type2', reason='reason2', message='message2', ref=REF2)
     event_queue = asyncio.Queue()
@@ -45,7 +46,7 @@ async def test_poster_polls_and_posts(mocker):
     # A way to cancel a `while True` cycle by timing, even if the routines are not called.
     with pytest.raises(asyncio.CancelledError):
         async with async_timeout.timeout(0.5):
-            await poster(event_queue=event_queue, backbone=backbone)
+            await poster(event_queue=event_queue, backbone=backbone, settings=settings)
 
     assert post.call_count == 2
     assert post.call_args_list[0][1]['url'] == '/api/v1/namespaces/ns1/events'

--- a/tests/reactor/test_patching_inconsistencies.py
+++ b/tests/reactor/test_patching_inconsistencies.py
@@ -54,6 +54,7 @@ async def test_patching_without_inconsistencies(
     body = Body({'metadata': {'namespace': namespace, 'name': 'name1'}})
     logger = LocalObjectLogger(body=body, settings=settings)
     await patch_and_check(
+        settings=settings,
         resource=resource,
         body=body,
         patch=Patch(patch),
@@ -116,6 +117,7 @@ async def test_patching_with_inconsistencies(
     body = Body({'metadata': {'namespace': namespace, 'name': 'name1'}})
     logger = LocalObjectLogger(body=body, settings=settings)
     await patch_and_check(
+        settings=settings,
         resource=resource,
         body=body,
         patch=Patch(patch),
@@ -141,6 +143,7 @@ async def test_patching_with_disappearance(
     body = Body({'metadata': {'namespace': namespace, 'name': 'name1'}})
     logger = LocalObjectLogger(body=body, settings=settings)
     await patch_and_check(
+        settings=settings,
         resource=resource,
         body=body,
         patch=Patch(patch),

--- a/tests/settings/test_defaults.py
+++ b/tests/settings/test_defaults.py
@@ -28,6 +28,8 @@ async def test_declared_public_interface_and_promised_defaults():
     assert settings.admission.managed is None
     assert settings.execution.executor is not None
     assert settings.execution.max_workers is None
+    assert settings.networking.request_timeout == 5 * 60
+    assert settings.networking.connect_timeout is None
 
 
 async def test_peering_namespaced_is_modified_by_clusterwide():


### PR DESCRIPTION
With this change, the timeouts can be configured for regular requests (cluster scanning, resource patching, etc). Specifically, two timeouts: for the whole request (default 5 minutes as before), and for the initial TCP connection (the default is not set, i.e. no timeout, but limited by the overall timeout of 5 minutes).

Previously, all requests except for the watch-streams were using the default timeout of aiohttp — which is 5 minutes — and it was not configurable.

Two exceptions:

* Watch-streams are configured with separate settings (`settings.watching`, not `settings.networking`).
* Auto-tunnelling webhook server always uses non-configurable default timeout (it was too difficult to make it configurable, and not worth the overcomplication for a utility dev tool).

Extracted from #788 for atomicity. Implicitly, this PR also passes the `settings` objects to all client routines.