### PR TITLE
Reverse the SSL authentication mode for API requests

### DIFF
--- a/kopf/_cogs/clients/auth.py
+++ b/kopf/_cogs/clients/auth.py
@@ -120,7 +120,7 @@ class APIContext:
         context: ssl.SSLContext
         if certificate_path and private_key_path:
             context = ssl.create_default_context(
-                purpose=ssl.Purpose.CLIENT_AUTH,
+                purpose=ssl.Purpose.SERVER_AUTH,
                 cafile=ca_path)
             context.load_cert_chain(
                 certfile=certificate_path,


### PR DESCRIPTION
It is unclear how did it happen that "client" and "server" modes were mixed up, and especially how did it work for years without being noticed. Anyway, since Python 3.10, the SSL modes became stricter, so the error broke all API requests.

Related: #828 