### PR TITLE
Exclude admission-only resources from streaming/watching

### DIFF
--- a/kopf/_core/reactor/observation.py
+++ b/kopf/_core/reactor/observation.py
@@ -99,7 +99,6 @@ async def resource_observer(
 
     # Scan only the resource-related handlers, ignore activies & co.
     all_handlers: List[handlers.ResourceHandler] = []
-    all_handlers.extend(registry._webhooks.get_all_handlers())
     all_handlers.extend(registry._indexing.get_all_handlers())
     all_handlers.extend(registry._watching.get_all_handlers())
     all_handlers.extend(registry._spawning.get_all_handlers())
@@ -215,7 +214,6 @@ def revise_resources(
 
     # Scan only the resource-related handlers, ignore activies & co.
     all_handlers: List[handlers.ResourceHandler] = []
-    all_handlers.extend(registry._webhooks.get_all_handlers())
     all_handlers.extend(registry._indexing.get_all_handlers())
     all_handlers.extend(registry._watching.get_all_handlers())
     all_handlers.extend(registry._spawning.get_all_handlers())

--- a/tests/observation/test_processing_of_resources.py
+++ b/tests/observation/test_processing_of_resources.py
@@ -219,32 +219,6 @@ async def test_followups_for_deletion_of_group(
     assert group1_404mock.called
 
 
-@pytest.mark.usefixtures('handlers')
-@pytest.mark.parametrize('etype', ['DELETED'])
-async def test_followups_for_deletion_of_group(
-        settings, registry, apis_mock, group1_404mock, timer, etype):
-
-    e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
-    r1 = Resource(group='group1', version='version1', plural='plural1')
-    insights = Insights()
-    insights.resources.add(r1)
-
-    async def delayed_injection(delay: float):
-        await asyncio.sleep(delay)
-        await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry, settings=settings)
-
-    task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1.0):
-        async with insights.revised:
-            await insights.revised.wait()
-    await task
-    assert 0.1 < timer.seconds < 1.0
-    assert not insights.resources
-    assert apis_mock.called
-    assert group1_404mock.called
-
-
 @pytest.mark.parametrize('etype', ['DELETED'])
 async def test_backbone_is_filled(
         settings, registry, core_mock, corev1_mock, timer, etype):


### PR DESCRIPTION
They were added by mistake: if there is an admission handler for a resource and no other handlers except admission, there is no need to start watching for this resource and for its updates. Among other things, the operator might be lacking RBAC permissions to do so — since it does not operate that resource. However, if there are admission handlers and some other handlers, the streaming/watching will happen as usual.

Introduced in 9c3bd1a378835ef2e65051ea2b21e6ab42a2c7ce by cloning the behaviour of other handler types without considering the actual need (or the lack of it).

Closes #816 