### PR TITLE
Update thirdparty.py for support kubernetes_asyncio.

### DIFF
--- a/docs/hierarchies.rst
+++ b/docs/hierarchies.rst
@@ -13,9 +13,10 @@ by manipulating their content before it is sent to the Kubernetes API.
     It does not provide any means to manipulate the Kubernetes resources
     in the cluster or to directly talk to the Kubernetes API in any other way.
     Use any of the existing libraries for that purpose,
-    such as the official `kubernetes client`_, pykorm_, or pykube-ng_.
+    such as the official `kubernetes client`_, `kubernetes asyncio client`_, pykorm_, or pykube-ng_.
 
 .. _kubernetes client: https://github.com/kubernetes-client/python
+.. _kubernetes asyncio client: https://github.com/tomplus/kubernetes_asyncio
 .. _pykorm: https://github.com/Frankkkkk/pykorm
 .. _pykube-ng: https://github.com/hjacobs/pykube
 

--- a/kopf/_cogs/helpers/thirdparty.py
+++ b/kopf/_cogs/helpers/thirdparty.py
@@ -21,10 +21,16 @@ try:
 except ImportError:
     PykubeObject = _dummy
 
+V1ObjectMeta = V1OwnerReference = None
+
+try:
+    from kubernetes_asyncio.client import V1ObjectMeta as V1ObjectMeta, V1OwnerReference as V1OwnerReference
+except ImportError:
+    pass
 try:
     from kubernetes.client import V1ObjectMeta as V1ObjectMeta, V1OwnerReference as V1OwnerReference
 except ImportError:
-    V1ObjectMeta = V1OwnerReference = None
+    pass
 
 
 # Kubernetes client does not have any common base classes, its code is fully generated.

--- a/kopf/_cogs/helpers/thirdparty.py
+++ b/kopf/_cogs/helpers/thirdparty.py
@@ -35,6 +35,8 @@ class KubernetesModel(abc.ABC):
         if cls is KubernetesModel:
             if any(C.__module__.startswith('kubernetes.client.models.') for C in subcls.__mro__):
                 return True
+            if any(C.__module__.startswith('kubernetes_asyncio.client.models.') for C in subcls.__mro__):
+                return True
         return NotImplemented
 
     @property


### PR DESCRIPTION
The model of the official sdk of kubernetes and the model of kubernetes_asyncio work the same. So we can support the model in the same way.

closes: #806