### PR TITLE
Show the proper class name in daemon-stopped flags

### DIFF
--- a/kopf/_cogs/aiokits/aioenums.py
+++ b/kopf/_cogs/aiokits/aioenums.py
@@ -82,7 +82,7 @@ class FlagWaiter(Generic[FlagReasonT]):
         self._setter = setter
 
     def __repr__(self) -> str:
-        return repr(self._setter)
+        return f'<{self.__class__.__name__}: {self.is_set()}, reason={self.reason}>'
 
     def __bool__(self) -> bool:
         return self._setter.is_set()


### PR DESCRIPTION
Related: #852 