### PR TITLE
Allow not using finalizers for timer

### DIFF
--- a/kopf/_core/intents/causes.py
+++ b/kopf/_core/intents/causes.py
@@ -193,6 +193,7 @@ class SpawningCause(ResourceCause):
     specific objects (loggers, etc).
     """
     reset: bool
+    raw_event_type: str
 
     @property
     def _kwargs(self) -> Mapping[str, Any]:
@@ -277,10 +278,12 @@ def detect_watching_cause(
 
 def detect_spawning_cause(
         body: bodies.Body,
+        raw_event_type: str,
         **kwargs: Any,
 ) -> SpawningCause:
     return SpawningCause(
         body=body,
+        raw_event_type=raw_event_type,
         **kwargs)
 
 

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -735,6 +735,7 @@ def timer(  # lgtm[py/similar-function]
         value: Optional[filters.ValueFilter] = None,
         # Operator specification:
         registry: Optional[registries.OperatorRegistry] = None,
+        requires_finalizer: bool = True,
 ) -> TimerDecorator:
     """ ``@kopf.timer()`` handler for the regular events. """
     def decorator(  # lgtm[py/similar-function]
@@ -755,7 +756,7 @@ def timer(  # lgtm[py/similar-function]
             errors=errors, timeout=timeout, retries=retries, backoff=backoff,
             selector=selector, labels=labels, annotations=annotations, when=when,
             field=real_field, value=value,
-            initial_delay=initial_delay, requires_finalizer=True,
+            initial_delay=initial_delay, requires_finalizer=requires_finalizer,
             sharp=sharp, idle=idle, interval=interval,
         )
         real_registry._spawning.append(handler)

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -40,7 +40,7 @@ def dummy():
 
 
 @pytest.fixture()
-def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
+def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker, raw_event=None):
     """
     Simulate K8s behaviour locally in memory (some meaningful approximation).
     """
@@ -52,7 +52,7 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
             else:
                 dst[key] = val
 
-    async def _simulate_cycle(event_object: RawBody):
+    async def _simulate_cycle(event_object: RawBody, raw_event_type: str = 'irrelevant'):
         mocker.resetall()
 
         await process_resource_event(
@@ -63,7 +63,7 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
             memories=memories,
             memobase=Memo(),
             indexers=OperatorIndexers(),
-            raw_event={'type': 'irrelevant', 'object': event_object},
+            raw_event={'type': raw_event_type, 'object': event_object},
             event_queue=asyncio.Queue(),
         )
 

--- a/tests/handling/daemons/test_timer_triggering.py
+++ b/tests/handling/daemons/test_timer_triggering.py
@@ -2,6 +2,8 @@ import logging
 
 import kopf
 
+import asyncio
+
 
 async def test_timer_is_spawned_at_least_once(
         resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
@@ -22,6 +24,35 @@ async def test_timer_is_spawned_at_least_once(
     assert k8s_mocked.sleep.call_count == 1
     assert k8s_mocked.sleep.call_args_list[0][0][0] == 1.0
 
+    await dummy.wait_for_daemon_done()
+
+
+async def test_timer_stopped_on_deletion_event_nofinalizer(
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle):
+    caplog.set_level(logging.DEBUG)
+
+    @kopf.timer(*resource, id='fn', interval=1.0, requires_finalizer=False)
+    async def fn(**kwargs):
+        dummy.mock()
+        dummy.kwargs = kwargs
+
+        if dummy.mock.call_count >= 2:
+            dummy.steps['called'].set()
+            kwargs['stopped']._setter.set()  # to exit the cycle
+
+    await simulate_cycle({})
+    await dummy.steps['called'].wait()
+
+    assert dummy.mock.call_count == 2
+    assert dummy.kwargs['retry'] == 0
+    assert k8s_mocked.sleep.call_count == 2
+
+    # Send deleted event, wait for 2 seconds (2x interval time)
+    # to ensure no more calls.
+    # verify no additional calls to fn via mock.call_count
+    await simulate_cycle({}, raw_event_type='DELETED')
+    await asyncio.sleep(2.0)
+    assert dummy.mock.call_count == 2
     await dummy.wait_for_daemon_done()
 
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping maintainers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I'd like to have to option to not use finalizers in timers. The reason is that finalizers, while perfectly reasonable for a daemon/timer/change event handler acting as the operator for a CRD, are not ideal when watching other resources (ex: a secret). My use case is im using the timer to periodically check on Secrets with a custom TTL annotation, and delete them after they have been alive for TTL time. I don't want to have a finalizer on the secrets, as that couples successful deletion of a secret with this operator running. Its not a necessary coupling, and in the case where the operator is not running or was turned off for any reason it creates a very strange behavior for someone using kubectl to manually delete the secret for whatever reason to see the deletion hung. I don't need the finalizer for any practical reason (they should be used to perform custom cleanup before the object disappears from K8s, but I have no such actions to do), so it seems like in this case, the finalizer is really just there for convenience of detection of deletion in the code, rather than a practical use-case for it.

In https://github.com/nolar/kopf/pull/548, finalizers were required on all spawning handlers (daemon and timer handlers). This needed to be done the fix the bug in https://github.com/nolar/kopf/issues/390, but only because the code in https://github.com/nolar/kopf/blob/main/kopf/_core/reactor/processing.py#L335 has an assumption that finalizers are enabled, as checking for is_deletion_ongoing will ever really return True if finalizers are there, otherwise you never see a resource with a deletionTimestamp, it just disappears faster than it can be detected.

There's still a way to detect that the object was deleted, namely, the watchers see the deletion event and raw_event['type'] == 'DELETED'. 

This diff introduces

1) Awareness of raw_event_type in the SpawningCause, to detect deletion even without finalizers on
2) Checking for which daemons to stop by checking for raw_event_type == 'DELETED' in the case where handler.requires_finalizers is False

This allows some daemons/timers to have finalizers and others not to, while still stopping the daemons/timers in both cases correctly.

I have tested manually against a kind cluster, and added a unit test to verify the timer stops when a deletion event is observed when requires_finalizer=False.