### PR TITLE
Release memory when a deamon exits

### DIFF
--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -419,8 +419,21 @@ async def _runner(
         # Only the filter-mismatching or peering-pausing daemons can be re-spawned.
         if stopper.reason is None:
             memory.forever_stopped.add(handler.id)
-            # Save memory by forgetting the live body, since it will no longer be used.
-            memory.live_fresh_body = None
+
+        # If this daemon is never going to be called again, we can release the
+        # live_fresh_body to save some memory.
+        if handler.id in memory.forever_stopped:
+            # If any other running daemon is referencing this Kubernetes 
+            # resource, we can't free it
+            can_free = True
+            this_daemon = daemons[handler.id]
+            for running_daemon in memory.running_daemons.values():
+                if running_daemon is not this_daemon:
+                    if running_daemon.handler.selector.check(cause.resource):
+                        can_free = False
+                        break
+            if can_free:
+                memory.live_fresh_body = None
 
         # Save the memory by not remembering the exited daemons (they may be never re-spawned).
         del daemons[handler.id]

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -429,9 +429,8 @@ async def _runner(
             this_daemon = daemons[handler.id]
             for running_daemon in memory.running_daemons.values():
                 if running_daemon is not this_daemon:
-                    if running_daemon.handler.selector.check(cause.resource):
-                        can_free = False
-                        break
+                    can_free = False
+                    break
             if can_free:
                 memory.live_fresh_body = None
 

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -419,6 +419,8 @@ async def _runner(
         # Only the filter-mismatching or peering-pausing daemons can be re-spawned.
         if stopper.reason is None:
             memory.forever_stopped.add(handler.id)
+            # Save memory by forgetting the live body, since it will no longer be used.
+            memory.live_fresh_body = None
 
         # Save the memory by not remembering the exited daemons (they may be never re-spawned).
         del daemons[handler.id]


### PR DESCRIPTION
Release local cache of Kubernetes objects when a demon exits

If a daemon finishes, the live_fresh_body copy of the Kubernetes object won't be used again, as
long as no other daemons are referencing the same object.  But it live_fresh_copy is never set
to None, so it will not be garbage collected.

This patch will mark live_fresh_body for garbage collection when a deamon exits, as long as
no other running daemon is referencing the same object.

Test suite completed without errors (log attached)
[kopf-test-log.txt](https://github.com/nolar/kopf/files/9464774/kopf-test-log.txt)
