### PR TITLE
Define credentials expiration time (optionally)

### DIFF
--- a/examples/13-hooks/example.py
+++ b/examples/13-hooks/example.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import random
 from typing import Dict
 
@@ -54,6 +55,7 @@ async def login_fn(**kwargs):
         certificate_path=cert.filename() if cert else None,  # can be a temporary file
         private_key_path=pkey.filename() if pkey else None,  # can be a temporary file
         default_namespace=config.namespace,
+        expiration=datetime.datetime.utcnow() + datetime.timedelta(seconds=30),
     )
 
 

--- a/kopf/_cogs/structs/credentials.py
+++ b/kopf/_cogs/structs/credentials.py
@@ -122,13 +122,13 @@ class Vault(AsyncIterable[Tuple[VaultKey, ConnectionInfo]]):
 
         # Mark a pre-populated vault to be usable instantly,
         # or trigger the initial authentication for an empty vault.
-        self._ready = aiotoggles.Toggle(bool(self))
+        self._ready = aiotoggles.Toggle(not self.is_empty())
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__}: {self._current!r}>'
 
     def __bool__(self) -> bool:
-        return bool(self._current)
+        raise NotImplementedError("The vault should not be evaluated as bool.")
 
     async def __aiter__(
             self,
@@ -283,6 +283,9 @@ class Vault(AsyncIterable[Tuple[VaultKey, ConnectionInfo]]):
         # Notify the consuming tasks (client wrappers) that new credentials are ready to be used.
         # Those tasks can be blocked in `vault.invalidate()` if there are no credentials left.
         await self._ready.turn_to(True)
+
+    def is_empty(self) -> bool:
+        return not self._current
 
     async def wait_for_readiness(self) -> None:
         await self._ready.wait_for(True)

--- a/kopf/_core/engines/activities.py
+++ b/kopf/_core/engines/activities.py
@@ -50,7 +50,7 @@ async def authenticator(
         memo: ephemera.AnyMemo,
 ) -> NoReturn:
     """ Keep the credentials forever up to date. """
-    counter: int = 1 if vault else 0
+    counter: int = 0 if vault.is_empty() else 1
     while True:
         await authenticate(
             registry=registry,

--- a/tests/authentication/test_authentication.py
+++ b/tests/authentication/test_authentication.py
@@ -21,7 +21,7 @@ async def test_empty_registry_produces_no_credentials(settings):
         indices=OperatorIndexers().indices,
     )
 
-    assert not vault
+    assert vault.is_empty()
     with pytest.raises(LoginError):
         async for _, _ in vault:
             pass
@@ -48,7 +48,7 @@ async def test_noreturn_handler_produces_no_credentials(settings):
         indices=OperatorIndexers().indices,
     )
 
-    assert not vault
+    assert vault.is_empty()
     with pytest.raises(LoginError):
         async for _, _ in vault:
             pass
@@ -76,7 +76,7 @@ async def test_single_credentials_provided_to_vault(settings):
         indices=OperatorIndexers().indices,
     )
 
-    assert vault
+    assert not vault.is_empty()
 
     items = []
     async for key, info in vault:

--- a/tests/authentication/test_connectioninfo.py
+++ b/tests/authentication/test_connectioninfo.py
@@ -1,3 +1,5 @@
+import datetime
+
 from kopf._cogs.structs.credentials import ConnectionInfo, VaultKey
 
 
@@ -24,6 +26,7 @@ def test_creation_with_minimal_fields():
     assert info.private_key_path is None
     assert info.private_key_data is None
     assert info.default_namespace is None
+    assert info.expiration is None
 
 
 def test_creation_with_maximal_fields():
@@ -41,6 +44,7 @@ def test_creation_with_maximal_fields():
         private_key_path='/pkey/path',
         private_key_data=b'pkey_data',
         default_namespace='default',
+        expiration=datetime.datetime.max,
     )
     assert info.server == 'https://localhost'
     assert info.ca_path == '/ca/path'
@@ -55,3 +59,4 @@ def test_creation_with_maximal_fields():
     assert info.private_key_path == '/pkey/path'
     assert info.private_key_data == b'pkey_data'
     assert info.default_namespace == 'default'
+    assert info.expiration == datetime.datetime.max

--- a/tests/authentication/test_vault.py
+++ b/tests/authentication/test_vault.py
@@ -3,17 +3,23 @@ import pytest
 from kopf._cogs.structs.credentials import ConnectionInfo, LoginError, Vault, VaultKey
 
 
-async def test_evals_as_false_when_empty():
+async def test_probits_evaluating_as_boolean():
     vault = Vault()
-    assert not vault
+    with pytest.raises(NotImplementedError):
+        bool(vault)
 
 
-async def test_evals_as_true_when_filled():
+async def test_empty_at_creation():
+    vault = Vault()
+    assert vault.is_empty()
+
+
+async def test_not_empty_when_populated():
     key1 = VaultKey('some-key')
     info1 = ConnectionInfo(server='https://expected/')
     vault = Vault()
     await vault.populate({key1: info1})
-    assert vault
+    assert not vault.is_empty()
 
 
 async def test_yielding_after_creation(mocker):


### PR DESCRIPTION
The re-authentication happens on the same trigger as before: when no valid credentials are left in the vault when they are needed.

The same as before, there is no preliminary vault population or credentials refreshment, including on credentials expiration: although we know that the credentials have expired, the re-authentication does not happen until an API call is attempted.

The existing API calls initiated before the expiration —e.g. the watch-streams— will continue running and will not be interrupted until closed from the server side or timed out due to settings.

Addresses #926.