### PR TITLE
Replace aiojobs with a simplified "fire-and-forget" scheduler

### DIFF
--- a/kopf/_cogs/aiokits/aiotasks.py
+++ b/kopf/_cogs/aiokits/aiotasks.py
@@ -7,7 +7,7 @@ as we not only wait for them, but also cancel them.
 
 Anyway, ``asyncio`` wraps all awaitables and coroutines into tasks on almost
 all function calls with multiple awaiables (e.g. :func:`asyncio.wait`),
-so there is no added overhead; intstead, the implicit overhead is made explicit.
+so there is no added overhead; instead, the implicit overhead is made explicit.
 """
 import asyncio
 import logging

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         'python-json-logger',   # 0.05 MB
         'iso8601',              # 0.07 MB
         'click',                # 0.60 MB
-        'aiojobs',              # 0.07 MB
         'aiohttp<4.0.0',        # 7.80 MB
         'pyyaml',               # 0.90 MB
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def pytest_configure(config):
     # Warnings from the testing tools out of our control should not fail the tests.
     config.addinivalue_line('filterwarnings', 'ignore:"@coroutine":DeprecationWarning:asynctest.mock')
     config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:aiohttp')
-    config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:asyncio.queues')
+    config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:asyncio')
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,7 @@ def pytest_configure(config):
     # Warnings from the testing tools out of our control should not fail the tests.
     config.addinivalue_line('filterwarnings', 'ignore:"@coroutine":DeprecationWarning:asynctest.mock')
     config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:aiohttp')
-    config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:aiojobs')
-    config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:asyncio.queues')  # aiojobs
+    config.addinivalue_line('filterwarnings', 'ignore:The loop argument:DeprecationWarning:asyncio.queues')
 
 
 def pytest_addoption(parser):

--- a/tests/utilities/aiotasks/test_coro_cancellation.py
+++ b/tests/utilities/aiotasks/test_coro_cancellation.py
@@ -1,0 +1,79 @@
+import asyncio
+import gc
+import warnings
+from unittest.mock import Mock
+
+import pytest
+from asynctest import CoroutineMock
+
+from kopf._cogs.aiokits.aiotasks import cancel_coro
+
+
+async def f(mock):
+    return mock()
+
+
+def factory(loop, coro_or_mock):
+    coro = coro_or_mock._mock_wraps if isinstance(coro_or_mock, CoroutineMock) else coro_or_mock
+    return asyncio.Task(coro, loop=loop)
+
+
+@pytest.fixture(autouse=True)
+async def coromock_task_factory():
+    factory_spy = Mock(wraps=factory)
+    asyncio.get_running_loop().set_task_factory(factory_spy)
+    yield factory_spy
+    asyncio.get_running_loop().set_task_factory(None)
+
+
+async def test_coro_issues_a_warning_normally(coromock_task_factory):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('default')
+        mock = Mock()
+        coro = f(mock)
+
+        # The warnings come only from the garbage collection, so dereference it.
+        del coro
+        gc.collect()
+
+    # The 1st coro is the test function itself; the 2nd coro would be the coro-under-test.
+    assert coromock_task_factory.call_count == 1  # i.e. the task was NOT created.
+    assert not mock.called
+    assert len(w) == 1
+    assert issubclass(w[0].category, RuntimeWarning)
+    assert str(w[0].message) == "coroutine 'f' was never awaited"
+
+
+async def test_coro_is_closed_via_a_hack_with_no_warning(coromock_task_factory):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('default')
+        mock = Mock()
+        coro = f(mock)
+        await cancel_coro(coro)
+
+        # The warnings come only from the garbage collection, so dereference it.
+        del coro
+        gc.collect()
+
+    # The 1st coro is the test function itself; the 2nd coro would be the coro-under-test.
+    assert coromock_task_factory.call_count == 1  # i.e. the task was NOT created.
+    assert not mock.called
+    assert not w
+
+
+async def test_coro_is_awaited_via_a_task_with_no_warning(coromock_task_factory):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('default')
+        mock = Mock()
+        coro = CoroutineMock(wraps=f(mock))
+        del coro.close
+        await cancel_coro(coro)
+
+        # The warnings come only from the garbage collection, so dereference it.
+        del coro
+        gc.collect()
+
+    # The 1st coro is the test function itself; the 2nd coro is the coro-under-test.
+    assert coromock_task_factory.call_count == 2  # i.e. the task WAS created.
+    assert not mock.called
+    assert not w

--- a/tests/utilities/aiotasks/test_scheduler.py
+++ b/tests/utilities/aiotasks/test_scheduler.py
@@ -1,0 +1,182 @@
+import asyncio
+from unittest.mock import Mock
+
+import async_timeout
+import pytest
+
+from kopf._cogs.aiokits.aiotasks import Scheduler
+
+CODE_OVERHEAD = 0.01
+
+
+async def f(mock, *args):
+    try:
+        mock('started')
+        for arg in args:
+            if isinstance(arg, asyncio.Event):
+                arg.set()
+            elif isinstance(arg, float):
+                await asyncio.sleep(arg)
+            elif callable(arg):
+                arg()
+    except asyncio.CancelledError:
+        mock('cancelled')
+    else:
+        mock('finished')
+
+
+async def test_empty_scheduler_lifecycle(timer):
+    with timer, async_timeout.timeout(1):
+        scheduler = Scheduler()
+        assert scheduler.empty()
+        await scheduler.wait()
+        assert scheduler.empty()
+        await scheduler.close()
+        assert scheduler.empty()
+    assert timer.seconds < CODE_OVERHEAD
+
+
+async def test_task_spawning_and_graceful_finishing(timer):
+    mock = Mock()
+    flag1 = asyncio.Event()
+    flag2 = asyncio.Event()
+    scheduler = Scheduler()
+
+    result = await scheduler.spawn(f(mock, flag1, 0.1, flag2))
+    assert result is None
+
+    with timer, async_timeout.timeout(1):
+        await flag1.wait()
+    assert timer.seconds < CODE_OVERHEAD
+    assert mock.call_args[0][0] == 'started'
+
+    with timer, async_timeout.timeout(1):
+        await flag2.wait()
+    assert timer.seconds > 0.1
+    assert timer.seconds < 0.1 + CODE_OVERHEAD
+    assert mock.call_args[0][0] == 'finished'
+
+    await scheduler.close()
+
+
+async def test_task_spawning_and_cancellation(timer):
+    mock = Mock()
+    flag1 = asyncio.Event()
+    flag2 = asyncio.Event()
+    scheduler = Scheduler()
+
+    result = await scheduler.spawn(f(mock, flag1, 1.0, flag2))
+    assert result is None
+
+    with timer, async_timeout.timeout(1):
+        await flag1.wait()
+    assert timer.seconds < CODE_OVERHEAD
+    assert mock.call_args[0][0] == 'started'
+
+    with timer, async_timeout.timeout(1):
+        await scheduler.close()
+    assert timer.seconds < CODE_OVERHEAD  # near-instant
+    assert mock.call_args[0][0] == 'cancelled'
+
+
+async def test_no_tasks_are_accepted_after_closing():
+    scheduler = Scheduler()
+    await scheduler.close()
+
+    assert scheduler._closed
+    assert scheduler._spawning_task.done()
+    assert scheduler._cleaning_task.done()
+
+    with async_timeout.timeout(1):
+        with pytest.raises(RuntimeError, match=r"Cannot add new coroutines"):
+            await scheduler.spawn(f(Mock(), 1.0))
+
+
+async def test_successes_are_not_reported():
+    exception_handler = Mock()
+    scheduler = Scheduler(exception_handler=exception_handler)
+    with async_timeout.timeout(1):
+        await scheduler.spawn(f(Mock()))
+        await scheduler.wait()
+        await scheduler.close()
+    assert exception_handler.call_count == 0
+
+
+async def test_cancellations_are_not_reported():
+    exception_handler = Mock()
+    mock = Mock(side_effect=asyncio.CancelledError())
+    scheduler = Scheduler(exception_handler=exception_handler)
+    with async_timeout.timeout(1):
+        await scheduler.spawn(f(mock, 1))
+        await scheduler.wait()
+        await scheduler.close()
+    assert exception_handler.call_count == 0
+
+
+async def test_exceptions_are_reported():
+    exception = ValueError('hello')
+    exception_handler = Mock()
+    mock = Mock(side_effect=exception)
+    scheduler = Scheduler(exception_handler=exception_handler)
+    with async_timeout.timeout(1):
+        await scheduler.spawn(f(mock))
+        await scheduler.wait()
+        await scheduler.close()
+    assert exception_handler.call_count == 1
+    assert exception_handler.call_args[0][0] is exception
+
+
+async def test_tasks_are_parallel_if_limit_is_not_reached(timer):
+    """
+    time:  ////////----------------------0.1s------------------0.2s--///
+    task1: ->spawn->start->sleep->finish->|
+    task2: ->spawn->start->sleep->finish->|
+    """
+    task1_started = asyncio.Event()
+    task1_finished = asyncio.Event()
+    task2_started = asyncio.Event()
+    task2_finished = asyncio.Event()
+    scheduler = Scheduler(limit=2)
+
+    with timer, async_timeout.timeout(1):
+        await scheduler.spawn(f(Mock(), task1_started, 0.1, task1_finished))
+        await scheduler.spawn(f(Mock(), task2_started, 0.1, task2_finished))
+    assert timer.seconds < CODE_OVERHEAD  # i.e. spawning is not not blocking
+
+    with timer, async_timeout.timeout(1):
+        await task1_finished.wait()
+        assert task2_started.is_set()
+        await task2_finished.wait()
+
+    assert timer.seconds > 0.1
+    assert timer.seconds < 0.1 + CODE_OVERHEAD
+
+    await scheduler.close()
+
+
+async def test_tasks_are_pending_if_limit_is_reached(timer):
+    """
+    time:  ////////----------------------0.1s------------------0.2s--///
+    task1: ->spawn->start->sleep->finish->|
+    task2: ->spawn->.....(pending)......->start->sleep->finish->|
+    """
+    task1_started = asyncio.Event()
+    task1_finished = asyncio.Event()
+    task2_started = asyncio.Event()
+    task2_finished = asyncio.Event()
+    scheduler = Scheduler(limit=1)
+
+    with timer, async_timeout.timeout(1):
+        await scheduler.spawn(f(Mock(), task1_started, 0.1, task1_finished))
+        await scheduler.spawn(f(Mock(), task2_started, 0.1, task2_finished))
+    assert timer.seconds < CODE_OVERHEAD  # i.e. spawning is not not blocking
+
+    with timer, async_timeout.timeout(1):
+        await task1_finished.wait()
+        assert not task2_started.is_set()
+        await task2_finished.wait()
+
+    assert timer.seconds > 0.2
+    assert timer.seconds < 0.2 + CODE_OVERHEAD * 2
+
+    await scheduler.close()


### PR DESCRIPTION
Python 3.10 removed some features explicitly used in aiojobs, such as `loop=` kwargs and `asyncio.get_event_loop()` (see code comments for details). Unfortunately, aiojobs seems essentially unmaintained for 2 years (since July 2019), so there is no hope it will be fixed soon. To keep Kopf compatible with Python 3.10, aiojobs' scheduler is replaced with a self-made and over-simplified "fire-and-forget" task scheduler — so that aiojobs can be removed as a dependency.

Note: enabling Python 3.10 is done as a separate change. This commit is only for refactoring.

Related: #828 