### PR TITLE
Allow setting controller block owner deletion false

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ and [Historic GitHub Contributors](https://github.com/zalando-incubator/kopf/gra
 
 ## Contributors sorted alphabetically
 
+- [Anthony Nash](https://github.com/nashant)
 - [Daniel Middlecote](https://github.com/dlmiddlecote)
 - [Henning Jacobs](https://github.com/hjacobs)
 - [Clement Liaw](https://github.com/iexalt)

--- a/docs/hierarchies.rst
+++ b/docs/hierarchies.rst
@@ -150,6 +150,14 @@ processed at the moment, omit the explicit owner argument or set it to ``None``:
         #      'name': 'kopf-example-1',
         #      'uid': '6b931859-5d50-4b5c-956b-ea2fed0d1058'}]}}]
 
+To set an owner to not be a controller or not block owner deletion:
+
+.. code-block:: python
+
+    kopf.append_owner_reference(objs, controller=False, block_owner_deletion=False)
+
+Both of the above are True by default
+
 .. seealso::
     :doc:`walkthrough/deletion`.
 

--- a/kopf/_cogs/structs/bodies.py
+++ b/kopf/_cogs/structs/bodies.py
@@ -246,6 +246,7 @@ def build_object_reference(
 
 def build_owner_reference(
         body: Body,
+        *,
         controller: Optional[bool] = True,
         block_owner_deletion: Optional[bool] = True,
 ) -> OwnerReference:

--- a/kopf/_cogs/structs/bodies.py
+++ b/kopf/_cogs/structs/bodies.py
@@ -246,6 +246,8 @@ def build_object_reference(
 
 def build_owner_reference(
         body: Body,
+        controller: Optional[bool] = True,
+        block_owner_deletion: Optional[bool] = True,
 ) -> OwnerReference:
     """
     Construct an owner reference object for the parent-children relationships.
@@ -257,8 +259,8 @@ def build_owner_reference(
     for cluster resources, or e.g. ``apiVersion`` for ``kind: Node``, etc.
     """
     ref = dict(
-        controller=True,
-        blockOwnerDeletion=True,
+        controller=controller,
+        blockOwnerDeletion=block_owner_deletion,
         apiVersion=body.get('apiVersion'),
         kind=body.get('kind'),
         name=body.get('metadata', {}).get('name'),

--- a/kopf/_cogs/structs/bodies.py
+++ b/kopf/_cogs/structs/bodies.py
@@ -266,4 +266,4 @@ def build_owner_reference(
         name=body.get('metadata', {}).get('name'),
         uid=body.get('metadata', {}).get('uid'),
     )
-    return cast(OwnerReference, {key: val for key, val in ref.items() if val})
+    return cast(OwnerReference, {key: val for key, val in ref.items() if val is not None})

--- a/kopf/_kits/hierarchies.py
+++ b/kopf/_kits/hierarchies.py
@@ -22,6 +22,7 @@ class _UNSET(enum.Enum):
 def append_owner_reference(
         objs: K8sObjects,
         owner: Optional[bodies.Body] = None,
+        *,
         controller: Optional[bool] = True,
         block_owner_deletion: Optional[bool] = True,
 ) -> None:

--- a/kopf/_kits/hierarchies.py
+++ b/kopf/_kits/hierarchies.py
@@ -22,6 +22,8 @@ class _UNSET(enum.Enum):
 def append_owner_reference(
         objs: K8sObjects,
         owner: Optional[bodies.Body] = None,
+        controller: Optional[bool] = True,
+        block_owner_deletion: Optional[bool] = True,
 ) -> None:
     """
     Append an owner reference to the resource(s), if it is not yet there.
@@ -30,7 +32,7 @@ def append_owner_reference(
     so the whole body can be modified, no patches are needed.
     """
     real_owner = _guess_owner(owner)
-    owner_ref = bodies.build_owner_reference(real_owner)
+    owner_ref = bodies.build_owner_reference(real_owner, controller, block_owner_deletion)
     for obj in cast(Iterator[K8sObject], dicts.walk(objs)):
         # Pykube is yielded as a usual dict, no need to specially treat it.
         if isinstance(obj, collections.abc.MutableMapping):

--- a/kopf/_kits/hierarchies.py
+++ b/kopf/_kits/hierarchies.py
@@ -33,7 +33,9 @@ def append_owner_reference(
     so the whole body can be modified, no patches are needed.
     """
     real_owner = _guess_owner(owner)
-    owner_ref = bodies.build_owner_reference(real_owner, controller, block_owner_deletion)
+    owner_ref = bodies.build_owner_reference(
+        real_owner, controller=controller, block_owner_deletion=block_owner_deletion
+    )
     for obj in cast(Iterator[K8sObject], dicts.walk(objs)):
         # Pykube is yielded as a usual dict, no need to specially treat it.
         if isinstance(obj, collections.abc.MutableMapping):

--- a/tests/hierarchies/test_owner_referencing.py
+++ b/tests/hierarchies/test_owner_referencing.py
@@ -27,7 +27,9 @@ OWNER = RawBody(
 def test_appending_to_dict():
     obj = {}
 
-    kopf.append_owner_reference(obj, owner=Body(OWNER))
+    kopf.append_owner_reference(
+        obj, owner=Body(OWNER), controller=False, block_owner_deletion=False
+    )
 
     assert 'metadata' in obj
     assert 'ownerReferences' in obj['metadata']
@@ -38,6 +40,8 @@ def test_appending_to_dict():
     assert obj['metadata']['ownerReferences'][0]['kind'] == OWNER_KIND
     assert obj['metadata']['ownerReferences'][0]['name'] == OWNER_NAME
     assert obj['metadata']['ownerReferences'][0]['uid'] == OWNER_UID
+    assert obj['metadata']['ownerReferences'][0]['controller'] == False
+    assert obj['metadata']['ownerReferences'][0]['blockOwnerDeletion'] == False
 
 
 def test_appending_to_dicts(multicls):


### PR DESCRIPTION

## What do these changes do?

This will allow setting controller and blockOwnerDeletion from both build_owner_references and append_owner_references


## Description

Previous behaviour:
Error from trying to set multiple owner controllers

New behaviour:
Allow explicitly setting `controller=False`, so no error

Does the change affect end users?
Only if they choose to use it


## Issues/PRs

> Related:
https://github.com/nolar/kopf/issues/687

## Type of changes

- New feature (non-breaking change which adds functionality)


## Checklist

- [x] The code addresses only the mentioned problem, and this problem only
- [x] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
