### PR TITLE
Refactor time-based tests to use fake and sharp loop time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
   linters:
     name: Linting and static analysis
     runs-on: ubuntu-24.04
-    timeout-minutes: 5  # usually 1-2, rarely 3 mins (because of installations)
+    timeout-minutes: 7  # usually 5 mins with coverage
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -44,7 +44,7 @@ jobs:
             python-version: "3.14"
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 5  # usually 2-3 mins
+    timeout-minutes: 7  # usually 5 mins with coverage
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -84,7 +84,7 @@ jobs:
         python-version: [ "pypy-3.10", "pypy-3.11" ]
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -17,7 +17,7 @@ jobs:
   linters:
     name: Linting and static analysis
     runs-on: ubuntu-24.04
-    timeout-minutes: 5  # usually 1-2, rarely 3 mins (because of installations)
+    timeout-minutes: 7  # usually 5 mins with coverage
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -48,7 +48,7 @@ jobs:
             python-version: "3.14"
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 5  # usually 2-3 mins
+    timeout-minutes: 7  # usually 5 mins with coverage
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -88,7 +88,7 @@ jobs:
         python-version: [ "pypy-3.10", "pypy-3.11" ]
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ test = [
     "codecov",
     "coverage>=7.12.0",
     "freezegun",
+    "looptime>=0.7",
     "lxml",
     "pyngrok",
     "pytest>=9.0.0",
@@ -116,7 +117,7 @@ ignore_missing_imports = true
 minversion = "9.0"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = ["--strict-markers"]
+addopts = ["--strict-markers", "--looptime"]
 
 [tool.isort]
 line_length = 100

--- a/tests/apis/test_api_requests.py
+++ b/tests/apis/test_api_requests.py
@@ -138,23 +138,23 @@ async def test_parsing_in_streams(
     (delete, 'delete'),
 ])
 async def test_direct_timeout_in_requests(
-        resp_mocker, aresponses, hostname, fn, method, settings, logger, timer):
+        resp_mocker, aresponses, hostname, fn, method, settings, logger, looptime):
 
     async def serve_slowly():
-        await asyncio.sleep(1.0)
+        await asyncio.sleep(10)
         return aiohttp.web.json_response({})
 
     mock = resp_mocker(side_effect=serve_slowly)
     aresponses.add(hostname, '/url', method, mock)
 
-    with timer, pytest.raises(asyncio.TimeoutError):
-        timeout = aiohttp.ClientTimeout(total=0.1)
+    with pytest.raises(asyncio.TimeoutError):
+        timeout = aiohttp.ClientTimeout(total=1.23)
         # aiohttp raises an asyncio.TimeoutError which is automatically retried.
         # To reduce the test duration we disable retries for this test.
         settings.networking.error_backoffs = None
         await fn('/url', timeout=timeout, settings=settings, logger=logger)
 
-    assert 0.1 < timer.seconds < 0.2
+    assert looptime == 1.23
 
     # Let the server request finish and release all resources (tasks).
     # TODO: Remove when fixed: https://github.com/aio-libs/aiohttp/issues/7551
@@ -168,23 +168,23 @@ async def test_direct_timeout_in_requests(
     (delete, 'delete'),
 ])
 async def test_settings_timeout_in_requests(
-        resp_mocker, aresponses, hostname, fn, method, settings, logger, timer):
+        resp_mocker, aresponses, hostname, fn, method, settings, logger, looptime):
 
     async def serve_slowly():
-        await asyncio.sleep(1.0)
+        await asyncio.sleep(10)
         return aiohttp.web.json_response({})
 
     mock = resp_mocker(side_effect=serve_slowly)
     aresponses.add(hostname, '/url', method, mock)
 
-    with timer, pytest.raises(asyncio.TimeoutError):
-        settings.networking.request_timeout = 0.1
+    with pytest.raises(asyncio.TimeoutError):
+        settings.networking.request_timeout = 1.23
         # aiohttp raises an asyncio.TimeoutError which is automatically retried.
         # To reduce the test duration we disable retries for this test.
         settings.networking.error_backoffs = None
         await fn('/url', settings=settings, logger=logger)
 
-    assert 0.1 < timer.seconds < 0.2
+    assert looptime == 1.23
 
     # Let the server request finish and release all resources (tasks).
     # TODO: Remove when fixed: https://github.com/aio-libs/aiohttp/issues/7551
@@ -193,24 +193,24 @@ async def test_settings_timeout_in_requests(
 
 @pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
 async def test_direct_timeout_in_streams(
-        resp_mocker, aresponses, hostname, method, settings, logger, timer):
+        resp_mocker, aresponses, hostname, method, settings, logger, looptime):
 
     async def serve_slowly():
-        await asyncio.sleep(1.0)
+        await asyncio.sleep(10)
         return "{}"
 
     mock = resp_mocker(side_effect=serve_slowly)
     aresponses.add(hostname, '/url', method, mock)
 
-    with timer, pytest.raises(asyncio.TimeoutError):
-        timeout = aiohttp.ClientTimeout(total=0.1)
+    with pytest.raises(asyncio.TimeoutError):
+        timeout = aiohttp.ClientTimeout(total=1.23)
         # aiohttp raises an asyncio.TimeoutError which is automatically retried.
         # To reduce the test duration we disable retries for this test.
         settings.networking.error_backoffs = None
         async for _ in stream('/url', timeout=timeout, settings=settings, logger=logger):
             pass
 
-    assert 0.1 < timer.seconds < 0.2
+    assert looptime == 1.23
 
     # Let the server request finish and release all resources (tasks).
     # TODO: Remove when fixed: https://github.com/aio-libs/aiohttp/issues/7551
@@ -219,46 +219,47 @@ async def test_direct_timeout_in_streams(
 
 @pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
 async def test_settings_timeout_in_streams(
-        resp_mocker, aresponses, hostname, method, settings, logger, timer):
+        resp_mocker, aresponses, hostname, method, settings, logger, looptime):
 
     async def serve_slowly():
-        await asyncio.sleep(1.0)
+        await asyncio.sleep(10)
         return "{}"
 
     mock = resp_mocker(side_effect=serve_slowly)
     aresponses.add(hostname, '/url', method, mock)
 
-    with timer, pytest.raises(asyncio.TimeoutError):
-        settings.networking.request_timeout = 0.1
+    with pytest.raises(asyncio.TimeoutError):
+        settings.networking.request_timeout = 1.23
         # aiohttp raises an asyncio.TimeoutError which is automatically retried.
         # To reduce the test duration we disable retries for this test.
         settings.networking.error_backoffs = None
         async for _ in stream('/url', settings=settings, logger=logger):
             pass
 
-    assert 0.1 < timer.seconds < 0.2
+    assert looptime == 1.23
 
     # Let the server request finish and release all resources (tasks).
     # TODO: Remove when fixed: https://github.com/aio-libs/aiohttp/issues/7551
     await asyncio.sleep(1.0)
 
 
-@pytest.mark.parametrize('delay, expected', [
-    pytest.param(0.0, [], id='instant-none'),
-    pytest.param(0.1, [{'fake': 'result1'}], id='fast-single'),
-    pytest.param(9.9, [{'fake': 'result1'}, {'fake': 'result2'}], id='inf-double'),
+@pytest.mark.parametrize('delay, expected_times, expected_items', [
+    pytest.param(0, [], [], id='instant-none'),
+    pytest.param(2, [1], [{'fake': 'result1'}], id='fast-single'),
+    pytest.param(9, [1, 4], [{'fake': 'result1'}, {'fake': 'result2'}], id='inf-double'),
 ])
 @pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
 async def test_stopper_in_streams(
-        resp_mocker, aresponses, hostname, method, delay, expected, settings, logger):
+        resp_mocker, aresponses, hostname, method, delay, settings, logger, looptime,
+        expected_items, expected_times):
 
     async def stream_slowly(request: aiohttp.web.Request) -> aiohttp.web.StreamResponse:
         response = aiohttp.web.StreamResponse()
         await response.prepare(request)
         try:
-            await asyncio.sleep(0.05)
+            await asyncio.sleep(1)
             await response.write(b'{"fake": "result1"}\n')
-            await asyncio.sleep(0.15)
+            await asyncio.sleep(3)
             await response.write(b'{"fake": "result2"}\n')
             await response.write_eof()
         except ConnectionError:
@@ -271,9 +272,13 @@ async def test_stopper_in_streams(
     asyncio.get_running_loop().call_later(delay, stopper.set_result, None)
 
     items = []
+    times = []
     async for item in stream('/url', stopper=stopper, settings=settings, logger=logger):
         items.append(item)
+        times.append(float(looptime))
 
-    assert items == expected
+    assert items == expected_items
+    assert times == expected_times
 
-    await asyncio.sleep(0.2)  # give the response some time to be cancelled and its tasks closed
+    # Give the response some time to be cancelled and its tasks closed. That is aiohttp's issue.
+    await asyncio.sleep(30)

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -1,9 +1,9 @@
 import asyncio
+import collections
 import contextlib
-import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import freezegun
+import looptime
 import pytest
 
 import kopf
@@ -20,23 +20,33 @@ class DaemonDummy:
     def __init__(self):
         super().__init__()
         self.mock = MagicMock()
-        self.kwargs = {}
+        self._flag_statuses = collections.defaultdict(bool)
         self.steps = {
             'called': asyncio.Event(),
             'finish': asyncio.Event(),
             'error': asyncio.Event(),
         }
+        self.called = asyncio.Condition()
+        self.failed = asyncio.Event()
+        self.finished = asyncio.Event()
 
-    async def wait_for_daemon_done(self):
-        stopped = self.kwargs['stopped']
+    async def wait_for_daemon_done(self) -> None:
+        stopped = self.mock.call_args[1]['stopped']
         await stopped.wait()
-        while not stopped.reason & stopped.reason.DONE:
+        while stopped.reason is None or not stopped.reason & stopped.reason.DONE:
             await asyncio.sleep(0)  # give control back to asyncio event loop
 
 
 @pytest.fixture()
-def dummy():
-    return DaemonDummy()
+async def dummy(simulate_cycle):
+    dummy = DaemonDummy()
+    yield dummy
+
+    # Cancel the background tasks, if any.
+    event_object = {'metadata': {'deletionTimestamp': '...'}}
+    with looptime.enabled(strict=True):
+        await simulate_cycle(event_object)
+        await dummy.wait_for_daemon_done()
 
 
 @pytest.fixture()
@@ -52,7 +62,11 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
             else:
                 dst[key] = val
 
-    async def _simulate_cycle(event_object: RawBody):
+    async def _simulate_cycle(
+            event_object: RawBody,
+            *,
+            stream_pressure: asyncio.Event | None = None,
+    ) -> None:
         mocker.resetall()
 
         await process_resource_event(
@@ -65,6 +79,7 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
             indexers=OperatorIndexers(),
             raw_event={'type': 'irrelevant', 'object': event_object},
             event_queue=asyncio.Queue(),
+            stream_pressure=stream_pressure,
         )
 
         # Do the same as k8s does: merge the patches into the object.
@@ -96,33 +111,3 @@ async def background_daemon_killer(settings, memories, operator_paused):
     with contextlib.suppress(asyncio.CancelledError):
         task.cancel()
         await task
-
-
-@pytest.fixture()
-async def frozen_time():
-    """
-    A helper to simulate time movements to step over long sleeps/timeouts.
-    """
-    with freezegun.freeze_time("2020-01-01 00:00:00") as frozen:
-        # Use freezegun-supported time instead of system clocks -- for testing purposes only.
-        # NB: Patch strictly after the time is frozen -- to use fake_time(), not real time().
-        # NB: StdLib's event loops use time.monotonic(), but uvloop uses its own C-level time,
-        #     so patch the loop object directly instead of its implied underlying implementation.
-        with patch.object(asyncio.get_running_loop(), 'time', time.time):
-            yield frozen
-
-
-# The time-driven tests mock the sleeps, and shift the time as much as it was requested to sleep.
-# This makes the sleep realistic for the app code, though executed instantly for the tests.
-@pytest.fixture()
-def manual_time(k8s_mocked, frozen_time):
-    async def sleep_substitute(delay, *_, **__):
-        if delay is None:
-            pass
-        elif isinstance(delay, float):
-            frozen_time.tick(delay)
-        else:
-            frozen_time.tick(min(delay))
-
-    k8s_mocked.sleep.side_effect = sleep_substitute
-    yield frozen_time

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -1,5 +1,4 @@
 import asyncio
-import collections
 import contextlib
 from unittest.mock import MagicMock
 
@@ -20,15 +19,6 @@ class DaemonDummy:
     def __init__(self):
         super().__init__()
         self.mock = MagicMock()
-        self._flag_statuses = collections.defaultdict(bool)
-        self.steps = {
-            'called': asyncio.Event(),
-            'finish': asyncio.Event(),
-            'error': asyncio.Event(),
-        }
-        self.called = asyncio.Condition()
-        self.failed = asyncio.Event()
-        self.finished = asyncio.Event()
 
     async def wait_for_daemon_done(self) -> None:
         stopped = self.mock.call_args[1]['stopped']

--- a/tests/handling/daemons/test_daemon_errors.py
+++ b/tests/handling/daemons/test_daemon_errors.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import kopf
@@ -5,26 +6,21 @@ from kopf._core.actions.execution import ErrorsMode, PermanentError, TemporaryEr
 
 
 async def test_daemon_stopped_on_permanent_error(
-        settings, resource, dummy, manual_time, caplog, assert_logs, k8s_mocked, simulate_cycle):
+        settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(*resource, id='fn', backoff=0.01)
+    @kopf.daemon(*resource, id='fn', backoff=1.23)
     async def fn(**kwargs):
-        dummy.mock()
-        dummy.kwargs = kwargs
-        dummy.steps['called'].set()
+        dummy.mock(**kwargs)
         raise PermanentError("boo!")
 
     finalizer = settings.persistence.finalizer
     event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
+    await asyncio.sleep(123)  # give it enough opportunities to misbehave (e.g. restart)
 
-    await dummy.steps['called'].wait()
-    await dummy.wait_for_daemon_done()
-
+    assert looptime == 123
     assert dummy.mock.call_count == 1
-    assert k8s_mocked.patch.call_count == 0
-    assert k8s_mocked.sleep.call_count == 0
 
     assert_logs([
         "Daemon 'fn' failed permanently: boo!",
@@ -35,25 +31,21 @@ async def test_daemon_stopped_on_permanent_error(
 
 
 async def test_daemon_stopped_on_arbitrary_errors_with_mode_permanent(
-        settings, resource, dummy, manual_time, caplog, assert_logs, k8s_mocked, simulate_cycle):
+        settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
     caplog.set_level(logging.DEBUG)
 
-    @kopf.daemon(*resource, id='fn', errors=ErrorsMode.PERMANENT, backoff=0.01)
+    @kopf.daemon(*resource, id='fn', errors=ErrorsMode.PERMANENT, backoff=1.23)
     async def fn(**kwargs):
-        dummy.mock()
-        dummy.kwargs = kwargs
-        dummy.steps['called'].set()
+        dummy.mock(**kwargs)
         raise Exception("boo!")
 
     finalizer = settings.persistence.finalizer
     event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
+    await asyncio.sleep(123)  # give it enough opportunities to misbehave (e.g. restart)
 
-    await dummy.steps['called'].wait()
-    await dummy.wait_for_daemon_done()
-
+    assert looptime == 123
     assert dummy.mock.call_count == 1
-    assert k8s_mocked.sleep.call_count == 0
 
     assert_logs([
         "Daemon 'fn' failed with an exception and will stop now: boo!",
@@ -64,31 +56,25 @@ async def test_daemon_stopped_on_arbitrary_errors_with_mode_permanent(
 
 
 async def test_daemon_retried_on_temporary_error(
-        registry, settings, resource, dummy, manual_time,
-        caplog, assert_logs, k8s_mocked, simulate_cycle):
+        registry, settings, resource, dummy,
+        caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
     caplog.set_level(logging.DEBUG)
+    finished = asyncio.Event()
 
-    @kopf.daemon(*resource, id='fn', backoff=1.0)
+    @kopf.daemon(*resource, id='fn', backoff=1.23)
     async def fn(retry, **kwargs):
-        dummy.mock()
-        dummy.kwargs = kwargs
-        dummy.steps['called'].set()
+        dummy.mock(**kwargs)
         if not retry:
-            raise TemporaryError("boo!", delay=1.0)
+            raise TemporaryError("boo!", delay=3.45)
         else:
-            dummy.steps['finish'].set()
+            finished.set()
 
     finalizer = settings.persistence.finalizer
     event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
+    await finished.wait()
 
-    await dummy.steps['called'].wait()
-    await dummy.steps['finish'].wait()
-    await dummy.wait_for_daemon_done()
-
-    assert k8s_mocked.sleep.call_count == 1  # one for each retry
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == 1.0  # [call#][args/kwargs][arg#]
-
+    assert looptime == 3.45
     assert_logs([
         "Daemon 'fn' failed temporarily: boo!",
         "Daemon 'fn' succeeded.",
@@ -97,70 +83,66 @@ async def test_daemon_retried_on_temporary_error(
 
 
 async def test_daemon_retried_on_arbitrary_error_with_mode_temporary(
-        settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
+        settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
     caplog.set_level(logging.DEBUG)
+    finished = asyncio.Event()
 
-    @kopf.daemon(*resource, id='fn', errors=ErrorsMode.TEMPORARY, backoff=1.0)
+    @kopf.daemon(*resource, id='fn', errors=ErrorsMode.TEMPORARY, backoff=1.23)
     async def fn(retry, **kwargs):
-        dummy.mock()
-        dummy.kwargs = kwargs
-        dummy.steps['called'].set()
+        dummy.mock(**kwargs)
         if not retry:
             raise Exception("boo!")
         else:
-            dummy.steps['finish'].set()
+            finished.set()
 
     finalizer = settings.persistence.finalizer
     event_object = {'metadata': {'finalizers': [finalizer]}}
     await simulate_cycle(event_object)
+    await finished.wait()
 
-    await dummy.steps['called'].wait()
-    await dummy.steps['finish'].wait()
-    await dummy.wait_for_daemon_done()
-
-    assert k8s_mocked.sleep.call_count == 1  # one for each retry
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == 1.0  # [call#][args/kwargs][arg#]
-
+    assert looptime == 1.23
     assert_logs([
-        "Daemon 'fn' failed with an exception and will try again in 1.0 seconds: boo!",
+        "Daemon 'fn' failed with an exception and will try again in 1.23 seconds: boo!",
         "Daemon 'fn' succeeded.",
         "Daemon 'fn' has exited on its own",
     ])
 
 
 async def test_daemon_retried_until_retries_limit(
-        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
     caplog.set_level(logging.DEBUG)
+    trigger = asyncio.Condition()
 
     @kopf.daemon(*resource, id='fn', retries=3)
     async def fn(**kwargs):
-        dummy.kwargs = kwargs
-        dummy.steps['called'].set()
-        raise TemporaryError("boo!", delay=1.0)
+        dummy.mock(**kwargs)
+        async with trigger:
+            trigger.notify_all()
+        raise TemporaryError("boo!", delay=1.23)
 
     await simulate_cycle({})
-    await dummy.steps['called'].wait()
-    await dummy.wait_for_daemon_done()
+    async with trigger:
+        await trigger.wait_for(lambda: any("but will" in m for m in caplog.messages))
 
-    assert k8s_mocked.sleep.call_count == 2  # one between each retry (3 attempts - 2 sleeps)
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == 1.0  # [call#][args/kwargs][arg#]
-    assert k8s_mocked.sleep.call_args_list[1][0][0] == 1.0  # [call#][args/kwargs][arg#]
+    assert looptime == 2.46
+    assert dummy.mock.call_count == 3
 
 
 async def test_daemon_retried_until_timeout(
-        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, manual_time):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
     caplog.set_level(logging.DEBUG)
+    trigger = asyncio.Condition()
 
-    @kopf.daemon(*resource, id='fn', timeout=3.0)
+    @kopf.daemon(*resource, id='fn', timeout=4)
     async def fn(**kwargs):
-        dummy.kwargs = kwargs
-        dummy.steps['called'].set()
-        raise TemporaryError("boo!", delay=1.0)
+        dummy.mock(**kwargs)
+        async with trigger:
+            trigger.notify_all()
+        raise TemporaryError("boo!", delay=1.23)
 
     await simulate_cycle({})
-    await dummy.steps['called'].wait()
-    await dummy.wait_for_daemon_done()
+    async with trigger:
+        await trigger.wait_for(lambda: any("but will" in m for m in caplog.messages))
 
-    assert k8s_mocked.sleep.call_count == 2  # one between each retry (3 attempts - 2 sleeps)
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == 1.0  # [call#][args/kwargs][arg#]
-    assert k8s_mocked.sleep.call_args_list[1][0][0] == 1.0  # [call#][args/kwargs][arg#]
+    assert looptime == 3.69
+    assert dummy.mock.call_count == 4

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -9,13 +9,13 @@ import kopf
 
 async def test_daemon_exits_gracefully_and_instantly_on_resource_deletion(
         settings, resource, dummy, simulate_cycle,
-        caplog, assert_logs, k8s_mocked, frozen_time, mocker, timer):
+        looptime, caplog, assert_logs, k8s_mocked, mocker):
     caplog.set_level(logging.DEBUG)
 
     # A daemon-under-test.
     @kopf.daemon(*resource, id='fn')
     async def fn(**kwargs):
-        dummy.kwargs = kwargs
+        dummy.mock(**kwargs)
         dummy.steps['called'].set()
         await kwargs['stopped'].wait()
 
@@ -32,24 +32,22 @@ async def test_daemon_exits_gracefully_and_instantly_on_resource_deletion(
     await simulate_cycle(event_object)
 
     # Check that the daemon has exited near-instantly, with no delays.
-    with timer:
-        await dummy.wait_for_daemon_done()
+    await dummy.wait_for_daemon_done()
 
-    assert timer.seconds < 0.01  # near-instantly
-    assert k8s_mocked.sleep.call_count == 0
+    assert looptime == 0
     assert k8s_mocked.patch.call_count == 1
     assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
 
 
 async def test_daemon_exits_gracefully_and_instantly_on_operator_exiting(
         settings, resource, dummy, simulate_cycle, background_daemon_killer,
-        caplog, assert_logs, k8s_mocked, frozen_time, mocker, timer):
+        looptime, caplog, assert_logs, k8s_mocked, mocker):
     caplog.set_level(logging.DEBUG)
 
     # A daemon-under-test.
     @kopf.daemon(*resource, id='fn')
     async def fn(**kwargs):
-        dummy.kwargs = kwargs
+        dummy.mock(**kwargs)
         dummy.steps['called'].set()
         await kwargs['stopped'].wait()
 
@@ -64,11 +62,9 @@ async def test_daemon_exits_gracefully_and_instantly_on_operator_exiting(
     background_daemon_killer.cancel()
 
     # Check that the daemon has exited near-instantly, with no delays.
-    with timer:
-        await dummy.wait_for_daemon_done()
+    await dummy.wait_for_daemon_done()
 
-    assert timer.seconds < 0.01  # near-instantly
-    assert k8s_mocked.sleep.call_count == 0
+    assert looptime == 0
     assert k8s_mocked.patch.call_count == 0
 
     # To prevent double-cancelling of the scheduler's system tasks in the fixture, let them finish:
@@ -79,13 +75,13 @@ async def test_daemon_exits_gracefully_and_instantly_on_operator_exiting(
 @pytest.mark.usefixtures('background_daemon_killer')
 async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing(
         settings, memories, resource, dummy, simulate_cycle, conflicts_found,
-        caplog, assert_logs, k8s_mocked, frozen_time, mocker, timer):
+        looptime, caplog, assert_logs, k8s_mocked, mocker):
     caplog.set_level(logging.DEBUG)
 
     # A daemon-under-test.
     @kopf.daemon(*resource, id='fn')
     async def fn(**kwargs):
-        dummy.kwargs = kwargs
+        dummy.mock(**kwargs)
         dummy.steps['called'].set()
         await kwargs['stopped'].wait()
 
@@ -100,9 +96,8 @@ async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing(
     await conflicts_found.turn_to(True)
 
     # Check that the daemon has exited near-instantly, with no delays.
-    with timer:
-        await dummy.wait_for_daemon_done()
-    assert timer.seconds < 0.01  # near-instantly
+    await dummy.wait_for_daemon_done()
+    assert looptime == 0
 
     # There is no way to test for re-spawning here: it is done by watch-events,
     # which are tested by the paused operators elsewhere (test_daemon_spawning.py).
@@ -111,21 +106,17 @@ async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing(
     assert not memory.daemons_memory.forever_stopped
 
 
-async def test_daemon_exits_instantly_via_cancellation_with_backoff(
+async def test_daemon_exits_instantly_on_cancellation_with_backoff(
         settings, resource, dummy, simulate_cycle,
-        caplog, assert_logs, k8s_mocked, frozen_time, mocker):
+        looptime, caplog, assert_logs, k8s_mocked, mocker):
     caplog.set_level(logging.DEBUG)
-    dummy.steps['finish'].set()
 
     # A daemon-under-test.
-    @kopf.daemon(*resource, id='fn', cancellation_backoff=5, cancellation_timeout=10)
+    @kopf.daemon(*resource, id='fn', cancellation_backoff=1.23, cancellation_timeout=10)
     async def fn(**kwargs):
-        dummy.kwargs = kwargs
+        dummy.mock(**kwargs)
         dummy.steps['called'].set()
-        try:
-            await asyncio.Event().wait()  # this one is cancelled.
-        except asyncio.CancelledError:
-            await dummy.steps['finish'].wait()  # simulated slow (non-instant) exiting.
+        await asyncio.Event().wait()  # this one is cancelled.
 
     # Trigger spawning and wait until ready. Assume the finalizers are already added.
     finalizer = settings.persistence.finalizer
@@ -139,17 +130,15 @@ async def test_daemon_exits_instantly_via_cancellation_with_backoff(
     event_object['metadata'] |= {'deletionTimestamp': '...'}
     await simulate_cycle(event_object)
 
-    assert k8s_mocked.sleep.call_count == 1
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == 5.0
+    assert looptime == 1.23  # i.e. the slept through the whole backoff time
     assert k8s_mocked.patch.call_count == 1
     assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
 
     # 2nd cycle: cancelling after the backoff is reached. Wait for cancellation timeout.
     mocker.resetall()
-    frozen_time.tick(5)  # backoff time or slightly above it
     await simulate_cycle(event_object)
 
-    assert k8s_mocked.sleep.call_count == 0
+    assert looptime == 1.23  # i.e. no additional sleeps happened
     assert k8s_mocked.patch.call_count == 1
     assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
 
@@ -157,15 +146,15 @@ async def test_daemon_exits_instantly_via_cancellation_with_backoff(
     await dummy.wait_for_daemon_done()
 
 
-async def test_daemon_exits_slowly_via_cancellation_with_backoff(
+async def test_daemon_exits_slowly_on_cancellation_with_backoff(
         settings, resource, dummy, simulate_cycle,
-        caplog, assert_logs, k8s_mocked, frozen_time, mocker):
+        looptime, caplog, assert_logs, k8s_mocked, mocker):
     caplog.set_level(logging.DEBUG)
 
     # A daemon-under-test.
-    @kopf.daemon(*resource, id='fn', cancellation_backoff=5, cancellation_timeout=10)
+    @kopf.daemon(*resource, id='fn', cancellation_backoff=1.23, cancellation_timeout=4.56)
     async def fn(**kwargs):
-        dummy.kwargs = kwargs
+        dummy.mock(**kwargs)
         dummy.steps['called'].set()
         try:
             await asyncio.Event().wait()  # this one is cancelled.
@@ -184,43 +173,39 @@ async def test_daemon_exits_slowly_via_cancellation_with_backoff(
     event_object['metadata'] |= {'deletionTimestamp': '...'}
     await simulate_cycle(event_object)
 
-    assert k8s_mocked.sleep.call_count == 1
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == 5.0
+    assert looptime == 1.23
     assert k8s_mocked.patch.call_count == 1
     assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
 
     # 2nd cycle: cancelling after the backoff is reached. Wait for cancellation timeout.
     mocker.resetall()
-    frozen_time.tick(5)  # backoff time or slightly above it
     await simulate_cycle(event_object)
 
-    assert k8s_mocked.sleep.call_count == 1
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == 10.0
+    assert looptime == 1.23 + 4.56  # i.e. it really spent all the timeout
     assert k8s_mocked.patch.call_count == 1
     assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
 
     # 3rd cycle: the daemon has exited, the resource should be unblocked from actual deletion.
     mocker.resetall()
-    frozen_time.tick(1)  # any time below timeout
     dummy.steps['finish'].set()
-    await asyncio.sleep(0)
+    await asyncio.sleep(0)  # let the daemon to exit and all the routines to trigger
     await simulate_cycle(event_object)
     await dummy.wait_for_daemon_done()
 
-    assert k8s_mocked.sleep.call_count == 0
+    assert looptime == 1.23 + 4.56  # i.e. not additional sleeps happened
     assert k8s_mocked.patch.call_count == 1
     assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
 
 
 async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
         settings, resource, dummy, simulate_cycle,
-        caplog, assert_logs, k8s_mocked, frozen_time, mocker):
+        looptime, caplog, assert_logs, k8s_mocked, mocker):
     caplog.set_level(logging.DEBUG)
 
     # A daemon-under-test.
-    @kopf.daemon(*resource, id='fn', cancellation_timeout=10)
+    @kopf.daemon(*resource, id='fn', cancellation_timeout=4.56)
     async def fn(**kwargs):
-        dummy.kwargs = kwargs
+        dummy.mock(**kwargs)
         dummy.steps['called'].set()
         try:
             await dummy.steps['finish'].wait()  # this one is cancelled.
@@ -239,18 +224,17 @@ async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
     event_object['metadata'] |= {'deletionTimestamp': '...'}
     await simulate_cycle(event_object)
 
-    assert k8s_mocked.sleep.call_count == 1
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == 10.0
+    assert looptime == 4.56
     assert k8s_mocked.patch.call_count == 1
     assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
 
     # 2rd cycle: the daemon has exited, the resource should be unblocked from actual deletion.
     mocker.resetall()
-    frozen_time.tick(50)
+    await asyncio.sleep(1000)  # unnecessary, but let's fast-forward time just in case
     with pytest.warns(ResourceWarning, match=r"Daemon .+ did not exit in time"):
         await simulate_cycle(event_object)
 
-    assert k8s_mocked.sleep.call_count == 0
+    assert looptime == 1000 + 4.56
     assert k8s_mocked.patch.call_count == 1
     assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
     assert_logs(["Daemon 'fn' did not exit in time. Leaving it orphaned."])

--- a/tests/handling/daemons/test_timer_errors.py
+++ b/tests/handling/daemons/test_timer_errors.py
@@ -140,13 +140,3 @@ async def test_timer_retried_until_timeout(
 
     assert looptime == 6.9  # 2*3.45 -- 2 sleeps between 3 attempts
     assert dummy.mock.call_count == 3
-
-
-# TODO: next steps:
-#   extract the PR with test refactoring, where it is all simplified:
-#       - "dummy" is converted to Condition, not just Events.
-#       - in all daemons & timers, not only here!
-#   specifically:
-#       - dummy.mock is now called WITH kwargs in one operation, not separately
-#       - dummy.steps must be gone entirely; instead, local Conditions should be used
-#       - daemon/timer handlers should look as natural as possible, no hacks

--- a/tests/handling/daemons/test_timer_filtration.py
+++ b/tests/handling/daemons/test_timer_filtration.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import pytest
@@ -11,21 +12,22 @@ import kopf
 async def test_timer_filtration_satisfied(
         settings, resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
     caplog.set_level(logging.DEBUG)
+    executed = asyncio.Event()
 
     @kopf.timer(*resource, id='fn',
                 labels={'a': 'value', 'b': kopf.PRESENT, 'c': kopf.ABSENT},
                 annotations={'x': 'value', 'y': kopf.PRESENT, 'z': kopf.ABSENT})
     async def fn(**kwargs):
-        dummy.kwargs = kwargs
-        dummy.steps['called'].set()
+        dummy.mock(**kwargs)
+        executed.set()
 
     event_body = {'metadata': {'labels': {'a': 'value', 'b': '...'},
                                'annotations': {'x': 'value', 'y': '...'},
                                'finalizers': [settings.persistence.finalizer]}}
     await simulate_cycle(event_body)
+    await executed.wait()
 
-    await dummy.steps['called'].wait()
-    await dummy.wait_for_daemon_done()
+    assert dummy.mock.call_count == 1
 
 
 @pytest.mark.parametrize('labels, annotations', [
@@ -54,6 +56,7 @@ async def test_timer_filtration_mismatched(
                                'annotations': annotations,
                                'finalizers': [settings.persistence.finalizer]}}
     await simulate_cycle(event_body)
+    await asyncio.sleep(123)  # give it enough time to do something when nothing is expected
 
     assert spawn_daemons.called
     assert spawn_daemons.call_args_list[0][1]['handlers'] == []

--- a/tests/handling/daemons/test_timer_intervals.py
+++ b/tests/handling/daemons/test_timer_intervals.py
@@ -1,54 +1,45 @@
+import asyncio
 import logging
 
 import kopf
 
-# TODO: tests for idle=  (more complicated)
-
 
 async def test_timer_regular_interval(
-        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, frozen_time):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
     caplog.set_level(logging.DEBUG)
+    trigger = asyncio.Condition()
 
     @kopf.timer(*resource, id='fn', interval=1.0, sharp=False)
     async def fn(**kwargs):
-        dummy.mock()
-        dummy.kwargs = kwargs
-        dummy.steps['called'].set()
-        frozen_time.tick(0.3)
-        if dummy.mock.call_count >= 2:
-            dummy.steps['finish'].set()
-            kwargs['stopped']._setter.set()  # to exit the cycle
+        dummy.mock(**kwargs)
+        async with trigger:
+            trigger.notify_all()
+        await asyncio.sleep(0.3)  # simulate a slow operation
 
     await simulate_cycle({})
-    await dummy.steps['called'].wait()
-    await dummy.wait_for_daemon_done()
+    async with trigger:
+        await trigger.wait()
+        await trigger.wait()
 
     assert dummy.mock.call_count == 2
-    assert k8s_mocked.sleep.call_count == 2
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == 1.0
-    assert k8s_mocked.sleep.call_args_list[1][0][0] == 1.0
+    assert looptime == 1.3
 
 
 async def test_timer_sharp_interval(
-        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, frozen_time):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
     caplog.set_level(logging.DEBUG)
+    trigger = asyncio.Condition()
 
     @kopf.timer(*resource, id='fn', interval=1.0, sharp=True)
     async def fn(**kwargs):
-        dummy.mock()
-        dummy.kwargs = kwargs
-        dummy.steps['called'].set()
-        frozen_time.tick(0.3)
-        if dummy.mock.call_count >= 2:
-            dummy.steps['finish'].set()
-            kwargs['stopped']._setter.set()  # to exit the cycle
+        dummy.mock(**kwargs)
+        async with trigger:
+            trigger.notify_all()
+        await asyncio.sleep(0.3)  # simulate a slow operation
 
     await simulate_cycle({})
-    await dummy.steps['called'].wait()
-    await dummy.steps['finish'].wait()
-    await dummy.wait_for_daemon_done()
+    async with trigger:
+        await trigger.wait_for(lambda: dummy.mock.call_count >= 2)
 
     assert dummy.mock.call_count == 2
-    assert k8s_mocked.sleep.call_count == 2
-    assert 0.7 <= k8s_mocked.sleep.call_args_list[0][0][0] < 0.71
-    assert 0.7 <= k8s_mocked.sleep.call_args_list[1][0][0] < 0.71
+    assert looptime == 1  # not 1.3!

--- a/tests/handling/daemons/test_timer_triggering.py
+++ b/tests/handling/daemons/test_timer_triggering.py
@@ -1,48 +1,44 @@
+import asyncio
 import logging
 
 import kopf
 
 
 async def test_timer_is_spawned_at_least_once(
-        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
     caplog.set_level(logging.DEBUG)
+    trigger = asyncio.Condition()
 
     @kopf.timer(*resource, id='fn', interval=1.0)
     async def fn(**kwargs):
-        dummy.mock()
-        dummy.kwargs = kwargs
-        dummy.steps['called'].set()
-        kwargs['stopped']._setter.set()  # to exit the cycle
+        dummy.mock(**kwargs)
+        async with trigger:
+            trigger.notify_all()
 
     await simulate_cycle({})
-    await dummy.steps['called'].wait()
+    async with trigger:
+        await trigger.wait()
+        await trigger.wait()
 
-    assert dummy.mock.call_count == 1
-    assert dummy.kwargs['retry'] == 0
-    assert k8s_mocked.sleep.call_count == 1
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == 1.0
-
-    await dummy.wait_for_daemon_done()
+    assert looptime == 1
+    assert dummy.mock.call_count == 2
 
 
 async def test_timer_initial_delay_obeyed(
-        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
     caplog.set_level(logging.DEBUG)
+    trigger = asyncio.Condition()
 
     @kopf.timer(*resource, id='fn', initial_delay=5.0, interval=1.0)
     async def fn(**kwargs):
-        dummy.mock()
-        dummy.kwargs = kwargs
-        dummy.steps['called'].set()
-        kwargs['stopped']._setter.set()  # to exit the cycle
+        dummy.mock(**kwargs)
+        async with trigger:
+            trigger.notify_all()
 
     await simulate_cycle({})
-    await dummy.steps['called'].wait()
+    async with trigger:
+        await trigger.wait()
+        await trigger.wait()
 
-    assert dummy.mock.call_count == 1
-    assert dummy.kwargs['retry'] == 0
-    assert k8s_mocked.sleep.call_count == 2
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == 5.0
-    assert k8s_mocked.sleep.call_args_list[1][0][0] == 1.0
-
-    await dummy.wait_for_daemon_done()
+    assert looptime == 6
+    assert dummy.mock.call_count == 2

--- a/tests/handling/subhandling/test_subhandling.py
+++ b/tests/handling/subhandling/test_subhandling.py
@@ -16,7 +16,7 @@ EVENT_TYPES_WHEN_EXISTS = [None, 'ADDED', 'MODIFIED']
 
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_1st_level(registry, settings, resource, cause_mock, event_type,
-                         caplog, assert_logs, k8s_mocked):
+                         caplog, assert_logs, k8s_mocked, looptime):
     caplog.set_level(logging.DEBUG)
     cause_mock.reason = Reason.CREATE
 
@@ -57,7 +57,7 @@ async def test_1st_level(registry, settings, resource, cause_mock, event_type,
     assert sub1a_mock.call_count == 1
     assert sub1b_mock.call_count == 1
 
-    assert k8s_mocked.sleep.call_count == 0
+    assert looptime == 0
     assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 
@@ -76,7 +76,7 @@ async def test_1st_level(registry, settings, resource, cause_mock, event_type,
 
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
 async def test_2nd_level(registry, settings, resource, cause_mock, event_type,
-                         caplog, assert_logs, k8s_mocked):
+                         caplog, assert_logs, k8s_mocked, looptime):
     caplog.set_level(logging.DEBUG)
     cause_mock.reason = Reason.CREATE
 
@@ -137,7 +137,7 @@ async def test_2nd_level(registry, settings, resource, cause_mock, event_type,
     assert sub1b2a_mock.call_count == 1
     assert sub1b2b_mock.call_count == 1
 
-    assert k8s_mocked.sleep.call_count == 0
+    assert looptime == 0
     assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -154,7 +154,7 @@ async def test_retries_are_simulated(settings, activity, mocker):
 
 
 @pytest.mark.parametrize('activity', list(Activity))
-async def test_delays_are_simulated(settings, activity, mocker):
+async def test_delays_are_simulated(settings, activity, looptime):
 
     def sample_fn(**_):
         raise TemporaryError('to be retried', delay=123)
@@ -165,24 +165,14 @@ async def test_delays_are_simulated(settings, activity, mocker):
         param=None, errors=None, timeout=None, retries=3, backoff=None,
     ))
 
-    with freezegun.freeze_time() as frozen:
+    with pytest.raises(ActivityError) as e:
+        await run_activity(
+            registry=registry,
+            settings=settings,
+            activity=activity,
+            lifecycle=all_at_once,
+            indices=OperatorIndexers().indices,
+            memo=Memo(),
+        )
 
-        async def sleep_substitute(*_, **__):
-            frozen.tick(123)
-
-        sleep = mocker.patch('kopf._cogs.aiokits.aiotime.sleep', wraps=sleep_substitute)
-
-        with pytest.raises(ActivityError) as e:
-            await run_activity(
-                registry=registry,
-                settings=settings,
-                activity=activity,
-                lifecycle=all_at_once,
-                indices=OperatorIndexers().indices,
-                memo=Memo(),
-            )
-
-    assert sleep.call_count >= 3  # 3 retries, 1 sleep each
-    assert sleep.call_count <= 4  # 3 retries, 1 final success (delay=None), not more
-    if sleep.call_count > 3:
-        sleep.call_args_list[-1][0][0] is None
+    assert looptime == 123 * 2

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -39,7 +39,6 @@ async def test_create(registry, settings, handlers, resource, cause_mock, event_
     assert not handlers.update_mock.called
     assert not handlers.delete_mock.called
 
-    assert k8s_mocked.sleep.call_count == 0
     assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 
@@ -80,7 +79,6 @@ async def test_update(registry, settings, handlers, resource, cause_mock, event_
     assert handlers.update_mock.call_count == 1
     assert not handlers.delete_mock.called
 
-    assert k8s_mocked.sleep.call_count == 0
     assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 
@@ -123,7 +121,6 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
     assert not handlers.update_mock.called
     assert handlers.delete_mock.call_count == 1
 
-    assert k8s_mocked.sleep.call_count == 0
     assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 
@@ -194,8 +191,6 @@ async def test_free(registry, settings, handlers, resource, cause_mock, event_ty
     assert not handlers.create_mock.called
     assert not handlers.update_mock.called
     assert not handlers.delete_mock.called
-
-    assert not k8s_mocked.sleep.called
     assert not k8s_mocked.patch.called
     assert event_queue.empty()
 
@@ -226,8 +221,6 @@ async def test_noop(registry, settings, handlers, resource, cause_mock, event_ty
     assert not handlers.create_mock.called
     assert not handlers.update_mock.called
     assert not handlers.delete_mock.called
-
-    assert not k8s_mocked.sleep.called
     assert not k8s_mocked.patch.called
     assert event_queue.empty()
 

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -52,7 +52,6 @@ async def test_delayed_handlers_progress(
     assert handlers.delete_mock.call_count == (1 if cause_reason == Reason.DELETE else 0)
     assert handlers.resume_mock.call_count == (1 if cause_reason == Reason.RESUME else 0)
 
-    assert not k8s_mocked.sleep.called
     assert k8s_mocked.patch.called
 
     fname = f'{cause_reason}_fn'
@@ -72,7 +71,7 @@ async def test_delayed_handlers_progress(
 ], ids=['fast', 'slow'])
 async def test_delayed_handlers_sleep(
         registry, settings, handlers, resource, cause_mock, cause_reason,
-        caplog, assert_logs, k8s_mocked, now, delayed_iso, delay):
+        caplog, assert_logs, k8s_mocked, now, delayed_iso, delay, looptime):
     caplog.set_level(logging.DEBUG)
 
     # Any "future" time works and affects nothing as long as it is the same
@@ -117,8 +116,7 @@ async def test_delayed_handlers_sleep(
     assert 'dummy' in k8s_mocked.patch.call_args_list[-1][1]['payload']['status']['kopf']
 
     # The duration of sleep should be as expected.
-    assert k8s_mocked.sleep.called
-    assert k8s_mocked.sleep.call_args_list[0][0][0] == delay
+    assert looptime == delay
 
     assert_logs([
         r"Sleeping for ([\d\.]+|[\d\.]+ \(capped [\d\.]+\)) seconds",

--- a/tests/handling/test_error_handling.py
+++ b/tests/handling/test_error_handling.py
@@ -16,7 +16,7 @@ from kopf._core.reactor.processing import process_resource_event
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_fatal_error_stops_handler(
         registry, settings, handlers, extrahandlers, resource, cause_mock, cause_type,
-        caplog, assert_logs, k8s_mocked):
+        caplog, assert_logs, k8s_mocked, looptime):
     caplog.set_level(logging.DEBUG)
     name1 = f'{cause_type}_fn'
 
@@ -44,7 +44,7 @@ async def test_fatal_error_stops_handler(
     assert handlers.delete_mock.call_count == (1 if cause_type == Reason.DELETE else 0)
     assert handlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
-    assert not k8s_mocked.sleep.called
+    assert looptime == 0
     assert k8s_mocked.patch.called
 
     patch = k8s_mocked.patch.call_args_list[0][1]['payload']
@@ -61,7 +61,7 @@ async def test_fatal_error_stops_handler(
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_retry_error_delays_handler(
         registry, settings, handlers, extrahandlers, resource, cause_mock, cause_type,
-        caplog, assert_logs, k8s_mocked):
+        caplog, assert_logs, k8s_mocked, looptime):
     caplog.set_level(logging.DEBUG)
     name1 = f'{cause_type}_fn'
 
@@ -89,7 +89,7 @@ async def test_retry_error_delays_handler(
     assert handlers.delete_mock.call_count == (1 if cause_type == Reason.DELETE else 0)
     assert handlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
-    assert not k8s_mocked.sleep.called
+    assert looptime == 0
     assert k8s_mocked.patch.called
 
     patch = k8s_mocked.patch.call_args_list[0][1]['payload']
@@ -107,7 +107,7 @@ async def test_retry_error_delays_handler(
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_arbitrary_error_delays_handler(
         registry, settings, handlers, extrahandlers, resource, cause_mock, cause_type,
-        caplog, assert_logs, k8s_mocked):
+        caplog, assert_logs, k8s_mocked, looptime):
     caplog.set_level(logging.DEBUG)
     name1 = f'{cause_type}_fn'
 
@@ -135,7 +135,7 @@ async def test_arbitrary_error_delays_handler(
     assert handlers.delete_mock.call_count == (1 if cause_type == Reason.DELETE else 0)
     assert handlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
-    assert not k8s_mocked.sleep.called
+    assert looptime == 0
     assert k8s_mocked.patch.called
 
     patch = k8s_mocked.patch.call_args_list[0][1]['payload']

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -18,7 +18,7 @@ from kopf._core.reactor.processing import process_resource_event
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_1st_step_stores_progress_by_patching(
         registry, settings, handlers, extrahandlers,
-        resource, cause_mock, cause_type, k8s_mocked, deletion_ts):
+        resource, cause_mock, cause_type, k8s_mocked, looptime, deletion_ts):
     name1 = f'{cause_type}_fn'
     name2 = f'{cause_type}_fn2'
 
@@ -46,7 +46,7 @@ async def test_1st_step_stores_progress_by_patching(
     assert handlers.delete_mock.call_count == (1 if cause_type == Reason.DELETE else 0)
     assert handlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
-    assert not k8s_mocked.sleep.called
+    assert looptime == 0
     assert k8s_mocked.patch.called
 
     patch = k8s_mocked.patch.call_args_list[0][1]['payload']
@@ -74,7 +74,7 @@ async def test_1st_step_stores_progress_by_patching(
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_2nd_step_finishes_the_handlers(caplog,
         registry, settings, handlers, extrahandlers,
-        resource, cause_mock, cause_type, k8s_mocked, deletion_ts):
+        resource, cause_mock, cause_type, k8s_mocked, looptime, deletion_ts):
     name1 = f'{cause_type}_fn'
     name2 = f'{cause_type}_fn2'
 
@@ -106,7 +106,7 @@ async def test_2nd_step_finishes_the_handlers(caplog,
     assert extrahandlers.delete_mock.call_count == (1 if cause_type == Reason.DELETE else 0)
     assert extrahandlers.resume_mock.call_count == (1 if cause_type == Reason.RESUME else 0)
 
-    assert not k8s_mocked.sleep.called
+    assert looptime == 0
     assert k8s_mocked.patch.called
 
     patch = k8s_mocked.patch.call_args_list[0][1]['payload']

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -46,7 +46,6 @@ async def test_skipped_with_no_handlers(
         event_queue=asyncio.Queue(),
     )
 
-    assert not k8s_mocked.sleep.called
     assert k8s_mocked.patch.called
 
     # The patch must contain ONLY the last-seen update, and nothing else.
@@ -102,6 +101,5 @@ async def test_stealth_mode_with_mismatching_handlers(
         event_queue=asyncio.Queue(),
     )
 
-    assert not k8s_mocked.sleep.called
     assert not k8s_mocked.patch.called
     assert not caplog.messages  # total stealth mode!

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -20,7 +20,7 @@ from kopf._core.reactor.processing import process_resource_event
 ], ids=['slow'])
 async def test_timed_out_handler_fails(
         registry, settings, handlers, extrahandlers, resource, cause_mock, cause_type,
-        caplog, assert_logs, k8s_mocked, now, ts):
+        caplog, assert_logs, k8s_mocked, looptime, now, ts):
     caplog.set_level(logging.DEBUG)
     name1 = f'{cause_type}_fn'
 
@@ -54,7 +54,7 @@ async def test_timed_out_handler_fails(
     assert not handlers.resume_mock.called
 
     # Progress is reset, as the handler is not going to retry.
-    assert not k8s_mocked.sleep.called
+    assert looptime == 0
     assert k8s_mocked.patch.called
 
     patch = k8s_mocked.patch.call_args_list[0][1]['payload']
@@ -71,7 +71,7 @@ async def test_timed_out_handler_fails(
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_retries_limited_handler_fails(
         registry, settings, handlers, extrahandlers, resource, cause_mock, cause_type,
-        caplog, assert_logs, k8s_mocked):
+        caplog, assert_logs, k8s_mocked, looptime):
     caplog.set_level(logging.DEBUG)
     name1 = f'{cause_type}_fn'
 
@@ -104,7 +104,7 @@ async def test_retries_limited_handler_fails(
     assert not handlers.resume_mock.called
 
     # Progress is reset, as the handler is not going to retry.
-    assert not k8s_mocked.sleep.called
+    assert looptime == 0
     assert k8s_mocked.patch.called
 
     patch = k8s_mocked.patch.call_args_list[0][1]['payload']

--- a/tests/logging/conftest.py
+++ b/tests/logging/conftest.py
@@ -10,11 +10,17 @@ def _caplog_all_levels(caplog):
     caplog.set_level(0)
 
 
+# We can get a properly scoped running loop of the test only in the async fixture.
+@pytest.fixture
+async def _event_queue_running_loop():
+    return asyncio.get_running_loop()
+
+
 @pytest.fixture(autouse=True)
-def event_queue_loop(loop):  # must be sync-def
-    token = event_queue_loop_var.set(loop)
+def event_queue_loop(_event_queue_running_loop):  # must be sync-def
+    token = event_queue_loop_var.set(_event_queue_running_loop)
     try:
-        yield loop
+        yield
     finally:
         event_queue_loop_var.reset(token)
 

--- a/tests/posting/conftest.py
+++ b/tests/posting/conftest.py
@@ -5,11 +5,18 @@ import pytest
 from kopf._core.engines.posting import event_queue_loop_var, event_queue_var
 
 
+# We can get a properly scoped running loop of the test only in the async fixture.
+@pytest.fixture
+async def _event_queue_running_loop():
+    return asyncio.get_running_loop()
+
+
+
 @pytest.fixture()
-def event_queue_loop(loop):  # must be sync-def
-    token = event_queue_loop_var.set(loop)
+def event_queue_loop(_event_queue_running_loop):  # must be sync-def
+    token = event_queue_loop_var.set(_event_queue_running_loop)
     try:
-        yield loop
+        yield
     finally:
         event_queue_loop_var.reset(token)
 

--- a/tests/posting/test_threadsafety.py
+++ b/tests/posting/test_threadsafety.py
@@ -33,13 +33,13 @@ posting is not thread-safe. Otherwise, it wakes up on ``queue.get()`` instantly.
 If thread safety is not ensured, the operators get sporadic errors regarding
 thread-unsafe calls, which are difficult to catch and reproduce.
 """
-
 import asyncio
 import contextvars
 import functools
 import threading
 import time
 
+import looptime
 import pytest
 
 from kopf import event
@@ -49,25 +49,15 @@ OBJ1 = {'apiVersion': 'group1/version1', 'kind': 'Kind1',
 
 
 @pytest.fixture()
-def awakener():
-    handles = []
-
-    def noop():
-        pass
-
-    def awaken_fn(delay, fn=noop):
-        handle = asyncio.get_running_loop().call_later(delay, fn)
-        handles.append(handle)
-
-    try:
-        yield awaken_fn
-    finally:
-        for handle in handles:
-            handle.cancel()
-
-
-@pytest.fixture()
 def threader():
+    """
+    Call a sync function after a delay. Finalize the thread afterwards.
+
+    Always put the threader setup **under** the chronometer or timer.
+    Otherwise, the code can seem to be executed faster than the sleep —
+    because there will be time spent on sleeping between the thread has started
+    and the chronometer/timer made its initial measurement of time: 0.01s or so.
+    """
     threads = []
 
     def start_fn(delay, fn):
@@ -87,46 +77,63 @@ def threader():
             thread.join()
 
 
-async def test_nonthreadsafe_indeed_fails(timer, awakener, threader, event_queue, event_queue_loop):
+# This test relies on an assumption that nothing is happening in the event loop
+# without new `await` statements or scheduled events/timers, i.e. nothing breaks
+# the event loop's sleep the same way as a threadsafe injection does. Because of
+# this, the 0.2s sync activity does not wake up the loop, only the 0.5s does.
+@pytest.mark.looptime(False)
+async def test_nonthreadsafe_indeed_fails(chronometer, threader, event_queue):
+    loop = asyncio.get_running_loop()
+    thread_was_called = threading.Event()
 
     def thread_fn():
+        thread_was_called.set()
         event_queue.put_nowait(object())
 
-    awakener(0.7)
-    threader(0.3, thread_fn)
-
-    with timer:
+    with chronometer, looptime.Chronometer(loop.time) as loopometer:
+        threader(0.5, lambda: loop.call_soon_threadsafe(lambda: None))
+        threader(0.2, thread_fn)
         await event_queue.get()
 
-    assert 0.6 <= timer.seconds <= 0.8
+    assert 0.5 <= chronometer.seconds < 0.6
+    assert 0.5 <= loopometer.seconds < 0.6
+    assert thread_was_called.is_set()
 
 
-async def test_threadsafe_indeed_works(timer, awakener, threader, event_queue, event_queue_loop):
+@pytest.mark.looptime(False)
+async def test_threadsafe_indeed_works(chronometer, threader, event_queue):
+    loop = asyncio.get_running_loop()
+    thread_was_called = threading.Event()
 
     def thread_fn():
-        asyncio.run_coroutine_threadsafe(event_queue.put(object()), loop=event_queue_loop)
+        thread_was_called.set()
+        asyncio.run_coroutine_threadsafe(event_queue.put(object()), loop=loop)
 
-    awakener(0.7)
-    threader(0.3, thread_fn)
-
-    with timer:
+    with chronometer, looptime.Chronometer(loop.time) as loopometer:
+        threader(0.5, lambda: loop.call_soon_threadsafe(lambda: None))
+        threader(0.2, thread_fn)
         await event_queue.get()
 
-    assert 0.2 <= timer.seconds <= 0.4
+    assert 0.2 <= chronometer.seconds < 0.3
+    assert 0.2 <= loopometer.seconds < 0.3
+    assert thread_was_called.is_set()
 
 
-async def test_queueing_is_threadsafe(timer, awakener, threader, event_queue, event_queue_loop,
-                                      settings_via_contextvar):
+@pytest.mark.looptime(False)
+@pytest.mark.usefixtures('event_queue_loop', 'settings_via_contextvar')
+async def test_queueing_is_threadsafe(chronometer, threader, event_queue):
+    loop = asyncio.get_running_loop()
+    thread_was_called = threading.Event()
 
     def thread_fn():
+        thread_was_called.set()
         event(OBJ1, type='type1', reason='reason1', message='message1')
 
-    awakener(0.7)
-    threader(0.3, thread_fn)
-
-    with timer:
+    with chronometer, looptime.Chronometer(loop.time) as loopometer:
+        threader(0.5, lambda: loop.call_soon_threadsafe(lambda: None))
+        threader(0.2, thread_fn)
         await event_queue.get()
 
-    # TODO revert back 0.6 -> 0.4? (why is it 0.43-0.52s in GHA python 3.12 full-auth only?)
-    #   probably caused by a bad vm/container randomly selected with "noisy neighbours".
-    assert 0.2 <= timer.seconds <= 0.6
+    assert 0.2 <= chronometer.seconds < 0.3
+    assert 0.2 <= loopometer.seconds < 0.3
+    assert thread_was_called.is_set()

--- a/tests/primitives/test_conditions.py
+++ b/tests/primitives/test_conditions.py
@@ -5,20 +5,21 @@ import pytest
 from kopf._cogs.aiokits.aiobindings import condition_chain
 
 
-async def test_no_triggering():
+async def test_no_triggering(looptime):
     source = asyncio.Condition()
     target = asyncio.Condition()
     task = asyncio.create_task(condition_chain(source, target))
     try:
         with pytest.raises(asyncio.TimeoutError):
             async with target:
-                await asyncio.wait_for(target.wait(), timeout=0.1)
+                await asyncio.wait_for(target.wait(), timeout=1.23)
+        assert looptime == 1.23
     finally:
         task.cancel()
         await asyncio.wait([task])
 
 
-async def test_triggering(timer):
+async def test_triggering(looptime):
     source = asyncio.Condition()
     target = asyncio.Condition()
     task = asyncio.create_task(condition_chain(source, target))
@@ -29,13 +30,12 @@ async def test_triggering(timer):
                 source.notify_all()
 
         loop = asyncio.get_running_loop()
-        loop.call_later(0.1, asyncio.create_task, delayed_trigger())
+        loop.call_later(1.23, asyncio.create_task, delayed_trigger())
 
-        with timer:
-            async with target:
-                await target.wait()
+        async with target:
+            await target.wait()
 
-        assert 0.1 <= timer.seconds <= 0.2
+        assert looptime == 1.23
 
     finally:
         task.cancel()

--- a/tests/primitives/test_containers.py
+++ b/tests/primitives/test_containers.py
@@ -5,82 +5,78 @@ import pytest
 from kopf._cogs.aiokits.aiovalues import Container
 
 
-async def test_empty_by_default():
+async def test_empty_by_default(looptime):
     container = Container()
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(container.wait(), timeout=0.1)
+        await asyncio.wait_for(container.wait(), timeout=9)
+    assert looptime == 9
 
 
-async def test_does_not_wake_up_when_reset(timer):
+async def test_does_not_wake_up_when_reset(looptime):
     container = Container()
 
     async def reset_it():
         await container.reset()
 
     loop = asyncio.get_running_loop()
-    loop.call_later(0.05, asyncio.create_task, reset_it())
+    loop.call_later(1, asyncio.create_task, reset_it())
 
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(container.wait(), timeout=0.1)
+        await asyncio.wait_for(container.wait(), timeout=9)
+    assert looptime == 9
 
 
-async def test_wakes_up_when_preset(timer):
+async def test_wakes_up_when_preset(looptime):
     container = Container()
     await container.set(123)
 
-    with timer:
-        result = await container.wait()
-
-    assert timer.seconds <= 0.1
+    result = await container.wait()
+    assert looptime == 0
     assert result == 123
 
 
-async def test_wakes_up_when_set(timer):
+async def test_wakes_up_when_set(looptime):
     container = Container()
 
     async def set_it():
         await container.set(123)
 
     loop = asyncio.get_running_loop()
-    loop.call_later(0.1, asyncio.create_task, set_it())
+    loop.call_later(9, asyncio.create_task, set_it())
 
-    with timer:
-        result = await container.wait()
-
-    assert 0.1 <= timer.seconds <= 0.2
+    result = await container.wait()
+    assert looptime == 9
     assert result == 123
 
 
-async def test_iterates_when_set(timer):
+async def test_iterates_when_set(looptime):
     container = Container()
 
     async def set_it(v):
         await container.set(v)
 
     loop = asyncio.get_running_loop()
-    loop.call_later(0.1, asyncio.create_task, set_it(123))
-    loop.call_later(0.2, asyncio.create_task, set_it(234))
+    loop.call_later(6, asyncio.create_task, set_it(123))
+    loop.call_later(9, asyncio.create_task, set_it(234))
 
     values = []
-    with timer:
-        async for value in container.as_changed():
-            values.append(value)
-            if value == 234:
-                break
+    async for value in container.as_changed():
+        values.append(value)
+        if value == 234:
+            break
 
-    assert 0.2 <= timer.seconds <= 0.3
+    assert looptime == 9
     assert values == [123, 234]
 
 
-async def test_iterates_when_preset(timer):
+async def test_iterates_when_preset(looptime):
     container = Container()
     await container.set(123)
 
     values = []
-    with timer:
-        async for value in container.as_changed():
-            values.append(value)
-            break
+    async for value in container.as_changed():
+        values.append(value)
+        break
 
-    assert timer.seconds <= 0.1
+    assert looptime == 0
     assert values == [123]

--- a/tests/primitives/test_toggles.py
+++ b/tests/primitives/test_toggles.py
@@ -37,50 +37,48 @@ async def test_turning_off():
     assert toggle.is_off()
 
 
-async def test_waiting_until_on_fails_when_not_turned_on():
+async def test_waiting_until_on_fails_when_not_turned_on(looptime):
     toggle = Toggle(False)
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(toggle.wait_for(True), timeout=0.1)
-
+        await asyncio.wait_for(toggle.wait_for(True), timeout=1.23)
     assert toggle.is_off()
+    assert looptime == 1.23
 
 
-async def test_waiting_until_off_fails_when_not_turned_off():
+async def test_waiting_until_off_fails_when_not_turned_off(looptime):
     toggle = Toggle(True)
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(toggle.wait_for(False), timeout=0.1)
-
+        await asyncio.wait_for(toggle.wait_for(False), timeout=1.23)
     assert toggle.is_on()
+    assert looptime == 1.23
 
 
-async def test_waiting_until_on_wakes_when_turned_on(timer):
+async def test_waiting_until_on_wakes_when_turned_on(looptime):
     toggle = Toggle(False)
 
     async def delayed_turning_on(delay: float):
         await asyncio.sleep(delay)
         await toggle.turn_to(True)
 
-    with timer:
-        asyncio.create_task(delayed_turning_on(0.05))
-        await toggle.wait_for(True)
+    asyncio.create_task(delayed_turning_on(9))
+    await toggle.wait_for(True)
 
     assert toggle.is_on()
-    assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead
+    assert looptime == 9
 
 
-async def test_waiting_until_off_wakes_when_turned_off(timer):
+async def test_waiting_until_off_wakes_when_turned_off(looptime):
     toggle = Toggle(True)
 
     async def delayed_turning_off(delay: float):
         await asyncio.sleep(delay)
         await toggle.turn_to(False)
 
-    with timer:
-        asyncio.create_task(delayed_turning_off(0.05))
-        await toggle.wait_for(False)
+    asyncio.create_task(delayed_turning_off(9))
+    await toggle.wait_for(False)
 
     assert toggle.is_off()
-    assert timer.seconds < 0.5  # approx. 0.05 plus some code overhead
+    assert looptime == 9
 
 
 async def test_secures_against_usage_as_a_boolean():

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -6,24 +6,18 @@ import asyncio
 _async_was_executed = False
 
 
-async def test_async_tests_are_enabled(timer):
+async def test_async_tests_are_enabled():
     global _async_was_executed
     _async_was_executed = True  # asserted in a sync-test below.
 
-    with timer as t:
-        await asyncio.sleep(0.5)
 
-    assert t.seconds > 0.5  # real sleep
-
-
-async def test_async_mocks_are_enabled(timer, mocker):
+async def test_async_mocks_are_enabled(mocker, looptime):
     p = mocker.patch('asyncio.sleep')
-    with timer as t:
-        await asyncio.sleep(1.0)
+    await asyncio.sleep(1.0)
 
     assert p.call_count > 0
     assert p.await_count > 0
-    assert t.seconds < 0.01  # mocked sleep
+    assert looptime == 0
 
 
 def test_async_test_was_executed_and_awaited():

--- a/tests/timing/test_sleeping.py
+++ b/tests/timing/test_sleeping.py
@@ -5,24 +5,21 @@ import pytest
 from kopf._cogs.aiokits.aiotime import sleep
 
 
-async def test_the_only_delay_is_awaited(timer):
-    with timer:
-        unslept = await sleep(0.10)
-    assert 0.10 <= timer.seconds < 0.11
+async def test_the_only_delay_is_awaited(looptime):
+    unslept = await sleep(123)
+    assert looptime == 123
     assert unslept is None
 
 
-async def test_the_shortest_delay_is_awaited(timer):
-    with timer:
-        unslept = await sleep([0.10, 0.20])
-    assert 0.10 <= timer.seconds < 0.11
+async def test_the_shortest_delay_is_awaited(looptime):
+    unslept = await sleep([123, 456])
+    assert looptime == 123
     assert unslept is None
 
 
-async def test_specific_delays_only_are_awaited(timer):
-    with timer:
-        unslept = await sleep([0.10, None])
-    assert 0.10 <= timer.seconds < 0.11
+async def test_specific_delays_only_are_awaited(looptime):
+    unslept = await sleep([123, None])
+    assert looptime == 123
     assert unslept is None
 
 
@@ -31,10 +28,9 @@ async def test_specific_delays_only_are_awaited(timer):
     pytest.param([-100, -10], id='all-negative'),
     pytest.param(-10, id='alone'),
 ])
-async def test_negative_delays_skip_sleeping(timer, delays):
-    with timer:
-        unslept = await sleep(delays)
-    assert timer.seconds < 0.01
+async def test_negative_delays_skip_sleeping(looptime, delays):
+    unslept = await sleep(delays)
+    assert looptime == 0
     assert unslept is None
 
 
@@ -42,36 +38,32 @@ async def test_negative_delays_skip_sleeping(timer, delays):
     pytest.param([], id='empty-list'),
     pytest.param([None], id='list-of-none'),
 ])
-async def test_no_delays_skip_sleeping(timer, delays):
-    with timer:
-        unslept = await sleep(delays)
-    assert timer.seconds < 0.01
+async def test_no_delays_skip_sleeping(looptime, delays):
+    unslept = await sleep(delays)
+    assert looptime == 0
     assert unslept is None
 
 
-async def test_by_event_set_before_time_comes(timer):
+async def test_by_event_set_before_time_comes(looptime):
     event = asyncio.Event()
-    asyncio.get_running_loop().call_later(0.07, event.set)
-    with timer:
-        unslept = await sleep(0.10, event)
+    asyncio.get_running_loop().call_later(7, event.set)
+    unslept = await sleep(10, event)
     assert unslept is not None
-    assert 0.02 <= unslept <= 0.04
-    assert 0.06 <= timer.seconds <= 0.08
+    assert unslept == 3
+    assert looptime == 7
 
 
-async def test_with_zero_time_and_event_initially_cleared(timer):
+async def test_with_zero_time_and_event_initially_cleared(looptime):
     event = asyncio.Event()
     event.clear()
-    with timer:
-        unslept = await sleep(0, event)
-    assert timer.seconds <= 0.01
+    unslept = await sleep(0, event)
+    assert looptime == 0
     assert unslept is None
 
 
-async def test_with_zero_time_and_event_initially_set(timer):
+async def test_with_zero_time_and_event_initially_set(looptime):
     event = asyncio.Event()
     event.set()
-    with timer:
-        unslept = await sleep(0, event)
-    assert timer.seconds <= 0.01
+    unslept = await sleep(0, event)
+    assert looptime == 0
     assert not unslept  # 0/None; undefined for such case: both goals reached.

--- a/tests/utilities/aiotasks/test_task_selection.py
+++ b/tests/utilities/aiotasks/test_task_selection.py
@@ -7,7 +7,7 @@ async def test_alltasks_exclusion():
     flag = asyncio.Event()
     task1 = asyncio.create_task(flag.wait())
     task2 = asyncio.create_task(flag.wait())
-    done, pending = await asyncio.wait([task1, task2], timeout=0.01)
+    done, pending = await asyncio.wait([task1, task2], timeout=0.01)  # let them start
     assert not done
 
     tasks = await all_tasks(ignored=[task2])

--- a/tests/utilities/aiotasks/test_task_waiting.py
+++ b/tests/utilities/aiotasks/test_task_waiting.py
@@ -3,17 +3,19 @@ import asyncio
 from kopf._cogs.aiokits.aiotasks import wait
 
 
-async def test_wait_with_no_tasks():
+async def test_wait_with_no_tasks(looptime):
     done, pending = await wait([])
     assert not done
     assert not pending
+    assert looptime == 0
 
 
-async def test_wait_with_timeout():
+async def test_wait_with_timeout(looptime):
     flag = asyncio.Event()
     task = asyncio.create_task(flag.wait())
-    done, pending = await wait([task], timeout=0.01)
+    done, pending = await wait([task], timeout=1.23)
     assert not done
     assert pending == {task}
+    assert looptime == 1.23
     flag.set()
     await task


### PR DESCRIPTION
Utilise a new library — https://github.com/nolar/looptime — to have a fake time in event loops. The library does a lot of things, but the most important one is the sharp time with predictable steps with **no code overhead included**, which is typically random.

Everything else goes as a side-effect: e.g. the fast execution of such tests with zero real-time for any fake duration of loop time, convenient `looptime` fixture for assertions, etc.

_This PR also demonstrates how the tests can be rewritten to use the provided looptime's features (and is mentioned in its README)._

Fixes #212; related: #338

Preparational PRs:

* #1203 
* #1205 
* #1206 