### PR TITLE
Return the connection to the pool as soon as it is parsed

### DIFF
--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -87,7 +87,8 @@ async def get(
         timeout=timeout,
         settings=settings,
     )
-    return await response.json()
+    async with response:
+        return await response.json()
 
 
 async def post(
@@ -106,7 +107,8 @@ async def post(
         timeout=timeout,
         settings=settings,
     )
-    return await response.json()
+    async with response:
+        return await response.json()
 
 
 async def patch(
@@ -125,7 +127,8 @@ async def patch(
         timeout=timeout,
         settings=settings,
     )
-    return await response.json()
+    async with response:
+        return await response.json()
 
 
 async def delete(
@@ -144,7 +147,8 @@ async def delete(
         timeout=timeout,
         settings=settings,
     )
-    return await response.json()
+    async with response:
+        return await response.json()
 
 
 async def stream(


### PR DESCRIPTION
By default, this was done by `__del__` destructor once the `response` object was not referred anymore — i.e. immediately at the end of the get/post/patch/delete routines. So, there was no actual leak or a bug (except if the garbage collector is disabled). Now, the responses & connections will be released to the pool and cleaned up explicitly, even with the garbage collector disabled.

This change does not apply to routines that get the raw response object for their own processing — e.g. streaming. Such routines do their own part in releasing the system resources properly. This change is only for those routines where we discard the response objects ourselves.
