### PR TITLE
Remove the linenos from code-block python files

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ and [Historic GitHub Contributors](https://github.com/zalando-incubator/kopf/gra
 - [Clement Liaw](https://github.com/iexalt)
 - [Ismail Kaboubi](https://github.com/smileisak)
 - [Michael Narodovitch](https://github.com/michaelnarodovitch)
+- [Rodrigo Tavares](https://github.com/tavaresrodrigo)
 - [Sergey Vasilyev](https://github.com/nolar)
 - [Soroosh Sarabadani](https://github.com/psycho-ir)
 - [Trond Hindenes](https://github.com/trondhindenes)

--- a/docs/walkthrough/creation.rst
+++ b/docs/walkthrough/creation.rst
@@ -50,7 +50,6 @@ We will use the official Kubernetes client library (``pip install kubernetes``):
 
 .. code-block:: python
     :name: creation
-    :linenos:
     :caption: ephemeral.py
 
     import os

--- a/docs/walkthrough/deletion.rst
+++ b/docs/walkthrough/deletion.rst
@@ -31,7 +31,6 @@ Let's extend the creation handler:
 
 .. code-block:: python
     :name: adopting
-    :linenos:
     :caption: ephemeral.py
     :emphasize-lines: 18
 

--- a/docs/walkthrough/diffs.rst
+++ b/docs/walkthrough/diffs.rst
@@ -27,7 +27,6 @@ but we will use another feature of Kopf to track one specific field only:
 
 .. code-block:: python
     :name: with-new
-    :linenos:
     :caption: ephemeral.py
     :emphasize-lines: 1, 5
 
@@ -90,7 +89,6 @@ exactly as needed for the patch object (i.e. the field is present there):
 
 .. code-block:: python
     :name: with-diff
-    :linenos:
     :caption: ephemeral.py
     :emphasize-lines: 4
 

--- a/docs/walkthrough/starting.rst
+++ b/docs/walkthrough/starting.rst
@@ -12,7 +12,6 @@ just to see how it can be started.
 
 .. code-block:: python
     :name: skeleton
-    :linenos:
     :caption: ephemeral.py
 
     import kopf

--- a/docs/walkthrough/updates.rst
+++ b/docs/walkthrough/updates.rst
@@ -21,7 +21,6 @@ Let's extend the creation handler we already have from the previous step
 with one additional line:
 
 .. code-block:: python
-    :linenos:
     :caption: ephemeral.py
     :emphasize-lines: 24
 


### PR DESCRIPTION
### What do these changes do?

Remove the :linenos: from .py files so we can copy and past python files from documentation without the need to remove the line numbers as below.

By removing the line numbers we would be following the same standard being applied to the yaml and bash files already in the documentation and also improve the code readability. 

### Description

Before:
``` python
 1import os
 2import kopf
 3import kubernetes
 4import yaml
 5
 6@kopf.on.create('ephemeralvolumeclaims')
 7def create_fn(spec, name, namespace, logger, **kwargs):
 8
 9    size = spec.get('size')
[...]
```

After:
```python
import os
import kopf
import kubernetes
import yaml

@kopf.on.create('ephemeralvolumeclaims')
def create_fn(spec, name, namespace, logger, **kwargs):

    size = spec.get('size')
```

### Issues/PRs
#807 

### Checklist

[x ]   The code addresses only the mentioned problem, and this problem only
[x]   I think the code is well written
[ ]   Unit tests for the changes exists
[x ]   Documentation reflects the changes
[x ]   If you provide code modification, please add yourself to CONTRIBUTORS.txt
