### PR TITLE
Replace async-timeout with pytest-timeout and builtin asyncio routines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: pip install -e .[${{ matrix.install-extras }}]
         if: ${{ matrix.install-extras }}
-      - run: pytest --color=yes --cov=kopf --cov-branch
+      - run: pytest --color=yes --timeout=2 --cov=kopf --cov-branch
 
       - name: Publish coverage to Coveralls.io
         if: success()
@@ -94,7 +94,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: pip install -e .[${{ matrix.install-extras }}]
         if: ${{ matrix.install-extras }}
-      - run: pytest --color=yes --no-cov
+      - run: pytest --color=yes --timeout=2 --no-cov
 
   functional:
     strategy:
@@ -114,7 +114,7 @@ jobs:
           version: ${{ matrix.k3s }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pip install -r requirements.txt -r examples/requirements.txt
-      - run: pytest --color=yes --only-e2e
+      - run: pytest --color=yes --timeout=30 --only-e2e
 
   coveralls-finish:
     name: Finalize coveralls.io

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -55,7 +55,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: pip install -e .[${{ matrix.install-extras }}]
         if: ${{ matrix.install-extras }}
-      - run: pytest --color=yes --cov=kopf --cov-branch
+      - run: pytest --color=yes --timeout=2 --cov=kopf --cov-branch
 
       - name: Publish coverage to Coveralls.io
         if: success()
@@ -98,7 +98,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: pip install -e .[${{ matrix.install-extras }}]
         if: ${{ matrix.install-extras }}
-      - run: pytest --color=yes --no-cov
+      - run: pytest --color=yes --timeout=2 --no-cov
 
   functional:
     strategy:
@@ -118,7 +118,7 @@ jobs:
           version: ${{ matrix.k3s }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pip install -r requirements.txt -r examples/requirements.txt
-      - run: pytest --color=yes --only-e2e
+      - run: pytest --color=yes --timeout=30 --only-e2e
 
   full-scale:
     strategy:
@@ -137,7 +137,7 @@ jobs:
           python-version: "3.10"
       - run: tools/install-minikube.sh
       - run: pip install -r requirements.txt -r examples/requirements.txt
-      - run: pytest --color=yes --only-e2e
+      - run: pytest --color=yes --timeout=30 --only-e2e
 
   coveralls-finish:
     name: Finalize coveralls.io

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts =
+    --strict-markers

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,6 @@ pytest-aiohttp
 pytest-asyncio
 pytest-cov
 pytest-mock
+pytest-timeout
 types-pkg_resources
 types-PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 -e .
 aresponses
 astpath[xpath]
-async-timeout
 asynctest
 certbuilder
 certvalidator

--- a/tests/observation/test_processing_of_namespaces.py
+++ b/tests/observation/test_processing_of_namespaces.py
@@ -1,6 +1,5 @@
 import asyncio
 
-import async_timeout
 import pytest
 
 from kopf._cogs.structs.bodies import RawBody, RawEvent
@@ -19,11 +18,9 @@ async def test_initial_listing_is_ignored():
 
     task = asyncio.create_task(delayed_injection(0))
     with pytest.raises(asyncio.TimeoutError):
-        async with async_timeout.timeout(0.1) as timeout:
-            async with insights.revised:
-                await insights.revised.wait()
+        async with insights.revised:
+            await asyncio.wait_for(insights.revised.wait(), timeout=0.1)
     await task
-    assert timeout.expired
     assert not insights.namespaces
 
 
@@ -38,7 +35,7 @@ async def test_followups_for_addition(timer, etype):
             insights=insights, raw_event=e1, namespaces=['ns*'])
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1):
+    with timer:
         async with insights.revised:
             await insights.revised.wait()
     await task
@@ -58,7 +55,7 @@ async def test_followups_for_deletion(timer, etype):
             insights=insights, raw_event=e1, namespaces=['ns*'])
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1):
+    with timer:
         async with insights.revised:
             await insights.revised.wait()
     await task

--- a/tests/observation/test_processing_of_resources.py
+++ b/tests/observation/test_processing_of_resources.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import aiohttp.web
-import async_timeout
 import pytest
 
 import kopf
@@ -126,7 +125,7 @@ async def test_nonwatchable_resources_are_ignored(
             insights=insights, raw_event=e1, registry=registry, settings=settings)
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1.0):
+    with timer:
         async with insights.revised:
             await insights.revised.wait()
     await task
@@ -148,11 +147,9 @@ async def test_initial_listing_is_ignored(
 
     task = asyncio.create_task(delayed_injection(0))
     with pytest.raises(asyncio.TimeoutError):
-        async with async_timeout.timeout(0.1) as timeout:
-            async with insights.revised:
-                await insights.revised.wait()
+        async with insights.revised:
+            await asyncio.wait_for(insights.revised.wait(), timeout=0.1)
     await task
-    assert timeout.expired
     assert not insights.indexed_resources
     assert not insights.watched_resources
     assert not insights.webhook_resources
@@ -173,7 +170,7 @@ async def test_followups_for_addition(
             insights=insights, raw_event=e1, registry=registry, settings=settings)
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1.0):
+    with timer:
         async with insights.revised:
             await insights.revised.wait()
     await task
@@ -198,7 +195,7 @@ async def test_followups_for_deletion_of_resource(
             insights=insights, raw_event=e1, registry=registry, settings=settings)
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1.0):
+    with timer:
         async with insights.revised:
             await insights.revised.wait()
     await task
@@ -222,7 +219,7 @@ async def test_followups_for_deletion_of_group(
             insights=insights, raw_event=e1, registry=registry, settings=settings)
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1.0):
+    with timer:
         async with insights.revised:
             await insights.revised.wait()
     await task
@@ -244,7 +241,7 @@ async def test_backbone_is_filled(
             insights=insights, raw_event=e1, registry=registry, settings=settings)
 
     task = asyncio.create_task(delayed_injection(0.1))
-    async with timer, async_timeout.timeout(1.0):
+    with timer:
         await insights.backbone.wait_for(NAMESPACES)
     await task
     assert 0.1 < timer.seconds < 1.0

--- a/tests/posting/test_poster.py
+++ b/tests/posting/test_poster.py
@@ -1,9 +1,7 @@
 import asyncio
 import logging
 
-import async_timeout
 import pytest
-from asynctest import call
 
 from kopf import event, exception, info, warn
 from kopf._cogs.structs.references import Backbone, Resource
@@ -45,8 +43,7 @@ async def test_poster_polls_and_posts(mocker, settings):
 
     # A way to cancel a `while True` cycle by timing, even if the routines are not called.
     with pytest.raises(asyncio.CancelledError):
-        async with async_timeout.timeout(0.5):
-            await poster(event_queue=event_queue, backbone=backbone, settings=settings)
+        await poster(event_queue=event_queue, backbone=backbone, settings=settings)
 
     assert post.call_count == 2
     assert post.call_args_list[0][1]['url'] == '/api/v1/namespaces/ns1/events'

--- a/tests/primitives/test_containers.py
+++ b/tests/primitives/test_containers.py
@@ -1,6 +1,5 @@
 import asyncio
 
-import async_timeout
 import pytest
 
 from kopf._cogs.aiokits.aiovalues import Container
@@ -9,9 +8,7 @@ from kopf._cogs.aiokits.aiovalues import Container
 async def test_empty_by_default():
     container = Container()
     with pytest.raises(asyncio.TimeoutError):
-        async with async_timeout.timeout(0.1) as timeout:
-            await container.wait()
-    assert timeout.expired
+        await asyncio.wait_for(container.wait(), timeout=0.1)
 
 
 async def test_does_not_wake_up_when_reset(event_loop, timer):
@@ -23,20 +20,16 @@ async def test_does_not_wake_up_when_reset(event_loop, timer):
     event_loop.call_later(0.05, asyncio.create_task, reset_it())
 
     with pytest.raises(asyncio.TimeoutError):
-        async with async_timeout.timeout(0.1) as timeout:
-            await container.wait()
-
-    assert timeout.expired
+        await asyncio.wait_for(container.wait(), timeout=0.1)
 
 
 async def test_wakes_up_when_preset(event_loop, timer):
     container = Container()
     await container.set(123)
 
-    async with timer, async_timeout.timeout(10) as timeout:
+    with timer:
         result = await container.wait()
 
-    assert not timeout.expired
     assert timer.seconds <= 0.1
     assert result == 123
 
@@ -49,10 +42,9 @@ async def test_wakes_up_when_set(event_loop, timer):
 
     event_loop.call_later(0.1, asyncio.create_task, set_it())
 
-    async with timer, async_timeout.timeout(10) as timeout:
+    with timer:
         result = await container.wait()
 
-    assert not timeout.expired
     assert 0.1 <= timer.seconds <= 0.2
     assert result == 123
 
@@ -67,13 +59,12 @@ async def test_iterates_when_set(event_loop, timer):
     event_loop.call_later(0.2, asyncio.create_task, set_it(234))
 
     values = []
-    async with timer, async_timeout.timeout(10) as timeout:
+    with timer:
         async for value in container.as_changed():
             values.append(value)
             if value == 234:
                 break
 
-    assert not timeout.expired
     assert 0.2 <= timer.seconds <= 0.3
     assert values == [123, 234]
 
@@ -83,11 +74,10 @@ async def test_iterates_when_preset(event_loop, timer):
     await container.set(123)
 
     values = []
-    async with timer, async_timeout.timeout(10) as timeout:
+    with timer:
         async for value in container.as_changed():
             values.append(value)
             break
 
-    assert not timeout.expired
     assert timer.seconds <= 0.1
     assert values == [123]

--- a/tests/timing/test_sleeping.py
+++ b/tests/timing/test_sleeping.py
@@ -1,32 +1,28 @@
 import asyncio
 
-import async_timeout
 import pytest
 
 from kopf._cogs.aiokits.aiotime import sleep
 
 
 async def test_the_only_delay_is_awaited(timer):
-    async with timer, async_timeout.timeout(1.0) as timeout:
+    with timer:
         unslept = await sleep(0.10)
     assert 0.10 <= timer.seconds < 0.11
-    assert not timeout.expired
     assert unslept is None
 
 
 async def test_the_shortest_delay_is_awaited(timer):
-    async with timer, async_timeout.timeout(1.0) as timeout:
+    with timer:
         unslept = await sleep([0.10, 0.20])
     assert 0.10 <= timer.seconds < 0.11
-    assert not timeout.expired
     assert unslept is None
 
 
 async def test_specific_delays_only_are_awaited(timer):
-    async with timer, async_timeout.timeout(1.0) as timeout:
+    with timer:
         unslept = await sleep([0.10, None])
     assert 0.10 <= timer.seconds < 0.11
-    assert not timeout.expired
     assert unslept is None
 
 
@@ -36,10 +32,9 @@ async def test_specific_delays_only_are_awaited(timer):
     pytest.param(-10, id='alone'),
 ])
 async def test_negative_delays_skip_sleeping(timer, delays):
-    async with timer, async_timeout.timeout(1.0) as timeout:
+    with timer:
         unslept = await sleep(delays)
     assert timer.seconds < 0.01
-    assert not timeout.expired
     assert unslept is None
 
 
@@ -48,39 +43,35 @@ async def test_negative_delays_skip_sleeping(timer, delays):
     pytest.param([None], id='list-of-none'),
 ])
 async def test_no_delays_skip_sleeping(timer, delays):
-    async with timer, async_timeout.timeout(1.0) as timeout:
+    with timer:
         unslept = await sleep(delays)
     assert timer.seconds < 0.01
-    assert not timeout.expired
     assert unslept is None
 
 
 async def test_by_event_set_before_time_comes(timer):
     event = asyncio.Event()
     asyncio.get_running_loop().call_later(0.07, event.set)
-    async with timer, async_timeout.timeout(1.0) as timeout:
+    with timer:
         unslept = await sleep(0.10, event)
     assert unslept is not None
     assert 0.02 <= unslept <= 0.04
     assert 0.06 <= timer.seconds <= 0.08
-    assert not timeout.expired
 
 
 async def test_with_zero_time_and_event_initially_cleared(timer):
     event = asyncio.Event()
     event.clear()
-    async with timer, async_timeout.timeout(1.0) as timeout:
+    with timer:
         unslept = await sleep(0, event)
     assert timer.seconds <= 0.01
-    assert not timeout.expired
     assert unslept is None
 
 
 async def test_with_zero_time_and_event_initially_set(timer):
     event = asyncio.Event()
     event.set()
-    async with timer, async_timeout.timeout(1.0) as timeout:
+    with timer:
         unslept = await sleep(0, event)
     assert timer.seconds <= 0.01
-    assert not timeout.expired
     assert not unslept  # 0/None; undefined for such case: both goals reached.

--- a/tests/utilities/aiotasks/test_task_stopping.py
+++ b/tests/utilities/aiotasks/test_task_stopping.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 
-import async_timeout
 import pytest
 
 from kopf._cogs.aiokits.aiotasks import create_task, stop
@@ -41,8 +40,7 @@ async def test_stop_immediately_with_finishing(assert_logs, caplog):
     caplog.set_level(0)
     task1 = create_task(simple())
     task2 = create_task(simple())
-    async with async_timeout.timeout(1):  # extra test safety
-        done, pending = await stop([task1, task2], title='sample', logger=logger, cancelled=False)
+    done, pending = await stop([task1, task2], title='sample', logger=logger, cancelled=False)
     assert done
     assert not pending
     assert_logs(["Sample tasks are stopped: finishing normally"])
@@ -55,8 +53,7 @@ async def test_stop_immediately_with_cancelling(assert_logs, caplog):
     caplog.set_level(0)
     task1 = create_task(simple())
     task2 = create_task(simple())
-    async with async_timeout.timeout(1):  # extra test safety
-        done, pending = await stop([task1, task2], title='sample', logger=logger, cancelled=True)
+    done, pending = await stop([task1, task2], title='sample', logger=logger, cancelled=True)
     assert done
     assert not pending
     assert_logs(["Sample tasks are stopped: cancelling normally"])
@@ -72,16 +69,14 @@ async def test_stop_iteratively(assert_logs, caplog, cancelled):
     task2 = create_task(stuck())
     stask = create_task(stop([task1, task2], title='sample', logger=logger, interval=0.01, cancelled=cancelled))
 
-    async with async_timeout.timeout(1):  # extra test safety
-        done, pending = await asyncio.wait({stask}, timeout=0.011)
+    done, pending = await asyncio.wait({stask}, timeout=0.011)
     assert not done
     assert task1.done()
     assert not task2.done()
 
     task2.cancel()
 
-    async with async_timeout.timeout(1):  # extra test safety
-        done, pending = await asyncio.wait({stask}, timeout=0.011)
+    done, pending = await asyncio.wait({stask}, timeout=0.011)
     assert done
     assert task1.done()
     assert task2.done()
@@ -100,16 +95,14 @@ async def test_stop_itself_is_cancelled(assert_logs, caplog, cancelled):
     task2 = create_task(stuck())
     stask = create_task(stop([task1, task2], title='sample', logger=logger, interval=0.01, cancelled=cancelled))
 
-    async with async_timeout.timeout(1):  # extra test safety
-        done, pending = await asyncio.wait({stask}, timeout=0.011)
+    done, pending = await asyncio.wait({stask}, timeout=0.011)
     assert not done
     assert task1.done()
     assert not task2.done()
 
     stask.cancel()
 
-    async with async_timeout.timeout(1):  # extra test safety
-        done, pending = await asyncio.wait({stask}, timeout=0.011)
+    done, pending = await asyncio.wait({stask}, timeout=0.011)
     assert done
     assert task1.done()
     assert not task2.done()
@@ -122,8 +115,7 @@ async def test_stop_itself_is_cancelled(assert_logs, caplog, cancelled):
     ])
 
     task2.cancel()
-    async with async_timeout.timeout(1):  # extra test safety
-        done, pending = await asyncio.wait({task1, task2})
+    done, pending = await asyncio.wait({task1, task2})
     assert done
     assert task1.done()
     assert task2.done()


### PR DESCRIPTION
`async-timeout` was used in tests for 2 purposes:

* Extra safety against hanging the test-run if some tests are designed improperly. This function is now taken by `pytest-timeout` in CI runs.
* As a part of test design to limit the expectedly infinite or long sleep.

`async-timeout` was convenient to put on the same line as the `pytest.raises(asyncio.TimeoutError)` that it causes. Since `async-timeout` stopped supporting sync context manager protocol, it now requires a separate `async with` and an additional level of indenting — so, it became less useful, or not useful at all. This job is better done by the native `asyncio.wait_for(…, timeout=…)`.

This change will also simplify the tests in the coming refactoring with the fake (simulated) time of event loops.
