### PR TITLE
Support Python 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
   linters:
     name: Linting and static analysis
     runs-on: ubuntu-20.04
-    timeout-minutes: 2  # usually 0.5-1 mins
+    timeout-minutes: 5  # usually 1-2, rarely 3 mins (because of installations)
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - run: pip install -r requirements.txt
       - run: pre-commit run --all-files
       - run: mypy kopf --strict
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.7", "3.8", "3.9" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
     name: Python ${{ matrix.python-version }} ${{ matrix.install-extras }}
     runs-on: ubuntu-20.04
     timeout-minutes: 5  # usually 2-3 mins
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - uses: nolar/setup-k3d-k3s@v1
         with:
           version: ${{ matrix.k3s }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - run: pip install --upgrade setuptools wheel twine
       - run: python setup.py sdist bdist_wheel
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -17,7 +17,7 @@ jobs:
   linters:
     name: Linting and static analysis
     runs-on: ubuntu-20.04
-    timeout-minutes: 2  # usually 0.5-1 mins
+    timeout-minutes: 5  # usually 1-2, rarely 3 mins (because of installations)
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - run: pip install -r requirements.txt
       - run: pre-commit run --all-files
       - run: mypy kopf --strict
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.7", "3.8", "3.9" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
     name: Python ${{ matrix.python-version }} ${{ matrix.install-extras }}
     runs-on: ubuntu-20.04
     timeout-minutes: 5  # usually 2-3 mins
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - uses: nolar/setup-k3d-k3s@v1
         with:
           version: ${{ matrix.k3s }}
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - run: tools/install-minikube.sh
       - run: pip install -r requirements.txt -r examples/requirements.txt
       - run: pytest --color=yes --only-e2e

--- a/kopf/_cogs/helpers/loaders.py
+++ b/kopf/_cogs/helpers/loaders.py
@@ -15,6 +15,7 @@ Multiple files/modules can be specified. They will be loaded in the order.
 """
 
 import importlib
+import importlib.abc
 import importlib.util
 import os.path
 import sys

--- a/kopf/_core/actions/loggers.py
+++ b/kopf/_core/actions/loggers.py
@@ -133,7 +133,7 @@ class ObjectLogger(logging.LoggerAdapter):
     ) -> Tuple[str, MutableMapping[str, Any]]:
         # Native logging overwrites the message's extra with the adapter's extra.
         # We merge them, so that both message's & adapter's extras are available.
-        kwargs["extra"] = dict(self.extra, **kwargs.get('extra', {}))
+        kwargs["extra"] = dict(self.extra or {}, **kwargs.get('extra', {}))
         return msg, kwargs
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ def pytest_configure(config):
     config.addinivalue_line('filterwarnings', 'ignore:"@coroutine":DeprecationWarning:asynctest.mock')
     config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:aiohttp')
     config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:asyncio')
+    config.addinivalue_line('filterwarnings', 'ignore:is deprecated, use current_thread:DeprecationWarning:threading')
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Python 3.10 is scheduled to be released in 2021-10-04, i.e. in one month from now ([PEP-619](https://www.python.org/dev/peps/pep-0619/#schedule)). It is time to prepare. There is a release candidate available already.

Required preparations and bugfixes are done in #835, #836, #837 (they are useful even without Python 3.10).