### PR TITLE
feat: batch window suppression

### DIFF
--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -204,10 +204,22 @@ class BatchingSettings:
     How soon an idle worker is exited and garbage-collected if no events arrive.
     """
 
-    batch_window: float = 0.1
+    batch_window: float = None
     """
-    How fast/slow does a worker deplete the queue when an event is received.
-    All events arriving within this window will be ignored except the last one.
+    A lossy but in some cases viable optimization mechanism to take some 
+    load off of event processing.
+    Defines the debouncing interval a worker depletes the incoming event queue with.
+    All events arriving within this window will be ignored except the last one. This can have 
+    consequences depending on the type and use-case of the operator implemented using kopf. 
+    Example: Given an event sequence of resource A of ``CREATED > MODIFIED > DELETED``, if this 
+    sequence is received by the incoming event queue within ``batch_window`` any handlers dealing
+    with ``CREATED`` or ``MODIFIED`` events of resource A will never be called. Instead the first handler 
+    being called for A will be the ``DELETED`` handler, if one exists. Depending on what your operator 
+    does, this might be problematic. 
+    
+    If your use-case allows debouncing of event sequences for a resource, set this to ``> 0``. 
+    A notable side effect of doing this is an implicit handler delay for all handlers as all events 
+    will only be dispatched to the handler after this interval. 
     """
 
     exit_timeout: float = 2.0

--- a/kopf/_core/reactor/queueing.py
+++ b/kopf/_core/reactor/queueing.py
@@ -304,16 +304,17 @@ async def worker(
                 else:
                     continue
             else:
-                try:
-                    while True:
-                        prev_event = raw_event
-                        next_event = await asyncio.wait_for(
-                            backlog.get(),
-                            timeout=settings.batching.batch_window)
-                        shouldstop = shouldstop or isinstance(next_event, EOS)
-                        raw_event = prev_event if isinstance(next_event, EOS) else next_event
-                except asyncio.TimeoutError:
-                    pass
+                if settings.batching.batch_window is not None:
+                    try:
+                        while True:
+                            prev_event = raw_event
+                            next_event = await asyncio.wait_for(
+                                backlog.get(),
+                                timeout=settings.batching.batch_window)
+                            shouldstop = shouldstop or isinstance(next_event, EOS)
+                            raw_event = prev_event if isinstance(next_event, EOS) else next_event
+                    except asyncio.TimeoutError:
+                        pass
 
             # Exit gracefully and immediately on the end-of-stream marker sent by the watcher.
             if isinstance(raw_event, EOS):


### PR DESCRIPTION
Hi @nolar,

it's been a while since #729. Back then I monkey patched the topics discussed in the issue and went with that up till now. 

I'd like to split this in two parts of which this PR is the first. It disables the batch_window by default and allows to return to the previous behaviour on-demand. I believe the idea behind batch_window is viable in some cases but incorrect to assume for all operator by default. The doc string tries to explain the situation. 

It would be great if you could have a look at it.

Thanks!