### PR TITLE
Deprecate Python 3.8 & upgrade to Python 3.13 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - uses: nolar/setup-k3d-k3s@v1
         with:
           version: ${{ matrix.k3s }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         include:
           - install-extras: "uvloop"
             python-version: "3.13"
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "pypy-3.8", "pypy-3.9", "pypy-3.10" ]
+        python-version: [ "pypy-3.9", "pypy-3.10" ]
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - run: pip install --upgrade pip setuptools wheel twine
       - run: python setup.py sdist bdist_wheel
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -42,10 +42,10 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         include:
           - install-extras: "uvloop"
-            python-version: "3.12"
+            python-version: "3.13"
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5  # usually 2-3 mins

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         include:
           - install-extras: "uvloop"
             python-version: "3.12"
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "pypy-3.8", "pypy-3.9", "pypy-3.10" ]
+        python-version: [ "pypy-3.9", "pypy-3.10" ]
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - run: pip install -r requirements.txt
       - run: pre-commit run --all-files
       - run: mypy kopf --strict
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - uses: nolar/setup-k3d-k3s@v1
         with:
           version: ${{ matrix.k3s }}
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - run: tools/install-minikube.sh
       - run: pip install -r requirements.txt -r examples/requirements.txt
       - run: pytest --color=yes --timeout=30 --only-e2e

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -80,7 +80,7 @@ If you use PyCharm, create a Run/Debug Configuration as follows:
 * Mode: `module name`
 * Module name: `kopf`
 * Arguments: `run examples/01-minimal/example.py --verbose`
-* Python Interpreter: anything with Python>=3.8
+* Python Interpreter: anything with Python>=3.9
 
 Stop the console operator, and start the IDE debug session.
 Put a breakpoint in the used operator script on the first line of the function.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ We assume that when the operator is executed in the cluster, it must be packaged
 into a docker image with a CI/CD tool of your preference.
 
 ```dockerfile
-FROM python:3.12
+FROM python:3.13
 ADD . /src
 RUN pip install kopf
 CMD kopf run /src/handlers.py --verbose

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ That easy! For more features, see the [documentation](https://kopf.readthedocs.i
 
 ## Usage
 
-Python 3.8+ is required:
+Python 3.9+ is required:
 [CPython](https://www.python.org/) and [PyPy](https://www.pypy.org/)
 are officially supported and tested; other Python implementations can work too.
 

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -10,7 +10,7 @@ But normally, the operators are usually deployed directly to the clusters.
 Docker image
 ============
 
-First of all, the operator must be packaged as a docker image with Python 3.8 or newer:
+First of all, the operator must be packaged as a docker image with Python 3.9 or newer:
 
 .. code-block:: dockerfile
     :caption: Dockerfile

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -16,7 +16,7 @@ First of all, the operator must be packaged as a docker image with Python 3.9 or
     :caption: Dockerfile
     :name: dockerfile
 
-    FROM python:3.12
+    FROM python:3.13
     RUN pip install kopf
     ADD . /src
     CMD kopf run /src/handlers.py --verbose

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,7 +6,7 @@ Installation
 
 Prerequisites:
 
-* Python >= 3.8 (CPython and PyPy are officially tested and supported).
+* Python >= 3.9 (CPython and PyPy are officially tested and supported).
 
 To install Kopf::
 

--- a/docs/walkthrough/prerequisites.rst
+++ b/docs/walkthrough/prerequisites.rst
@@ -6,7 +6,7 @@ We need a running Kubernetes cluster and some tools for our experiments.
 If you have a cluster already preconfigured, you can skip this section.
 Otherwise, let's install minikube locally (e.g. for MacOS):
 
-* Python >= 3.8 (running in a venv is recommended, though is not necessary).
+* Python >= 3.9 (running in a venv is recommended, though is not necessary).
 * `Install kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
 * :doc:`Install minikube </minikube>` (a local Kubernetes cluster)
 * :doc:`Install Kopf </install>`

--- a/kopf/_cogs/aiokits/aioadapters.py
+++ b/kopf/_cogs/aiokits/aioadapters.py
@@ -1,16 +1,11 @@
 import asyncio
 import concurrent.futures
 import threading
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import Any, Optional, Union
 
 from kopf._cogs.aiokits import aiotasks
 
-if TYPE_CHECKING:
-    concurrent_Future = concurrent.futures.Future[Any]
-else:
-    concurrent_Future = concurrent.futures.Future  # Python<=3.8
-
-Flag = Union[aiotasks.Future, asyncio.Event, concurrent_Future, threading.Event]
+Flag = Union[aiotasks.Future, asyncio.Event, concurrent.futures.Future[Any], threading.Event]
 
 
 async def wait_flag(

--- a/kopf/_cogs/helpers/typedefs.py
+++ b/kopf/_cogs/helpers/typedefs.py
@@ -2,7 +2,7 @@
 Rudimentary type [re-]definitions for cross-versioned Python & mypy.
 
 The problem is that new mypy versions often bring type-sheds with StdLib types
-defined as generics, while the old Python runtime (down to 3.8 & 3.9 & 3.10)
+defined as generics, while the old Python runtime (down to 3.9 & 3.10)
 does not support the usual syntax.
 Examples: asyncio.Task, asyncio.Future, logging.LoggerAdapter, and others.
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -54,7 +53,7 @@ setup(
         ],
     },
 
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     setup_requires=[
         'setuptools_scm',
     ],


### PR DESCRIPTION
Python 3.8 is end-of-life since October 2024; it is now almost April 2025 — so half a year ago. Besides, Python 3.8 blocks upgrading MyPy in #1163, since 3.8 is not supported anymore (cannot install). It is time to move on…

Enable Python 3.13 and PyPy 3.11 as replacements in CI for the released capacity. And make Python 3.13 the default image to use in CI.

The code changes & uprades will follow in separate PR(s): 

* #1165
* #1166