### PR TITLE
Handle event refs with no apiVersion/kind fields at all

### DIFF
--- a/kopf/_cogs/clients/events.py
+++ b/kopf/_cogs/clients/events.py
@@ -32,7 +32,7 @@ async def post_event(
 
     # Prevent "event explosion", when core v1 events are handled and create other core v1 events.
     # This can happen with `EVERYTHING` without additional filters, or by explicitly serving them.
-    if ref['apiVersion'] == 'v1' and ref['kind'] == 'Event':
+    if ref.get('apiVersion') == 'v1' and ref.get('kind') == 'Event':
         return
 
     # See #164. For cluster-scoped objects, use the current namespace from the current context.


### PR DESCRIPTION
closes #1144

Requires extra info: why does it happen so that there is no apiVersion? How will k8s behave in that case, if the ref has no apiVersion and/or kind in it? Which operator was reported in the original issue, in order to reproduce it locally?