### PR TITLE
fix the outdated doc for installing minikube on macos, brew cask inst…

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,12 +8,11 @@ use [minikube](https://github.com/kubernetes/minikube):
 MacOS:
 
 ```bash
-brew install docker-machine-driver-hyperkit
-sudo chown root:wheel /usr/local/opt/docker-machine-driver-hyperkit/bin/docker-machine-driver-hyperkit
-sudo chmod u+s /usr/local/opt/docker-machine-driver-hyperkit/bin/docker-machine-driver-hyperkit
+brew install minikube
+brew install hyperkit
 
-brew cask install minikube
-minikube config set vm-driver hyperkit
+minikube start --driver=hyperkit
+minikube config set driver hyperkit
 ```
 
 Start the minikube cluster:

--- a/docs/minikube.rst
+++ b/docs/minikube.rst
@@ -11,12 +11,11 @@ use minikube_.
 
 MacOS::
 
-    brew install docker-machine-driver-hyperkit
-    sudo chown root:wheel /usr/local/opt/docker-machine-driver-hyperkit/bin/docker-machine-driver-hyperkit
-    sudo chmod u+s /usr/local/opt/docker-machine-driver-hyperkit/bin/docker-machine-driver-hyperkit
+    brew install minikube
+    brew install hyperkit
 
-    brew cask install minikube
-    minikube config set vm-driver hyperkit
+    minikube start --driver=hyperkit
+    minikube config set driver hyperkit
 
 Start the minikube cluster::
 


### PR DESCRIPTION
…all is not a valid brew command anymore

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping maintainers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
