### PR TITLE
Fix the numerous failures in CI: setuptools (python 3.8/3.9), pre-commit, import-linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5  # usually 1-2, rarely 3 mins (because of installations)
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - run: pip install -r requirements.txt
@@ -46,8 +46,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5  # usually 2-3 mins
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -86,8 +86,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -108,8 +108,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10  # usually 4-5 mins
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - uses: nolar/setup-k3d-k3s@v1
@@ -124,7 +124,7 @@ jobs:
     needs: [unit-tests, pypy-tests, functional]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - run: pip install coveralls
       - run: coveralls --service=github --finish
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: sudo apt-get update && sudo apt-get install libxml2-dev libxslt-dev
-      - run: pip install wheel
+      - run: pip install --upgrade pip wheel setuptools
 
       - run: pip install -r requirements.txt
       - run: pip install -e .[${{ matrix.install-extras }}]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         include:
           - install-extras: "uvloop"
             python-version: "3.13"
-    name: Python ${{ matrix.python-version }} ${{ matrix.install-extras }}
+    name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5  # usually 2-3 mins
     steps:
@@ -82,7 +82,7 @@ jobs:
       matrix:
         install-extras: [ "", "full-auth" ]
         python-version: [ "pypy-3.8", "pypy-3.9", "pypy-3.10" ]
-    name: Python ${{ matrix.python-version }} ${{ matrix.install-extras }}
+    name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"
-      - run: pip install --upgrade setuptools wheel twine
+      - run: pip install --upgrade pip setuptools wheel twine
       - run: python setup.py sdist bdist_wheel
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,8 +13,8 @@ jobs:
     name: Build and publish
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - run: pip install --upgrade pip setuptools wheel twine

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -46,7 +46,7 @@ jobs:
         include:
           - install-extras: "uvloop"
             python-version: "3.12"
-    name: Python ${{ matrix.python-version }} ${{ matrix.install-extras }}
+    name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-22.04
     timeout-minutes: 5  # usually 2-3 mins
     steps:
@@ -86,7 +86,7 @@ jobs:
       matrix:
         install-extras: [ "", "full-auth" ]
         python-version: [ "pypy-3.8", "pypy-3.9", "pypy-3.10" ]
-    name: Python ${{ matrix.python-version }} ${{ matrix.install-extras }}
+    name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5  # usually 1-2, rarely 3 mins (because of installations)
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - run: pip install -r requirements.txt
@@ -50,8 +50,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5  # usually 2-3 mins
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -90,8 +90,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -112,8 +112,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10  # usually 4-5 mins
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - uses: nolar/setup-k3d-k3s@v1
@@ -134,8 +134,8 @@ jobs:
     env:
       K8S: ${{ matrix.k8s }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - run: tools/install-minikube.sh
@@ -147,7 +147,7 @@ jobs:
     needs: [unit-tests, pypy-tests, functional]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
       - run: pip install coveralls
       - run: coveralls --service=github --finish
         env:

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -96,7 +96,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - run: sudo apt-get update && sudo apt-get install libxml2-dev libxslt-dev
-      - run: pip install wheel
+      - run: pip install --upgrade pip wheel setuptools
 
       - run: pip install -r requirements.txt
       - run: pip install -e .[${{ matrix.install-extras }}]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: |
   )
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-ast
       - id: trailing-whitespace
@@ -61,20 +61,20 @@ repos:
       # - id: python-no-log-warn  # overreacts to `kopf.warn()`.
 
   - repo: https://github.com/seddonym/import-linter
-    rev: v1.7.0
+    rev: v2.2
     hooks:
       - id: import-linter
         additional_dependencies:
           - astpath[xpath]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort-source-code
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort-examples
@@ -82,7 +82,7 @@ repos:
         files: '^examples/'
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.19.1
     hooks:
     -   id: pyupgrade
         args: [--py37-plus, --keep-mock]

--- a/_importlinter_conditional.py
+++ b/_importlinter_conditional.py
@@ -17,8 +17,8 @@ https://import-linter.readthedocs.io/en/stable/custom_contract_types.html
 import os.path
 
 import astpath
+from grimp import ImportGraph
 from importlinter import Contract, ContractCheck, fields, output
-from importlinter.domain.ports.graph import ImportGraph
 
 
 class ConditionalImportContract(Contract):


### PR DESCRIPTION
Fix all the CI pipelines for Python 3.8 & 3.9, which are broken by the absence of setuptools/distutils. Python 3.10+ are fine.

Upgrade the GitHub Actions & pre-commit repos. All in all, make it pass the checks.