### PR TITLE
Manage event loops via policies in Python 3.10

### DIFF
--- a/kopf/_core/actions/invocation.py
+++ b/kopf/_core/actions/invocation.py
@@ -131,7 +131,7 @@ async def invoke(
         # in the task than to have orphan threads which deplete the executor's pool capacity.
         # Cancellation is postponed until the thread exits, but it happens anyway (for consistency).
         # Note: the docs say the result is a future, but typesheds say it is a coroutine => cast()!
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         executor = settings.execution.executor if settings is not None else None
         future = cast(aiotasks.Future, loop.run_in_executor(executor, real_fn))
         cancellation: Optional[asyncio.CancelledError] = None

--- a/kopf/_core/actions/loggers.py
+++ b/kopf/_core/actions/loggers.py
@@ -192,7 +192,8 @@ def configure(
         if not debug:
             logger.handlers[:] = [logging.NullHandler()]
 
-    loop = asyncio.get_event_loop()
+    # Since Python 3.10, get_event_loop() is deprecated, issues a warning. Here is a way around:
+    loop = asyncio.get_event_loop_policy().get_event_loop()
     loop.set_debug(bool(debug))
 
 

--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -45,9 +45,15 @@ def run(
     """
     Run the whole operator synchronously.
 
-    This function should be used to run an operator in normal sync mode.
+    If the loop is not specified, the operator runs in the event loop
+    of the current _context_ (by asyncio's default, the current thread).
+    See: https://docs.python.org/3/library/asyncio-policy.html for details.
+
+    Alternatively, use `asyncio.run(kopf.operator(...))` with the same options.
+    It will take care of a new event loop's creation and finalization for this
+    call. See: :func:`asyncio.run`.
     """
-    loop = loop if loop is not None else asyncio.get_event_loop()
+    loop = loop if loop is not None else asyncio.get_event_loop_policy().get_event_loop()
     try:
         loop.run_until_complete(operator(
             lifecycle=lifecycle,

--- a/tests/cli/test_logging.py
+++ b/tests/cli/test_logging.py
@@ -59,7 +59,7 @@ def test_no_lowlevel_dumps_in_nondebug(invoke, caplog, options, preload, real_ru
 
     alien_records = [m for m in caplog.records if not m.name.startswith('kopf')]
     assert len(alien_records) == 0
-    assert not asyncio.get_event_loop().get_debug()
+    assert not asyncio.get_event_loop_policy().get_event_loop().get_debug()
 
 
 @pytest.mark.parametrize('options', [
@@ -73,5 +73,5 @@ def test_lowlevel_dumps_in_debug_mode(invoke, caplog, options, preload, real_run
     logging.getLogger('asyncio').debug('hello!')
 
     alien_records = [m for m in caplog.records if not m.name.startswith('kopf')]
-    assert len(alien_records) == 1
-    assert asyncio.get_event_loop().get_debug()
+    assert len(alien_records) >= 1
+    assert asyncio.get_event_loop_policy().get_event_loop().get_debug()


### PR DESCRIPTION
In Python 3.10, `asyncio.get_event_loop()` is deprecated and issues a warning — which is considered an error in Kopf's tests. `asyncio.get_running_loop()` can be used only from inside the event loops, not from outside. From the outside, the event loop policies should be used — they do not issue warnings.

Also mention `asyncio.run()` as a good alternative (maybe even better than the policies, but we keep Kopf behaving backwards-compatible for now — i.e., use the contexts/threads for event loop detection).

Related: #828 
