### PR TITLE
Exclude admission-only resources from streaming/watching (2nd try)

### DIFF
--- a/kopf/_cogs/structs/references.py
+++ b/kopf/_cogs/structs/references.py
@@ -478,8 +478,15 @@ class Insights:
     """
     Actual resources & namespaces served by the operator.
     """
+
+    # The precomputed specialised sets of resources as used in independent parts of the framework.
+    # - **Indexed** resources block the operator startup until all objects are initially indexed.
+    # - **Watched** resources spawn the watch-streams; the set excludes all webhook-only resources.
+    # - **Webhook** resources are served via webhooks; the set excludes all watch-only resources.
+    webhook_resources: Set[Resource] = dataclasses.field(default_factory=set)
+    indexed_resources: Set[Resource] = dataclasses.field(default_factory=set)
+    watched_resources: Set[Resource] = dataclasses.field(default_factory=set)
     namespaces: Set[Namespace] = dataclasses.field(default_factory=set)
-    resources: Set[Resource] = dataclasses.field(default_factory=set)
     backbone: Backbone = dataclasses.field(default_factory=Backbone)
 
     # Signalled when anything changes in the insights.
@@ -488,6 +495,3 @@ class Insights:
     # The flags that are set after the initial listing is finished. Not cleared afterwards.
     ready_namespaces: asyncio.Event = dataclasses.field(default_factory=asyncio.Event)
     ready_resources: asyncio.Event = dataclasses.field(default_factory=asyncio.Event)
-
-    # The resources that are part of indices and can block the operator readiness on start.
-    indexable: Set[Resource] = dataclasses.field(default_factory=set)

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -181,7 +181,7 @@ def find_resource(
     version = request_resource['version']
     plural = request_resource['resource']
     selector = references.Selector(group=group, version=version, plural=plural)
-    resources = selector.select(insights.resources)
+    resources = selector.select(insights.webhook_resources)
     if not resources:
         raise UnknownResourceError(f"The specified resource has no handlers: {request_resource}")
     elif len(resources) > 1:
@@ -352,7 +352,7 @@ async def configuration_manager(
             logger.info(f"Reconfiguring the {reason.value} webhook {settings.admission.managed}.")
             webhooks = build_webhooks(
                 all_handlers,
-                resources=insights.resources,
+                resources=insights.webhook_resources,
                 name_suffix=settings.admission.managed,
                 client_config=client_config)
             await patching.patch_obj(
@@ -369,7 +369,7 @@ async def configuration_manager(
             logger.info(f"Cleaning up the admission webhook {settings.admission.managed}.")
             webhooks = build_webhooks(
                 all_handlers,
-                resources=insights.resources,
+                resources=insights.webhook_resources,
                 name_suffix=settings.admission.managed,
                 client_config=client_config,
                 persistent_only=True)

--- a/kopf/_core/intents/handlers.py
+++ b/kopf/_core/intents/handlers.py
@@ -25,10 +25,6 @@ class ResourceHandler(execution.Handler):
     field: Optional[dicts.FieldPath]
     value: Optional[filters.ValueFilter]
 
-    @property
-    def requires_patching(self) -> bool:
-        return True  # all typical handlers except several ones with overrides
-
     def adjust_cause(self, cause: execution.CauseT) -> execution.CauseT:
         if self.field is not None and isinstance(cause, causes.ChangingCause):
             old = dicts.resolve(cause.old, self.field, None)
@@ -52,10 +48,6 @@ class WebhookHandler(ResourceHandler):
     def __str__(self) -> str:
         return f"Webhook {self.id!r}"
 
-    @property
-    def requires_patching(self) -> bool:
-        return False
-
 
 @dataclasses.dataclass
 class IndexingHandler(ResourceHandler):
@@ -64,18 +56,10 @@ class IndexingHandler(ResourceHandler):
     def __str__(self) -> str:
         return f"Indexer {self.id!r}"
 
-    @property
-    def requires_patching(self) -> bool:
-        return False
-
 
 @dataclasses.dataclass
 class WatchingHandler(ResourceHandler):
     fn: callbacks.WatchingFn  # typing clarification
-
-    @property
-    def requires_patching(self) -> bool:
-        return False
 
 
 @dataclasses.dataclass

--- a/kopf/_core/intents/registries.py
+++ b/kopf/_core/intents/registries.py
@@ -15,8 +15,8 @@ import abc
 import enum
 import functools
 from types import FunctionType, MethodType
-from typing import Any, Callable, Collection, Container, Generic, Iterable, Iterator, List, \
-                   Mapping, MutableMapping, Optional, Sequence, Set, Tuple, TypeVar, cast
+from typing import Any, Callable, Collection, Container, FrozenSet, Generic, Iterable, Iterator, \
+                   List, Mapping, MutableMapping, Optional, Sequence, Set, Tuple, TypeVar, cast
 
 from kopf._cogs.structs import dicts, ids, references
 from kopf._core.actions import execution
@@ -71,6 +71,13 @@ class ActivityRegistry(GenericRegistry[handlers.ActivityHandler]):
 
 
 class ResourceRegistry(GenericRegistry[ResourceHandlerT], Generic[ResourceHandlerT, CauseT]):
+
+    def get_all_selectors(self) -> FrozenSet[references.Selector]:
+        return frozenset(
+            handler.selector
+            for handler in self.get_all_handlers()
+            if handler.selector is not None  # None is reserved for sub-handlers
+        )
 
     def has_handlers(
             self,

--- a/tests/admission/conftest.py
+++ b/tests/admission/conftest.py
@@ -111,7 +111,8 @@ async def insights(settings, resource):
     val_resource = Resource('admissionregistration.k8s.io', 'v1', 'validatingwebhookconfigurations')
     mut_resource = Resource('admissionregistration.k8s.io', 'v1', 'mutatingwebhookconfigurations')
     insights = Insights()
-    insights.resources.add(resource)
+    insights.watched_resources.add(resource)
+    insights.webhook_resources.add(resource)
     await insights.backbone.fill(resources=[val_resource, mut_resource])
     insights.ready_resources.set()
     return insights

--- a/tests/observation/test_processing_of_resources.py
+++ b/tests/observation/test_processing_of_resources.py
@@ -194,32 +194,6 @@ async def test_followups_for_deletion_of_group(
     assert group1_404mock.called
 
 
-@pytest.mark.usefixtures('handlers')
-@pytest.mark.parametrize('etype', ['DELETED'])
-async def test_followups_for_deletion_of_group(
-        settings, registry, apis_mock, group1_404mock, timer, etype):
-
-    e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
-    r1 = Resource(group='group1', version='version1', plural='plural1')
-    insights = Insights()
-    insights.resources.add(r1)
-
-    async def delayed_injection(delay: float):
-        await asyncio.sleep(delay)
-        await process_discovered_resource_event(
-            insights=insights, raw_event=e1, registry=registry, settings=settings)
-
-    task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1.0):
-        async with insights.revised:
-            await insights.revised.wait()
-    await task
-    assert 0.1 < timer.seconds < 1.0
-    assert not insights.resources
-    assert apis_mock.called
-    assert group1_404mock.called
-
-
 @pytest.mark.parametrize('etype', ['DELETED'])
 async def test_backbone_is_filled(
         settings, registry, core_mock, corev1_mock, timer, etype):

--- a/tests/observation/test_processing_of_resources.py
+++ b/tests/observation/test_processing_of_resources.py
@@ -83,21 +83,62 @@ def group1_404mock(resp_mocker, aresponses, hostname, apis_mock):
     return mock
 
 
+@pytest.fixture()
+async def insights():
+    return Insights()
+
+
 @pytest.fixture(params=[
-    kopf.on.event, kopf.daemon, kopf.timer, kopf.index,
-    kopf.on.resume, kopf.on.create, kopf.on.update, kopf.on.delete,
-    kopf.on.validate, kopf.on.mutate,
+    (kopf.on.event, 'watched_resources'),
+    (kopf.daemon, 'watched_resources'),
+    (kopf.timer, 'watched_resources'),
+    (kopf.index, 'watched_resources'),
+    (kopf.index, 'indexed_resources'),
+    (kopf.on.resume, 'watched_resources'),
+    (kopf.on.create, 'watched_resources'),
+    (kopf.on.update, 'watched_resources'),
+    (kopf.on.delete, 'watched_resources'),
+    (kopf.on.validate, 'webhook_resources'),
+    (kopf.on.mutate, 'webhook_resources'),
 ])
-def handlers(request, registry):
-    @request.param('group1', 'version1', 'plural1')
+def insights_resources(request, registry, insights):
+    decorator, insights_field = request.param
+
+    @decorator('group1', 'version1', 'plural1')
     def fn(**_): ...
 
+    return getattr(insights, insights_field)
+
+
+@pytest.mark.parametrize('decorator', [kopf.on.validate, kopf.on.mutate])
+@pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED'])
+async def test_nonwatchable_resources_are_ignored(
+        settings, registry, apis_mock, group1_mock, timer, etype, decorator, insights):
+
+    @decorator('group1', 'version1', 'plural1')
+    def fn(**_): ...
+
+    e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
+
+    async def delayed_injection(delay: float):
+        await asyncio.sleep(delay)
+        await process_discovered_resource_event(
+            insights=insights, raw_event=e1, registry=registry, settings=settings)
+
+    task = asyncio.create_task(delayed_injection(0.1))
+    async with timer, async_timeout.timeout(1.0):
+        async with insights.revised:
+            await insights.revised.wait()
+    await task
+    assert 0.1 < timer.seconds < 1.0
+    assert not insights.watched_resources
+    assert apis_mock.called
+    assert group1_mock.called
 
 
 async def test_initial_listing_is_ignored(
-        settings, registry, apis_mock, group1_mock):
+        settings, registry, apis_mock, group1_mock, insights):
 
-    insights = Insights()
     e1 = RawEvent(type=None, object=RawBody(spec={'group': 'group1'}))
 
     async def delayed_injection(delay: float):
@@ -112,19 +153,19 @@ async def test_initial_listing_is_ignored(
                 await insights.revised.wait()
     await task
     assert timeout.expired
-    assert not insights.resources
+    assert not insights.indexed_resources
+    assert not insights.watched_resources
+    assert not insights.webhook_resources
     assert not apis_mock.called
     assert not group1_mock.called
 
 
-@pytest.mark.usefixtures('handlers')
 @pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED'])
 async def test_followups_for_addition(
-        settings, registry, apis_mock, group1_mock, timer, etype):
+        settings, registry, apis_mock, group1_mock, timer, etype, insights, insights_resources):
 
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
     r1 = Resource(group='group1', version='version1', plural='plural1')
-    insights = Insights()
 
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
@@ -137,20 +178,19 @@ async def test_followups_for_addition(
             await insights.revised.wait()
     await task
     assert 0.1 < timer.seconds < 1.0
-    assert insights.resources == {r1}
+    assert insights_resources == {r1}
     assert apis_mock.called
     assert group1_mock.called
 
 
-@pytest.mark.usefixtures('handlers')
 @pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED', 'DELETED'])
 async def test_followups_for_deletion_of_resource(
-        settings, registry, apis_mock, group1_empty_mock, timer, etype):
+        settings, registry, apis_mock, group1_empty_mock, timer, etype,
+        insights, insights_resources):
 
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
     r1 = Resource(group='group1', version='version1', plural='plural1')
-    insights = Insights()
-    insights.resources.add(r1)
+    insights_resources.add(r1)
 
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
@@ -163,20 +203,18 @@ async def test_followups_for_deletion_of_resource(
             await insights.revised.wait()
     await task
     assert 0.1 < timer.seconds < 1.0
-    assert not insights.resources
+    assert not insights_resources
     assert apis_mock.called
     assert group1_empty_mock.called
 
 
-@pytest.mark.usefixtures('handlers')
 @pytest.mark.parametrize('etype', ['ADDED', 'MODIFIED', 'DELETED'])
 async def test_followups_for_deletion_of_group(
-        settings, registry, apis_mock, group1_404mock, timer, etype):
+        settings, registry, apis_mock, group1_404mock, timer, etype, insights, insights_resources):
 
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': 'group1'}))
     r1 = Resource(group='group1', version='version1', plural='plural1')
-    insights = Insights()
-    insights.resources.add(r1)
+    insights_resources.add(r1)
 
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)
@@ -189,17 +227,16 @@ async def test_followups_for_deletion_of_group(
             await insights.revised.wait()
     await task
     assert 0.1 < timer.seconds < 1.0
-    assert not insights.resources
+    assert not insights_resources
     assert apis_mock.called
     assert group1_404mock.called
 
 
 @pytest.mark.parametrize('etype', ['DELETED'])
 async def test_backbone_is_filled(
-        settings, registry, core_mock, corev1_mock, timer, etype):
+        settings, registry, core_mock, corev1_mock, timer, etype, insights):
 
     e1 = RawEvent(type=etype, object=RawBody(spec={'group': ''}))
-    insights = Insights()
 
     async def delayed_injection(delay: float):
         await asyncio.sleep(delay)

--- a/tests/orchestration/test_task_adjustments.py
+++ b/tests/orchestration/test_task_adjustments.py
@@ -71,8 +71,8 @@ async def test_new_resources_and_namespaces_spawn_new_tasks(
 
     r1 = Resource(group='group1', version='version1', plural='plural1', namespaced=True)
     r2 = Resource(group='group2', version='version2', plural='plural2', namespaced=True)
-    insights.resources.add(r1)
-    insights.resources.add(r2)
+    insights.watched_resources.add(r1)
+    insights.watched_resources.add(r2)
     insights.namespaces.add('ns1')
     insights.namespaces.add('ns2')
     r1ns1 = EnsembleKey(resource=r1, namespace='ns1')
@@ -103,8 +103,8 @@ async def test_gone_resources_and_namespaces_stop_running_tasks(
 
     r1 = Resource(group='group1', version='version1', plural='plural1', namespaced=True)
     r2 = Resource(group='group2', version='version2', plural='plural2', namespaced=True)
-    insights.resources.add(r1)
-    insights.resources.add(r2)
+    insights.watched_resources.add(r1)
+    insights.watched_resources.add(r2)
     insights.namespaces.add('ns1')
     insights.namespaces.add('ns2')
     r1ns1 = EnsembleKey(resource=r1, namespace='ns1')
@@ -126,7 +126,7 @@ async def test_gone_resources_and_namespaces_stop_running_tasks(
     r2ns1_task = ensemble.watcher_tasks[r2ns1]
     r2ns2_task = ensemble.watcher_tasks[r2ns2]
 
-    insights.resources.discard(r2)
+    insights.watched_resources.discard(r2)
     insights.namespaces.discard('ns2')
 
     await adjust_tasks(  # action-under-test
@@ -152,8 +152,8 @@ async def test_cluster_tasks_continue_running_on_namespace_deletion(
 
     r1 = Resource(group='group1', version='version1', plural='plural1', namespaced=True)
     r2 = Resource(group='group2', version='version2', plural='plural2', namespaced=True)
-    insights.resources.add(r1)
-    insights.resources.add(r2)
+    insights.watched_resources.add(r1)
+    insights.watched_resources.add(r2)
     insights.namespaces.add(None)
     r1nsN = EnsembleKey(resource=r1, namespace=None)
     r2nsN = EnsembleKey(resource=r2, namespace=None)
@@ -196,7 +196,7 @@ async def test_no_peering_tasks_with_no_peering_resources(
     settings.peering.mandatory = False
     insights = Insights()
     r1 = Resource(group='group1', version='version1', plural='plural1', namespaced=True)
-    insights.resources.add(r1)
+    insights.watched_resources.add(r1)
     insights.namespaces.add('ns1')
 
     await adjust_tasks(


### PR DESCRIPTION
Split the all-in-one set of resources into 3 separate sets: "watched", "indexed", and "webhook" — to be used in separate engines or for separate purposes. Unless there is an overlap via handlers, the resource sets will not be overlapping anymore.

As a result, the webhook-only resources will not be watched anymore (#816), i.e. no watching tasks will be spawned (which required RBAC permissions and failed). The opposite is also true — the watched-only resources will not be considered in admissions — but it was already avoided by checking for webhook handlers even if all resources were scanned there.

_The namespaces are renamed to "watched" to be aligned with the "watched" resources — as the namespaces are only used in pair with them, not with other kinds of resources._

Fixes #816, reimplements #826 #830.