### PR TITLE
Configure global aiohttp session timeouts

### DIFF
--- a/kopf/_cogs/clients/auth.py
+++ b/kopf/_cogs/clients/auth.py
@@ -10,6 +10,7 @@ import aiohttp
 
 from kopf._cogs.clients import errors
 from kopf._cogs.helpers import versions
+from kopf._cogs.configs import configuration
 from kopf._cogs.structs import credentials
 
 # Per-operator storage and exchange point for authentication methods.
@@ -101,6 +102,8 @@ class APIContext:
         certificate_path: Optional[str]
         private_key_path: Optional[str]
 
+        settings = configuration.OperatorSettings()
+
         if info.ca_path and info.ca_data:
             raise credentials.LoginError("Both CA path & data are set. Need only one.")
         elif info.ca_path:
@@ -172,6 +175,12 @@ class APIContext:
             ),
             headers=headers,
             auth=auth,
+            timeout=aiohttp.ClientTimeout(
+                total=settings.session.total_timeout,
+                sock_connect=settings.session.sock_connect_timeout,
+                sock_read=settings.session.sock_read_timeout,
+                connect=settings.session.connect_timeout
+            ),
         )
 
         # Add the extra payload information. We avoid overriding the constructor.

--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -167,6 +167,31 @@ class PeeringSettings:
 
 
 @dataclasses.dataclass
+class SessionSettings:
+
+    total_timeout: Optional[float] = 1 * 600
+    """
+    An HTTP/HTTPS session Total timeout for the whole request.
+    """
+
+    sock_connect_timeout: Optional[float] = 1 * 60
+    """
+    An HTTP/HTTPS session timeout for connecting to a peer for a new connection,
+    not given from a pool. See also connect.
+    """
+
+    sock_read_timeout: Optional[float] = 1 * 60
+    """
+    An HTTP/HTTPS session timeout for reading a portion of data from a peer.
+    """
+
+    connect_timeout: Optional[float] = 1 * 60
+    """
+    An HTTP/HTTPS session timeout for acquiring a connection from pool.
+    """
+
+
+@dataclasses.dataclass
 class WatchingSettings:
 
     server_timeout: Optional[float] = None
@@ -443,6 +468,7 @@ class OperatorSettings:
     process: ProcessSettings = dataclasses.field(default_factory=ProcessSettings)
     posting: PostingSettings = dataclasses.field(default_factory=PostingSettings)
     peering: PeeringSettings = dataclasses.field(default_factory=PeeringSettings)
+    session: SessionSettings = dataclasses.field(default_factory=SessionSettings)
     watching: WatchingSettings = dataclasses.field(default_factory=WatchingSettings)
     batching: BatchingSettings = dataclasses.field(default_factory=BatchingSettings)
     scanning: ScanningSettings = dataclasses.field(default_factory=ScanningSettings)


### PR DESCRIPTION
Introduce new  operator settings which allows to configure global session timeouts. Implement default timeouts as

 total_timeout: 600sec
 sock_connect_timeout: 60sec
 sock_read_timeout: 60sec
 connect_timeout: 60sec

Closes: #377
