### PR TITLE
Use `async_timeout` as async context manager only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k3s: [v1.21, v1.20, v1.19, v1.18]
+        k3s: [v1.21, v1.20, v1.19]
     name: K3s ${{matrix.k3s}}
     runs-on: ubuntu-20.04
     timeout-minutes: 10  # usually 4-5 mins

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -102,7 +102,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k3s: [latest, v1.21, v1.20, v1.19, v1.18]
+        k3s: [latest, v1.21, v1.20, v1.19]
     name: K3s ${{matrix.k3s}}
     runs-on: ubuntu-20.04
     timeout-minutes: 10  # usually 4-5 mins
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s: [latest, v1.21.2, v1.20.8, v1.19.12, v1.18.20]
+        k8s: [latest, v1.21.2, v1.20.8, v1.19.12]
     name: K8s ${{matrix.k8s}}
     runs-on: ubuntu-20.04
     timeout-minutes: 10  # usually 4-5 mins

--- a/tests/primitives/test_conditions.py
+++ b/tests/primitives/test_conditions.py
@@ -13,7 +13,7 @@ async def test_no_triggering():
     try:
 
         with pytest.raises(asyncio.TimeoutError):
-            with async_timeout.timeout(0.1) as timeout:
+            async with async_timeout.timeout(0.1) as timeout:
                 async with target:
                     await target.wait()
 
@@ -36,7 +36,7 @@ async def test_triggering(event_loop, timer):
 
         event_loop.call_later(0.1, asyncio.create_task, delayed_trigger())
 
-        with timer, async_timeout.timeout(10) as timeout:
+        async with timer, async_timeout.timeout(10) as timeout:
             async with target:
                 await target.wait()
 

--- a/tests/primitives/test_containers.py
+++ b/tests/primitives/test_containers.py
@@ -9,7 +9,7 @@ from kopf._cogs.aiokits.aiovalues import Container
 async def test_empty_by_default():
     container = Container()
     with pytest.raises(asyncio.TimeoutError):
-        with async_timeout.timeout(0.1) as timeout:
+        async with async_timeout.timeout(0.1) as timeout:
             await container.wait()
     assert timeout.expired
 
@@ -23,7 +23,7 @@ async def test_does_not_wake_up_when_reset(event_loop, timer):
     event_loop.call_later(0.05, asyncio.create_task, reset_it())
 
     with pytest.raises(asyncio.TimeoutError):
-        with async_timeout.timeout(0.1) as timeout:
+        async with async_timeout.timeout(0.1) as timeout:
             await container.wait()
 
     assert timeout.expired
@@ -33,7 +33,7 @@ async def test_wakes_up_when_preset(event_loop, timer):
     container = Container()
     await container.set(123)
 
-    with timer, async_timeout.timeout(10) as timeout:
+    async with timer, async_timeout.timeout(10) as timeout:
         result = await container.wait()
 
     assert not timeout.expired
@@ -49,7 +49,7 @@ async def test_wakes_up_when_set(event_loop, timer):
 
     event_loop.call_later(0.1, asyncio.create_task, set_it())
 
-    with timer, async_timeout.timeout(10) as timeout:
+    async with timer, async_timeout.timeout(10) as timeout:
         result = await container.wait()
 
     assert not timeout.expired
@@ -67,7 +67,7 @@ async def test_iterates_when_set(event_loop, timer):
     event_loop.call_later(0.2, asyncio.create_task, set_it(234))
 
     values = []
-    with timer, async_timeout.timeout(10) as timeout:
+    async with timer, async_timeout.timeout(10) as timeout:
         async for value in container.as_changed():
             values.append(value)
             if value == 234:
@@ -83,7 +83,7 @@ async def test_iterates_when_preset(event_loop, timer):
     await container.set(123)
 
     values = []
-    with timer, async_timeout.timeout(10) as timeout:
+    async with timer, async_timeout.timeout(10) as timeout:
         async for value in container.as_changed():
             values.append(value)
             break

--- a/tests/utilities/aiotasks/test_scheduler.py
+++ b/tests/utilities/aiotasks/test_scheduler.py
@@ -26,7 +26,7 @@ async def f(mock, *args):
 
 
 async def test_empty_scheduler_lifecycle(timer):
-    with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1):
         scheduler = Scheduler()
         assert scheduler.empty()
         await scheduler.wait()
@@ -45,12 +45,12 @@ async def test_task_spawning_and_graceful_finishing(timer):
     result = await scheduler.spawn(f(mock, flag1, 0.1, flag2))
     assert result is None
 
-    with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1):
         await flag1.wait()
     assert timer.seconds < CODE_OVERHEAD
     assert mock.call_args[0][0] == 'started'
 
-    with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1):
         await flag2.wait()
     assert timer.seconds > 0.1
     assert timer.seconds < 0.1 + CODE_OVERHEAD
@@ -68,12 +68,12 @@ async def test_task_spawning_and_cancellation(timer):
     result = await scheduler.spawn(f(mock, flag1, 1.0, flag2))
     assert result is None
 
-    with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1):
         await flag1.wait()
     assert timer.seconds < CODE_OVERHEAD
     assert mock.call_args[0][0] == 'started'
 
-    with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1):
         await scheduler.close()
     assert timer.seconds < CODE_OVERHEAD  # near-instant
     assert mock.call_args[0][0] == 'cancelled'
@@ -87,7 +87,7 @@ async def test_no_tasks_are_accepted_after_closing():
     assert scheduler._spawning_task.done()
     assert scheduler._cleaning_task.done()
 
-    with async_timeout.timeout(1):
+    async with async_timeout.timeout(1):
         with pytest.raises(RuntimeError, match=r"Cannot add new coroutines"):
             await scheduler.spawn(f(Mock(), 1.0))
 
@@ -95,7 +95,7 @@ async def test_no_tasks_are_accepted_after_closing():
 async def test_successes_are_not_reported():
     exception_handler = Mock()
     scheduler = Scheduler(exception_handler=exception_handler)
-    with async_timeout.timeout(1):
+    async with async_timeout.timeout(1):
         await scheduler.spawn(f(Mock()))
         await scheduler.wait()
         await scheduler.close()
@@ -106,7 +106,7 @@ async def test_cancellations_are_not_reported():
     exception_handler = Mock()
     mock = Mock(side_effect=asyncio.CancelledError())
     scheduler = Scheduler(exception_handler=exception_handler)
-    with async_timeout.timeout(1):
+    async with async_timeout.timeout(1):
         await scheduler.spawn(f(mock, 1))
         await scheduler.wait()
         await scheduler.close()
@@ -118,7 +118,7 @@ async def test_exceptions_are_reported():
     exception_handler = Mock()
     mock = Mock(side_effect=exception)
     scheduler = Scheduler(exception_handler=exception_handler)
-    with async_timeout.timeout(1):
+    async with async_timeout.timeout(1):
         await scheduler.spawn(f(mock))
         await scheduler.wait()
         await scheduler.close()
@@ -138,12 +138,12 @@ async def test_tasks_are_parallel_if_limit_is_not_reached(timer):
     task2_finished = asyncio.Event()
     scheduler = Scheduler(limit=2)
 
-    with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1):
         await scheduler.spawn(f(Mock(), task1_started, 0.1, task1_finished))
         await scheduler.spawn(f(Mock(), task2_started, 0.1, task2_finished))
     assert timer.seconds < CODE_OVERHEAD  # i.e. spawning is not not blocking
 
-    with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1):
         await task1_finished.wait()
         assert task2_started.is_set()
         await task2_finished.wait()
@@ -166,12 +166,12 @@ async def test_tasks_are_pending_if_limit_is_reached(timer):
     task2_finished = asyncio.Event()
     scheduler = Scheduler(limit=1)
 
-    with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1):
         await scheduler.spawn(f(Mock(), task1_started, 0.1, task1_finished))
         await scheduler.spawn(f(Mock(), task2_started, 0.1, task2_finished))
     assert timer.seconds < CODE_OVERHEAD  # i.e. spawning is not not blocking
 
-    with timer, async_timeout.timeout(1):
+    async with timer, async_timeout.timeout(1):
         await task1_finished.wait()
         assert not task2_started.is_set()
         await task2_finished.wait()


### PR DESCRIPTION
It is a change in the `async_timeout` itself (https://github.com/aio-libs/async-timeout/commit/e53ae7db6700c3ce933f34e12f2b65cca5510ea4) — made 2 years ago but released as version 4.0.0 a few days ago. We have no strong reasons to use it as a sync context manager.

Affected #858, #857, and all new CI runs.