### PR TITLE
Configure the "auto" mode explicitly for pytest-asyncio>=0.19

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
+asyncio_mode = auto
 addopts =
     --strict-markers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,15 +43,6 @@ def pytest_addoption(parser):
     parser.addoption("--with-e2e", action="store_true", help="Include end-to-end tests.")
 
 
-# Make all tests in this directory and below asyncio-compatible by default.
-# Due to how pytest-async checks for these markers, they should be added as early as possible.
-@pytest.hookimpl(hookwrapper=True)
-def pytest_pycollect_makeitem(collector, name, obj):
-    if collector.funcnamefilter(name) and asyncio.iscoroutinefunction(obj):
-        pytest.mark.asyncio(obj)
-    yield
-
-
 # This logic is not applied if pytest is started explicitly on ./examples/.
 # In that case, regular pytest behaviour applies -- this is intended.
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
pytest-asyncio has introduced a breaking change in 0.19.0 — the tests/fixture mode is not "strict" instead of "auto" or "legacy" as before. 

* https://github.com/pytest-dev/pytest-asyncio#modes

As a result, all `async def` fixtures are not considered as asyncio-driven and failed the tests massively. The `async def` tests were still considered because of our hook (now removed too).

Now, the "auto" mode is used for all `async def` tests & fixtures, and the self-made override is removed.