### PR TITLE
Add retry after receiving `too many requests` error from kubernetes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ env
 
 # VSCode
 .vscode
+
+# Idea / PyCharm
+.idea


### PR DESCRIPTION
Add retry when receiving HTTP 429 (too many reequests) from k8s when performing `infinite_watch`.

Fixes #962  