### PR TITLE
Revert "Exclude admission-only resources from streaming/watching"

### DIFF
--- a/kopf/_core/reactor/observation.py
+++ b/kopf/_core/reactor/observation.py
@@ -99,6 +99,7 @@ async def resource_observer(
 
     # Scan only the resource-related handlers, ignore activies & co.
     all_handlers: List[handlers.ResourceHandler] = []
+    all_handlers.extend(registry._webhooks.get_all_handlers())
     all_handlers.extend(registry._indexing.get_all_handlers())
     all_handlers.extend(registry._watching.get_all_handlers())
     all_handlers.extend(registry._spawning.get_all_handlers())
@@ -214,6 +215,7 @@ def revise_resources(
 
     # Scan only the resource-related handlers, ignore activies & co.
     all_handlers: List[handlers.ResourceHandler] = []
+    all_handlers.extend(registry._webhooks.get_all_handlers())
     all_handlers.extend(registry._indexing.get_all_handlers())
     all_handlers.extend(registry._watching.get_all_handlers())
     all_handlers.extend(registry._spawning.get_all_handlers())

--- a/tests/observation/test_processing_of_resources.py
+++ b/tests/observation/test_processing_of_resources.py
@@ -86,37 +86,12 @@ def group1_404mock(resp_mocker, aresponses, hostname, apis_mock):
 @pytest.fixture(params=[
     kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
+    kopf.on.validate, kopf.on.mutate,
 ])
 def handlers(request, registry):
     @request.param('group1', 'version1', 'plural1')
     def fn(**_): ...
 
-
-@pytest.mark.parametrize('decorator', [kopf.on.validate, kopf.on.mutate])
-@pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED'])
-async def test_nonwatchable_resources_are_ignored(
-        settings, registry, apis_mock, group1_mock, timer, etype, decorator):
-
-    @decorator('group1', 'version1', 'plural1')
-    def fn(**_): ...
-
-    e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
-    insights = Insights()
-
-    async def delayed_injection(delay: float):
-        await asyncio.sleep(delay)
-        await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry, settings=settings)
-
-    task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1.0):
-        async with insights.revised:
-            await insights.revised.wait()
-    await task
-    assert 0.1 < timer.seconds < 1.0
-    assert not insights.resources
-    assert apis_mock.called
-    assert group1_mock.called
 
 
 async def test_initial_listing_is_ignored(
@@ -195,6 +170,32 @@ async def test_followups_for_deletion_of_resource(
 
 @pytest.mark.usefixtures('handlers')
 @pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED', 'DELETED'])
+async def test_followups_for_deletion_of_group(
+        settings, registry, apis_mock, group1_404mock, timer, etype):
+
+    e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
+    r1 = Resource(group='group1', version='version1', plural='plural1')
+    insights = Insights()
+    insights.resources.add(r1)
+
+    async def delayed_injection(delay: float):
+        await asyncio.sleep(delay)
+        await process_discovered_resource_event(
+            insights=insights, raw_event=e1, registry=registry, settings=settings)
+
+    task = asyncio.create_task(delayed_injection(0.1))
+    async with timer, async_timeout.timeout(1.0):
+        async with insights.revised:
+            await insights.revised.wait()
+    await task
+    assert 0.1 < timer.seconds < 1.0
+    assert not insights.resources
+    assert apis_mock.called
+    assert group1_404mock.called
+
+
+@pytest.mark.usefixtures('handlers')
+@pytest.mark.parametrize('etype', ['DELETED'])
 async def test_followups_for_deletion_of_group(
         settings, registry, apis_mock, group1_404mock, timer, etype):
 

--- a/tests/observation/test_revision_of_resources.py
+++ b/tests/observation/test_revision_of_resources.py
@@ -10,25 +10,12 @@ VERBS = ['list', 'watch', 'patch']
 @pytest.fixture(params=[
     kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
+    kopf.on.validate, kopf.on.mutate,
 ])
 def handlers(request, registry):
     @request.param('group1', 'version1', 'plural1')
     @request.param('group2', 'version2', 'plural2')
     def fn(**_): ...
-
-
-@pytest.mark.parametrize('decorator', [kopf.on.validate, kopf.on.mutate])
-def test_nonwatchable_resources_are_ignored(registry, decorator):
-
-    @decorator('group1', 'version1', 'plural1')
-    @decorator('group2', 'version2', 'plural2')
-    def fn(**_): ...
-
-    r1 = Resource(group='group1', version='version1', plural='plural1', verbs=VERBS)
-    r2 = Resource(group='group2', version='version2', plural='plural2', verbs=VERBS)
-    insights = Insights()
-    revise_resources(registry=registry, insights=insights, group=None, resources=[r1, r2])
-    assert not insights.resources
 
 
 @pytest.mark.usefixtures('handlers')
@@ -72,6 +59,7 @@ def test_replacing_a_new_group(registry):
 @pytest.mark.parametrize('decorator', [
     kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
+    kopf.on.validate, kopf.on.mutate,
 ])
 def test_ambiguity_in_specific_selectors(registry, decorator, caplog, assert_logs):
     r1 = Resource(group='g1', version='v1', plural='plural', verbs=VERBS)
@@ -89,6 +77,7 @@ def test_ambiguity_in_specific_selectors(registry, decorator, caplog, assert_log
 @pytest.mark.parametrize('decorator', [
     kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
+    kopf.on.validate, kopf.on.mutate,
 ])
 def test_corev1_overrides_ambuigity(registry, decorator, caplog, assert_logs):
     r1 = Resource(group='', version='v1', plural='pods', verbs=VERBS)
@@ -106,6 +95,7 @@ def test_corev1_overrides_ambuigity(registry, decorator, caplog, assert_logs):
 @pytest.mark.parametrize('decorator', [
     kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
+    kopf.on.validate, kopf.on.mutate,
 ])
 def test_no_ambiguity_in_generic_selector(registry, decorator, caplog, assert_logs):
     r1 = Resource(group='g1', version='v1', plural='plural', verbs=VERBS)
@@ -123,6 +113,7 @@ def test_no_ambiguity_in_generic_selector(registry, decorator, caplog, assert_lo
 @pytest.mark.parametrize('decorator', [
     kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
     kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
+    kopf.on.validate, kopf.on.mutate,
 ])
 def test_selectors_with_no_resources(registry, decorator, caplog, assert_logs):
     r1 = Resource(group='group1', version='version1', plural='plural1', verbs=VERBS)


### PR DESCRIPTION
It seems, the solution in #826 excludes the admission-only resources not only from watching but also from being included in the managed webhook configurations — so that such resources are not served even for admission.

It has to be re-implemented properly, but it will be slightly more complicated than this — will be a separate PR.

Reverts #826, re-opens #816.