### PR TITLE
Retry asyncio.TimeoutErrors during API requests

### DIFF
--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -84,7 +84,7 @@ async def request(
             )
             await errors.check_response(response)  # but do not parse it!
 
-        except (aiohttp.ClientConnectionError, errors.APIServerError) as e:
+        except (aiohttp.ClientConnectionError, errors.APIServerError, asyncio.TimeoutError) as e:
             if backoff is None:  # i.e. the last or the only attempt.
                 logger.error(f"Request attempt {idx} failed; escalating: {what} -> {e!r}")
                 raise

--- a/tests/apis/test_api_requests.py
+++ b/tests/apis/test_api_requests.py
@@ -149,6 +149,9 @@ async def test_direct_timeout_in_requests(
 
     with timer, pytest.raises(asyncio.TimeoutError):
         timeout = aiohttp.ClientTimeout(total=0.1)
+        # aiohttp raises an asyncio.TimeoutError which is automatically retried.
+        # To reduce the test duration we disable retries for this test.
+        settings.networking.error_backoffs = None
         await fn('/url', timeout=timeout, settings=settings, logger=logger)
 
     assert 0.1 < timer.seconds < 0.2
@@ -172,6 +175,9 @@ async def test_settings_timeout_in_requests(
 
     with timer, pytest.raises(asyncio.TimeoutError):
         settings.networking.request_timeout = 0.1
+        # aiohttp raises an asyncio.TimeoutError which is automatically retried.
+        # To reduce the test duration we disable retries for this test.
+        settings.networking.error_backoffs = None
         await fn('/url', settings=settings, logger=logger)
 
     assert 0.1 < timer.seconds < 0.2
@@ -190,6 +196,9 @@ async def test_direct_timeout_in_streams(
 
     with timer, pytest.raises(asyncio.TimeoutError):
         timeout = aiohttp.ClientTimeout(total=0.1)
+        # aiohttp raises an asyncio.TimeoutError which is automatically retried.
+        # To reduce the test duration we disable retries for this test.
+        settings.networking.error_backoffs = None
         async for _ in stream('/url', timeout=timeout, settings=settings, logger=logger):
             pass
 
@@ -209,6 +218,9 @@ async def test_settings_timeout_in_streams(
 
     with timer, pytest.raises(asyncio.TimeoutError):
         settings.networking.request_timeout = 0.1
+        # aiohttp raises an asyncio.TimeoutError which is automatically retried.
+        # To reduce the test duration we disable retries for this test.
+        settings.networking.error_backoffs = None
         async for _ in stream('/url', settings=settings, logger=logger):
             pass
 


### PR DESCRIPTION
aiohttp is no longer using aiohttp specific timeout errors (the
only exception being the ServerTimeoutError which is used in two
cases https://github.com/aio-libs/aiohttp/blob/v3.7.4/tests/test_client_functional.py).
In all other scenarios aiohttp instead expects an asyncio.TimeoutError.
A timeout during an API request should be considered temporary and
therefore only be escalated when all retries are exhausted.

I hope this is the correct place to handle the error. If not let me know and I can update the PR.

closes: #840 
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping maintainers for the review!

In case of existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
