### PR TITLE
fix: pythonjsonlogger.jsonlogger is now pythonjsonlogger.json

### DIFF
--- a/kopf/_core/actions/loggers.py
+++ b/kopf/_core/actions/loggers.py
@@ -13,7 +13,7 @@ import enum
 import logging
 from typing import Any, Dict, MutableMapping, Optional, Tuple
 
-import pythonjsonlogger.jsonlogger
+import pythonjsonlogger.json
 
 from kopf._cogs.configs import configuration
 from kopf._cogs.helpers import typedefs


### PR DESCRIPTION
`pythonjsonlogger.jsonlogger` has been changed to `pythonjsonlogger.json` as of 3.1.0. The versions of the packages in `kopf` are not pinned, which caused the latest of this package to be installed, and causing a traceback on startup. Since pinning versions is more of a maintainer decision, I decided to make this minor change to the `kopf/_core/actions/loggers.py` for this package until a long-term solution is decided on by the core maintainers.

closes: #1146 
related: #1147 
