### PR TITLE
Bug #1095. Update probing.py

### DIFF
--- a/kopf/_core/engines/probing.py
+++ b/kopf/_core/engines/probing.py
@@ -79,10 +79,10 @@ async def health_reporter(
     app = aiohttp.web.Application()
     app.add_routes([aiohttp.web.get(path, get_health)])
 
-    runner = aiohttp.web.AppRunner(app, handle_signals=False, shutdown_timeout=1.0)
+    runner = aiohttp.web.AppRunner(app, handle_signals=False)
     await runner.setup()
 
-    site = aiohttp.web.TCPSite(runner, host, port)
+    site = aiohttp.web.TCPSite(runner, host, port, shutdown_timeout=1.0)
     await site.start()
 
     # Log with the actual URL: normalised, with hostname/port set.


### PR DESCRIPTION
Pass shutdown_timeout into TCPSite instead of AppRunner

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping maintainers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
