### PR TITLE
Upgrade Ubuntu in CI (and pin oscrypto to an unreleased bugfix)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   linters:
     name: Linting and static analysis
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5  # usually 1-2, rarely 3 mins (because of installations)
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
           - install-extras: "uvloop"
             python-version: "3.13"
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5  # usually 2-3 mins
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +83,7 @@ jobs:
         install-extras: [ "", "full-auth" ]
         python-version: [ "pypy-3.8", "pypy-3.9", "pypy-3.10" ]
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -105,7 +105,7 @@ jobs:
       matrix:
         k3s: [latest, v1.31, v1.30, v1.29]
     name: K3s ${{matrix.k3s}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10  # usually 4-5 mins
     steps:
       - uses: actions/checkout@v4
@@ -122,7 +122,7 @@ jobs:
   coveralls-finish:
     name: Finalize coveralls.io
     needs: [unit-tests, pypy-tests, functional]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/setup-python@v5
       - run: pip install coveralls

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   linters:
     name: Linting and static analysis
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5  # usually 1-2, rarely 3 mins (because of installations)
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
           - install-extras: "uvloop"
             python-version: "3.12"
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5  # usually 2-3 mins
     steps:
       - uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
         install-extras: [ "", "full-auth" ]
         python-version: [ "pypy-3.8", "pypy-3.9", "pypy-3.10" ]
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
       matrix:
         k3s: [latest, v1.31, v1.30, v1.29]
     name: K3s ${{matrix.k3s}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10  # usually 4-5 mins
     steps:
       - uses: actions/checkout@v4
@@ -129,7 +129,7 @@ jobs:
       matrix:
         k8s: [latest, v1.31.2, v1.30.6, v1.29.10]
     name: K8s ${{matrix.k8s}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10  # usually 4-5 mins
     env:
       K8S: ${{ matrix.k8s }}
@@ -145,7 +145,7 @@ jobs:
   coveralls-finish:
     name: Finalize coveralls.io
     needs: [unit-tests, pypy-tests, functional]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/setup-python@v5
       - run: pip install coveralls

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@
 version: 2
 formats: all
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3"
 python:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,16 @@ codecov
 coverage
 coveralls
 freezegun
+
+# Enforce the hotfix for Ubuntu 24.04 in CI. Otherwise, we are stuck in Ubuntu 22.04.
+# The bugfix is merged but not released: https://github.com/wbond/oscrypto/issues/78
+# Pinning this in the end operators is the decision of the operator developers,
+# including the protocols of accessing the repo or vendoring the dependency code.
+# The dev-mode dependency is used ONLY with an temporary & insecure self-signed CA for simplicity,
+# and ONLY with Ubuntu 24.04+. Therefore, it is not pinned in setup.py (e.g., works fine in 22.04).
+# In the worst case, configure the operator with a self-signed CA made in the OpenSSL CLI manually.
+git+https://github.com/wbond/oscrypto.git@1547f535001ba568b239b8797465536759c742a3
+
 import-linter
 isort
 lxml

--- a/setup.py
+++ b/setup.py
@@ -77,10 +77,11 @@ setup(
             'uvloop>=0.18.0; python_version>="3.12"',
         ],
         'dev': [
-            'pyngrok',          # 1.00 MB + downloaded binary
+            # NB: oscrypto is pinned for Ubuntu 24.04+ in requirements.txt - read the details there.
             'oscrypto',         # 2.80 MB (smaller than cryptography: 8.7 MB)
             'certbuilder',      # +0.1 MB (2.90 MB if alone)
             'certvalidator',    # +0.1 MB (2.90 MB if alone)
+            'pyngrok',          # 1.00 MB + downloaded binary
         ],
     },
     package_data={"kopf": ["py.typed"]},


### PR DESCRIPTION
Ubuntu 24.04 is blocked by https://github.com/wbond/oscrypto/issues/78:

```
____________ ERROR collecting tests/admission/test_certificates.py _____________
tests/admission/test_certificates.py:1: in <module>
    import certvalidator
/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/site-packages/certvalidator/__init__.py:9: in <module>
    from .validate import validate_path, validate_tls_hostname, validate_usage
/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/site-packages/certvalidator/validate.py:5: in <module>
    from oscrypto import asymmetric
/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/site-packages/oscrypto/asymmetric.py:19: in <module>
    from ._asymmetric import _unwrap_private_key_info
/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/site-packages/oscrypto/_asymmetric.py:[27](https://github.com/nolar/kopf/actions/runs/11899842142/job/33159360248#step:6:28): in <module>
    from .kdf import pbkdf1, pbkdf2, pkcs12_kdf
/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/site-packages/oscrypto/kdf.py:9: in <module>
    from .util import rand_bytes
/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/site-packages/oscrypto/util.py:14: in <module>
    from ._openssl.util import rand_bytes
/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/site-packages/oscrypto/_openssl/util.py:6: in <module>
    from ._libcrypto import libcrypto, libcrypto_version_info, handle_openssl_error
/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/site-packages/oscrypto/_openssl/_libcrypto.py:15: in <module>
    from ._libcrypto_ctypes import (
/opt/hostedtoolcache/Python/3.13.0/x64/lib/python3.13/site-packages/oscrypto/_openssl/_libcrypto_ctypes.py:47: in <module>
    raise LibraryNotFoundError('Error detecting the version of libcrypto')
E   oscrypto.errors.LibraryNotFoundError: Error detecting the version of libcrypto
```