### PR TITLE
Re-authenticate if the session is closed by a concurrent request

### DIFF
--- a/kopf/_cogs/clients/auth.py
+++ b/kopf/_cogs/clients/auth.py
@@ -54,7 +54,7 @@ def authenticated(fn: _F) -> _F:
                     context.add_response(response)
                 return response
             except (errors.APIUnauthorizedError, errors.APISessionClosed) as e:
-                await vault.invalidate(key, exc=e)
+                await vault.invalidate(key, info, exc=e)
 
         # Normally, either `vault.extended()` or `vault.invalidate()` raise the login errors.
         # The for-cycle can only end if the yielded credentials are not invalidated before trying

--- a/kopf/_cogs/clients/auth.py
+++ b/kopf/_cogs/clients/auth.py
@@ -53,7 +53,7 @@ def authenticated(fn: _F) -> _F:
                     # Keep track of responses which are using this context.
                     context.add_response(response)
                 return response
-            except errors.APIUnauthorizedError as e:
+            except (errors.APIUnauthorizedError, errors.APISessionClosed) as e:
                 await vault.invalidate(key, exc=e)
 
         # Normally, either `vault.extended()` or `vault.invalidate()` raise the login errors.

--- a/kopf/_cogs/clients/errors.py
+++ b/kopf/_cogs/clients/errors.py
@@ -113,6 +113,19 @@ class APIConflictError(APIClientError):
     pass
 
 
+class APISessionClosed(Exception):
+    """
+    A helper to escalate from inside the requests to cause re-authentication.
+
+    This happens when credentials expire while multiple concurrent requests
+    are ongoing (including their retries, mostly their back-off timeouts):
+    one random request will raise HTTP 401 and cause the re-authentication,
+    while others will retry their requests with the old session (now closed!)
+    and get a generic RuntimeError from aiohttp, thus failing their whole task.
+    """
+    pass
+
+
 async def check_response(
         response: aiohttp.ClientResponse,
 ) -> None:

--- a/kopf/_cogs/structs/credentials.py
+++ b/kopf/_cogs/structs/credentials.py
@@ -117,7 +117,6 @@ class Vault(AsyncIterable[tuple[VaultKey, ConnectionInfo]]):
         super().__init__()
         self._current = {}
         self._invalid = collections.defaultdict(list)
-        self._lock = asyncio.Lock()
         self._next_expiration: Optional[datetime.datetime] = None
 
         if __src is not None:
@@ -125,7 +124,8 @@ class Vault(AsyncIterable[tuple[VaultKey, ConnectionInfo]]):
 
         # Mark a pre-populated vault to be usable instantly,
         # or trigger the initial authentication for an empty vault.
-        self._ready = aiotoggles.Toggle(not self.is_empty())
+        self._guard = asyncio.Condition()
+        self._ready: bool = not self.is_empty()
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__}: {self._current!r}>'
@@ -157,11 +157,11 @@ class Vault(AsyncIterable[tuple[VaultKey, ConnectionInfo]]):
         purpose = purpose if purpose is not None else repr(factory)
         async for key, item in self._items():
             if item.caches is None:  # quick-check with no locking overhead.
-                async with self._lock:
+                async with self._guard:
                     if item.caches is None:  # securely synchronised check.
                         item.caches = {}
             if purpose not in item.caches:  # quick-check with no locking overhead.
-                async with self._lock:
+                async with self._guard:
                     if purpose not in item.caches:  # securely synchronised check.
                         item.caches[purpose] = factory(item.info)
             yield key, item.info, cast(_T, item.caches[purpose])
@@ -182,23 +182,26 @@ class Vault(AsyncIterable[tuple[VaultKey, ConnectionInfo]]):
         # Restart on every re-authentication (if new items are added).
         while True:
 
-            # Whether on the 1st run, or during the active re-authentication,
-            # ensure that the items are ready before yielding them.
-            await self._ready.wait_for(True)
+            async with self._guard:
 
-            # Check for expiration strictly after a possible re-authentication.
-            # This might cause another re-authentication if the credentials are expired at creation.
-            await self.expire()
+                # Whether on the 1st run, or during the active re-authentication,
+                # ensure that the items are ready before yielding them.
+                await self._guard.wait_for(lambda: self._ready)
 
-            # Select the items to yield and let it (i.e. a consumer) work.
-            async with self._lock:
+                # Check for expiration strictly after a possible re-authentication.
+                # This might cause another re-authentication if the credentials are pre-expired.
+                await self._expire()
+
+                # Select the items to yield and let it (i.e. a consumer task) work.
                 yielded_key, yielded_item = self.select()
+
+            # Yield strictly outside of locks/conditions. The vault must be free for invalidations.
             yield yielded_key, yielded_item
 
             # If the yielded item has been invalidated, assume that this item has failed.
-            # Otherwise (the item is in the list), it has succeeded -- we are done.
+            # Otherwise (the item is in the list), it has succeeded -- we are done iterating.
             # Note: checked by identity, in case a similar item is re-added as a different object.
-            async with self._lock:
+            async with self._guard:
                 if yielded_key in self._current and self._current[yielded_key] is yielded_item:
                     break
 
@@ -222,7 +225,20 @@ class Vault(AsyncIterable[tuple[VaultKey, ConnectionInfo]]):
         key, item = random.choice(prioritised[top_priority])
         return key, item
 
-    async def expire(self) -> None:
+    async def expire(self) -> None:  # unused, but declared public (deprecate)
+        """
+        Discard the expired credentials, and re-authenticate as needed.
+
+        Unlike invalidation, the expired credentials are not remembered
+        and not blocked from reappearing.
+        """
+        # Quick & lockless for speed: it is done on every API call, we have no time for locks.
+        now = datetime.datetime.now(datetime.timezone.utc)
+        if self._next_expiration is not None and now >= self._next_expiration:
+            async with self._guard:
+                await self._expire()
+
+    async def _expire(self) -> None:
         """
         Discard the expired credentials, and re-authenticate as needed.
 
@@ -231,24 +247,25 @@ class Vault(AsyncIterable[tuple[VaultKey, ConnectionInfo]]):
         """
         now = datetime.datetime.now(datetime.timezone.utc)
 
-        # Quick & lockless for speed: it is done on every API call, we have no time for locks.
+        # Avoid waiting for re-auth afterwards if there is nothing to expire or change.
+        expired = False
         if self._next_expiration is not None and now >= self._next_expiration:
-            async with self._lock:
-                for key, item in list(self._current.items()):
-                    expiration = item.info.expiration
-                    if expiration is not None:
-                        if expiration.tzinfo is None:
-                            expiration = expiration.replace(tzinfo=datetime.timezone.utc)
-                        if now >= expiration:
-                            await self._flush_caches(item)
-                            del self._current[key]
-                self._update_expiration()
-                need_reauth = not self._current  # i.e. nothing is left at all
+            for key, item in list(self._current.items()):
+                expiration = item.info.expiration
+                if expiration is not None:
+                    if expiration.tzinfo is None:
+                        expiration = expiration.replace(tzinfo=datetime.timezone.utc)
+                    if now >= expiration:
+                        await self._flush_caches(item)
+                        del self._current[key]
+                        expired = True
+            self._update_expiration()
 
-            # Initiate a re-authentication activity, and block until it is finished.
-            if need_reauth:
-                await self._ready.turn_to(False)
-                await self._ready.wait_for(True)
+        # Initiate a re-authentication activity, and block until it is finished.
+        if expired and not self._current:  # i.e. nothing is left at all
+            self._ready = False
+            self._guard.notify_all()
+            await self._guard.wait_for(lambda: self._ready)
 
     async def invalidate(
             self,
@@ -272,10 +289,10 @@ class Vault(AsyncIterable[tuple[VaultKey, ConnectionInfo]]):
         The background task continues to run and tries to re-authenticate
         on the next API calls until cancelled due to the operator exit.
         """
-
         # Exclude the failed connection items from the list of available ones.
         # But keep a short history of invalid items, so that they are not re-added.
-        async with self._lock:
+        # The history size is estimated by the number of parallel streams trying to re-auth at once.
+        async with self._guard:
             # Note: not "==", but "is". If not the same, then it was invalidated by other consumers,
             # the new current credentials is something new to use (maybe equal to the old one).
             if key in self._current and self._current[key].info is info:
@@ -283,18 +300,17 @@ class Vault(AsyncIterable[tuple[VaultKey, ConnectionInfo]]):
                 self._invalid[key] = self._invalid[key][-2:] + [self._current[key]]
                 del self._current[key]
                 self._update_expiration()
-            need_reauth = not self._current  # i.e. nothing is left at all
 
-        # Initiate a re-authentication activity, and block until it is finished.
-        if need_reauth:
-            await self._ready.turn_to(False)
-            await self._ready.wait_for(True)
+            # Initiate a re-authentication activity, and block until it is finished.
+            if not self._current:  # i.e. nothing is left at all
+                self._ready = False
+                self._guard.notify_all()
+                await self._guard.wait_for(lambda: self._ready)
 
-        # If the re-auth has failed, re-raise the original exception in the current stack.
-        # If the original exception is unknown, raise normally on the next iteration's yield.
-        # The error here is optional -- for better stack traces of the original exception `exc`.
-        # Keep in mind, this routine is called in parallel from many tasks for the same keys.
-        async with self._lock:
+            # If the re-auth has failed, re-raise the original exception in the current stack.
+            # If the original exception is unknown, raise normally on the next iteration's yield.
+            # The error here is optional -- for better stack traces of the original exception `exc`.
+            # Keep in mind, this routine is called in parallel from many tasks for the same keys.
             if not self._current:
                 if exc is not None:
                     raise LoginError("Ran out of valid credentials. Consider installing "
@@ -312,16 +328,17 @@ class Vault(AsyncIterable[tuple[VaultKey, ConnectionInfo]]):
         from the authentication activity handlers. Some of the credentials
         can be duplicates of the existing ones -- only one of them is used then.
         """
+        async with self._guard:
 
-        # Remember the new info items (or replace the old ones). If we already see that the item
-        # is invalid (as seen in our short per-key history), we keep it as such -- this prevents
-        # consistently invalid credentials from causing infinite re-authentication again and again.
-        async with self._lock:
+            # Remember the new credentials or replace the old ones. If we already see that the item
+            # is invalid (as seen in our short per-key history), we keep it as such -- this prevents
+            # repeatedly invalid credentials from causing infinite re-authentication again & again.
             self._update_converted(__src)
 
-        # Notify the consuming tasks (client wrappers) that new credentials are ready to be used.
-        # Those tasks can be blocked in `vault.invalidate()` if there are no credentials left.
-        await self._ready.turn_to(True)
+            # Notify the consuming tasks (API clients) that new credentials are ready to be used.
+            # Those tasks can be blocked in `vault.invalidate()` if there are no credentials left.
+            self._ready = True
+            self._guard.notify_all()
 
     def is_empty(self) -> bool:
         now = datetime.datetime.now(datetime.timezone.utc)
@@ -332,16 +349,18 @@ class Vault(AsyncIterable[tuple[VaultKey, ConnectionInfo]]):
         return all(dt is not None and now >= dt for dt in expirations)  # i.e. expired
 
     async def wait_for_readiness(self) -> None:
-        await self._ready.wait_for(True)
+        async with self._guard:
+            await self._guard.wait_for(lambda: self._ready)
 
     async def wait_for_emptiness(self) -> None:
-        await self._ready.wait_for(False)
+        async with self._guard:
+            await self._guard.wait_for(lambda: not self._ready)
 
     async def close(self) -> None:
         """
         Finalize all the cached objects when the operator is ending.
         """
-        async with self._lock:
+        async with self._guard:
             for key in self._current:
                 await self._flush_caches(self._current[key])
 

--- a/kopf/_core/engines/activities.py
+++ b/kopf/_core/engines/activities.py
@@ -74,6 +74,9 @@ async def authenticate(
         _activity_title: str = "Authentication",
 ) -> None:
     """ Retrieve the credentials once, successfully or not, and exit. """
+    # We do not need the locks protection here. There is only one activity for vault population.
+    # Even with 2+ activities, if the vault is empty, all consumers will be blocked by waiting.
+    # The API clients wake up only on the final population with the internal lock protection.
 
     # Sleep most of the time waiting for a signal to re-auth.
     await vault.wait_for_emptiness()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -434,7 +434,7 @@ async def _fake_vault(mocker, hostname, aresponses):
     key = VaultKey('fixture')
     info = ConnectionInfo(server=f'https://{hostname}')
     vault = Vault({key: info})
-    mocker.patch.object(vault._ready, 'wait_for')
+    mocker.patch.object(vault._guard, 'wait_for')
     try:
         yield vault
     finally:


### PR DESCRIPTION
Several concurrent requests can step on each others toes while catching HTTP 401s: one of them will catch 401 and cause the re-auth normally (by invalidating the APIContext via the Vault), while others will be left with the closed session and will not be able even to try executing their retried requests to get that 401. Instead, they will get a generic RuntimeError("Session is closed") from aiohttp.

The concurrent requests are highly likely if the API returned some other errors previously, so that the requests went into the back-off sleep for a few seconds before retrying.

_A proper fix would be to retry with a new session, but we currently have no mechanisms to replace the session in a context object (safely). Hence, escalate and try again with new credentials (loosing the retry counter as a side effect)._

---

Under the hood, this concurrency caused conflicts in the vault over the state of the current and invalid credentials:

The credentials invalidation happens by the key only, which is the login handler name. It does not feed the actual credentials object that failed with 401 and thus must be remembered as broken. As a result, the 2nd, 3rd, and following failed API streams invalidated the valid credentials, which was acquired after the 1st failure and re-authentication. Therefore, the following re-authentications that tried to add the same credentials, failed — because that credentials was known to be invalid.

---

The second contributng factor was the inconsistency between the vault's credentials set (`._current`) and its boolean readiness (`._state`), protected by different locks.

Specifically, the case was this:

* Client A waits for the vault readiness state (the presence of credentials) under `Vault._ready._condition` — and gets it, and proceeds further.
* Client B gets 401, invalidates the credentials under the lock `Vault._lock`, leaves the lock, initiates the re-auth again.
* Client A reaches the lock `Vault._lock` and acquires it.
* Client A tries to get the next avalable valid credentials — but there is nothing. It fails.
* The re-authentication catches up and populates the vault with a new credentials, but it is too late.

Most likely it was overlooked before in Python 3.10-3.11 or so — because they were relatively slow and the sequence of operations managed to be fast, the event loop control was not going out of the routines fast enough on `await`. Now everything is fasy, so the control leaves the coroutines more often.

Now, all these operations are protected under the same condition object, and there should be no unprotected inconsistencies between the current credentials and the vault's boolean readiness state.

---

**TODO:** Requires tests to simulate the situation — if the hypothesis is correct.

Presumably fixes #980 #1158 