### PR TITLE
Add old, new, diff and operation to WebhookCause

### DIFF
--- a/kopf/_core/intents/causes.py
+++ b/kopf/_core/intents/causes.py
@@ -153,13 +153,15 @@ class WebhookCause(ResourceCause):
     warnings: List[str]  # mutable!
     operation: Optional[reviews.Operation]  # None if not provided for some reason
     subresource: Optional[str]  # e.g. "status", "scale"; None for the main resource body
+    old: Optional[bodies.Body] = None
+    new: Optional[bodies.Body] = None
+    diff: Optional[diffs.Diff] = None
 
     @property
     def _kwargs(self) -> Mapping[str, Any]:
         kwargs = dict(super()._kwargs)
         del kwargs['reason']
         del kwargs['webhook']
-        del kwargs['operation']
         return kwargs
 
 

--- a/tests/causation/test_kwargs.py
+++ b/tests/causation/test_kwargs.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import pytest
 
 from kopf._cogs.configs.configuration import OperatorSettings
+from kopf._cogs.structs import diffs
 from kopf._cogs.structs.bodies import Body, BodyEssence
 from kopf._cogs.structs.diffs import Diff
 from kopf._cogs.structs.ephemera import Memo
@@ -85,13 +86,16 @@ def test_admission_kwargs(resource, attr):
         reason=None,
         operation=None,
         subresource=None,
+        new=BodyEssence(body),
+        old=None,
+        diff=diffs.diff(BodyEssence(body), None),
     )
     kwargs = getattr(cause, attr)  # cause.kwargs / cause.sync_kwargs / cause.async_kwargs
     assert set(kwargs) == {'logger', 'resource',
                            'dryrun', 'headers', 'sslpeer', 'userinfo', 'warnings', 'subresource',
                            'patch', 'memo',
                            'body', 'spec', 'status', 'meta', 'uid', 'name', 'namespace',
-                           'labels', 'annotations'}
+                           'labels', 'annotations', 'old', 'new', 'diff', 'operation'}
     assert kwargs['resource'] is cause.resource
     assert kwargs['logger'] is cause.logger
     assert kwargs['dryrun'] is cause.dryrun
@@ -110,6 +114,10 @@ def test_admission_kwargs(resource, attr):
     assert kwargs['uid'] == cause.body.metadata.uid
     assert kwargs['name'] == cause.body.metadata.name
     assert kwargs['namespace'] == cause.body.metadata.namespace
+    assert kwargs['operation'] == cause.operation
+    assert kwargs['new'] == cause.new
+    assert kwargs['old'] == cause.old
+    assert kwargs['diff'] == cause.diff
 
 
 @pytest.mark.parametrize('attr', ['kwargs', 'sync_kwargs', 'async_kwargs'])


### PR DESCRIPTION
Adding kwargs old, new, diff and operation to the WebhookCause and
passing them to the appropriate handler. This allows users to write
more powerful webhooks and allows them to create validation and
mutation webhooks that can look at the old object to determine
their behavior. This commit also adds the operation field to the
passed kwargs to allow users to create more powerful/flexibly webhooks.

closes: #851

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping maintainers for the review!

In case of existing issue, reference it using one of the following:



How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
