### PR TITLE
deployment.rst: make incremental builds faster

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -17,8 +17,8 @@ First of all, the operator must be packaged as a docker image with Python 3.7 or
     :name: dockerfile
 
     FROM python:3.11
-    ADD . /src
     RUN pip install kopf
+    ADD . /src
     CMD kopf run /src/handlers.py --verbose
 
 Build and push it to some repository of your choice.


### PR DESCRIPTION
Hi,

This just makes incremental builds faster since the `pip install` is cached