### PR TITLE
Update README.md - spelling/grammar fixes

### DIFF
--- a/examples/05-handlers/README.md
+++ b/examples/05-handlers/README.md
@@ -3,7 +3,7 @@
 Multiple handlers can be registered for the same event.
 They are executed in the order of registration.
 
-Beside the stardard create-update-delete events, a per-field diff can be registered.
+Besides the standard create-update-delete events, a per-field diff can be registered.
 It is called only in case of the specified field changes,
 with `old` & `new` set to that field's values.
 


### PR DESCRIPTION
Fix the spelling of standard.

Also replace 'Beside' which means next to (in a space: The hammer is beside the screwdriver on the bench) real word sense) with Besides which means "in addition to".