### PR TITLE
Fix crash when an APIResource has no verbs

### DIFF
--- a/kopf/_cogs/clients/scanning.py
+++ b/kopf/_cogs/clients/scanning.py
@@ -118,7 +118,7 @@ async def _read_version(
                 ),
                 namespaced=resource['namespaced'],
                 preferred=preferred,
-                verbs=frozenset(resource.get('verbs', [])),
+                verbs=frozenset(resource.get('verbs') or []),
             )
             for resource in rsp.get('resources', [])
             if '/' not in resource['name']


### PR DESCRIPTION
When running a Kopf operator in a cluster that has a recent version of [KubeVirt](https://github.com/kubevirt/kubevirt) installed, it crashes on startup with `TypeError: 'NoneType' object is not iterable`.

The problem appears to be that KubeVirt registers an APIResource with no verbs, so the resource that is being fetched here contains `"verbs": None`, which causes the code in `_read_version` to fail.

There are actually quite a few such resources, but all the others contain slashes in their name so the filter in line 124 ignores them, which is why it worked before KubeVirt v0.58.1.