### PR TITLE
fix(doc): Fix name of parameter

### DIFF
--- a/docs/admission.rst
+++ b/docs/admission.rst
@@ -119,7 +119,7 @@ Handler options
 Handlers have a limited capability to inform Kubernetes about its behaviour.
 The following options are supported:
 
-``persisted`` (``bool``) webhooks will not be removed from the managed
+``persistent`` (``bool``) webhooks will not be removed from the managed
 configurations on exit; non-persisted webhooks will be removed if possible.
 Such webhooks will prevent all admissions even when the operator is down.
 This option has no effect if there is no managed configuration.


### PR DESCRIPTION
The name of the parameter in the doc for `kopf.on.validate` does not match the code. This PR updates the doc to match the code.

https://github.com/nolar/kopf/blob/fb10a44f5a5f6e5c458c4973c51395383303a8d6/kopf/on.py#L158

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping maintainers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
