### PR TITLE
Render the lists properly in the docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,4 @@
 sphinx>=2.0.0
 sphinx-autobuild
 sphinx-autodoc-typehints
-sphinx_rtd_theme
+sphinx_rtd_theme>=0.5


### PR DESCRIPTION
The old theme (0.4.3) fails the list rendering and makes them a regular text with a regular flow (not bulleted). The old version comes from a constraint `<0.5` somewhere inside the ReadTheDocs service — not from Kopf's code.
