### PR TITLE
Fix the SphinxDocs builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ pytest-asyncio
 pytest-cov
 pytest-mock
 pytest-timeout
-types-pkg_resources
 types-PyYAML
+types-setuptools


### PR DESCRIPTION
The `types-pkg_resources` was replaced by `types-setuptools`, and it broke the ReadTheDocs builds (Sphinx), so as all CI builds in general.