### PR TITLE
Support logging in via kubernetes_asyncio

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -150,6 +150,7 @@ from kopf._core.intents.stoppers import (
 from kopf._core.intents.piggybacking import (
     login_via_pykube,
     login_via_client,
+    login_via_async_client,
     login_with_kubeconfig,
     login_with_service_account,
 )
@@ -184,6 +185,7 @@ __all__ = [
     'configure', 'LogFormat',
     'login_via_pykube',
     'login_via_client',
+    'login_via_async_client',
     'login_with_kubeconfig',
     'login_with_service_account',
     'LoginError',

--- a/kopf/_core/intents/piggybacking.py
+++ b/kopf/_core/intents/piggybacking.py
@@ -122,7 +122,7 @@ async def login_via_async_client(
         *,
         logger: typedefs.Logger,
         **_: Any,
-) -> Optional[credentials.ConnectionInfo]:
+) -> credentials.ConnectionInfo | None:
 
     # Keep imports in the function, as module imports are mocked in some tests.
     try:
@@ -151,7 +151,7 @@ async def login_via_async_client(
     # For auth-providers, this method is monkey-patched with the auth-provider's one.
     # We need the actual auth-provider's token, so we call it instead of accessing api_key.
     # Other keys (token, tokenFile) also end up being retrieved via this method.
-    header: Optional[str] = config.get_api_key_with_prefix('BearerToken')
+    header: str | None = config.get_api_key_with_prefix('BearerToken')
     parts: Sequence[str] = header.split(' ', 1) if header else []
     scheme, token = ((None, None) if len(parts) == 0 else
                      (None, parts[0]) if len(parts) == 1 else

--- a/kopf/_core/intents/piggybacking.py
+++ b/kopf/_core/intents/piggybacking.py
@@ -20,6 +20,7 @@ from kopf._cogs.structs import credentials
 
 # Keep as constants to make them patchable. Higher priority is more preferred.
 PRIORITY_OF_CLIENT: int = 10
+PRIORITY_OF_ASYNC_CLIENT: int = 15
 PRIORITY_OF_PYKUBE: int = 20
 
 # Rudimentary logins are added only if the clients are absent, so the priorities can overlap.
@@ -28,8 +29,21 @@ PRIORITY_OF_SERVICE_ACCOUNT: int = 20
 
 
 def has_client() -> bool:
+    return has_sync_client() or has_async_client()
+
+
+def has_sync_client() -> bool:
     try:
         import kubernetes
+    except ImportError:
+        return False
+    else:
+        return True
+
+
+def has_async_client() -> bool:
+    try:
+        import kubernetes_asyncio
     except ImportError:
         return False
     else:
@@ -99,6 +113,63 @@ def login_via_client(
         certificate_path=config.cert_file,  # can be a temporary file
         private_key_path=config.key_file,  # can be a temporary file
         priority=PRIORITY_OF_CLIENT,
+    )
+
+
+# This is basically a copy of `login_via_client` changed to use the
+# kubernetes_asyncio client library.
+async def login_via_async_client(
+        *,
+        logger: typedefs.Logger,
+        **_: Any,
+) -> Optional[credentials.ConnectionInfo]:
+
+    # Keep imports in the function, as module imports are mocked in some tests.
+    try:
+        import kubernetes_asyncio.config
+    except ImportError:
+        return None
+
+    try:
+        kubernetes_asyncio.config.load_incluster_config()  # cluster env vars
+        logger.debug("Async client is configured in cluster with service account.")
+    except kubernetes_asyncio.config.ConfigException as e1:
+        try:
+            await kubernetes_asyncio.config.load_kube_config()  # developer's config files
+            logger.debug("Async client is configured via kubeconfig file.")
+        except kubernetes_asyncio.config.ConfigException as e2:
+            raise credentials.LoginError("Cannot authenticate the async client library "
+                                         "neither in-cluster, nor via kubeconfig.")
+
+    # We do not even try to understand how it works and why. Just load it, and extract the results.
+    # For kubernetes client >= 12.0.0 use the new 'get_default_copy' method
+    if callable(getattr(kubernetes_asyncio.client.Configuration, 'get_default_copy', None)):
+        config = kubernetes_asyncio.client.Configuration.get_default_copy()
+    else:
+        config = kubernetes_asyncio.client.Configuration()
+
+    # For auth-providers, this method is monkey-patched with the auth-provider's one.
+    # We need the actual auth-provider's token, so we call it instead of accessing api_key.
+    # Other keys (token, tokenFile) also end up being retrieved via this method.
+    header: Optional[str] = config.get_api_key_with_prefix('BearerToken')
+    parts: Sequence[str] = header.split(' ', 1) if header else []
+    scheme, token = ((None, None) if len(parts) == 0 else
+                     (None, parts[0]) if len(parts) == 1 else
+                     (parts[0], parts[1]))  # RFC-7235, Appendix C.
+
+    # Interpret the config object for our own minimalistic credentials.
+    # Note: kubernetes client has no concept of a "current" context's namespace.
+    return credentials.ConnectionInfo(
+        server=config.host,
+        ca_path=config.ssl_ca_cert,  # can be a temporary file
+        insecure=not config.verify_ssl,
+        username=config.username or None,  # an empty string when not defined
+        password=config.password or None,  # an empty string when not defined
+        scheme=scheme,
+        token=token,
+        certificate_path=config.cert_file,  # can be a temporary file
+        private_key_path=config.key_file,  # can be a temporary file
+        priority=PRIORITY_OF_ASYNC_CLIENT,
     )
 
 

--- a/kopf/_core/intents/registries.py
+++ b/kopf/_core/intents/registries.py
@@ -279,14 +279,24 @@ class SmartOperatorRegistry(OperatorRegistry):
                 _fallback=True,
             ))
         if piggybacking.has_client():
-            self._activities.append(handlers.ActivityHandler(
-                id=ids.HandlerId('login_via_client'),
-                fn=piggybacking.login_via_client,
-                activity=causes.Activity.AUTHENTICATION,
-                errors=execution.ErrorsMode.IGNORED,
-                param=None, timeout=None, retries=None, backoff=None,
-                _fallback=True,
-            ))
+            if piggybacking.has_sync_client():
+                self._activities.append(handlers.ActivityHandler(
+                    id=ids.HandlerId('login_via_client'),
+                    fn=piggybacking.login_via_client,
+                    activity=causes.Activity.AUTHENTICATION,
+                    errors=execution.ErrorsMode.IGNORED,
+                    param=None, timeout=None, retries=None, backoff=None,
+                    _fallback=True,
+                ))
+            elif piggybacking.has_async_client():
+                self._activities.append(handlers.ActivityHandler(
+                    id=ids.HandlerId('login_via_async_client'),
+                    fn=piggybacking.login_via_async_client,
+                    activity=causes.Activity.AUTHENTICATION,
+                    errors=execution.ErrorsMode.IGNORED,
+                    param=None, timeout=None, retries=None, backoff=None,
+                    _fallback=True,
+                ))
 
         # As a last resort, fall back to rudimentary logins if no advanced ones are available.
         thirdparties_present = piggybacking.has_pykube() or piggybacking.has_client()


### PR DESCRIPTION
Since kubernetes and kubernetes_asyncio are generated from the same openapi spec they can both be used interchangeably to provide the `login_via_client` activity.

closes: #1008

I did not find any tests for the existing `login_via_client`. Let me know if/how this could be done (or is needed at all).