### PR TITLE
Add Admission Request to admission handler parameters

### DIFF
--- a/docs/kwargs.rst
+++ b/docs/kwargs.rst
@@ -323,6 +323,17 @@ unless they declare themselves as ``side_effects=True``.
 See more: :doc:`admission`.
 
 
+.. kwarg:: request
+
+Request
+-------
+
+`request` (``Map[str,Any]``) is the AdmissionRequest that triggered the admission
+handler.
+
+See more: :doc:`admission`.
+
+
 .. kwarg:: subresource
 
 Subresources

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -132,6 +132,7 @@ async def serve_admission_request(
     patch = patches.Patch(body=raw_body)
     warnings: List[str] = []
     cause = causes.WebhookCause(
+        request=request.get('request'),
         resource=resource,
         indices=indices,
         logger=loggers.LocalObjectLogger(body=body, settings=settings),

--- a/kopf/_core/intents/causes.py
+++ b/kopf/_core/intents/causes.py
@@ -145,6 +145,7 @@ class ResourceCause(BaseCause):
 @dataclasses.dataclass
 class WebhookCause(ResourceCause):
     dryrun: bool
+    request: Mapping[str, Any]
     reason: Optional[WebhookType]  # None means "all" or expects the webhook id
     webhook: Optional[ids.HandlerId]  # None means "all"
     headers: Mapping[str, str]

--- a/tests/admission/test_serving_kwargs_passthrough.py
+++ b/tests/admission/test_serving_kwargs_passthrough.py
@@ -129,3 +129,23 @@ async def test_subresource_passed(
     )
     assert mock.call_count == 1
     assert mock.call_args[1]['subresource'] == 'xyz'
+
+
+async def test_request_passed(
+        settings, registry, resource, memories, insights, indices, adm_request):
+    mock = Mock()
+
+    @kopf.on.validate(*resource)
+    def fn(**kwargs):
+        mock(**kwargs)
+
+    await serve_admission_request(
+        adm_request,
+        settings=settings, registry=registry, insights=insights,
+        memories=memories, memobase=object(), indices=indices,
+    )
+    assert mock.call_count == 1
+    assert mock.call_args[1]['request']['resource']['group'] == 'kopf.dev'
+    assert mock.call_args[1]['request']['resource']['version'] == 'v1'
+    assert mock.call_args[1]['request']['resource']['resource'] == 'kopfexamples'
+


### PR DESCRIPTION
Adds the Admission Request to the function arguments for admission handlers.

closes: #1002 
