### PR TITLE
Update `Mapping` type to match new `mypy`

### DIFF
--- a/kopf/_core/engines/peering.py
+++ b/kopf/_core/engines/peering.py
@@ -116,7 +116,7 @@ async def process_peering_event(
         return
 
     # Find if we are still the highest priority operator.
-    pairs = cast(Mapping[str, Mapping[str, object]], body.get('status', {}))
+    pairs = cast(Mapping[str, Mapping[str, Any]], body.get('status', {}))
     peers = [Peer(identity=Identity(opid), **opinfo) for opid, opinfo in pairs.items()]
     dead_peers = [peer for peer in peers if peer.is_dead]
     live_peers = [peer for peer in peers if not peer.is_dead and peer.identity != identity]


### PR DESCRIPTION
Hi!

I am working on a new feature in `mypy` and it identified a problem in your code.
`Mapping[str, object]` cannot be unpacked into `priority: int = 0, lifetime: int = 60, lastseen: Optional[str] = None,`, but `Mapping[str, Any]` can be.

Link: https://github.com/python/mypy/pull/11151