### PR TITLE
update deployment-rbac.yaml

### DIFF
--- a/docs/deployment-rbac.yaml
+++ b/docs/deployment-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "{{NAMESPACE}}"
   name: kopfexample-account
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kopfexample-role-cluster
@@ -34,7 +34,7 @@ rules:
     resources: [kopfexamples]
     verbs: [list, watch]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: "{{NAMESPACE}}"
@@ -65,7 +65,7 @@ rules:
     resources: [pods, persistentvolumeclaims]
     verbs: [create]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kopfexample-rolebinding-cluster
@@ -78,7 +78,7 @@ subjects:
     name: kopfexample-account
     namespace: "{{NAMESPACE}}"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: "{{NAMESPACE}}"


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta1 ClusterRole, ClusterRoleBinding, and RoleBinding are deprecated in v1.17+, unavailable in v1.22+; 

The new api version to use use is rbac.authorization.k8s.io/v1

`Warning: rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
clusterrole.rbac.authorization.k8s.io/kopfexample-role-cluster created
Warning: rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
role.rbac.authorization.k8s.io/kopfexample-role-namespaced created
Warning: rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
clusterrolebinding.rbac.authorization.k8s.io/kopfexample-rolebinding-cluster created
Warning: rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
rolebinding.rbac.authorization.k8s.io/kopfexample-rolebinding-namespaced created`
