### PR TITLE
Manage uvloop's loops & policies properly in tests

### DIFF
--- a/kopf/_kits/loops.py
+++ b/kopf/_kits/loops.py
@@ -1,0 +1,36 @@
+import asyncio
+import contextlib
+from typing import Generator, Optional
+
+
+@contextlib.contextmanager
+def proper_loop(suggested_loop: Optional[asyncio.AbstractEventLoop] = None) -> Generator[None, None, None]:
+    """
+    Ensure that we have the proper loop, either suggested or properly managed.
+
+    A "properly managed" loop is the one we own and therefore close.
+    If ``uvloop`` is installed, it is used.
+    Otherwise, the event loop policy remains unaffected.
+
+    This loop manager is usually used in CLI only, not deeper than that;
+    i.e. not even in ``kopf.run()``, since uvloop is only auto-managed for CLI.
+    """
+    original_policy = asyncio.get_event_loop_policy()
+    if suggested_loop is None:  # the pure CLI use, not a KopfRunner or other code
+        try:
+            import uvloop
+        except ImportError:
+            pass
+        else:
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+    try:
+        yield
+
+    finally:
+        try:
+            import uvloop
+        except ImportError:
+            pass
+        else:
+            asyncio.set_event_loop_policy(original_policy)


### PR DESCRIPTION
Otherwise, pytest-asyncio complains with deprecation warnings (only with uvloop!):

```
E               DeprecationWarning: pytest-asyncio detected an unclosed event loop when tearing down the event_loop
E               fixture: <uvloop.Loop running=False closed=False debug=False>
E               pytest-asyncio will close the event loop for you, but future versions of the
E               library will no longer do so. In order to ensure compatibility with future
E               versions, please make sure that:
E                   1. Any custom "event_loop" fixture properly closes the loop after yielding it
E                   2. Your code does not modify the event loop in async fixtures or tests

…/python3.11/site-packages/pytest_asyncio/plugin.py:444: DeprecationWarning
```

This makes no difference for the real CLI usage as it is usually used only once and then the process is closed.

Related: #998.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping maintainers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
