### PR TITLE
Treat listable but non-watchable resources as non-watchable

### DIFF
--- a/kopf/_core/reactor/observation.py
+++ b/kopf/_core/reactor/observation.py
@@ -316,7 +316,7 @@ def _disable_unsuitable_resources(
 
     # For both watching & patching, only look at watched resources, ignore webhook-only resources.
     nonwatchable_resources = {resource for resource in resources
-                              if 'watch' not in resource.verbs and 'list' not in resource.verbs}
+                              if 'watch' not in resource.verbs or 'list' not in resource.verbs}
     nonpatchable_resources = {resource for resource in resources
                               if 'patch' not in resource.verbs} - nonwatchable_resources
 


### PR DESCRIPTION
Accidentally detected when trying to reproduce an unrelated issue #870:

It fails on pods & nodes of `metrics.k8s.io`, on "componentstatuses" of "v1", and some other resources, which are now **listable but non-watchable**:

```
[2021-11-28 23:13:18,250] kopf._core.reactor.o [ERROR   ] Watcher for componentstatuses.v1@none has failed: ('watch is not supported on resources of kind "componentstatuses"', {'kind': 'Status', 'apiVersion': 'v1', 'metadata': {}, 'status': 'Failure', 'message': 'watch is not supported on resources of kind "componentstatuses"', 'reason': 'MethodNotAllowed', 'details': {'kind': 'componentstatuses'}, 'code': 405})
Traceback (most recent call last):
  File "/Users/nolar/src/kopf/kopf/_cogs/clients/errors.py", line 148, in check_response
    response.raise_for_status()
  File "/Users/nolar/.pyenv/versions/kopf397/lib/python3.9/site-packages/aiohttp/client_reqrep.py", line 1000, in raise_for_status
    raise ClientResponseError(
aiohttp.client_exceptions.ClientResponseError: 405, message='Method Not Allowed', url=URL('https://127.0.0.1:61610/api/v1/componentstatuses?watch=true')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/nolar/src/kopf/kopf/_cogs/aiokits/aiotasks.py", line 107, in guard
    await coro
  File "/Users/nolar/src/kopf/kopf/_core/reactor/queueing.py", line 175, in watcher
    async for raw_event in stream:
  File "/Users/nolar/src/kopf/kopf/_cogs/clients/watching.py", line 82, in infinite_watch
    async for raw_event in stream:
  File "/Users/nolar/src/kopf/kopf/_cogs/clients/watching.py", line 186, in continuous_watch
    async for raw_input in stream:
  File "/Users/nolar/src/kopf/kopf/_cogs/clients/watching.py", line 251, in watch_objs
    async for raw_input in api.stream(
  File "/Users/nolar/src/kopf/kopf/_cogs/clients/api.py", line 200, in stream
    response = await request(
  File "/Users/nolar/src/kopf/kopf/_cogs/clients/auth.py", line 45, in wrapper
    return await fn(*args, **kwargs, context=context)
  File "/Users/nolar/src/kopf/kopf/_cogs/clients/api.py", line 85, in request
    await errors.check_response(response)  # but do not parse it!
  File "/Users/nolar/src/kopf/kopf/_cogs/clients/errors.py", line 150, in check_response
    raise cls(payload, status=response.status) from e
kopf._cogs.clients.errors.APIClientError: ('watch is not supported on resources of kind "componentstatuses"', {'kind': 'Status', 'apiVersion': 'v1', 'metadata': {}, 'status': 'Failure', 'message': 'watch is not supported on resources of kind "componentstatuses"', 'reason': 'MethodNotAllowed', 'details': {'kind': 'componentstatuses'}, 'code': 405})
```

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.4", GitCommit:"e87da0bd6e03ec3fea7933c4b5263d151aafd07c", GitTreeState:"clean", BuildDate:"2021-02-18T16:12:00Z", GoVersion:"go1.15.8", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.3+k3s1", GitCommit:"61a2aab25eeb97c26fa3f2b177e4355a7654c991", GitTreeState:"clean", BuildDate:"2021-11-04T00:24:35Z", GoVersion:"go1.16.8", Compiler:"gc", Platform:"linux/amd64"}
```
```
$ kubectl get --raw /api/v1/ | jq '.resources[] | select(.name=="componentstatuses")'
{
  "name": "componentstatuses",
  "singularName": "",
  "namespaced": false,
  "kind": "ComponentStatus",
  "verbs": [
    "get",
    "list"
  ],
  "shortNames": [
    "cs"
  ]
}
```

The same behaviour can be observed at least down to Kubernetes 1.17.

It is not clear how and why did it work before, especially when this feature (the cluster observation and monitoring of "everything") was added.