### PR TITLE
Handle connection errors during list_obj calls gracefully

### DIFF
--- a/tests/k8s/test_watching_continuously.py
+++ b/tests/k8s/test_watching_continuously.py
@@ -190,9 +190,8 @@ async def test_long_line_parsing(
     ]
 )
 async def test_list_objs_connection_errors_are_caught(
-        settings, resource, stream, namespace, enforced_session, mocker, caplog, connection_error):
+        settings, resource, stream, namespace, enforced_session, mocker, connection_error):
 
-    caplog.set_level(logging.DEBUG)
     enforced_session.request = mocker.Mock(side_effect=connection_error())
     stream.feed([], namespace=namespace)
     stream.close(namespace=namespace)
@@ -202,7 +201,6 @@ async def test_list_objs_connection_errors_are_caught(
                                             resource=resource,
                                             namespace=namespace,
                                             operator_pause_waiter=asyncio.Future()):
-            events.append(event)
+        events.append(event)
 
     assert len(events) == 0
-    assert "Could not list objs" in caplog.text

--- a/tests/k8s/test_watching_continuously.py
+++ b/tests/k8s/test_watching_continuously.py
@@ -11,6 +11,7 @@ They are NOT part of the public interface of the framework.
 import asyncio
 import logging
 
+import aiohttp
 import pytest
 
 from kopf._cogs.clients.watching import Bookmark, WatchingError, continuous_watch
@@ -180,3 +181,28 @@ async def test_long_line_parsing(
     assert len(events[1]['object']['spec']['field']) == 1
     assert len(events[2]['object']['spec']['field']) == 2 * 1024 * 1024
     assert len(events[3]['object']['spec']['field']) == 4 * 1024 * 1024
+
+@pytest.mark.parametrize("connection_error",
+    [
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientPayloadError,
+        asyncio.TimeoutError
+    ]
+)
+async def test_list_objs_connection_errors_are_caught(
+        settings, resource, stream, namespace, enforced_session, mocker, caplog, connection_error):
+
+    caplog.set_level(logging.DEBUG)
+    enforced_session.request = mocker.Mock(side_effect=connection_error())
+    stream.feed([], namespace=namespace)
+    stream.close(namespace=namespace)
+
+    events = []
+    async for event in continuous_watch(settings=settings,
+                                            resource=resource,
+                                            namespace=namespace,
+                                            operator_pause_waiter=asyncio.Future()):
+            events.append(event)
+
+    assert len(events) == 0
+    assert "Could not list objs" in caplog.text


### PR DESCRIPTION
This should catch any errors that occur during the initial listing of the objects, even those that make it through the retries. 
The listing should then be retried automatically like usual when the continuous watch ends.

I am not sure if this is the best way to fix this. I am not that familiar with the code base yet. So if you have any recommendations here let me know.

closes: #787

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping maintainers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #787

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
