### PR TITLE
Upgrade Kubernetes and drop unmaintained versions in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k3s: [latest, v1.22, v1.21, v1.20, v1.19]
+        k3s: [latest, v1.23, v1.22, v1.21]
     name: K3s ${{matrix.k3s}}
     runs-on: ubuntu-20.04
     timeout-minutes: 10  # usually 4-5 mins

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k3s: [latest, v1.22, v1.21, v1.20, v1.19]
+        k3s: [latest, v1.23, v1.22, v1.21]
     name: K3s ${{matrix.k3s}}
     runs-on: ubuntu-20.04
     timeout-minutes: 10  # usually 4-5 mins
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s: [latest, v1.22.8, v1.21.11, v1.20.15, v1.19.16]
+        k8s: [latest, v1.23.7, v1.22.10, v1.21.13]
     name: K8s ${{matrix.k8s}}
     runs-on: ubuntu-20.04
     timeout-minutes: 10  # usually 4-5 mins


### PR DESCRIPTION
As per https://kubernetes.io/releases/patch-releases/#support-period
