### PR TITLE
Modify JSONPatch to include `add` operation on missing keys

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,3 +18,4 @@ and [Historic GitHub Contributors](https://github.com/zalando-incubator/kopf/gra
 - [Trond Hindenes](https://github.com/trondhindenes)
 - [Vennamaneni Sai Narasimha](https://github.com/thevennamaneni)
 - [Cliff Burdick](https://github.com/cliffburdick)
+- [CJ Baar](https://github.com/cjbaar)

--- a/kopf/_cogs/structs/patches.py
+++ b/kopf/_cogs/structs/patches.py
@@ -58,12 +58,12 @@ class StatusPatch(dicts.MutableMappingView[str, Any]):
 # Event-handling structures, used internally in the framework and handlers only.
 class Patch(Dict[str, Any]):
 
-    def __init__(self, __src: Optional[MutableMapping[str, Any]] = None) -> None:
+    def __init__(self, __src: Optional[MutableMapping[str, Any]] = None, body = {}) -> None:
         super().__init__(__src or {})
         self._meta = MetaPatch(self)
         self._spec = SpecPatch(self)
         self._status = StatusPatch(self)
-        self._original = {}
+        self._original = body
 
     @property
     def metadata(self) -> MetaPatch:
@@ -84,10 +84,6 @@ class Patch(Dict[str, Any]):
     @property
     def original(self):
         return self._original
-
-    @original.setter
-    def original(self, value):
-        self._original = value
 
     def as_json_patch(self) -> JSONPatch:
         return [] if not self else self._as_json_patch(self, keys=[''])
@@ -115,4 +111,3 @@ class Patch(Dict[str, Any]):
             except (KeyError, TypeError):
                 return False
         return True
-        

--- a/kopf/_cogs/structs/patches.py
+++ b/kopf/_cogs/structs/patches.py
@@ -81,10 +81,6 @@ class Patch(Dict[str, Any]):
     def status(self) -> StatusPatch:
         return self._status
 
-    @property
-    def original(self):
-        return self._original
-
     def as_json_patch(self) -> JSONPatch:
         return [] if not self else self._as_json_patch(self, keys=[''])
 

--- a/kopf/_cogs/structs/patches.py
+++ b/kopf/_cogs/structs/patches.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, MutableMapping, Optional
 
 from typing_extensions import Literal, TypedDict
 
-from kopf._cogs.structs import dicts
+from kopf._cogs.structs import bodies, dicts
 
 JSONPatchOp = Literal["add", "replace", "remove"]
 
@@ -58,7 +58,11 @@ class StatusPatch(dicts.MutableMappingView[str, Any]):
 # Event-handling structures, used internally in the framework and handlers only.
 class Patch(Dict[str, Any]):
 
-    def __init__(self, __src: Optional[MutableMapping[str, Any]] = None, body = {}) -> None:
+    def __init__(
+        self,
+        __src: Optional[MutableMapping[str, Any]] = None,
+        body: Optional[bodies.RawBody] = None
+    ) -> None:
         super().__init__(__src or {})
         self._meta = MetaPatch(self)
         self._spec = SpecPatch(self)
@@ -103,7 +107,7 @@ class Patch(Dict[str, Any]):
             if key == '':
                 continue
             try:
-                _search = _search[key]
+                _search = _search[key]  # type: ignore
             except (KeyError, TypeError):
                 return False
         return True

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -126,6 +126,7 @@ async def serve_admission_request(
     memo = await memories.recall_memo(raw_body, memobase=memobase, ephemeral=operation=='CREATE')
     body = bodies.Body(raw_body)
     patch = patches.Patch()
+    patch.original = raw_body
     warnings: List[str] = []
     cause = causes.WebhookCause(
         resource=resource,

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -125,8 +125,7 @@ async def serve_admission_request(
 
     memo = await memories.recall_memo(raw_body, memobase=memobase, ephemeral=operation=='CREATE')
     body = bodies.Body(raw_body)
-    patch = patches.Patch()
-    patch.original = raw_body
+    patch = patches.Patch(body=raw_body)
     warnings: List[str] = []
     cause = causes.WebhookCause(
         resource=resource,

--- a/tests/admission/test_jsonpatch.py
+++ b/tests/admission/test_jsonpatch.py
@@ -2,8 +2,8 @@ from kopf._cogs.structs.patches import Patch
 
 
 def test_addition_of_the_key():
-    patch = Patch()
-    patch.original = {'abc': 456}
+    body = {'abc': 456}
+    patch = Patch(body=body)
     patch['xyz'] = 123
     jsonpatch = patch.as_json_patch()
     assert jsonpatch == [
@@ -12,8 +12,8 @@ def test_addition_of_the_key():
 
 
 def test_replacement_of_the_key():
-    patch = Patch()
-    patch.original = {'xyz': 456}
+    body = {'xyz': 456}
+    patch = Patch(body=body)
     patch['xyz'] = 123
     jsonpatch = patch.as_json_patch()
     assert jsonpatch == [
@@ -31,8 +31,8 @@ def test_removal_of_the_key():
 
 
 def test_addition_of_the_subkey():
-    patch = Patch()
-    patch.original = {'xyz': {'def': 456}}
+    body = {'xyz': {'def': 456}}
+    patch = Patch(body=body)
     patch['xyz'] = {'abc': 123}
     jsonpatch = patch.as_json_patch()
     assert jsonpatch == [
@@ -40,8 +40,8 @@ def test_addition_of_the_subkey():
     ]
 
 def test_replacement_of_the_subkey():
-    patch = Patch()
-    patch.original = {'xyz': {'abc': 456}}
+    body = {'xyz': {'abc': 456}}
+    patch = Patch(body=body)
     patch['xyz'] = {'abc': 123}
     jsonpatch = patch.as_json_patch()
     assert jsonpatch == [
@@ -50,8 +50,8 @@ def test_replacement_of_the_subkey():
 
 
 def test_addition_of_the_sub_subkey():
-    patch = Patch()
-    patch.original = {'xyz': {'uvw': 123}}
+    body = {'xyz': {'uvw': 123}}
+    patch = Patch(body=body)
     patch['xyz'] = {'abc': {'def': {'ghi': 456}}}
     jsonpatch = patch.as_json_patch()
     assert jsonpatch == [

--- a/tests/admission/test_jsonpatch.py
+++ b/tests/admission/test_jsonpatch.py
@@ -49,6 +49,16 @@ def test_replacement_of_the_subkey():
     ]
 
 
+def test_addition_of_the_sub_subkey():
+    patch = Patch()
+    patch.original = {'xyz': {'uvw': 123}}
+    patch['xyz'] = {'abc': {'def': {'ghi': 456}}}
+    jsonpatch = patch.as_json_patch()
+    assert jsonpatch == [
+        {'op': 'add', 'path': '/xyz/abc', 'value': {'def': {'ghi': 456}}},
+    ]
+
+
 def test_removal_of_the_subkey():
     patch = Patch()
     patch['xyz'] = {'abc': None}

--- a/tests/admission/test_jsonpatch.py
+++ b/tests/admission/test_jsonpatch.py
@@ -3,6 +3,17 @@ from kopf._cogs.structs.patches import Patch
 
 def test_addition_of_the_key():
     patch = Patch()
+    patch.original = {'abc': 456}
+    patch['xyz'] = 123
+    jsonpatch = patch.as_json_patch()
+    assert jsonpatch == [
+        {'op': 'add', 'path': '/xyz', 'value': 123},
+    ]
+
+
+def test_replacement_of_the_key():
+    patch = Patch()
+    patch.original = {'xyz': 456}
     patch['xyz'] = 123
     jsonpatch = patch.as_json_patch()
     assert jsonpatch == [
@@ -21,6 +32,16 @@ def test_removal_of_the_key():
 
 def test_addition_of_the_subkey():
     patch = Patch()
+    patch.original = {'xyz': {'def': 456}}
+    patch['xyz'] = {'abc': 123}
+    jsonpatch = patch.as_json_patch()
+    assert jsonpatch == [
+        {'op': 'add', 'path': '/xyz/abc', 'value': 123},
+    ]
+
+def test_replacement_of_the_subkey():
+    patch = Patch()
+    patch.original = {'xyz': {'abc': 456}}
     patch['xyz'] = {'abc': 123}
     jsonpatch = patch.as_json_patch()
     assert jsonpatch == [

--- a/tests/admission/test_serving_responses.py
+++ b/tests/admission/test_serving_responses.py
@@ -153,7 +153,8 @@ async def test_patch_is_returned_to_kubernetes(
 
     @decorator(*resource)
     def fn(patch, **_):
-        patch['xyz'] = 123
+        patch['xyz'] = 'added'
+        patch.spec['field'] = 'replaced'
 
     response = await serve_admission_request(
         adm_request,
@@ -165,5 +166,6 @@ async def test_patch_is_returned_to_kubernetes(
     assert response['response']['allowed'] is True
     assert response['response']['patchType'] == 'JSONPatch'
     assert json.loads(base64.b64decode(response['response']['patch'])) == [
-        {'op': 'replace', 'path': '/xyz', 'value': 123},
+        {'op': 'add', 'path': '/xyz', 'value': 'added'},
+        {'op': 'replace', 'path': '/spec/field', 'value': 'replaced'},
     ]


### PR DESCRIPTION
## What do these changes do?

The original implementation of JSONpatch construction only allowed for `replace` operations. This did not work when attempting to patch a key that did not already exist. Comments in the code indicate this was intended to be implemented, but was never completed. This is my initial attempt at implementing the `add` operation.

## Description

* Attempt to complete the "to-do" list item previously located at https://github.com/nolar/kopf/blob/main/kopf/_cogs/structs/patches.py#L94
* Create new `original` property of the `Patch()` class to store original body used in comparison
* In admission controller request, copy `raw_body` to `patch.original`
* While iterating over patch keys, if not present, change to `add` method and use rest of dictionary as value
* Additional tests for multi-layer patches

This has been tested with patching appsv1/Deployment, adding layered annotations when the annotation key did not exist. Existing unit tests still succeed, though unsure of potential side effects to `delete` ops.

## Issues/PRs

https://github.com/nolar/kopf/issues/801


## Type of changes

- New feature (non-breaking change which adds functionality)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

