### PR TITLE
Cleanup the system resources of webhook servers/tunnels

### DIFF
--- a/kopf/_kits/webhacks.py
+++ b/kopf/_kits/webhacks.py
@@ -1,0 +1,92 @@
+import functools
+from typing import Any, AsyncGenerator, AsyncIterator, Callable, Dict, List, Tuple, TypeVar, cast
+
+from kopf._cogs.structs import reviews
+
+_SelfT = TypeVar('_SelfT')
+_ServerFn = TypeVar('_ServerFn', bound=Callable[..., AsyncIterator[reviews.WebhookClientConfig]])
+
+
+class WebhookContextManagerMeta(type):
+    """
+    Auto-decorate all ``__call__`` functions to persist their generators.
+
+    Another way is via ``__init_subclass__``, but that requires monkey-patching
+    and will not work on slotted classes (when they will be made slotted).
+    """
+    def __new__(
+            cls,
+            name: str,
+            bases: Tuple[type, ...],
+            namespace: Dict[str, Any],
+            **kwargs: Any,
+    ) -> "WebhookContextManagerMeta":
+        if '__call__' in namespace:
+            namespace['__call__'] = WebhookContextManager._persisted(namespace['__call__'])
+        return super().__new__(cls, name, bases, namespace, **kwargs)
+
+
+class WebhookContextManager(metaclass=WebhookContextManagerMeta):
+    """
+    A hack to make webhook servers/tunnels re-entrant.
+
+    Generally, the webhook servers/tunnels are used only once per operator run,
+    so the re-entrant servers/tunnels are not needed. This hack solves
+    a problem that exists only in the unit-tests (because they are fast):
+
+    When the garbage collection is postponed (as in PyPy), the server/tunnel
+    frees the system resources (e.g. sockets) much later than the test is over
+    (in ``finally:`` when the ``GeneratorExit`` is thrown into the generator).
+
+    As a result, the resources (sockets) are released while the unrelated tests
+    are running, and inject the exceptions into one of those unrelated tests
+    (e.g. ``ResourceWarning: unclosed transport`` or alike).
+
+    The obvious solution — the context managers — would break the protocol,
+    which is promised to be a single callable that yields the client configs.
+
+    To keep the backwards compatibility while cleaning up the resources on time:
+
+    - Support the _optional_ async context manager protocol, _if_ implemented.
+    - Implement a minimalistic context manager for the provided servers/tunnels.
+    - Keep them fully functional when the context manager is not used.
+
+    So, the servers/tunnels are left with the ``finally:`` block for cleanup.
+    But the iterator-generator is remembered and force-closed on exit from
+    the context manager — the same way as the garbage collector would close it.
+
+    See more at :doc:`/admission`.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore
+        self.__generators: List[AsyncGenerator[reviews.WebhookClientConfig, None]] = []
+
+    async def __aenter__(self: _SelfT) -> _SelfT:
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        # The order of cleanups is probably irrelevant, but prefer LIFO just in case:
+        # the innermost and latest super() calls freed first, the outermost and earliest — last.
+        for generator in reversed(self.__generators):
+            try:
+                await generator.aclose()
+            except (GeneratorExit, StopAsyncIteration, StopIteration):
+                pass
+        self.__generators[:] = []
+
+    @staticmethod
+    def _persisted(wrapped: _ServerFn) -> _ServerFn:
+        @functools.wraps(wrapped)
+        async def wrapper(
+                self: "WebhookContextManager",
+                fn: reviews.WebhookFn,
+        ) -> AsyncIterator[reviews.WebhookClientConfig]:
+            iterator = wrapped(self, fn)
+            if isinstance(iterator, AsyncGenerator):
+                self.__generators.append(iterator)
+            async for value in iterator:
+                yield value
+            if isinstance(iterator, AsyncGenerator):
+                self.__generators.remove(iterator)
+        return cast(_ServerFn, wrapper)

--- a/tests/admission/test_admission_server.py
+++ b/tests/admission/test_admission_server.py
@@ -1,3 +1,6 @@
+import contextlib
+from unittest.mock import Mock
+
 import pytest
 
 import kopf
@@ -10,7 +13,7 @@ async def webhookfn(*_, **__):
 
 
 async def test_requires_webserver_if_webhooks_are_defined(
-        settings, registry, insights, resource, k8s_mocked):
+        settings, registry, insights, resource):
 
     @kopf.on.validate(*resource, registry=registry)
     def fn_v(**_): ...
@@ -33,7 +36,7 @@ async def test_requires_webserver_if_webhooks_are_defined(
 
 
 async def test_configures_client_configs(
-        settings, registry, insights, resource, k8s_mocked):
+        settings, registry, insights):
 
     async def server(_):
         yield {'url': 'https://hostname/'}
@@ -48,4 +51,68 @@ async def test_configures_client_configs(
         webhookfn=webhookfn,
     )
 
+    assert container.get_nowait() == {'url': 'https://hostname/'}
+
+
+async def test_contextmanager_class(
+        settings, registry, insights):
+
+    aenter_mock = Mock()
+    aexit_mock = Mock()
+    container = Container()
+
+    class CtxMgrServer:
+        async def __aenter__(self) -> "CtxMgrServer":
+            aenter_mock()
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+            aexit_mock()
+
+        async def __call__(self, _):
+            yield {'url': 'https://hostname/'}
+
+    settings.admission.server = CtxMgrServer()
+    await admission_webhook_server(
+        registry=registry,
+        settings=settings,
+        insights=insights,
+        container=container,
+        webhookfn=webhookfn,
+    )
+
+    assert aenter_mock.call_count == 1
+    assert aexit_mock.call_count == 1
+    assert container.get_nowait() == {'url': 'https://hostname/'}
+
+
+async def test_contextmanager_decorator(
+        settings, registry, insights):
+
+    aenter_mock = Mock()
+    aexit_mock = Mock()
+    container = Container()
+
+    async def server(_):
+        yield {'url': 'https://hostname/'}
+
+    @contextlib.asynccontextmanager
+    async def server_manager():
+        aenter_mock()
+        try:
+            yield server
+        finally:
+            aexit_mock()
+
+    settings.admission.server = server_manager()  # can be entered only once
+    await admission_webhook_server(
+        registry=registry,
+        settings=settings,
+        insights=insights,
+        container=container,
+        webhookfn=webhookfn,
+    )
+
+    assert aenter_mock.call_count == 1
+    assert aexit_mock.call_count == 1
     assert container.get_nowait() == {'url': 'https://hostname/'}

--- a/tests/admission/test_webhook_detection.py
+++ b/tests/admission/test_webhook_detection.py
@@ -70,8 +70,9 @@ async def test_server_detects(responder, aresponses, hostname, caplog, assert_lo
     caplog.set_level(0)
     aresponses.add(hostname, '/version', 'get', {'gitVersion': 'v1.20.4+k3s1'})
     server = WebhookAutoServer(insecure=True)
-    async for _ in server(responder.fn):
-        break  # do not sleep
+    async with server:
+        async for _ in server(responder.fn):
+            break  # do not sleep
     assert_logs(["Cluster detection found the hostname: host.k3d.internal"])
 
 
@@ -80,8 +81,9 @@ async def test_server_works(
     caplog.set_level(0)
     aresponses.add(hostname, '/version', 'get', {'gitVersion': 'v1.20.4'})
     server = WebhookAutoServer(insecure=True)
-    async for _ in server(responder.fn):
-        break  # do not sleep
+    async with server:
+        async for _ in server(responder.fn):
+            break  # do not sleep
     assert_logs(["Cluster detection failed, running a simple local server"])
 
 
@@ -89,8 +91,9 @@ async def test_tunnel_detects(responder, pyngrok_mock, aresponses, hostname, cap
     caplog.set_level(0)
     aresponses.add(hostname, '/version', 'get', {'gitVersion': 'v1.20.4+k3s1'})
     server = WebhookAutoTunnel()
-    async for _ in server(responder.fn):
-        break  # do not sleep
+    async with server:
+        async for _ in server(responder.fn):
+            break  # do not sleep
     assert_logs(["Cluster detection found the hostname: host.k3d.internal"])
 
 
@@ -98,6 +101,7 @@ async def test_tunnel_works(responder, pyngrok_mock, aresponses, hostname, caplo
     caplog.set_level(0)
     aresponses.add(hostname, '/version', 'get', {'gitVersion': 'v1.20.4'})
     server = WebhookAutoTunnel()
-    async for _ in server(responder.fn):
-        break  # do not sleep
+    async with server:
+        async for _ in server(responder.fn):
+            break  # do not sleep
     assert_logs(["Cluster detection failed, using an ngrok tunnel."])

--- a/tests/admission/test_webhook_ngrok.py
+++ b/tests/admission/test_webhook_ngrok.py
@@ -8,8 +8,9 @@ from kopf._kits.webhooks import WebhookNgrokTunnel
 async def test_missing_pyngrok(no_pyngrok, responder):
     with pytest.raises(ImportError) as err:
         server = WebhookNgrokTunnel()
-        async for _ in server(responder.fn):
-            break  # do not sleep
+        async with server:
+            async for _ in server(responder.fn):
+                break  # do not sleep
     assert "pip install pyngrok" in str(err.value)
 
 
@@ -19,10 +20,11 @@ async def test_ngrok_tunnel(
     responder.fut.set_result({'hello': 'world'})
     server = WebhookNgrokTunnel(port=54321, path='/p1/p2',
                                 region='xx', token='xyz', binary='/bin/ngrok')
-    async for client_config in server(responder.fn):
-        assert 'caBundle' not in client_config  # trust the default CA
-        assert client_config['url'] == 'https://nowhere/p1/p2'
-        break  # do not sleep
+    async with server:
+        async for client_config in server(responder.fn):
+            assert 'caBundle' not in client_config  # trust the default CA
+            assert client_config['url'] == 'https://nowhere/p1/p2'
+            break  # do not sleep
 
     assert pyngrok_mock.conf.get_default.called
     assert pyngrok_mock.conf.get_default.return_value.ngrok_path == '/bin/ngrok'
@@ -32,6 +34,6 @@ async def test_ngrok_tunnel(
     assert pyngrok_mock.ngrok.connect.called
     assert pyngrok_mock.ngrok.connect.call_args_list[0][0][0] == '54321'
     assert pyngrok_mock.ngrok.connect.call_args_list[0][1]['bind_tls'] == True
-    assert not pyngrok_mock.ngrok.disconnect.called
+    assert pyngrok_mock.ngrok.disconnect.called
 
     await asyncio.get_running_loop().shutdown_asyncgens()

--- a/tests/admission/test_webhook_server.py
+++ b/tests/admission/test_webhook_server.py
@@ -12,55 +12,61 @@ from kopf._kits.webhooks import WebhookK3dServer, WebhookMinikubeServer, Webhook
 
 async def test_starts_as_http_ipv4(responder):
     server = WebhookServer(addr='127.0.0.1', port=22533, path='/p1/p2', insecure=True)
-    async for client_config in server(responder.fn):
-        assert client_config['url'] == 'http://127.0.0.1:22533/p1/p2'
-        assert 'caBundle' not in client_config
-        break  # do not sleep
+    async with server:
+        async for client_config in server(responder.fn):
+            assert client_config['url'] == 'http://127.0.0.1:22533/p1/p2'
+            assert 'caBundle' not in client_config
+            break  # do not sleep
 
 
 async def test_starts_as_http_ipv6(responder):
     server = WebhookServer(addr='::1', port=22533, path='/p1/p2', insecure=True)
-    async for client_config in server(responder.fn):
-        assert client_config['url'] == 'http://[::1]:22533/p1/p2'
-        assert 'caBundle' not in client_config
-        break  # do not sleep
+    async with server:
+        async for client_config in server(responder.fn):
+            assert client_config['url'] == 'http://[::1]:22533/p1/p2'
+            assert 'caBundle' not in client_config
+            break  # do not sleep
 
 
 async def test_unspecified_port_allocates_a_random_port(responder):
     server1 = WebhookServer(addr='127.0.0.1', path='/p1/p2', insecure=True)
     server2 = WebhookServer(addr='127.0.0.1', path='/p1/p2', insecure=True)
-    async for client_config1 in server1(responder.fn):
-        async for client_config2 in server2(responder.fn):
-            assert client_config1['url'] != client_config2['url']
+    async with server1, server2:
+        async for client_config1 in server1(responder.fn):
+            async for client_config2 in server2(responder.fn):
+                assert client_config1['url'] != client_config2['url']
+                break  # do not sleep
             break  # do not sleep
-        break  # do not sleep
 
 
 async def test_unspecified_addr_uses_all_interfaces(responder, caplog, assert_logs):
     caplog.set_level(0)
     server = WebhookServer(port=22533, path='/p1/p2', insecure=True)
-    async for client_config in server(responder.fn):
-        assert client_config['url'] == 'http://localhost:22533/p1/p2'
-        break  # do not sleep
+    async with server:
+        async for client_config in server(responder.fn):
+            assert client_config['url'] == 'http://localhost:22533/p1/p2'
+            break  # do not sleep
     assert_logs([r"Listening for webhooks at http://\*:22533/p1/p2"])
 
 
 async def test_webhookserver_starts_as_https_with_selfsigned_cert(
         responder):
     server = WebhookServer(addr='127.0.0.1', port=22533, path='/p1/p2', host='somehost')
-    async for client_config in server(responder.fn):
-        assert client_config['url'] == 'https://somehost:22533/p1/p2'
-        assert 'caBundle' in client_config  # regardless of the value
-        break  # do not sleep
+    async with server:
+        async for client_config in server(responder.fn):
+            assert client_config['url'] == 'https://somehost:22533/p1/p2'
+            assert 'caBundle' in client_config  # regardless of the value
+            break  # do not sleep
 
 
 async def test_webhookserver_starts_as_https_with_provided_cert(
         certfile, pkeyfile, certpkey, responder):
     server = WebhookServer(port=22533, certfile=certfile, pkeyfile=pkeyfile)
-    async for client_config in server(responder.fn):
-        assert client_config['url'] == 'https://localhost:22533'
-        assert base64.b64decode(client_config['caBundle']) == certpkey[0]
-        break  # do not sleep
+    async with server:
+        async for client_config in server(responder.fn):
+            assert client_config['url'] == 'https://localhost:22533'
+            assert base64.b64decode(client_config['caBundle']) == certpkey[0]
+            break  # do not sleep
 
 
 @pytest.mark.parametrize('cls, url', [
@@ -70,9 +76,10 @@ async def test_webhookserver_starts_as_https_with_provided_cert(
 async def test_webhookserver_flavours_inject_hostnames(
         certfile, pkeyfile, certpkey, responder, cls, url):
     server = cls(port=22533, certfile=certfile, pkeyfile=pkeyfile, path='/p1/p2')
-    async for client_config in server(responder.fn):
-        assert client_config['url'] == url
-        break  # do not sleep
+    async with server:
+        async for client_config in server(responder.fn):
+            assert client_config['url'] == url
+            break  # do not sleep
 
 
 @pytest.mark.usefixtures('no_sslproto_warnings')
@@ -80,15 +87,16 @@ async def test_webhookserver_serves(
         certfile, pkeyfile, responder, adm_request):
     responder.fut.set_result({'hello': 'world'})
     server = WebhookServer(certfile=certfile, pkeyfile=pkeyfile)
-    async for client_config in server(responder.fn):
-        cadata = base64.b64decode(client_config['caBundle']).decode('ascii')
-        sslctx = ssl.create_default_context(cadata=cadata)
-        async with aiohttp.ClientSession() as client:
-            async with client.post(client_config['url'], ssl=sslctx, json=adm_request) as resp:
-                text = await resp.text()
-                assert text == '{"hello": "world"}'
-                assert resp.status == 200
-        break  # do not sleep
+    async with server:
+        async for client_config in server(responder.fn):
+            cadata = base64.b64decode(client_config['caBundle']).decode('ascii')
+            sslctx = ssl.create_default_context(cadata=cadata)
+            async with aiohttp.ClientSession() as client:
+                async with client.post(client_config['url'], ssl=sslctx, json=adm_request) as resp:
+                    text = await resp.text()
+                    assert text == '{"hello": "world"}'
+                    assert resp.status == 200
+            break  # do not sleep
 
 
 @pytest.mark.parametrize('code, error', [
@@ -105,10 +113,11 @@ async def test_webhookserver_errors(
         certfile, pkeyfile, responder, adm_request, code, error):
     responder.fut.set_exception(error())
     server = WebhookServer(certfile=certfile, pkeyfile=pkeyfile)
-    async for client_config in server(responder.fn):
-        cadata = base64.b64decode(client_config['caBundle']).decode('ascii')
-        sslctx = ssl.create_default_context(cadata=cadata)
-        async with aiohttp.ClientSession() as client:
-            async with client.post(client_config['url'], ssl=sslctx, json=adm_request) as resp:
-                assert resp.status == code
-        break  # do not sleep
+    async with server:
+        async for client_config in server(responder.fn):
+            cadata = base64.b64decode(client_config['caBundle']).decode('ascii')
+            sslctx = ssl.create_default_context(cadata=cadata)
+            async with aiohttp.ClientSession() as client:
+                async with client.post(client_config['url'], ssl=sslctx, json=adm_request) as resp:
+                    assert resp.status == code
+            break  # do not sleep


### PR DESCRIPTION
The webhook server/tunnel protocol is extended with an optional part: it can now be an asynchronous context manager. This is a more explicit way of cleaning up the system resources than relying on the `finally:` block or the `GeneratorExit` exception. The latter is not guaranteed to happen until the generator is garbage-collected, which can happen much later than expected (or never). In that case, the resources remain leaked and can fail the tests. For example, this was happening in PyPy 3.8.

The webhook servers & tunnels provided by Kopf support both protocols: the simple callable protocol (with the cleanup on garbage collection in the `finally:` block) and the async context manager (with the explicit cleanup on exiting).

Related: #872.
