### PR TITLE
Fix issue with APIService entities on reading cluster resources

### DIFF
--- a/kopf/_cogs/clients/scanning.py
+++ b/kopf/_cogs/clients/scanning.py
@@ -113,13 +113,13 @@ async def _read_version(
                 categories=frozenset(resource.get('categories', [])),
                 subresources=frozenset(
                     subresource['name'].split('/', 1)[-1]
-                    for subresource in rsp['resources']
+                    for subresource in rsp.get('resources', [])
                     if subresource['name'].startswith(f'{resource["name"]}/')
                 ),
                 namespaced=resource['namespaced'],
                 preferred=preferred,
                 verbs=frozenset(resource.get('verbs', [])),
             )
-            for resource in rsp['resources']
+            for resource in rsp.get('resources', [])
             if '/' not in resource['name']
         }


### PR DESCRIPTION
In case of `APIService`'s are presented in the cluster a `kopf` application is crushing with the following stack trace:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opt/venv/lib/python3.9/site-packages/kopf/__main__.py", line 9, in <module>
    cli.main()
  File "/opt/venv/lib/python3.9/site-packages/click/core.py", line 1128, in call
    return self.main(*args, **kwargs)
  File "/opt/venv/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/opt/venv/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/venv/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/venv/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/opt/venv/lib/python3.9/site-packages/kopf/cli.py", line 57, in wrapper
    return fn(*args, **kwargs)
  File "/opt/venv/lib/python3.9/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/opt/venv/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/opt/venv/lib/python3.9/site-packages/kopf/cli.py", line 104, in run
    return running.run(
  File "/opt/venv/lib/python3.9/site-packages/kopf/_core/reactor/running.py", line 58, in run
    loop.run_until_complete(operator(
  File "/usr/local/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/opt/venv/lib/python3.9/site-packages/kopf/_core/reactor/running.py", line 135, in operator
    await run_tasks(operator_tasks, ignored=existing_tasks)
  File "/opt/venv/lib/python3.9/site-packages/kopf/_core/reactor/running.py", line 416, in run_tasks
    await aiotasks.reraise(root_done | root_cancelled | hung_done | hung_cancelled)
  File "/opt/venv/lib/python3.9/site-packages/kopf/_cogs/aiokits/aiotasks.py", line 237, in reraise
    task.result()  # can raise the regular (non-cancellation) exceptions.
  File "/opt/venv/lib/python3.9/site-packages/kopf/_cogs/aiokits/aiotasks.py", line 107, in guard
    await coro
  File "/opt/venv/lib/python3.9/site-packages/kopf/_core/reactor/observation.py", line 113, in resource_observer
    resources = await scanning.scan_resources(groups=group_filter, settings=settings, logger=logger)
  File "/opt/venv/lib/python3.9/site-packages/kopf/_cogs/clients/scanning.py", line 31, in scan_resources
    resources.update(await coro)
  File "/usr/local/lib/python3.9/asyncio/tasks.py", line 611, in _wait_for_one
    return f.result()  # May raise f.exception().
  File "/opt/venv/lib/python3.9/site-packages/kopf/_cogs/clients/scanning.py", line 83, in _read_new_apis
    resources.update(await coro)
  File "/usr/local/lib/python3.9/asyncio/tasks.py", line 611, in _wait_for_one
    return f.result()  # May raise f.exception().
  File "/opt/venv/lib/python3.9/site-packages/kopf/_cogs/clients/scanning.py", line 123, in _read_version
    for resource in rsp['resources']
KeyError: 'resources'
```

due to the `APIService` has no `resources` field
