### PR TITLE
Add python 3.13 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - run: pip install -r requirements.txt
       - run: pre-commit run --all-files
       - run: mypy kopf --strict
@@ -38,10 +38,10 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
         include:
           - install-extras: "uvloop"
-            python-version: "3.12"
+            python-version: "3.13"
     name: Python ${{ matrix.python-version }} ${{ matrix.install-extras }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5  # usually 2-3 mins

--- a/kopf/_core/engines/posting.py
+++ b/kopf/_core/engines/posting.py
@@ -183,11 +183,13 @@ class K8sPoster(logging.Handler):
     """
     A handler to post all log messages as K8s events.
     """
-
-    def createLock(self) -> None:
-        # Save some time on unneeded locks. Events are posted in the background.
-        # We only put events to the queue, which is already lock-protected.
-        self.lock = None
+    if sys.version_info[:2] < (3, 13):
+        # Disable this optimisation for Python >= 3.13.
+        # The `handle` no longer support having `None` as lock.
+        def createLock(self) -> None:
+            # Save some time on unneeded locks. Events are posted in the background.
+            # We only put events to the queue, which is already lock-protected.
+            self.lock = None
 
     def filter(self, record: logging.LogRecord) -> bool:
         # Only those which have a k8s object referred (see: `ObjectLogger`).

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
 addopts =
     --strict-markers

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ pytest-asyncio
 pytest-cov
 pytest-mock
 pytest-timeout
-types-pkg_resources
+types-setuptools
 types-PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ pytest-asyncio
 pytest-cov
 pytest-mock
 pytest-timeout
-types-setuptools
 types-PyYAML
+types-setuptools

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tests/peering/test_keepalive.py
+++ b/tests/peering/test_keepalive.py
@@ -1,8 +1,9 @@
+from itertools import chain, repeat
+from unittest import mock
+
 import pytest
 
 from kopf._core.engines.peering import keepalive
-from itertools import chain, repeat
-from unittest import mock
 
 
 class StopInfiniteCycleException(Exception):

--- a/tests/peering/test_keepalive.py
+++ b/tests/peering/test_keepalive.py
@@ -1,6 +1,8 @@
 import pytest
 
 from kopf._core.engines.peering import keepalive
+from itertools import chain, repeat
+from unittest import mock
 
 
 class StopInfiniteCycleException(Exception):
@@ -11,7 +13,9 @@ async def test_background_task_runs(mocker, settings, namespaced_peering_resourc
     touch_mock = mocker.patch('kopf._core.engines.peering.touch')
 
     sleep_mock = mocker.patch('asyncio.sleep')
-    sleep_mock.side_effect = [None, None, StopInfiniteCycleException]
+    # restore the default behavior after exhausting test values.
+    # pytest-aiohttp calls asyncio.sleep during teardown, before the mock is removed.
+    sleep_mock.side_effect = chain([None, None, StopInfiniteCycleException], repeat(mock.DEFAULT))
 
     randint_mock = mocker.patch('random.randint')
     randint_mock.side_effect = [7, 5, 9]


### PR DESCRIPTION
The  `logging.Handler` class changed in 3.13 and will now always try to acquire the lock in its `handle` method. (cf https://github.com/python/cpython/pull/109462)

Removed the optimization that created the handler without a lock.

Also configure the CI to run on Python 3.13.