### PR TITLE
Upgrade to Python 3.11 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: pip install -r requirements.txt
       - run: pre-commit run --all-files
       - run: mypy kopf --strict
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
     name: Python ${{ matrix.python-version }} ${{ matrix.install-extras }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5  # usually 2-3 mins
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: nolar/setup-k3d-k3s@v1
         with:
           version: ${{ matrix.k3s }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: pip install --upgrade setuptools wheel twine
       - run: python setup.py sdist bdist_wheel
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: pip install -r requirements.txt
       - run: pre-commit run --all-files
       - run: mypy kopf --strict
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
     name: Python ${{ matrix.python-version }} ${{ matrix.install-extras }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5  # usually 2-3 mins
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: nolar/setup-k3d-k3s@v1
         with:
           version: ${{ matrix.k3s }}
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: tools/install-minikube.sh
       - run: pip install -r requirements.txt -r examples/requirements.txt
       - run: pytest --color=yes --timeout=30 --only-e2e

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ We assume that when the operator is executed in the cluster, it must be packaged
 into a docker image with a CI/CD tool of your preference.
 
 ```dockerfile
-FROM python:3.7
+FROM python:3.11
 ADD . /src
 RUN pip install kopf
 CMD kopf run /src/handlers.py --verbose

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -10,13 +10,13 @@ But normally, the operators are usually deployed directly to the clusters.
 Docker image
 ============
 
-First of all, the operator must be packaged as a docker image with Python 3.7:
+First of all, the operator must be packaged as a docker image with Python 3.7 or newer:
 
 .. code-block:: dockerfile
     :caption: Dockerfile
     :name: dockerfile
 
-    FROM python:3.7
+    FROM python:3.11
     ADD . /src
     RUN pip install kopf
     CMD kopf run /src/handlers.py --verbose

--- a/kopf/_cogs/structs/diffs.py
+++ b/kopf/_cogs/structs/diffs.py
@@ -72,6 +72,10 @@ class Diff(Sequence[DiffItem]):
         super().__init__()
         self._items = tuple(DiffItem(*item) for item in __items)
 
+    def __hash__(self) -> int:
+        # Hashes mark diffs as immutable to be usable as dataclasses' defaults in Python 3.11.
+        return hash(self._items)
+
     def __repr__(self) -> str:
         return repr(self._items)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+; The standalone `mock` instead of stdlib `unittest.mock` is only for AsyncMock in Python 3.7.
+mock_use_standalone_module = true
 asyncio_mode = auto
 addopts =
     --strict-markers

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 -e .
 aresponses
 astpath[xpath]
-asynctest
 certbuilder
 certvalidator
 codecov
@@ -13,6 +12,9 @@ freezegun
 import-linter
 isort
 lxml
+# Generally, `unittest.mock` is enough, but it lacks `AsyncMock` for Py 3.7.
+# TODO: Once 3.7 is removed (Jun 2023), roll back to unittest.mock.
+mock
 # Mypy requires typed-ast, which is broken on PyPy 3.7 (could work in PyPy 3.8).
 mypy==0.982; implementation_name == "cpython"
 pre-commit

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tests/admission/test_admission_server.py
+++ b/tests/admission/test_admission_server.py
@@ -1,7 +1,7 @@
 import contextlib
-from unittest.mock import Mock
 
 import pytest
+from mock import Mock
 
 import kopf
 from kopf._cogs.aiokits.aiovalues import Container

--- a/tests/admission/test_serving_handler_selection.py
+++ b/tests/admission/test_serving_handler_selection.py
@@ -1,6 +1,5 @@
-from unittest.mock import Mock
-
 import pytest
+from mock import Mock
 
 import kopf
 from kopf._cogs.structs.ids import HandlerId

--- a/tests/admission/test_serving_kwargs_passthrough.py
+++ b/tests/admission/test_serving_kwargs_passthrough.py
@@ -1,6 +1,5 @@
-from unittest.mock import Mock
-
 import pytest
+from mock import Mock
 
 import kopf
 from kopf._core.engines.admission import serve_admission_request

--- a/tests/apis/test_iterjsonlines.py
+++ b/tests/apis/test_iterjsonlines.py
@@ -1,4 +1,4 @@
-import asynctest
+from mock import Mock
 
 from kopf._cogs.clients.api import iter_jsonlines
 
@@ -8,7 +8,7 @@ async def test_empty_content():
         if False:  # to make this function a generator
             yield b''
 
-    content = asynctest.Mock(iter_chunked=iter_chunked)
+    content = Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in iter_jsonlines(content):
         lines.append(line)
@@ -20,7 +20,7 @@ async def test_empty_chunk():
     async def iter_chunked(n: int):
         yield b''
 
-    content = asynctest.Mock(iter_chunked=iter_chunked)
+    content = Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in iter_jsonlines(content):
         lines.append(line)
@@ -32,7 +32,7 @@ async def test_one_chunk_one_line():
     async def iter_chunked(n: int):
         yield b'hello'
 
-    content = asynctest.Mock(iter_chunked=iter_chunked)
+    content = Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in iter_jsonlines(content):
         lines.append(line)
@@ -44,7 +44,7 @@ async def test_one_chunk_two_lines():
     async def iter_chunked(n: int):
         yield b'hello\nworld'
 
-    content = asynctest.Mock(iter_chunked=iter_chunked)
+    content = Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in iter_jsonlines(content):
         lines.append(line)
@@ -56,7 +56,7 @@ async def test_one_chunk_empty_lines():
     async def iter_chunked(n: int):
         yield b'\n\nhello\n\nworld\n\n'
 
-    content = asynctest.Mock(iter_chunked=iter_chunked)
+    content = Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in iter_jsonlines(content):
         lines.append(line)
@@ -70,7 +70,7 @@ async def test_a_few_chunks_split():
         yield b'o\n\nwor'
         yield b'ld\n\n'
 
-    content = asynctest.Mock(iter_chunked=iter_chunked)
+    content = Mock(iter_chunked=iter_chunked)
     lines = []
     async for line in iter_jsonlines(content):
         lines.append(line)

--- a/tests/basic-structs/test_memories.py
+++ b/tests/basic-structs/test_memories.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from mock import Mock
 
 from kopf._cogs.structs.bodies import Body
 from kopf._cogs.structs.ephemera import Memo

--- a/tests/causation/test_kwargs.py
+++ b/tests/causation/test_kwargs.py
@@ -1,9 +1,9 @@
 import dataclasses
 import logging
 from typing import Type
-from unittest.mock import Mock
 
 import pytest
+from mock import Mock
 
 from kopf._cogs.configs.configuration import OperatorSettings
 from kopf._cogs.structs import diffs

--- a/tests/diffs/test_protocols.py
+++ b/tests/diffs/test_protocols.py
@@ -53,3 +53,5 @@ def test_diff_comparison_to_the_same():
         DiffItem(DiffOperation.REMOVE, ('key3',), 'old3', None),
     ])
     assert d1 == d2
+    assert hash(d1) == hash(d2)
+    assert d1 is not d2

--- a/tests/handling/conftest.py
+++ b/tests/handling/conftest.py
@@ -35,9 +35,9 @@ and only check for the upper-level behaviour, not all of the input combinations.
 """
 import dataclasses
 from typing import Callable
-from unittest.mock import Mock
 
 import pytest
+from mock import Mock
 
 import kopf
 from kopf._core.intents.causes import ChangingCause

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -1,10 +1,10 @@
 import asyncio
 import contextlib
 import time
-import unittest.mock
 
 import freezegun
 import pytest
+from mock import MagicMock, patch
 
 import kopf
 from kopf._cogs.aiokits.aiotoggles import ToggleSet
@@ -19,7 +19,7 @@ class DaemonDummy:
 
     def __init__(self):
         super().__init__()
-        self.mock = unittest.mock.MagicMock()
+        self.mock = MagicMock()
         self.kwargs = {}
         self.steps = {
             'called': asyncio.Event(),
@@ -107,8 +107,7 @@ def frozen_time():
     with freezegun.freeze_time("2020-01-01 00:00:00") as frozen:
         # Use freezegun-supported time instead of system clocks -- for testing purposes only.
         # NB: Patch strictly after the time is frozen -- to use fake_time(), not real time().
-        with unittest.mock.patch('time.monotonic', time.time), \
-             unittest.mock.patch('time.perf_counter', time.time):
+        with patch('time.monotonic', time.time), patch('time.perf_counter', time.time):
             yield frozen
 
 

--- a/tests/handling/subhandling/test_subhandling.py
+++ b/tests/handling/subhandling/test_subhandling.py
@@ -1,8 +1,8 @@
 import asyncio
 import logging
-from unittest.mock import Mock
 
 import pytest
+from mock import Mock
 
 import kopf
 from kopf._cogs.structs.ephemera import Memo

--- a/tests/handling/test_parametrization.py
+++ b/tests/handling/test_parametrization.py
@@ -1,5 +1,6 @@
 import asyncio
-from unittest.mock import Mock
+
+from mock import Mock
 
 import kopf
 from kopf._cogs.structs.ephemera import Memo

--- a/tests/hierarchies/conftest.py
+++ b/tests/hierarchies/conftest.py
@@ -1,6 +1,5 @@
-from unittest.mock import Mock
-
 import pytest
+from mock import Mock
 
 
 class CustomIterable:

--- a/tests/hierarchies/test_owner_referencing.py
+++ b/tests/hierarchies/test_owner_referencing.py
@@ -1,7 +1,7 @@
 import copy
-from unittest.mock import call
 
 import pytest
+from mock import call
 
 import kopf
 from kopf._cogs.structs.bodies import Body, RawBody, RawMeta

--- a/tests/persistence/test_states.py
+++ b/tests/persistence/test_states.py
@@ -1,8 +1,8 @@
 import datetime
-from unittest.mock import Mock
 
 import freezegun
 import pytest
+from mock import Mock
 
 from kopf._cogs.configs.progress import SmartProgressStorage, StatusProgressStorage
 from kopf._cogs.structs.bodies import Body

--- a/tests/reactor/conftest.py
+++ b/tests/reactor/conftest.py
@@ -2,7 +2,7 @@ import asyncio
 import functools
 
 import pytest
-from asynctest import CoroutineMock
+from mock import AsyncMock
 
 from kopf._cogs.clients.watching import infinite_watch
 from kopf._core.reactor.queueing import watcher, worker as original_worker
@@ -16,13 +16,13 @@ def _autouse_resp_mocker(resp_mocker):
 @pytest.fixture()
 def processor():
     """ A mock for processor -- to be checked if the handler has been called. """
-    return CoroutineMock()
+    return AsyncMock()
 
 
 @pytest.fixture()
 def worker_spy(mocker):
     """ Spy on the watcher: actually call it, but provide the mock-fields. """
-    spy = CoroutineMock(spec=original_worker, wraps=original_worker)
+    spy = AsyncMock(spec=original_worker, wraps=original_worker)
     return mocker.patch('kopf._core.reactor.queueing.worker', spy)
 
 

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -74,9 +74,9 @@ async def test_watchevent_demultiplexing(worker_mock, timer, resource, processor
 
     # The processor must not be called by the watcher, only by the worker.
     # But the worker (even if mocked) must be called & awaited by the watcher.
-    assert not processor.awaited
-    assert not processor.called
-    assert worker_mock.awaited
+    assert processor.call_count == 0
+    assert processor.await_count == 0
+    assert worker_mock.await_count > 0
 
     # Are the worker-streams created by the watcher? Populated as expected?
     # One stream per unique uid? All events are sequential? EOS marker appended?
@@ -150,7 +150,7 @@ async def test_watchevent_batching(settings, resource, processor, timer,
     assert timer.seconds < settings.batching.batch_window * 2
 
     # Was the processor called at all? Awaited as needed for async fns?
-    assert processor.awaited
+    assert processor.await_count > 0
 
     # Was it called only once per uid? Only with the latest event?
     # Note: the calls can be in arbitrary order, not as we expect then.

--- a/tests/registries/test_matching_of_callbacks.py
+++ b/tests/registries/test_matching_of_callbacks.py
@@ -1,7 +1,7 @@
 import dataclasses
-from unittest.mock import Mock
 
 import pytest
+from mock import Mock
 
 from kopf._cogs.structs.bodies import Body
 from kopf._cogs.structs.dicts import parse_field

--- a/tests/registries/test_matching_of_resources.py
+++ b/tests/registries/test_matching_of_resources.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from mock import Mock
 
 from kopf._cogs.structs.references import Resource, Selector
 from kopf._core.intents.registries import _matches_resource

--- a/tests/settings/test_executor.py
+++ b/tests/settings/test_executor.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import threading
-from unittest.mock import MagicMock
+
+from mock import MagicMock
 
 import kopf
 from kopf._core.actions.invocation import invoke

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -21,8 +21,8 @@ async def test_async_mocks_are_enabled(timer, mocker):
     with timer as t:
         await asyncio.sleep(1.0)
 
-    assert p.called
-    assert p.awaited
+    assert p.call_count > 0
+    assert p.await_count > 0
     assert t.seconds < 0.01  # mocked sleep
 
 

--- a/tests/timing/test_throttling.py
+++ b/tests/timing/test_throttling.py
@@ -1,8 +1,8 @@
 import asyncio
 import logging
-from unittest.mock import call
 
 import pytest
+from mock import call
 
 from kopf._core.actions.throttlers import Throttler, throttled
 

--- a/tests/utilities/aiotasks/test_coro_cancellation.py
+++ b/tests/utilities/aiotasks/test_coro_cancellation.py
@@ -1,10 +1,9 @@
 import asyncio
 import gc
 import warnings
-from unittest.mock import Mock
 
 import pytest
-from asynctest import CoroutineMock
+from mock import AsyncMock, Mock
 
 from kopf._cogs.aiokits.aiotasks import cancel_coro
 
@@ -14,7 +13,7 @@ async def f(mock):
 
 
 def factory(loop, coro_or_mock):
-    coro = coro_or_mock._mock_wraps if isinstance(coro_or_mock, CoroutineMock) else coro_or_mock
+    coro = coro_or_mock._mock_wraps if isinstance(coro_or_mock, AsyncMock) else coro_or_mock
     return asyncio.Task(coro, loop=loop)
 
 
@@ -65,7 +64,7 @@ async def test_coro_is_awaited_via_a_task_with_no_warning(coromock_task_factory)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('default')
         mock = Mock()
-        coro = CoroutineMock(wraps=f(mock))
+        coro = AsyncMock(wraps=f(mock))
         del coro.close
         await cancel_coro(coro)
 

--- a/tests/utilities/aiotasks/test_scheduler.py
+++ b/tests/utilities/aiotasks/test_scheduler.py
@@ -1,7 +1,7 @@
 import asyncio
-from unittest.mock import Mock
 
 import pytest
+from mock import Mock
 
 from kopf._cogs.aiokits.aiotasks import Scheduler
 


### PR DESCRIPTION
Besides, replace `unittest.mock` + `aynctest` with backported `mock` to support Python 3.7–3.11. The root of the conflict between 3.7 and 3.11 is `asynctest`, which is intensively used in the unit tests.

Python 3.11 removed `@asyncio.coroutine` (it was issuing warnings since Python 3.8). As a result, `asynctest` is completely broken in 3.11. The latest commit of `asynctest` is 3 years old (Nov 2019; now is Nov 2022), so `asynctest` can be deemed unmaintained.

The closest equivalent of `asynctest` is `unittest.mock.AsyncMock`, but it is available in Python 3.8 only. Python 3.7 can be supported with a back-ported standalone library `mock`. But if we use it, we should use it consistently in all places, not mixed with the StdLib's `unittest.mock`.

_An alternative would be to drop Python 3.7 support prematurely — 8 months before its official end of life (Jun 2023) — in order to support Python 3.11 now._

