### PR TITLE
Convert to Python 3.9: all the basic syntax as per pyuprade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,4 +85,4 @@ repos:
     rev: v3.19.1
     hooks:
     -   id: pyupgrade
-        args: [--py37-plus, --keep-mock]
+        args: [--py39-plus, --keep-mock]

--- a/examples/10-builtins/example.py
+++ b/examples/10-builtins/example.py
@@ -1,10 +1,9 @@
 import asyncio
-from typing import Dict
 
 import kopf
 import pykube
 
-tasks: Dict[str, Dict[str, asyncio.Task]] = {}  # dict{namespace: dict{name: asyncio.Task}}
+tasks: dict[str, dict[str, asyncio.Task]] = {}  # dict{namespace: dict{name: asyncio.Task}}
 
 
 @kopf.on.resume('pods')

--- a/examples/13-hooks/example.py
+++ b/examples/13-hooks/example.py
@@ -1,13 +1,12 @@
 import asyncio
 import datetime
 import random
-from typing import Dict
 
 import kopf
 import pykube
 
 LOCK: asyncio.Lock  # requires a loop on creation
-STOPPERS: Dict[str, Dict[str, asyncio.Event]] = {}  # [namespace][name]
+STOPPERS: dict[str, dict[str, asyncio.Event]] = {}  # [namespace][name]
 
 
 @kopf.on.startup()

--- a/examples/16-indexing/example.py
+++ b/examples/16-indexing/example.py
@@ -43,6 +43,4 @@ def intervalled(is_running: kopf.Index, by_label: kopf.Index, patch: kopf.Patch,
 
 # Marks for the e2e tests (see tests/e2e/test_examples.py):
 # We do not care: pods can have 6-10 updates here.
-from typing import Dict
-
-E2E_SUCCESS_COUNTS: Dict[str, int] = {}
+E2E_SUCCESS_COUNTS: dict[str, int] = {}

--- a/examples/17-admission/example.py
+++ b/examples/17-admission/example.py
@@ -1,5 +1,4 @@
 import pathlib
-from typing import List
 
 import kopf
 
@@ -48,7 +47,7 @@ def config(settings: kopf.OperatorSettings, **_):
 
 
 @kopf.on.validate('kex')
-def authhook(headers: kopf.Headers, sslpeer: kopf.SSLPeer, warnings: List[str], **_):
+def authhook(headers: kopf.Headers, sslpeer: kopf.SSLPeer, warnings: list[str], **_):
     user_agent = headers.get('User-Agent', '(unidentified)')
     warnings.append(f"Accessing as user-agent: {user_agent}")
     if not sslpeer.get('subject'):
@@ -73,7 +72,7 @@ def validate2(**_):
 
 
 @kopf.on.validate('kex', subresource='*')
-def validate_subresources(spec, subresource, status, warnings: List[str], **_):
+def validate_subresources(spec, subresource, status, warnings: list[str], **_):
     if subresource == 'status' and status.get('field') != spec.get('field'):
         raise kopf.AdmissionError("status.field MUST be equal to spec.field!")
     elif subresource is None and status.get('field') != spec.get('field'):
@@ -88,6 +87,4 @@ def mutate1(patch: kopf.Patch, **_):
 
 # Marks for the e2e tests (see tests/e2e/test_examples.py):
 # We do not care: pods can have 6-10 updates here.
-from typing import Dict
-
-E2E_SUCCESS_COUNTS: Dict[str, int] = {}
+E2E_SUCCESS_COUNTS: dict[str, int] = {}

--- a/kopf/_cogs/aiokits/aioenums.py
+++ b/kopf/_cogs/aiokits/aioenums.py
@@ -2,7 +2,8 @@ import asyncio
 import enum
 import threading
 import time
-from typing import Awaitable, Generator, Generic, Optional, TypeVar
+from collections.abc import Awaitable, Generator
+from typing import Generic, Optional, TypeVar
 
 FlagReasonT = TypeVar('FlagReasonT', bound=enum.Flag)
 

--- a/kopf/_cogs/aiokits/aiotasks.py
+++ b/kopf/_cogs/aiokits/aiotasks.py
@@ -10,8 +10,8 @@ all function calls with multiple awaiables (e.g. :func:`asyncio.wait`),
 so there is no added overhead; instead, the implicit overhead is made explicit.
 """
 import asyncio
-from typing import TYPE_CHECKING, Any, Callable, Collection, Coroutine, \
-                   NamedTuple, Optional, Set, Tuple, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Collection, \
+                   Coroutine, NamedTuple, Optional, TypeVar
 
 from kopf._cogs.helpers import typedefs
 
@@ -137,7 +137,7 @@ async def wait(
         *,
         timeout: Optional[float] = None,
         return_when: Any = asyncio.ALL_COMPLETED,
-) -> Tuple[Set[Task], Set[Task]]:
+) -> tuple[set[Task], set[Task]]:
     """
     A safer version of :func:`asyncio.wait` -- does not fail on an empty list.
     """
@@ -155,7 +155,7 @@ async def stop(
         cancelled: bool = False,
         interval: Optional[float] = None,
         logger: Optional[typedefs.Logger] = None,
-) -> Tuple[Set[Task], Set[Task]]:
+) -> tuple[set[Task], set[Task]]:
     """
     Cancel the tasks and wait for them to finish; log if some are stuck.
 
@@ -185,8 +185,8 @@ async def stop(
         task.cancel()
 
     iterations = 0
-    done_ever: Set[Task] = set()
-    pending: Set[Task] = set(tasks)
+    done_ever: set[Task] = set()
+    pending: set[Task] = set(tasks)
     while pending:
         iterations += 1
 
@@ -289,7 +289,7 @@ class Scheduler:
         self._exception_handler = exception_handler
         self._condition = asyncio.Condition()
         self._pending_coros: asyncio.Queue[SchedulerJob] = asyncio.Queue()
-        self._running_tasks: Set[Task] = set()
+        self._running_tasks: set[Task] = set()
         self._cleaning_queue: asyncio.Queue[Task] = asyncio.Queue()
         self._cleaning_task = asyncio.create_task(self._task_cleaner(), name=f"cleaner of {self!r}")
         self._spawning_task = asyncio.create_task(self._task_spawner(), name=f"spawner of {self!r}")

--- a/kopf/_cogs/aiokits/aiotasks.py
+++ b/kopf/_cogs/aiokits/aiotasks.py
@@ -10,8 +10,8 @@ all function calls with multiple awaiables (e.g. :func:`asyncio.wait`),
 so there is no added overhead; instead, the implicit overhead is made explicit.
 """
 import asyncio
-from typing import TYPE_CHECKING, Any, Callable, Collection, \
-                   Coroutine, NamedTuple, Optional, TypeVar
+from collections.abc import Collection, Coroutine
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional, TypeVar
 
 from kopf._cogs.helpers import typedefs
 

--- a/kopf/_cogs/aiokits/aiotime.py
+++ b/kopf/_cogs/aiokits/aiotime.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections.abc
-from typing import Collection, Optional, Union
+from collections.abc import Collection
+from typing import Optional, Union
 
 
 async def sleep(

--- a/kopf/_cogs/aiokits/aiotoggles.py
+++ b/kopf/_cogs/aiokits/aiotoggles.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Callable, Collection, Iterable, Iterator, Optional
+from collections.abc import Collection, Iterable, Iterator
+from typing import Callable, Optional
 
 
 class Toggle:

--- a/kopf/_cogs/aiokits/aiotoggles.py
+++ b/kopf/_cogs/aiokits/aiotoggles.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Callable, Collection, Iterable, Iterator, Optional, Set
+from typing import Callable, Collection, Iterable, Iterator, Optional
 
 
 class Toggle:
@@ -96,7 +96,7 @@ class ToggleSet(Collection[Toggle]):
     def __init__(self, fn: Callable[[Iterable[bool]], bool]) -> None:
         super().__init__()
         self._condition = asyncio.Condition()
-        self._toggles: Set[Toggle] = set()
+        self._toggles: set[Toggle] = set()
         self._fn = fn
 
     def __repr__(self) -> str:

--- a/kopf/_cogs/aiokits/aiovalues.py
+++ b/kopf/_cogs/aiokits/aiovalues.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import AsyncIterator, Collection, Generic, TypeVar
+from collections.abc import AsyncIterator, Collection
+from typing import Generic, TypeVar
 
 _T = TypeVar('_T')
 

--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -4,7 +4,8 @@ import itertools
 import json
 import ssl
 import urllib.parse
-from typing import Any, AsyncIterator, Mapping, Optional
+from collections.abc import AsyncIterator, Mapping
+from typing import Any, Optional
 
 import aiohttp
 

--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -4,7 +4,7 @@ import itertools
 import json
 import ssl
 import urllib.parse
-from typing import Any, AsyncIterator, Mapping, Optional, Tuple
+from typing import Any, AsyncIterator, Mapping, Optional
 
 import aiohttp
 
@@ -28,7 +28,7 @@ async def get_default_namespace(
 async def read_sslcert(
         *,
         context: Optional[auth.APIContext] = None,
-) -> Tuple[str, bytes]:
+) -> tuple[str, bytes]:
     if context is None:
         raise RuntimeError("API instance is not injected by the decorator.")
 

--- a/kopf/_cogs/clients/auth.py
+++ b/kopf/_cogs/clients/auth.py
@@ -4,7 +4,7 @@ import os
 import ssl
 import tempfile
 from contextvars import ContextVar
-from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, TypeVar, cast
+from typing import Any, Callable, Iterator, Mapping, Optional, TypeVar, cast
 
 import aiohttp
 
@@ -84,7 +84,7 @@ class APIContext:
     default_namespace: Optional[str]
 
     # List of open responses.
-    responses: List[aiohttp.ClientResponse]
+    responses: list[aiohttp.ClientResponse]
 
     # Temporary caches of the information retrieved for and from the environment.
     _tempfiles: "_TempFiles"
@@ -146,7 +146,7 @@ class APIContext:
             context.verify_mode = ssl.CERT_NONE
 
         # The token auth part.
-        headers: Dict[str, str] = {}
+        headers: dict[str, str] = {}
         if info.scheme and info.token:
             headers['Authorization'] = f'{info.scheme} {info.token}'
         elif info.scheme:
@@ -224,7 +224,7 @@ class _TempFiles(Mapping[bytes, str]):
 
     def __init__(self) -> None:
         super().__init__()
-        self._paths: Dict[bytes, str] = {}
+        self._paths: dict[bytes, str] = {}
 
     def __del__(self) -> None:
         self.purge()

--- a/kopf/_cogs/clients/auth.py
+++ b/kopf/_cogs/clients/auth.py
@@ -3,8 +3,9 @@ import functools
 import os
 import ssl
 import tempfile
+from collections.abc import Iterator, Mapping
 from contextvars import ContextVar
-from typing import Any, Callable, Iterator, Mapping, Optional, TypeVar, cast
+from typing import Any, Callable, Optional, TypeVar, cast
 
 import aiohttp
 

--- a/kopf/_cogs/clients/errors.py
+++ b/kopf/_cogs/clients/errors.py
@@ -27,7 +27,8 @@ as the reasons of failures. However, the errors are exposed to other packages.
 """
 import collections.abc
 import json
-from typing import Collection, Optional
+from collections.abc import Collection
+from typing import Optional
 
 import aiohttp
 from typing_extensions import Literal, TypedDict

--- a/kopf/_cogs/clients/errors.py
+++ b/kopf/_cogs/clients/errors.py
@@ -28,10 +28,9 @@ as the reasons of failures. However, the errors are exposed to other packages.
 import collections.abc
 import json
 from collections.abc import Collection
-from typing import Optional
+from typing import Literal, Optional, TypedDict
 
 import aiohttp
-from typing_extensions import Literal, TypedDict
 
 
 class RawStatusCause(TypedDict):

--- a/kopf/_cogs/clients/fetching.py
+++ b/kopf/_cogs/clients/fetching.py
@@ -1,4 +1,4 @@
-from typing import Collection
+from collections.abc import Collection
 
 from kopf._cogs.clients import api
 from kopf._cogs.configs import configuration

--- a/kopf/_cogs/clients/fetching.py
+++ b/kopf/_cogs/clients/fetching.py
@@ -1,4 +1,4 @@
-from typing import Collection, List, Tuple
+from typing import Collection
 
 from kopf._cogs.clients import api
 from kopf._cogs.configs import configuration
@@ -12,7 +12,7 @@ async def list_objs(
         resource: references.Resource,
         namespace: references.Namespace,
         logger: typedefs.Logger,
-) -> Tuple[Collection[bodies.RawBody], str]:
+) -> tuple[Collection[bodies.RawBody], str]:
     """
     List the objects of specific resource type.
 
@@ -31,7 +31,7 @@ async def list_objs(
         settings=settings,
     )
 
-    items: List[bodies.RawBody] = []
+    items: list[bodies.RawBody] = []
     resource_version = rsp.get('metadata', {}).get('resourceVersion', None)
     for item in rsp.get('items', []):
         if 'kind' in rsp:

--- a/kopf/_cogs/clients/fetching.py
+++ b/kopf/_cogs/clients/fetching.py
@@ -35,7 +35,7 @@ async def list_objs(
     resource_version = rsp.get('metadata', {}).get('resourceVersion', None)
     for item in rsp.get('items', []):
         if 'kind' in rsp:
-            item.setdefault('kind', rsp['kind'][:-4] if rsp['kind'][-4:] == 'List' else rsp['kind'])
+            item.setdefault('kind', rsp['kind'].removesuffix('List'))
         if 'apiVersion' in rsp:
             item.setdefault('apiVersion', rsp['apiVersion'])
         items.append(item)

--- a/kopf/_cogs/clients/scanning.py
+++ b/kopf/_cogs/clients/scanning.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Collection, Mapping, Optional, Set
+from typing import Collection, Mapping, Optional
 
 from kopf._cogs.clients import api, errors
 from kopf._cogs.configs import configuration
@@ -26,7 +26,7 @@ async def scan_resources(
         _read_old_api(groups=groups, settings=settings, logger=logger),
         _read_new_apis(groups=groups, settings=settings, logger=logger),
     }
-    resources: Set[references.Resource] = set()
+    resources: set[references.Resource] = set()
     for coro in asyncio.as_completed(coros):
         resources.update(await coro)
     return resources
@@ -38,7 +38,7 @@ async def _read_old_api(
         logger: typedefs.Logger,
         groups: Optional[Collection[str]],
 ) -> Collection[references.Resource]:
-    resources: Set[references.Resource] = set()
+    resources: set[references.Resource] = set()
     if groups is None or '' in groups:
         rsp = await api.get('/api', settings=settings, logger=logger)
         coros = {
@@ -63,7 +63,7 @@ async def _read_new_apis(
         logger: typedefs.Logger,
         groups: Optional[Collection[str]],
 ) -> Collection[references.Resource]:
-    resources: Set[references.Resource] = set()
+    resources: set[references.Resource] = set()
     if groups is None or set(groups or {}) - {''}:
         rsp = await api.get('/apis', settings=settings, logger=logger)
         items = [d for d in rsp['groups'] if groups is None or d['name'] in groups]

--- a/kopf/_cogs/clients/scanning.py
+++ b/kopf/_cogs/clients/scanning.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Collection, Mapping, Optional
+from collections.abc import Collection, Mapping
+from typing import Optional
 
 from kopf._cogs.clients import api, errors
 from kopf._cogs.configs import configuration

--- a/kopf/_cogs/clients/watching.py
+++ b/kopf/_cogs/clients/watching.py
@@ -21,7 +21,8 @@ import asyncio
 import contextlib
 import enum
 import logging
-from typing import AsyncIterator, Optional, Union, cast
+from collections.abc import AsyncIterator
+from typing import Optional, Union, cast
 
 import aiohttp
 

--- a/kopf/_cogs/clients/watching.py
+++ b/kopf/_cogs/clients/watching.py
@@ -21,7 +21,7 @@ import asyncio
 import contextlib
 import enum
 import logging
-from typing import AsyncIterator, Dict, Optional, Union, cast
+from typing import AsyncIterator, Optional, Union, cast
 
 import aiohttp
 
@@ -247,7 +247,7 @@ async def watch_objs(
 
     * The resource is namespace-scoped AND operator is namespaced-restricted.
     """
-    params: Dict[str, str] = {}
+    params: dict[str, str] = {}
     params['watch'] = 'true'
     if since is not None:
         params['resourceVersion'] = since

--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -28,7 +28,8 @@ the root object, while keeping the legacy names for backward compatibility.
 import concurrent.futures
 import dataclasses
 import logging
-from typing import Iterable, Optional, Union
+from collections.abc import Iterable
+from typing import Optional, Union
 
 from kopf._cogs.configs import diffbase, progress
 from kopf._cogs.structs import reviews

--- a/kopf/_cogs/configs/conventions.py
+++ b/kopf/_cogs/configs/conventions.py
@@ -33,7 +33,7 @@ replaced; in some cases, they will be cut and hash-suffixed.
 import base64
 import hashlib
 import warnings
-from typing import Any, Collection, Iterable, Optional, Set
+from typing import Any, Collection, Iterable, Optional
 
 from kopf._cogs.structs import bodies, patches
 
@@ -231,7 +231,7 @@ class StorageKeyMarkingConvention:
         """
         Detect annotation prefixes managed by any other Kopf-based operators.
         """
-        prefixes: Set[str] = set()
+        prefixes: set[str] = set()
         for prefix, name in (key.split('/', 1) for key in keys if '/' in key):
             if name in self.__KNOWN_MARKERS:
                 prefixes.add(prefix)

--- a/kopf/_cogs/configs/conventions.py
+++ b/kopf/_cogs/configs/conventions.py
@@ -33,7 +33,8 @@ replaced; in some cases, they will be cut and hash-suffixed.
 import base64
 import hashlib
 import warnings
-from typing import Any, Collection, Iterable, Optional
+from collections.abc import Collection, Iterable
+from typing import Any, Optional
 
 from kopf._cogs.structs import bodies, patches
 

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -1,7 +1,7 @@
 import abc
 import copy
 import json
-from typing import Any, Collection, Dict, Iterable, Optional, cast
+from typing import Any, Collection, Iterable, Optional, cast
 
 from kopf._cogs.configs import conventions
 from kopf._cogs.structs import bodies, dicts, patches
@@ -48,7 +48,7 @@ class DiffBaseStorage(conventions.StorageKeyMarkingConvention,
         """
 
         # Always use a copy, so that future changes do not affect the extracted essence.
-        essence = cast(Dict[Any, Any], copy.deepcopy(dict(body)))
+        essence = cast(dict[Any, Any], copy.deepcopy(dict(body)))
 
         # The top-level identifying fields never change, so there is not need to track them.
         if 'apiVersion' in essence:
@@ -183,7 +183,7 @@ class StatusDiffBaseStorage(DiffBaseStorage):
         essence = super().build(body=body, extra_fields=extra_fields)
 
         # Work around an issue with mypy not treating TypedDicts as MutableMappings.
-        essence_dict = cast(Dict[Any, Any], essence)
+        essence_dict = cast(dict[Any, Any], essence)
         dicts.remove(essence_dict, self.field)
 
         return essence

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -1,7 +1,8 @@
 import abc
 import copy
 import json
-from typing import Any, Collection, Iterable, Optional, cast
+from collections.abc import Collection, Iterable
+from typing import Any, Optional, cast
 
 from kopf._cogs.configs import conventions
 from kopf._cogs.structs import bodies, dicts, patches

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -41,7 +41,8 @@ All timestamps are strings in ISO8601 format in UTC (no explicit ``Z`` suffix).
 import abc
 import copy
 import json
-from typing import Any, Collection, Mapping, Optional, cast
+from collections.abc import Collection, Mapping
+from typing import Any, Optional, cast
 
 from typing_extensions import TypedDict
 

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -42,9 +42,7 @@ import abc
 import copy
 import json
 from collections.abc import Collection, Mapping
-from typing import Any, Optional, cast
-
-from typing_extensions import TypedDict
+from typing import Any, Optional, TypedDict, cast
 
 from kopf._cogs.configs import conventions
 from kopf._cogs.structs import bodies, dicts, ids, patches

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -41,7 +41,7 @@ All timestamps are strings in ISO8601 format in UTC (no explicit ``Z`` suffix).
 import abc
 import copy
 import json
-from typing import Any, Collection, Dict, Mapping, Optional, cast
+from typing import Any, Collection, Mapping, Optional, cast
 
 from typing_extensions import TypedDict
 
@@ -364,7 +364,7 @@ class StatusProgressStorage(ProgressStorage):
         essence = super().clear(essence=essence)
 
         # Work around an issue with mypy not treating TypedDicts as MutableMappings.
-        essence_dict = cast(Dict[Any, Any], essence)
+        essence_dict = cast(dict[Any, Any], essence)
         dicts.remove(essence_dict, self.field)
 
         self.remove_empty_stanzas(essence)

--- a/kopf/_cogs/helpers/hostnames.py
+++ b/kopf/_cogs/helpers/hostnames.py
@@ -50,6 +50,5 @@ def remove_useless_suffixes(hostname: str) -> str:
     suffixes = ['.local', '.localdomain']
     while any(hostname.endswith(suffix) for suffix in suffixes):
         for suffix in suffixes:
-            if hostname.endswith(suffix):
-                hostname = hostname[:-len(suffix)]
+            hostname = hostname.removesuffix(suffix)
     return hostname

--- a/kopf/_cogs/helpers/hostnames.py
+++ b/kopf/_cogs/helpers/hostnames.py
@@ -1,6 +1,6 @@
 import ipaddress
 import socket
-from typing import List, Optional, Tuple
+from typing import Optional
 
 
 def get_descriptive_hostname() -> str:
@@ -20,7 +20,7 @@ def get_descriptive_hostname() -> str:
     else:
         ipv4: Optional[ipaddress.IPv4Address]
         ipv6: Optional[ipaddress.IPv6Address]
-        parsed: List[Tuple[str, Optional[ipaddress.IPv4Address], Optional[ipaddress.IPv6Address]]]
+        parsed: list[tuple[str, Optional[ipaddress.IPv4Address], Optional[ipaddress.IPv6Address]]]
         parsed = []
         for name in [hostname] + list(aliases) + list(ipaddrs):
             try:

--- a/kopf/_cogs/helpers/loaders.py
+++ b/kopf/_cogs/helpers/loaders.py
@@ -19,7 +19,8 @@ import importlib.abc
 import importlib.util
 import os.path
 import sys
-from typing import Iterable, cast
+from collections.abc import Iterable
+from typing import cast
 
 
 def preload(

--- a/kopf/_cogs/structs/bodies.py
+++ b/kopf/_cogs/structs/bodies.py
@@ -42,9 +42,7 @@ In case the operators are also type-checked, type casting can be used
 """
 
 from collections.abc import Mapping
-from typing import Any, Optional, Union, cast
-
-from typing_extensions import Literal, TypedDict
+from typing import Any, Literal, Optional, TypedDict, Union, cast
 
 from kopf._cogs.structs import dicts, references
 

--- a/kopf/_cogs/structs/bodies.py
+++ b/kopf/_cogs/structs/bodies.py
@@ -41,7 +41,7 @@ In case the operators are also type-checked, type casting can be used
     and object-processing functions. The internal dicts will remain the same.
 """
 
-from typing import Any, List, Mapping, Optional, Union, cast
+from typing import Any, Mapping, Optional, Union, cast
 
 from typing_extensions import Literal, TypedDict
 
@@ -69,7 +69,7 @@ class RawMeta(TypedDict, total=False):
     namespace: str
     labels: Labels
     annotations: Annotations
-    finalizers: List[str]
+    finalizers: list[str]
     resourceVersion: str
     deletionTimestamp: str
     creationTimestamp: str

--- a/kopf/_cogs/structs/bodies.py
+++ b/kopf/_cogs/structs/bodies.py
@@ -41,7 +41,8 @@ In case the operators are also type-checked, type casting can be used
     and object-processing functions. The internal dicts will remain the same.
 """
 
-from typing import Any, Mapping, Optional, Union, cast
+from collections.abc import Mapping
+from typing import Any, Optional, Union, cast
 
 from typing_extensions import Literal, TypedDict
 

--- a/kopf/_cogs/structs/credentials.py
+++ b/kopf/_cogs/structs/credentials.py
@@ -28,8 +28,7 @@ import collections
 import dataclasses
 import datetime
 import random
-from typing import AsyncIterable, AsyncIterator, Callable, Dict, List, \
-                   Mapping, NewType, Optional, Tuple, TypeVar, cast
+from typing import AsyncIterable, AsyncIterator, Callable, Mapping, NewType, Optional, TypeVar, cast
 
 from kopf._cogs.aiokits import aiotoggles
 
@@ -81,10 +80,10 @@ class VaultItem:
     The caches are populated by `Vault.extended` on-demand.
     """
     info: ConnectionInfo
-    caches: Optional[Dict[str, object]] = None
+    caches: Optional[dict[str, object]] = None
 
 
-class Vault(AsyncIterable[Tuple[VaultKey, ConnectionInfo]]):
+class Vault(AsyncIterable[tuple[VaultKey, ConnectionInfo]]):
     """
     A store for currently valid authentication methods.
 
@@ -107,8 +106,8 @@ class Vault(AsyncIterable[Tuple[VaultKey, ConnectionInfo]]):
     .. seealso::
         :func:`auth.authenticated` and :func:`authentication`.
     """
-    _current: Dict[VaultKey, VaultItem]
-    _invalid: Dict[VaultKey, List[VaultItem]]
+    _current: dict[VaultKey, VaultItem]
+    _invalid: dict[VaultKey, list[VaultItem]]
 
     def __init__(
             self,
@@ -135,7 +134,7 @@ class Vault(AsyncIterable[Tuple[VaultKey, ConnectionInfo]]):
 
     async def __aiter__(
             self,
-    ) -> AsyncIterator[Tuple[VaultKey, ConnectionInfo]]:
+    ) -> AsyncIterator[tuple[VaultKey, ConnectionInfo]]:
         async for key, item in self._items():
             yield key, item.info
 
@@ -143,7 +142,7 @@ class Vault(AsyncIterable[Tuple[VaultKey, ConnectionInfo]]):
             self,
             factory: Callable[[ConnectionInfo], _T],
             purpose: Optional[str] = None,
-    ) -> AsyncIterator[Tuple[VaultKey, ConnectionInfo, _T]]:
+    ) -> AsyncIterator[tuple[VaultKey, ConnectionInfo, _T]]:
         """
         Iterate the connection info items with their cached object.
 
@@ -168,7 +167,7 @@ class Vault(AsyncIterable[Tuple[VaultKey, ConnectionInfo]]):
 
     async def _items(
             self,
-    ) -> AsyncIterator[Tuple[VaultKey, VaultItem]]:
+    ) -> AsyncIterator[tuple[VaultKey, VaultItem]]:
         """
         Yield the raw items as stored in the vault in random order.
 
@@ -202,7 +201,7 @@ class Vault(AsyncIterable[Tuple[VaultKey, ConnectionInfo]]):
                 if yielded_key in self._current and self._current[yielded_key] is yielded_item:
                     break
 
-    def select(self) -> Tuple[VaultKey, VaultItem]:
+    def select(self) -> tuple[VaultKey, VaultItem]:
         """
         Select the next item (not the info!) to try (and do so infinitely).
 
@@ -214,7 +213,7 @@ class Vault(AsyncIterable[Tuple[VaultKey, ConnectionInfo]]):
             raise LoginError("Ran out of valid credentials. Consider installing "
                              "an API client library or adding a login handler. See more: "
                              "https://kopf.readthedocs.io/en/stable/authentication/")
-        prioritised: Dict[int, List[Tuple[VaultKey, VaultItem]]]
+        prioritised: dict[int, list[tuple[VaultKey, VaultItem]]]
         prioritised = collections.defaultdict(list)
         for key, item in self._current.items():
             prioritised[item.info.priority].append((key, item))

--- a/kopf/_cogs/structs/credentials.py
+++ b/kopf/_cogs/structs/credentials.py
@@ -28,7 +28,8 @@ import collections
 import dataclasses
 import datetime
 import random
-from typing import AsyncIterable, AsyncIterator, Callable, Mapping, NewType, Optional, TypeVar, cast
+from collections.abc import AsyncIterable, AsyncIterator, Mapping
+from typing import Callable, NewType, Optional, TypeVar, cast
 
 from kopf._cogs.aiokits import aiotoggles
 

--- a/kopf/_cogs/structs/dicts.py
+++ b/kopf/_cogs/structs/dicts.py
@@ -3,13 +3,13 @@ Some basic dicts and field-in-a-dict manipulation helpers.
 """
 import collections.abc
 import enum
-from typing import Any, Callable, Generic, Iterable, Iterator, List, \
-                   Mapping, MutableMapping, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Generic, Iterable, Iterator, \
+                   Mapping, MutableMapping, Optional, TypeVar, Union
 
 from kopf._cogs.helpers import thirdparty
 
-FieldPath = Tuple[str, ...]
-FieldSpec = Union[None, str, FieldPath, List[str]]
+FieldPath = tuple[str, ...]
+FieldSpec = Union[None, str, FieldPath, list[str]]
 
 _T = TypeVar('_T')
 _K = TypeVar('_K', bound=str)  # int & bool keys are possible but discouraged

--- a/kopf/_cogs/structs/dicts.py
+++ b/kopf/_cogs/structs/dicts.py
@@ -3,8 +3,8 @@ Some basic dicts and field-in-a-dict manipulation helpers.
 """
 import collections.abc
 import enum
-from typing import Any, Callable, Generic, Iterable, Iterator, \
-                   Mapping, MutableMapping, Optional, TypeVar, Union
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping
+from typing import Any, Callable, Generic, Optional, TypeVar, Union
 
 from kopf._cogs.helpers import thirdparty
 

--- a/kopf/_cogs/structs/diffs.py
+++ b/kopf/_cogs/structs/diffs.py
@@ -3,7 +3,8 @@ All the functions to calculate the diffs of the dicts.
 """
 import collections.abc
 import enum
-from typing import Any, Iterable, Iterator, NamedTuple, Sequence, Union, overload
+from collections.abc import Iterable, Iterator, Sequence
+from typing import Any, NamedTuple, Union, overload
 
 from kopf._cogs.structs import dicts
 

--- a/kopf/_cogs/structs/ephemera.py
+++ b/kopf/_cogs/structs/ephemera.py
@@ -1,4 +1,5 @@
-from typing import Any, Collection, Generic, Mapping, NewType, TypeVar
+from collections.abc import Collection, Mapping
+from typing import Any, Generic, NewType, TypeVar
 
 # For users, memos are exposed as `Any`, though usually used with `kopf.Memo`.
 # However, the framework cannot rely on any methods/properties of it, so it is

--- a/kopf/_cogs/structs/ephemera.py
+++ b/kopf/_cogs/structs/ephemera.py
@@ -1,4 +1,4 @@
-from typing import Any, Collection, Dict, Generic, Mapping, NewType, TypeVar
+from typing import Any, Collection, Generic, Mapping, NewType, TypeVar
 
 # For users, memos are exposed as `Any`, though usually used with `kopf.Memo`.
 # However, the framework cannot rely on any methods/properties of it, so it is
@@ -6,7 +6,7 @@ from typing import Any, Collection, Dict, Generic, Mapping, NewType, TypeVar
 AnyMemo = NewType('AnyMemo', object)
 
 
-class Memo(Dict[Any, Any]):
+class Memo(dict[Any, Any]):
     """
     A container to hold arbitrary keys-values assigned by operator developers.
 

--- a/kopf/_cogs/structs/patches.py
+++ b/kopf/_cogs/structs/patches.py
@@ -9,7 +9,7 @@ a dict-like behaviour, and remembers the changes in order of their execution,
 and then generates the JSON patch (RFC 6902).
 """
 import collections.abc
-from typing import Any, Dict, List, MutableMapping, Optional
+from typing import Any, Optional
 
 from typing_extensions import Literal, TypedDict
 
@@ -18,7 +18,7 @@ from kopf._cogs.structs import bodies, dicts
 JSONPatchOp = Literal["add", "replace", "remove"]
 
 
-def _escaped_path(keys: List[str]) -> str:
+def _escaped_path(keys: list[str]) -> str:
     """Provides an appropriately escaped path for JSON Patches.
 
     See https://datatracker.ietf.org/doc/html/rfc6901#section-3 for more details.
@@ -32,7 +32,7 @@ class JSONPatchItem(TypedDict, total=False):
     value: Optional[Any]
 
 
-JSONPatch = List[JSONPatchItem]
+JSONPatch = list[JSONPatchItem]
 
 
 class MetaPatch(dicts.MutableMappingView[str, Any]):
@@ -64,11 +64,11 @@ class StatusPatch(dicts.MutableMappingView[str, Any]):
 
 
 # Event-handling structures, used internally in the framework and handlers only.
-class Patch(Dict[str, Any]):
+class Patch(dict[str, Any]):
 
     def __init__(
         self,
-        __src: Optional[MutableMapping[str, Any]] = None,
+        __src: Optional[collections.abc.MutableMapping[str, Any]] = None,
         body: Optional[bodies.RawBody] = None
     ) -> None:
         super().__init__(__src or {})
@@ -96,7 +96,7 @@ class Patch(Dict[str, Any]):
     def as_json_patch(self) -> JSONPatch:
         return [] if not self else self._as_json_patch(self, keys=[''])
 
-    def _as_json_patch(self, value: object, keys: List[str]) -> JSONPatch:
+    def _as_json_patch(self, value: object, keys: list[str]) -> JSONPatch:
         result: JSONPatch = []
         if value is None:
             result.append(JSONPatchItem(op='remove', path=_escaped_path(keys)))
@@ -109,7 +109,7 @@ class Patch(Dict[str, Any]):
             result.append(JSONPatchItem(op='replace', path=_escaped_path(keys), value=value))
         return result
 
-    def _is_in_original_path(self, keys: List[str]) -> bool:
+    def _is_in_original_path(self, keys: list[str]) -> bool:
         _search = self._original
         for key in keys:
             if key == '':

--- a/kopf/_cogs/structs/patches.py
+++ b/kopf/_cogs/structs/patches.py
@@ -9,9 +9,7 @@ a dict-like behaviour, and remembers the changes in order of their execution,
 and then generates the JSON patch (RFC 6902).
 """
 import collections.abc
-from typing import Any, Optional
-
-from typing_extensions import Literal, TypedDict
+from typing import Any, Literal, Optional, TypedDict
 
 from kopf._cogs.structs import bodies, dicts
 

--- a/kopf/_cogs/structs/references.py
+++ b/kopf/_cogs/structs/references.py
@@ -4,12 +4,11 @@ import enum
 import fnmatch
 import re
 import urllib.parse
-from typing import Collection, FrozenSet, Iterable, Iterator, List, Mapping, \
-                   MutableMapping, NewType, Optional, Pattern, Set, Union
+from typing import Collection, Iterable, Iterator, Mapping, MutableMapping, NewType, Optional, Union
 
 # A namespace specification with globs, negations, and some minimal syntax; see `match_namespace()`.
 # Regexps are also supported if pre-compiled from the code, not from the CLI options as raw strings.
-NamespacePattern = Union[str, Pattern[str]]
+NamespacePattern = Union[str, re.Pattern[str]]
 
 # A specific really existing addressable namespace (at least, the one assumed to be so).
 # Made as a NewType for stricter type-checking to avoid collisions with patterns and other strings.
@@ -138,17 +137,17 @@ class Resource:
     The resource's singular name; e.g. ``"pod"``, ``"kopfexample"``.
     """
 
-    shortcuts: FrozenSet[str] = frozenset()
+    shortcuts: frozenset[str] = frozenset()
     """
     The resource's short names; e.g. ``{"po"}``, ``{"kex", "kexes"}``.
     """
 
-    categories: FrozenSet[str] = frozenset()
+    categories: frozenset[str] = frozenset()
     """
     The resource's categories, to which the resource belongs; e.g. ``{"all"}``.
     """
 
-    subresources: FrozenSet[str] = frozenset()
+    subresources: frozenset[str] = frozenset()
     """
     The resource's subresources, if defined; e.g. ``{"status", "scale"}``.
     """
@@ -164,7 +163,7 @@ class Resource:
     Only "preferred" resources are served when the version is not specified.
     """
 
-    verbs: FrozenSet[str] = frozenset()
+    verbs: frozenset[str] = frozenset()
     """
     All available verbs for the resource, as supported by K8s API;
     e.g., ``{"list", "watch", "create", "update", "delete", "patch"}``.
@@ -222,7 +221,7 @@ class Resource:
         if self.namespaced and namespace is None and name is not None:
             raise ValueError("Specific namespaces are required for specific namespaced resources.")
 
-        parts: List[Optional[str]] = [
+        parts: list[Optional[str]] = [
             '/api' if self.group == '' and self.version == 'v1' else '/apis',
             self.group,
             self.version,
@@ -483,10 +482,10 @@ class Insights:
     # - **Indexed** resources block the operator startup until all objects are initially indexed.
     # - **Watched** resources spawn the watch-streams; the set excludes all webhook-only resources.
     # - **Webhook** resources are served via webhooks; the set excludes all watch-only resources.
-    webhook_resources: Set[Resource] = dataclasses.field(default_factory=set)
-    indexed_resources: Set[Resource] = dataclasses.field(default_factory=set)
-    watched_resources: Set[Resource] = dataclasses.field(default_factory=set)
-    namespaces: Set[Namespace] = dataclasses.field(default_factory=set)
+    webhook_resources: set[Resource] = dataclasses.field(default_factory=set)
+    indexed_resources: set[Resource] = dataclasses.field(default_factory=set)
+    watched_resources: set[Resource] = dataclasses.field(default_factory=set)
+    namespaces: set[Namespace] = dataclasses.field(default_factory=set)
     backbone: Backbone = dataclasses.field(default_factory=Backbone)
 
     # Signalled when anything changes in the insights.

--- a/kopf/_cogs/structs/references.py
+++ b/kopf/_cogs/structs/references.py
@@ -4,7 +4,8 @@ import enum
 import fnmatch
 import re
 import urllib.parse
-from typing import Collection, Iterable, Iterator, Mapping, MutableMapping, NewType, Optional, Union
+from collections.abc import Collection, Iterable, Iterator, Mapping, MutableMapping
+from typing import NewType, Optional, Union
 
 # A namespace specification with globs, negations, and some minimal syntax; see `match_namespace()`.
 # Regexps are also supported if pre-compiled from the code, not from the CLI options as raw strings.

--- a/kopf/_cogs/structs/reviews.py
+++ b/kopf/_cogs/structs/reviews.py
@@ -2,9 +2,7 @@
 Admission reviews: requests & responses, also the webhook server protocols.
 """
 from collections.abc import AsyncIterator, Awaitable, Mapping
-from typing import Any, Callable, Optional, Union
-
-from typing_extensions import Literal, Protocol, TypedDict
+from typing import Any, Callable, Literal, Optional, Protocol, TypedDict, Union
 
 from kopf._cogs.structs import bodies
 

--- a/kopf/_cogs/structs/reviews.py
+++ b/kopf/_cogs/structs/reviews.py
@@ -1,7 +1,8 @@
 """
 Admission reviews: requests & responses, also the webhook server protocols.
 """
-from typing import Any, AsyncIterator, Awaitable, Callable, Mapping, Optional, Union
+from collections.abc import AsyncIterator, Awaitable, Mapping
+from typing import Any, Callable, Optional, Union
 
 from typing_extensions import Literal, Protocol, TypedDict
 

--- a/kopf/_cogs/structs/reviews.py
+++ b/kopf/_cogs/structs/reviews.py
@@ -1,7 +1,7 @@
 """
 Admission reviews: requests & responses, also the webhook server protocols.
 """
-from typing import Any, AsyncIterator, Awaitable, Callable, List, Mapping, Optional, Union
+from typing import Any, AsyncIterator, Awaitable, Callable, Mapping, Optional, Union
 
 from typing_extensions import Literal, Protocol, TypedDict
 
@@ -28,7 +28,7 @@ class RequestResource(TypedDict):
 class UserInfo(TypedDict):
     username: str
     uid: str
-    groups: List[str]
+    groups: list[str]
 
 
 class CreateOptions(TypedDict, total=False):
@@ -78,7 +78,7 @@ class ResponseStatus(TypedDict, total=False):
 class ResponsePayload(TypedDict, total=False):
     uid: str
     allowed: bool
-    warnings: Optional[List[str]]
+    warnings: Optional[list[str]]
     status: Optional[ResponseStatus]
     patch: Optional[str]
     patchType: Optional[Literal["JSONPatch"]]

--- a/kopf/_core/actions/application.py
+++ b/kopf/_core/actions/application.py
@@ -20,7 +20,8 @@ all the modules, of which the reactor's core consists.
 """
 import asyncio
 import datetime
-from typing import Collection, Optional
+from collections.abc import Collection
+from typing import Optional
 
 from kopf._cogs.aiokits import aiotime
 from kopf._cogs.clients import patching

--- a/kopf/_core/actions/execution.py
+++ b/kopf/_core/actions/execution.py
@@ -14,9 +14,7 @@ import datetime
 import enum
 from collections.abc import AsyncIterator, Collection, Iterable, Mapping, MutableMapping, Sequence
 from contextvars import ContextVar
-from typing import Any, AsyncContextManager, Callable, NewType, Optional, TypeVar
-
-from typing_extensions import Protocol
+from typing import Any, AsyncContextManager, Callable, NewType, Optional, Protocol, TypeVar
 
 from kopf._cogs.configs import configuration
 from kopf._cogs.helpers import typedefs

--- a/kopf/_core/actions/execution.py
+++ b/kopf/_core/actions/execution.py
@@ -12,9 +12,9 @@ import contextlib
 import dataclasses
 import datetime
 import enum
+from collections.abc import AsyncIterator, Collection, Iterable, Mapping, MutableMapping, Sequence
 from contextvars import ContextVar
-from typing import Any, AsyncContextManager, AsyncIterator, Callable, Collection, Iterable, \
-                   Mapping, MutableMapping, NewType, Optional, Sequence, TypeVar
+from typing import Any, AsyncContextManager, Callable, NewType, Optional, TypeVar
 
 from typing_extensions import Protocol
 

--- a/kopf/_core/actions/execution.py
+++ b/kopf/_core/actions/execution.py
@@ -14,7 +14,7 @@ import datetime
 import enum
 from contextvars import ContextVar
 from typing import Any, AsyncContextManager, AsyncIterator, Callable, Collection, Iterable, \
-                   Mapping, MutableMapping, NewType, Optional, Sequence, Set, TypeVar
+                   Mapping, MutableMapping, NewType, Optional, Sequence, TypeVar
 
 from typing_extensions import Protocol
 
@@ -179,7 +179,7 @@ class LifeCycleFn(Protocol):
 # Used in `@kopf.subhandler` and `kopf.execute()` to add/get the sub-handlers.
 sublifecycle_var: ContextVar[Optional[LifeCycleFn]] = ContextVar('sublifecycle_var')
 subsettings_var: ContextVar[configuration.OperatorSettings] = ContextVar('subsettings_var')
-subrefs_var: ContextVar[Iterable[Set[ids.HandlerId]]] = ContextVar('subrefs_var')
+subrefs_var: ContextVar[Iterable[set[ids.HandlerId]]] = ContextVar('subrefs_var')
 handler_var: ContextVar[Handler] = ContextVar('handler_var')
 cause_var: ContextVar[Cause] = ContextVar('cause_var')
 
@@ -261,7 +261,7 @@ async def execute_handler_once(
     logger = cause.logger
 
     # Mutable accumulator for all the sub-handlers of any level deep; populated in `kopf.execute`.
-    subrefs: Set[ids.HandlerId] = set()
+    subrefs: set[ids.HandlerId] = set()
 
     # The exceptions are handled locally and are not re-raised, to keep the operator running.
     try:
@@ -342,7 +342,7 @@ async def invoke_handler(
         runtime: datetime.timedelta,
         settings: configuration.OperatorSettings,
         lifecycle: Optional[LifeCycleFn],
-        subrefs: Set[ids.HandlerId],
+        subrefs: set[ids.HandlerId],
         extra_context: ExtraContext,
 ) -> Optional[Result]:
     """

--- a/kopf/_core/actions/invocation.py
+++ b/kopf/_core/actions/invocation.py
@@ -9,7 +9,8 @@ import asyncio
 import contextlib
 import contextvars
 import functools
-from typing import Any, Callable, Coroutine, Iterable, Iterator, Mapping, Optional, TypeVar, Union
+from collections.abc import Coroutine, Iterable, Iterator, Mapping
+from typing import Any, Callable, Optional, TypeVar, Union
 
 from typing_extensions import final
 

--- a/kopf/_core/actions/invocation.py
+++ b/kopf/_core/actions/invocation.py
@@ -10,9 +10,7 @@ import contextlib
 import contextvars
 import functools
 from collections.abc import Coroutine, Iterable, Iterator, Mapping
-from typing import Any, Callable, Optional, TypeVar, Union
-
-from typing_extensions import final
+from typing import Any, Callable, Optional, TypeVar, Union, final
 
 from kopf._cogs.configs import configuration
 

--- a/kopf/_core/actions/invocation.py
+++ b/kopf/_core/actions/invocation.py
@@ -9,8 +9,7 @@ import asyncio
 import contextlib
 import contextvars
 import functools
-from typing import Any, Callable, Coroutine, Iterable, Iterator, \
-                   List, Mapping, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Coroutine, Iterable, Iterator, Mapping, Optional, TypeVar, Union
 
 from typing_extensions import final
 
@@ -72,12 +71,12 @@ class Kwargable:
 
 @contextlib.contextmanager
 def context(
-        values: Iterable[Tuple[contextvars.ContextVar[Any], Any]],
+        values: Iterable[tuple[contextvars.ContextVar[Any], Any]],
 ) -> Iterator[None]:
     """
     A context manager to set the context variables temporarily.
     """
-    tokens: List[Tuple[contextvars.ContextVar[Any], contextvars.Token[Any]]] = []
+    tokens: list[tuple[contextvars.ContextVar[Any], contextvars.Token[Any]]] = []
     try:
         for var, val in values:
             token = var.set(val)

--- a/kopf/_core/actions/invocation.py
+++ b/kopf/_core/actions/invocation.py
@@ -57,17 +57,17 @@ class Kwargable:
     @final
     @property
     def kwargs(self) -> Mapping[str, Any]:
-        return dict(self._kwargs, **self._super_kwargs)
+        return dict(self._kwargs) | dict(self._super_kwargs)
 
     @final
     @property
     def sync_kwargs(self) -> Mapping[str, Any]:
-        return dict(self._sync_kwargs, **self._super_kwargs)
+        return dict(self._sync_kwargs) | dict(self._super_kwargs)
 
     @final
     @property
     def async_kwargs(self) -> Mapping[str, Any]:
-        return dict(self._async_kwargs, **self._super_kwargs)
+        return dict(self._async_kwargs) | dict(self._super_kwargs)
 
 
 @contextlib.contextmanager
@@ -112,10 +112,10 @@ async def invoke(
     """
     kwargs = {} if kwargs is None else kwargs
     if is_async_fn(fn):
-        kwargs = kwargs if kwargsrc is None else dict(kwargs, **kwargsrc.async_kwargs)
+        kwargs = dict(kwargs) | ({} if kwargsrc is None else dict(kwargsrc.async_kwargs))
         result = await fn(**kwargs)  # type: ignore
     else:
-        kwargs = kwargs if kwargsrc is None else dict(kwargs, **kwargsrc.sync_kwargs)
+        kwargs = dict(kwargs) | ({} if kwargsrc is None else dict(kwargsrc.sync_kwargs))
 
         # Not that we want to use functools, but for executors kwargs, it is officially recommended:
         # https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor

--- a/kopf/_core/actions/lifecycles.py
+++ b/kopf/_core/actions/lifecycles.py
@@ -10,7 +10,8 @@ execute in the order they are registered, one by one.
 """
 import logging
 import random
-from typing import Any, Optional, Sequence
+from collections.abc import Sequence
+from typing import Any, Optional
 
 from kopf._core.actions import execution
 

--- a/kopf/_core/actions/loggers.py
+++ b/kopf/_core/actions/loggers.py
@@ -11,7 +11,8 @@ the operators' code, and can lead to information loss or mismatch
 import copy
 import enum
 import logging
-from typing import Any, MutableMapping, Optional
+from collections.abc import MutableMapping
+from typing import Any, Optional
 
 # Luckily, we do not mock these ones in tests, so we can import them into our namespace.
 try:

--- a/kopf/_core/actions/loggers.py
+++ b/kopf/_core/actions/loggers.py
@@ -59,7 +59,7 @@ class ObjectJsonFormatter(ObjectFormatter, _pjl_JsonFormatter):
         reserved_attrs = kwargs.pop('reserved_attrs', _pjl_RESERVED_ATTRS)
         reserved_attrs = set(reserved_attrs)
         reserved_attrs |= {'k8s_skip', 'k8s_ref', 'settings'}
-        kwargs.update(reserved_attrs=reserved_attrs)
+        kwargs |= dict(reserved_attrs=reserved_attrs)
         kwargs.setdefault('timestamp', True)
         super().__init__(*args, **kwargs)
         self._refkey: str = refkey or DEFAULT_JSON_REFKEY
@@ -141,7 +141,7 @@ class ObjectLogger(typedefs.LoggerAdapter):
     ) -> Tuple[str, MutableMapping[str, Any]]:
         # Native logging overwrites the message's extra with the adapter's extra.
         # We merge them, so that both message's & adapter's extras are available.
-        kwargs["extra"] = dict(self.extra or {}, **kwargs.get('extra', {}))
+        kwargs["extra"] = (self.extra or {}) | kwargs.get('extra', {})
         return msg, kwargs
 
 

--- a/kopf/_core/actions/loggers.py
+++ b/kopf/_core/actions/loggers.py
@@ -11,7 +11,7 @@ the operators' code, and can lead to information loss or mismatch
 import copy
 import enum
 import logging
-from typing import Any, Dict, MutableMapping, Optional, Tuple
+from typing import Any, MutableMapping, Optional
 
 # Luckily, we do not mock these ones in tests, so we can import them into our namespace.
 try:
@@ -66,9 +66,9 @@ class ObjectJsonFormatter(ObjectFormatter, _pjl_JsonFormatter):
 
     def add_fields(
             self,
-            log_record: Dict[str, object],
+            log_record: dict[str, object],
             record: logging.LogRecord,
-            message_dict: Dict[str, object],
+            message_dict: dict[str, object],
     ) -> None:
         super().add_fields(log_record, record, message_dict)
 
@@ -138,7 +138,7 @@ class ObjectLogger(typedefs.LoggerAdapter):
             self,
             msg: str,
             kwargs: MutableMapping[str, Any],
-    ) -> Tuple[str, MutableMapping[str, Any]]:
+    ) -> tuple[str, MutableMapping[str, Any]]:
         # Native logging overwrites the message's extra with the adapter's extra.
         # We merge them, so that both message's & adapter's extras are available.
         kwargs["extra"] = (self.extra or {}) | kwargs.get('extra', {})

--- a/kopf/_core/actions/progression.py
+++ b/kopf/_core/actions/progression.py
@@ -15,7 +15,8 @@ import collections.abc
 import copy
 import dataclasses
 import datetime
-from typing import Any, Collection, Iterable, Iterator, Mapping, NamedTuple, Optional, overload
+from collections.abc import Collection, Iterable, Iterator, Mapping
+from typing import Any, NamedTuple, Optional, overload
 
 import iso8601
 

--- a/kopf/_core/actions/progression.py
+++ b/kopf/_core/actions/progression.py
@@ -15,8 +15,7 @@ import collections.abc
 import copy
 import dataclasses
 import datetime
-from typing import Any, Collection, Dict, Iterable, Iterator, \
-                   Mapping, NamedTuple, Optional, overload
+from typing import Any, Collection, Iterable, Iterator, Mapping, NamedTuple, Optional, overload
 
 import iso8601
 
@@ -165,7 +164,7 @@ class State(execution.State):
             handlers: Iterable[execution.Handler],
     ) -> "State":
         handler_ids = {handler.id for handler in handlers}
-        handler_states: Dict[ids.HandlerId, HandlerState] = {}
+        handler_states: dict[ids.HandlerId, HandlerState] = {}
         for handler_id in handler_ids:
             content = storage.fetch(key=handler_id, body=body)
             if content is not None:
@@ -177,7 +176,7 @@ class State(execution.State):
             purpose: Optional[str],
             handlers: Iterable[execution.Handler] = (),  # to be re-purposed
     ) -> "State":
-        handler_states: Dict[ids.HandlerId, HandlerState] = dict(self)
+        handler_states: dict[ids.HandlerId, HandlerState] = dict(self)
         for handler in handlers:
             handler_states[handler.id] = handler_states[handler.id].with_purpose(purpose)
         cls = type(self)
@@ -187,7 +186,7 @@ class State(execution.State):
             self,
             handlers: Iterable[execution.Handler],
     ) -> "State":
-        handler_states: Dict[ids.HandlerId, HandlerState] = dict(self)
+        handler_states: dict[ids.HandlerId, HandlerState] = dict(self)
         for handler in handlers:
             if handler.id not in handler_states:
                 handler_states[handler.id] = HandlerState.from_scratch(purpose=self.purpose)

--- a/kopf/_core/actions/throttlers.py
+++ b/kopf/_core/actions/throttlers.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import dataclasses
 import time
-from typing import AsyncGenerator, Iterable, Iterator, Optional, Tuple, Type, Union
+from typing import AsyncGenerator, Iterable, Iterator, Optional, Union
 
 from kopf._cogs.aiokits import aiotime
 from kopf._cogs.helpers import typedefs
@@ -23,7 +23,7 @@ async def throttled(
         delays: Iterable[float],
         wakeup: Optional[asyncio.Event] = None,
         logger: typedefs.Logger,
-        errors: Union[Type[BaseException], Tuple[Type[BaseException], ...]] = Exception,
+        errors: Union[type[BaseException], tuple[type[BaseException], ...]] = Exception,
 ) -> AsyncGenerator[bool, None]:
     """
     A helper to throttle any arbitrary operation.

--- a/kopf/_core/actions/throttlers.py
+++ b/kopf/_core/actions/throttlers.py
@@ -2,7 +2,8 @@ import asyncio
 import contextlib
 import dataclasses
 import time
-from typing import AsyncGenerator, Iterable, Iterator, Optional, Union
+from collections.abc import AsyncGenerator, Iterable, Iterator
+from typing import Optional, Union
 
 from kopf._cogs.aiokits import aiotime
 from kopf._cogs.helpers import typedefs

--- a/kopf/_core/engines/activities.py
+++ b/kopf/_core/engines/activities.py
@@ -17,7 +17,8 @@ The process is intentionally split into multiple packages:
   belong to neither the reactor, nor the engines, nor the client wrappers.
 """
 import logging
-from typing import Mapping, MutableMapping, NoReturn
+from collections.abc import Mapping, MutableMapping
+from typing import NoReturn
 
 from kopf._cogs.aiokits import aiotime
 from kopf._cogs.configs import configuration

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -6,7 +6,8 @@ import json
 import logging
 import re
 import urllib.parse
-from typing import Any, AsyncContextManager, Collection, Iterable, Mapping, Optional
+from collections.abc import Collection, Iterable, Mapping
+from typing import Any, AsyncContextManager, Optional
 
 from typing_extensions import Literal, TypedDict
 

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -7,9 +7,7 @@ import logging
 import re
 import urllib.parse
 from collections.abc import Collection, Iterable, Mapping
-from typing import Any, AsyncContextManager, Optional
-
-from typing_extensions import Literal, TypedDict
+from typing import Any, AsyncContextManager, Literal, Optional, TypedDict
 
 from kopf._cogs.aiokits import aiovalues
 from kopf._cogs.clients import creating, errors, patching

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -6,7 +6,7 @@ import json
 import logging
 import re
 import urllib.parse
-from typing import Any, AsyncContextManager, Collection, Dict, Iterable, List, Mapping, Optional
+from typing import Any, AsyncContextManager, Collection, Iterable, Mapping, Optional
 
 from typing_extensions import Literal, TypedDict
 
@@ -130,7 +130,7 @@ async def serve_admission_request(
     new = bodies.Body(new_body) if new_body is not None else None
     diff = diffs.diff(old, new)
     patch = patches.Patch(body=raw_body)
-    warnings: List[str] = []
+    warnings: list[str] = []
     cause = causes.WebhookCause(
         resource=resource,
         indices=indices,
@@ -402,7 +402,7 @@ def build_webhooks(
         name_suffix: str,
         client_config: reviews.WebhookClientConfig,
         persistent_only: bool = False,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Construct the content for ``[Validating|Mutating]WebhookConfiguration``.
 

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -25,8 +25,7 @@ import asyncio
 import dataclasses
 import time
 import warnings
-from typing import Collection, Dict, Iterable, List, Mapping, \
-                   MutableMapping, Optional, Sequence, Set
+from typing import Collection, Iterable, Mapping, MutableMapping, Optional, Sequence
 
 from kopf._cogs.aiokits import aiotasks, aiotime, aiotoggles
 from kopf._cogs.configs import configuration
@@ -49,8 +48,8 @@ class DaemonsMemory:
     # For background and timed threads/tasks (invoked with the kwargs of the last-seen body).
     live_fresh_body: Optional[bodies.Body] = None
     idle_reset_time: float = dataclasses.field(default_factory=time.monotonic)
-    forever_stopped: Set[ids.HandlerId] = dataclasses.field(default_factory=set)
-    running_daemons: Dict[ids.HandlerId, Daemon] = dataclasses.field(default_factory=dict)
+    forever_stopped: set[ids.HandlerId] = dataclasses.field(default_factory=set)
+    running_daemons: dict[ids.HandlerId, Daemon] = dataclasses.field(default_factory=dict)
 
 
 class DaemonsMemoriesIterator(metaclass=abc.ABCMeta):
@@ -182,7 +181,7 @@ async def stop_daemons(
     Hence, these duplicating methods of termination for different cases
     (as by their surrounding circumstances: deletion handlers and finalizers).
     """
-    delays: List[float] = []
+    delays: list[float] = []
     now = time.monotonic()
     for daemon in list(daemons.values()):
         logger = daemon.logger

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -25,7 +25,8 @@ import asyncio
 import dataclasses
 import time
 import warnings
-from typing import Collection, Iterable, Mapping, MutableMapping, Optional, Sequence
+from collections.abc import Collection, Iterable, Mapping, MutableMapping, Sequence
+from typing import Optional
 
 from kopf._cogs.aiokits import aiotasks, aiotime, aiotoggles
 from kopf._cogs.configs import configuration

--- a/kopf/_core/engines/indexing.py
+++ b/kopf/_core/engines/indexing.py
@@ -1,6 +1,6 @@
 import collections.abc
 import dataclasses
-from typing import Any, Dict, Generic, Iterable, Iterator, Mapping, Optional, Set, Tuple, TypeVar
+from typing import Any, Generic, Iterable, Iterator, Mapping, Optional, TypeVar
 
 from kopf._cogs.configs import configuration
 from kopf._cogs.helpers import typedefs
@@ -8,7 +8,7 @@ from kopf._cogs.structs import bodies, ephemera, ids, patches, references
 from kopf._core.actions import execution, lifecycles, progression
 from kopf._core.intents import causes, handlers, registries
 
-Key = Tuple[references.Namespace, Optional[str], Optional[str]]
+Key = tuple[references.Namespace, Optional[str], Optional[str]]
 _K = TypeVar('_K')
 _V = TypeVar('_V')
 
@@ -24,7 +24,7 @@ class Store(ephemera.Store[_V], Generic[_V]):
 
     The store is O(1) for updates/deletions due to ``dict`` used internally.
     """
-    __items: Dict[Key, _V]
+    __items: dict[Key, _V]
 
     def __init__(self) -> None:
         super().__init__()
@@ -75,8 +75,8 @@ class Index(ephemera.Index[_K, _V], Generic[_K, _V]):
     "K" is the number of all keys, "k" is the number of keys per object.
     Assuming the amount of keys per object is usually fixed, it is O(1).
     """
-    __items: Dict[_K, Store[_V]]
-    __reverse: Dict[Key, Set[_K]]
+    __items: dict[_K, Store[_V]]
+    __reverse: dict[Key, set[_K]]
 
     def __init__(self) -> None:
         super().__init__()
@@ -169,7 +169,7 @@ class OperatorIndexer:
         self.index._replace(key, obj)
 
 
-class OperatorIndexers(Dict[ids.HandlerId, OperatorIndexer]):
+class OperatorIndexers(dict[ids.HandlerId, OperatorIndexer]):
 
     def __init__(self) -> None:
         super().__init__()

--- a/kopf/_core/engines/indexing.py
+++ b/kopf/_core/engines/indexing.py
@@ -1,6 +1,7 @@
 import collections.abc
 import dataclasses
-from typing import Any, Generic, Iterable, Iterator, Mapping, Optional, TypeVar
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Any, Generic, Optional, TypeVar
 
 from kopf._cogs.configs import configuration
 from kopf._cogs.helpers import typedefs

--- a/kopf/_core/engines/peering.py
+++ b/kopf/_core/engines/peering.py
@@ -35,7 +35,8 @@ import getpass
 import logging
 import os
 import random
-from typing import Any, Iterable, Mapping, NewType, NoReturn, Optional, cast
+from collections.abc import Iterable, Mapping
+from typing import Any, NewType, NoReturn, Optional, cast
 
 import iso8601
 

--- a/kopf/_core/engines/peering.py
+++ b/kopf/_core/engines/peering.py
@@ -216,7 +216,7 @@ async def touch(
     )
 
     patch = patches.Patch()
-    patch.update({'status': {identity: None if peer.is_dead else peer.as_dict()}})
+    patch |= {'status': {identity: None if peer.is_dead else peer.as_dict()}}
     rsp = await patching.patch_obj(
         settings=settings,
         resource=resource,
@@ -241,7 +241,7 @@ async def clean(
 ) -> None:
     name = settings.peering.name
     patch = patches.Patch()
-    patch.update({'status': {peer.identity: None for peer in peers}})
+    patch |= {'status': {peer.identity: None for peer in peers}}
     await patching.patch_obj(
         settings=settings,
         resource=resource,

--- a/kopf/_core/engines/peering.py
+++ b/kopf/_core/engines/peering.py
@@ -35,7 +35,7 @@ import getpass
 import logging
 import os
 import random
-from typing import Any, Dict, Iterable, Mapping, NewType, NoReturn, Optional, cast
+from typing import Any, Iterable, Mapping, NewType, NoReturn, Optional, cast
 
 import iso8601
 
@@ -77,7 +77,7 @@ class Peer:
         options = ", ".join(f"{key!s}={val!r}" for key, val in self.as_dict().items())
         return f"<{clsname} {self.identity}: {options}>"
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         # Only the non-calculated and non-identifying fields.
         return {
             'priority': int(self.priority),

--- a/kopf/_core/engines/posting.py
+++ b/kopf/_core/engines/posting.py
@@ -17,8 +17,9 @@ This also includes all logging messages posted by the framework itself.
 import asyncio
 import logging
 import sys
+from collections.abc import Iterable, Iterator
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Iterable, Iterator, NamedTuple, NoReturn, Optional, Union, cast
+from typing import TYPE_CHECKING, NamedTuple, NoReturn, Optional, Union, cast
 
 from kopf._cogs.clients import events
 from kopf._cogs.configs import configuration

--- a/kopf/_core/engines/probing.py
+++ b/kopf/_core/engines/probing.py
@@ -2,7 +2,8 @@ import asyncio
 import datetime
 import logging
 import urllib.parse
-from typing import MutableMapping, Optional
+from collections.abc import MutableMapping
+from typing import Optional
 
 import aiohttp.web
 

--- a/kopf/_core/engines/probing.py
+++ b/kopf/_core/engines/probing.py
@@ -17,8 +17,6 @@ logger = logging.getLogger(__name__)
 LOCALHOST: str = 'localhost'
 HTTP_PORT: int = 80
 
-_Key = Tuple[str, int]  # hostname, port
-
 
 async def health_reporter(
         endpoint: str,

--- a/kopf/_core/engines/probing.py
+++ b/kopf/_core/engines/probing.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime
 import logging
 import urllib.parse
-from typing import MutableMapping, Optional, Tuple
+from typing import MutableMapping, Optional
 
 import aiohttp.web
 

--- a/kopf/_core/intents/callbacks.py
+++ b/kopf/_core/intents/callbacks.py
@@ -9,7 +9,8 @@ a corresponding type or class ``kopf.Whatever`` with all the typing tricks
 (``Union[...]``, ``Optional[...]``, partial ``Any`` values, etc) included.
 """
 import datetime
-from typing import TYPE_CHECKING, Any, Callable, Collection, Optional, TypeVar, Union
+from collections.abc import Collection
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
 
 from kopf._cogs.configs import configuration
 from kopf._cogs.helpers import typedefs

--- a/kopf/_core/intents/callbacks.py
+++ b/kopf/_core/intents/callbacks.py
@@ -9,7 +9,7 @@ a corresponding type or class ``kopf.Whatever`` with all the typing tricks
 (``Union[...]``, ``Optional[...]``, partial ``Any`` values, etc) included.
 """
 import datetime
-from typing import TYPE_CHECKING, Any, Callable, Collection, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Collection, Optional, TypeVar, Union
 
 from kopf._cogs.configs import configuration
 from kopf._cogs.helpers import typedefs
@@ -124,7 +124,7 @@ else:
     WebhookFn = Callable[
         [
             NamedArg(bool, "dryrun"),
-            NamedArg(List[str], "warnings"),  # mutable!
+            NamedArg(list[str], "warnings"),  # mutable!
             NamedArg(Optional[str], "subresource"),
             NamedArg(reviews.UserInfo, "userinfo"),
             NamedArg(reviews.SSLPeer, "sslpeer"),

--- a/kopf/_core/intents/causes.py
+++ b/kopf/_core/intents/causes.py
@@ -21,7 +21,7 @@ could execute on the yet-existing object (and its children, if created).
 """
 import dataclasses
 import enum
-from typing import Any, List, Mapping, Optional
+from typing import Any, Mapping, Optional
 
 from kopf._cogs.configs import configuration
 from kopf._cogs.structs import bodies, diffs, ephemera, finalizers, \
@@ -150,7 +150,7 @@ class WebhookCause(ResourceCause):
     headers: Mapping[str, str]
     sslpeer: Mapping[str, Any]
     userinfo: reviews.UserInfo
-    warnings: List[str]  # mutable!
+    warnings: list[str]  # mutable!
     operation: Optional[reviews.Operation]  # None if not provided for some reason
     subresource: Optional[str]  # e.g. "status", "scale"; None for the main resource body
     old: Optional[bodies.Body] = None

--- a/kopf/_core/intents/causes.py
+++ b/kopf/_core/intents/causes.py
@@ -305,9 +305,9 @@ def detect_changing_cause(
     """
 
     # Put them back to the pass-through kwargs (to avoid code duplication).
-    kwargs.update(body=body, old=old, new=new, initial=initial)
+    kwargs |= dict(body=body, old=old, new=new, initial=initial)
     if diff is not None:
-        kwargs.update(diff=diff)
+        kwargs |= dict(diff=diff)
 
     # The object was really deleted from the cluster. But we do not care anymore.
     if raw_event['type'] == 'DELETED':

--- a/kopf/_core/intents/causes.py
+++ b/kopf/_core/intents/causes.py
@@ -21,7 +21,8 @@ could execute on the yet-existing object (and its children, if created).
 """
 import dataclasses
 import enum
-from typing import Any, Mapping, Optional
+from collections.abc import Mapping
+from typing import Any, Optional
 
 from kopf._cogs.configs import configuration
 from kopf._cogs.structs import bodies, diffs, ephemera, finalizers, \

--- a/kopf/_core/intents/filters.py
+++ b/kopf/_core/intents/filters.py
@@ -1,5 +1,6 @@
 import enum
-from typing import Any, Mapping, Union
+from collections.abc import Mapping
+from typing import Any, Union
 
 from kopf._core.intents import callbacks
 

--- a/kopf/_core/intents/handlers.py
+++ b/kopf/_core/intents/handlers.py
@@ -1,6 +1,7 @@
 import dataclasses
 import warnings
-from typing import Collection, Optional, cast
+from collections.abc import Collection
+from typing import Optional, cast
 
 from kopf._cogs.structs import dicts, diffs, references
 from kopf._core.actions import execution

--- a/kopf/_core/intents/piggybacking.py
+++ b/kopf/_core/intents/piggybacking.py
@@ -11,7 +11,7 @@ in them, and extracts the basic credentials for its own use.
     :mod:`credentials` and :func:`authentication`.
 """
 import os
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Optional, Sequence
 
 import yaml
 
@@ -221,9 +221,9 @@ def login_with_kubeconfig(**_: Any) -> Optional[credentials.ConnectionInfo]:
 
     # As prescribed: if the file is absent or non-deserialisable, then fail. The first value wins.
     current_context: Optional[str] = None
-    contexts: Dict[Any, Any] = {}
-    clusters: Dict[Any, Any] = {}
-    users: Dict[Any, Any] = {}
+    contexts: dict[Any, Any] = {}
+    clusters: dict[Any, Any] = {}
+    users: dict[Any, Any] = {}
     for path in paths:
 
         with open(path, encoding='utf-8') as f:

--- a/kopf/_core/intents/piggybacking.py
+++ b/kopf/_core/intents/piggybacking.py
@@ -11,7 +11,8 @@ in them, and extracts the basic credentials for its own use.
     :mod:`credentials` and :func:`authentication`.
 """
 import os
-from typing import Any, Optional, Sequence
+from collections.abc import Sequence
+from typing import Any, Optional
 
 import yaml
 

--- a/kopf/_core/intents/registries.py
+++ b/kopf/_core/intents/registries.py
@@ -14,9 +14,10 @@ of the handlers to be executed on each reaction cycle.
 import abc
 import enum
 import functools
+from collections.abc import Collection, Container, Iterable, Iterator, \
+                            Mapping, MutableMapping, Sequence
 from types import FunctionType, MethodType
-from typing import Any, Callable, Collection, Container, Generic, Iterable, Iterator, \
-                   Mapping, MutableMapping, Optional, Sequence, TypeVar, cast
+from typing import Any, Callable, Generic, Optional, TypeVar, cast
 
 from kopf._cogs.structs import dicts, ids, references
 from kopf._core.actions import execution

--- a/kopf/_core/intents/registries.py
+++ b/kopf/_core/intents/registries.py
@@ -15,8 +15,8 @@ import abc
 import enum
 import functools
 from types import FunctionType, MethodType
-from typing import Any, Callable, Collection, Container, FrozenSet, Generic, Iterable, Iterator, \
-                   List, Mapping, MutableMapping, Optional, Sequence, Set, Tuple, TypeVar, cast
+from typing import Any, Callable, Collection, Container, Generic, Iterable, Iterator, \
+                   Mapping, MutableMapping, Optional, Sequence, TypeVar, cast
 
 from kopf._cogs.structs import dicts, ids, references
 from kopf._core.actions import execution
@@ -30,7 +30,7 @@ ResourceHandlerT = TypeVar('ResourceHandlerT', bound=handlers.ResourceHandler)
 
 class GenericRegistry(Generic[HandlerT]):
     """ A generic base class of a simple registry (with no handler getters). """
-    _handlers: List[HandlerT]
+    _handlers: list[HandlerT]
 
     def __init__(self) -> None:
         super().__init__()
@@ -72,7 +72,7 @@ class ActivityRegistry(GenericRegistry[handlers.ActivityHandler]):
 
 class ResourceRegistry(GenericRegistry[ResourceHandlerT], Generic[ResourceHandlerT, CauseT]):
 
-    def get_all_selectors(self) -> FrozenSet[references.Selector]:
+    def get_all_selectors(self) -> frozenset[references.Selector]:
         return frozenset(
             handler.selector
             for handler in self.get_all_handlers()
@@ -106,7 +106,7 @@ class ResourceRegistry(GenericRegistry[ResourceHandlerT], Generic[ResourceHandle
     def get_extra_fields(
             self,
             resource: references.Resource,
-    ) -> Set[dicts.FieldPath]:
+    ) -> set[dicts.FieldPath]:
         return set(self.iter_extra_fields(resource=resource))
 
     def iter_extra_fields(
@@ -218,7 +218,7 @@ class ChangingRegistry(ResourceRegistry[handlers.ChangingHandler, causes.Changin
             self,
             resource: references.Resource,
     ) -> Sequence[handlers.ChangingHandler]:
-        found_handlers: List[handlers.ChangingHandler] = []
+        found_handlers: list[handlers.ChangingHandler] = []
         for handler in self._handlers:
             if _matches_resource(handler, resource):
                 found_handlers.append(handler)
@@ -366,7 +366,7 @@ def _deduplicated(
     handled) **AND** it is detected as per-existing before operator start.
     But `fn()` should be called only once for this cause.
     """
-    seen_ids: Set[Tuple[int, ids.HandlerId]] = set()
+    seen_ids: set[tuple[int, ids.HandlerId]] = set()
     for handler in src:
         key = (id(handler.fn), handler.id)
         if key in seen_ids:

--- a/kopf/_core/reactor/inventory.py
+++ b/kopf/_core/reactor/inventory.py
@@ -19,7 +19,8 @@ must be kept together with their owning modules rather than mirrored in structs.
 """
 import copy
 import dataclasses
-from typing import Iterator, MutableMapping, Optional
+from collections.abc import Iterator, MutableMapping
+from typing import Optional
 
 from kopf._cogs.structs import bodies, ephemera
 from kopf._core.actions import throttlers

--- a/kopf/_core/reactor/observation.py
+++ b/kopf/_core/reactor/observation.py
@@ -23,7 +23,7 @@ to declare this restricted mode as the desired mode of operation.
 import asyncio
 import functools
 import logging
-from typing import Collection, FrozenSet, Iterable, List, Optional, Set
+from typing import Collection, Iterable, Optional
 
 from kopf._cogs.aiokits import aiotoggles
 from kopf._cogs.clients import errors, fetching, scanning
@@ -98,7 +98,7 @@ async def resource_observer(
 ) -> None:
 
     # Scan only the resource-related handlers, ignore activies & co.
-    all_handlers: List[handlers.ResourceHandler] = []
+    all_handlers: list[handlers.ResourceHandler] = []
     all_handlers.extend(registry._webhooks.get_all_handlers())
     all_handlers.extend(registry._indexing.get_all_handlers())
     all_handlers.extend(registry._watching.get_all_handlers())
@@ -241,7 +241,7 @@ def revise_resources(
 
 
 def _update_resources(
-        resources: Set[references.Resource],
+        resources: set[references.Resource],
         selectors: Iterable[references.Selector],
         *,
         group: Optional[str],
@@ -269,7 +269,7 @@ def _update_resources(
 
 def _disable_ambiguous_selectors(
         *,
-        resources: Set[references.Resource],
+        resources: set[references.Resource],
         selectors: Iterable[references.Selector],
 ) -> None:
     """
@@ -290,8 +290,8 @@ def _disable_ambiguous_selectors(
 
 def _disable_mismatched_selectors(
         *,
-        resources: Set[references.Resource],
-        selectors: FrozenSet[references.Selector],
+        resources: set[references.Resource],
+        selectors: frozenset[references.Selector],
 ) -> None:
     """
     Warn for handlers that specify nonexistent resources.
@@ -310,8 +310,8 @@ def _disable_mismatched_selectors(
 
 def _disable_unsuitable_resources(
         *,
-        resources: Set[references.Resource],
-        selectors: FrozenSet[references.Selector],
+        resources: set[references.Resource],
+        selectors: frozenset[references.Selector],
 ) -> None:
 
     # For both watching & patching, only look at watched resources, ignore webhook-only resources.

--- a/kopf/_core/reactor/observation.py
+++ b/kopf/_core/reactor/observation.py
@@ -23,7 +23,8 @@ to declare this restricted mode as the desired mode of operation.
 import asyncio
 import functools
 import logging
-from typing import Collection, Iterable, Optional
+from collections.abc import Collection, Iterable
+from typing import Optional
 
 from kopf._cogs.aiokits import aiotoggles
 from kopf._cogs.clients import errors, fetching, scanning

--- a/kopf/_core/reactor/orchestration.py
+++ b/kopf/_core/reactor/orchestration.py
@@ -27,8 +27,8 @@ import dataclasses
 import functools
 import itertools
 import logging
-from typing import Any, Collection, Container, Iterable, \
-                   MutableMapping, NamedTuple, Optional, Protocol
+from collections.abc import Collection, Container, Iterable, MutableMapping
+from typing import Any, NamedTuple, Optional, Protocol
 
 from kopf._cogs.aiokits import aiotasks, aiotoggles
 from kopf._cogs.configs import configuration

--- a/kopf/_core/reactor/orchestration.py
+++ b/kopf/_core/reactor/orchestration.py
@@ -27,7 +27,7 @@ import dataclasses
 import functools
 import itertools
 import logging
-from typing import Any, Collection, Container, Dict, Iterable, \
+from typing import Any, Collection, Container, Iterable, \
                    MutableMapping, NamedTuple, Optional, Protocol
 
 from kopf._cogs.aiokits import aiotasks, aiotoggles
@@ -68,12 +68,12 @@ class Ensemble:
     # Multidimentional pausing: for every namespace, and a few for the whole cluster (for CRDs).
     operator_paused: aiotoggles.ToggleSet
     peering_missing: aiotoggles.Toggle
-    conflicts_found: Dict[EnsembleKey, aiotoggles.Toggle] = dataclasses.field(default_factory=dict)
+    conflicts_found: dict[EnsembleKey, aiotoggles.Toggle] = dataclasses.field(default_factory=dict)
 
     # Multidimensional tasks -- one for every combination of relevant dimensions.
-    watcher_tasks: Dict[EnsembleKey, aiotasks.Task] = dataclasses.field(default_factory=dict)
-    peering_tasks: Dict[EnsembleKey, aiotasks.Task] = dataclasses.field(default_factory=dict)
-    pinging_tasks: Dict[EnsembleKey, aiotasks.Task] = dataclasses.field(default_factory=dict)
+    watcher_tasks: dict[EnsembleKey, aiotasks.Task] = dataclasses.field(default_factory=dict)
+    peering_tasks: dict[EnsembleKey, aiotasks.Task] = dataclasses.field(default_factory=dict)
+    pinging_tasks: dict[EnsembleKey, aiotasks.Task] = dataclasses.field(default_factory=dict)
 
     def get_keys(self) -> Collection[EnsembleKey]:
         return (frozenset(self.watcher_tasks) |

--- a/kopf/_core/reactor/processing.py
+++ b/kopf/_core/reactor/processing.py
@@ -15,7 +15,7 @@ and therefore do not trigger the user-defined handlers.
 """
 import asyncio
 import time
-from typing import Collection, Optional, Tuple
+from typing import Collection, Optional
 
 from kopf._cogs.aiokits import aiotoggles
 from kopf._cogs.configs import configuration
@@ -152,7 +152,7 @@ async def process_resource_causes(
         memory: inventory.ResourceMemory,
         local_logger: loggers.ObjectLogger,
         event_logger: loggers.ObjectLogger,
-) -> Tuple[Collection[float], bool]:
+) -> tuple[Collection[float], bool]:
 
     finalizer = settings.persistence.finalizer
     extra_fields = (

--- a/kopf/_core/reactor/processing.py
+++ b/kopf/_core/reactor/processing.py
@@ -15,7 +15,8 @@ and therefore do not trigger the user-defined handlers.
 """
 import asyncio
 import time
-from typing import Collection, Optional
+from collections.abc import Collection
+from typing import Optional
 
 from kopf._cogs.aiokits import aiotoggles
 from kopf._cogs.configs import configuration

--- a/kopf/_core/reactor/queueing.py
+++ b/kopf/_core/reactor/queueing.py
@@ -27,9 +27,7 @@ import contextlib
 import enum
 import logging
 from collections.abc import MutableMapping
-from typing import TYPE_CHECKING, NamedTuple, NewType, Optional, Union
-
-from typing_extensions import Protocol
+from typing import TYPE_CHECKING, NamedTuple, NewType, Optional, Protocol, Union
 
 from kopf._cogs.aiokits import aiotasks, aiotoggles
 from kopf._cogs.clients import watching

--- a/kopf/_core/reactor/queueing.py
+++ b/kopf/_core/reactor/queueing.py
@@ -26,7 +26,7 @@ import asyncio
 import contextlib
 import enum
 import logging
-from typing import TYPE_CHECKING, MutableMapping, NamedTuple, NewType, Optional, Tuple, Union
+from typing import TYPE_CHECKING, MutableMapping, NamedTuple, NewType, Optional, Union
 
 from typing_extensions import Protocol
 
@@ -68,7 +68,7 @@ class Stream(NamedTuple):
 
 
 ObjectUid = NewType('ObjectUid', str)
-ObjectRef = Tuple[references.Resource, ObjectUid]
+ObjectRef = tuple[references.Resource, ObjectUid]
 Streams = MutableMapping[ObjectRef, Stream]
 
 

--- a/kopf/_core/reactor/queueing.py
+++ b/kopf/_core/reactor/queueing.py
@@ -26,7 +26,8 @@ import asyncio
 import contextlib
 import enum
 import logging
-from typing import TYPE_CHECKING, MutableMapping, NamedTuple, NewType, Optional, Union
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING, NamedTuple, NewType, Optional, Union
 
 from typing_extensions import Protocol
 

--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -4,7 +4,8 @@ import logging
 import signal
 import threading
 import warnings
-from typing import Collection, Coroutine, MutableSequence, Optional, Sequence
+from collections.abc import Collection, Coroutine, MutableSequence, Sequence
+from typing import Optional
 
 from kopf._cogs.aiokits import aioadapters, aiobindings, aiotasks, aiotoggles, aiovalues
 from kopf._cogs.clients import auth

--- a/kopf/_core/reactor/subhandling.py
+++ b/kopf/_core/reactor/subhandling.py
@@ -1,7 +1,7 @@
 import collections.abc
 import contextlib
 from contextvars import ContextVar
-from typing import AsyncIterator, Iterable, Optional, Set
+from typing import AsyncIterator, Iterable, Optional
 
 from kopf._cogs.configs import configuration
 from kopf._cogs.structs import ids
@@ -139,7 +139,7 @@ async def execute(
 
     # Enrich all parents with references to sub-handlers of any level deep (sub-sub-handlers, etc).
     # There is at least one container, as this function can be called only from a handler.
-    subrefs_containers: Iterable[Set[ids.HandlerId]] = execution.subrefs_var.get()
+    subrefs_containers: Iterable[set[ids.HandlerId]] = execution.subrefs_var.get()
     for key in state:
         for subrefs_container in subrefs_containers:
             subrefs_container.add(key)

--- a/kopf/_core/reactor/subhandling.py
+++ b/kopf/_core/reactor/subhandling.py
@@ -1,7 +1,8 @@
 import collections.abc
 import contextlib
+from collections.abc import AsyncIterator, Iterable
 from contextvars import ContextVar
-from typing import AsyncIterator, Iterable, Optional
+from typing import Optional
 
 from kopf._cogs.configs import configuration
 from kopf._cogs.structs import ids

--- a/kopf/_kits/hierarchies.py
+++ b/kopf/_kits/hierarchies.py
@@ -4,7 +4,8 @@ All the functions to properly build the object hierarchies.
 import collections.abc
 import enum
 import warnings
-from typing import Any, Iterable, Iterator, Mapping, MutableMapping, Optional, Union, cast
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping
+from typing import Any, Optional, Union, cast
 
 from kopf._cogs.helpers import thirdparty
 from kopf._cogs.structs import bodies, dicts

--- a/kopf/_kits/loops.py
+++ b/kopf/_kits/loops.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
-from typing import Generator, Optional
+from collections.abc import Generator
+from typing import Optional
 
 
 @contextlib.contextmanager

--- a/kopf/_kits/runner.py
+++ b/kopf/_kits/runner.py
@@ -3,7 +3,7 @@ import concurrent.futures
 import contextlib
 import threading
 import types
-from typing import TYPE_CHECKING, Any, Optional, Tuple, Type, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import click.testing
 from typing_extensions import Literal
@@ -13,7 +13,7 @@ from kopf._cogs.configs import configuration
 from kopf._core.intents import registries
 
 _ExcType = BaseException
-_ExcInfo = Tuple[Type[_ExcType], _ExcType, types.TracebackType]
+_ExcInfo = tuple[type[_ExcType], _ExcType, types.TracebackType]
 
 if TYPE_CHECKING:
     ResultFuture = concurrent.futures.Future[click.testing.Result]
@@ -85,7 +85,7 @@ class KopfRunner(_AbstractKopfRunner):
 
     def __exit__(
             self,
-            exc_type: Optional[Type[BaseException]],
+            exc_type: Optional[type[BaseException]],
             exc_val: Optional[BaseException],
             exc_tb: Optional[types.TracebackType],
     ) -> Literal[False]:

--- a/kopf/_kits/runner.py
+++ b/kopf/_kits/runner.py
@@ -3,10 +3,9 @@ import concurrent.futures
 import contextlib
 import threading
 import types
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 import click.testing
-from typing_extensions import Literal
 
 from kopf import cli
 from kopf._cogs.configs import configuration

--- a/kopf/_kits/webhacks.py
+++ b/kopf/_kits/webhacks.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, AsyncGenerator, AsyncIterator, Callable, Dict, List, Tuple, TypeVar, cast
+from typing import Any, AsyncGenerator, AsyncIterator, Callable, TypeVar, cast
 
 from kopf._cogs.structs import reviews
 
@@ -17,8 +17,8 @@ class WebhookContextManagerMeta(type):
     def __new__(
             cls,
             name: str,
-            bases: Tuple[type, ...],
-            namespace: Dict[str, Any],
+            bases: tuple[type, ...],
+            namespace: dict[str, Any],
             **kwargs: Any,
     ) -> "WebhookContextManagerMeta":
         if '__call__' in namespace:
@@ -60,7 +60,7 @@ class WebhookContextManager(metaclass=WebhookContextManagerMeta):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.__generators: List[AsyncGenerator[reviews.WebhookClientConfig, None]] = []
+        self.__generators: list[AsyncGenerator[reviews.WebhookClientConfig, None]] = []
 
     async def __aenter__(self: _SelfT) -> _SelfT:
         return self

--- a/kopf/_kits/webhacks.py
+++ b/kopf/_kits/webhacks.py
@@ -1,5 +1,6 @@
 import functools
-from typing import Any, AsyncGenerator, AsyncIterator, Callable, TypeVar, cast
+from collections.abc import AsyncGenerator, AsyncIterator
+from typing import Any, Callable, TypeVar, cast
 
 from kopf._cogs.structs import reviews
 

--- a/kopf/_kits/webhooks.py
+++ b/kopf/_kits/webhooks.py
@@ -14,7 +14,7 @@ import socket
 import ssl
 import tempfile
 import urllib.parse
-from typing import TYPE_CHECKING, AsyncIterator, Collection, Dict, Iterable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, AsyncIterator, Collection, Iterable, Optional, Union
 
 import aiohttp.web
 
@@ -270,7 +270,7 @@ class WebhookServer(webhacks.WebhookContextManager):
         netloc = host if is_default_port else f'{host}:{port}'
         return urllib.parse.urlunsplit([schema, netloc, path, '', ''])
 
-    def _build_ssl(self) -> Tuple[Optional[bytes], Optional[ssl.SSLContext]]:
+    def _build_ssl(self) -> tuple[Optional[bytes], Optional[ssl.SSLContext]]:
         """
         A macros to construct an SSL context, possibly generating SSL certs.
 
@@ -345,7 +345,7 @@ class WebhookServer(webhacks.WebhookContextManager):
     def build_certificate(
             hostnames: Collection[str],
             password: Optional[str] = None,
-    ) -> Tuple[bytes, bytes]:
+    ) -> tuple[bytes, bytes]:
         """
         Build a self-signed certificate with SANs (subject alternative names).
 
@@ -379,7 +379,7 @@ class WebhookServer(webhacks.WebhookContextManager):
 
         # Detect which ones of the hostnames are probably IPv4/IPv6 addresses.
         # A side-effect: bring them all to their canonical forms.
-        parsed_ips: Dict[str, Union[ipaddress.IPv4Address, ipaddress.IPv6Address]] = {}
+        parsed_ips: dict[str, Union[ipaddress.IPv4Address, ipaddress.IPv6Address]] = {}
         for hostname in hostnames:
             try:
                 parsed_ips[hostname] = ipaddress.IPv4Address(hostname)

--- a/kopf/_kits/webhooks.py
+++ b/kopf/_kits/webhooks.py
@@ -14,7 +14,8 @@ import socket
 import ssl
 import tempfile
 import urllib.parse
-from typing import TYPE_CHECKING, AsyncIterator, Collection, Iterable, Optional, Union
+from collections.abc import AsyncIterator, Collection, Iterable
+from typing import TYPE_CHECKING, Optional, Union
 
 import aiohttp.web
 

--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -2,7 +2,8 @@ import asyncio
 import dataclasses
 import functools
 import os
-from typing import Any, Callable, Collection, Optional
+from collections.abc import Collection
+from typing import Any, Callable, Optional
 
 import click
 

--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -2,7 +2,7 @@ import asyncio
 import dataclasses
 import functools
 import os
-from typing import Any, Callable, Collection, List, Optional
+from typing import Any, Callable, Collection, Optional
 
 import click
 
@@ -85,8 +85,8 @@ def main(__controls: CLIControls) -> None:
 @click.make_pass_decorator(CLIControls, ensure=True)
 def run(
         __controls: CLIControls,
-        paths: List[str],
-        modules: List[str],
+        paths: list[str],
+        modules: list[str],
         peering_name: Optional[str],
         priority: Optional[int],
         standalone: Optional[bool],

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -10,8 +10,9 @@ The decorators for the event handlers. Usually used as::
 This module is a part of the framework's public interface.
 """
 import warnings
+from collections.abc import Collection
 # TODO: add cluster=True support (different API methods)
-from typing import Any, Callable, Collection, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 from kopf._cogs.structs import dicts, references, reviews
 from kopf._core.actions import execution

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         'setuptools_scm',
     ],
     install_requires=[
-        'typing_extensions',    # 0.20 MB
         'python-json-logger',   # 0.05 MB
         'iso8601',              # 0.07 MB
         'click',                # 0.60 MB

--- a/tests/authentication/test_reauthentication.py
+++ b/tests/authentication/test_reauthentication.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional
 
 import aiohttp.web
 
@@ -11,7 +11,7 @@ async def fn(
         x: int,
         *,
         context: Optional[APIContext],
-) -> Tuple[APIContext, int]:
+) -> tuple[APIContext, int]:
     return context, x + 100
 
 

--- a/tests/causation/test_detection.py
+++ b/tests/causation/test_detection.py
@@ -143,8 +143,8 @@ def check_kwargs(cause, kwargs):
 def test_for_gone(
         kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
-    event['object']['metadata'].update(finalizers)
-    event['object']['metadata'].update(deletion_ts)
+    event['object']['metadata'] |= finalizers
+    event['object']['metadata'] |= deletion_ts
     cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
@@ -160,8 +160,8 @@ def test_for_gone(
 def test_for_free(
         kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
-    event['object']['metadata'].update(finalizers)
-    event['object']['metadata'].update(deletion_ts)
+    event['object']['metadata'] |= finalizers
+    event['object']['metadata'] |= deletion_ts
     cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
@@ -177,8 +177,8 @@ def test_for_free(
 def test_for_delete(
         kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
-    event['object']['metadata'].update(finalizers)
-    event['object']['metadata'].update(deletion_ts)
+    event['object']['metadata'] |= finalizers
+    event['object']['metadata'] |= deletion_ts
     cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
@@ -195,10 +195,10 @@ def test_for_delete(
 def test_for_create(
         kwargs, event, finalizers, deletion_ts, old, annotations, content, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
-    event['object'].update(content)
-    event['object']['metadata'].update(finalizers)
-    event['object']['metadata'].update(deletion_ts)
-    event['object']['metadata'].update(annotations)
+    event['object'] |= content
+    event['object']['metadata'] |= finalizers
+    event['object']['metadata'] |= deletion_ts
+    event['object']['metadata'] |= annotations
     cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
@@ -215,8 +215,8 @@ def test_for_create(
 def test_for_create_skip_acquire(
         kwargs, event, finalizers, deletion_ts, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
-    event['object']['metadata'].update(finalizers)
-    event['object']['metadata'].update(deletion_ts)
+    event['object']['metadata'] |= finalizers
+    event['object']['metadata'] |= deletion_ts
     cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
@@ -233,10 +233,10 @@ def test_for_create_skip_acquire(
 def test_for_no_op(
         kwargs, event, finalizers, deletion_ts, old, annotations, content, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
-    event['object'].update(content)
-    event['object']['metadata'].update(finalizers)
-    event['object']['metadata'].update(deletion_ts)
-    event['object']['metadata'].update(annotations)
+    event['object'] |= content
+    event['object']['metadata'] |= finalizers
+    event['object']['metadata'] |= deletion_ts
+    event['object']['metadata'] |= annotations
     cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),
@@ -254,10 +254,10 @@ def test_for_no_op(
 def test_for_update(
         kwargs, event, finalizers, deletion_ts, old, annotations, content, requires_finalizer):
     event = {'type': event, 'object': {'metadata': {}}}
-    event['object'].update(content)
-    event['object']['metadata'].update(finalizers)
-    event['object']['metadata'].update(deletion_ts)
-    event['object']['metadata'].update(annotations)
+    event['object'] |= content
+    event['object']['metadata'] |= finalizers
+    event['object']['metadata'] |= deletion_ts
+    event['object']['metadata'] |= annotations
     cause = detect_changing_cause(
         raw_event=event,
         body=Body(event['object']),

--- a/tests/causation/test_kwargs.py
+++ b/tests/causation/test_kwargs.py
@@ -1,6 +1,5 @@
 import dataclasses
 import logging
-from typing import Type
 from unittest.mock import Mock
 
 import pytest
@@ -33,7 +32,7 @@ ALL_FIELDS = {
 @pytest.mark.parametrize('cls', ALL_CAUSES)
 @pytest.mark.parametrize('name', ALL_FIELDS)
 @pytest.mark.parametrize('attr', ['kwargs', 'sync_kwargs', 'async_kwargs'])
-def test_indices_overwrite_kwargs(cls: Type[BaseCause], name, attr):
+def test_indices_overwrite_kwargs(cls: type[BaseCause], name, attr):
     indexers = OperatorIndexers()
     indexers['index1'] = OperatorIndexer()
     indexers['index2'] = OperatorIndexer()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -389,7 +389,7 @@ def login_mocks(mocker):
             'contexts': [{'name': 'self',
                           'context': {'cluster': 'self', 'namespace': 'default'}}],
         })
-        kwargs.update(
+        kwargs |= dict(
             pykube_in_cluster=mocker.patch.object(pykube.KubeConfig, 'from_service_account', return_value=cfg),
             pykube_from_file=mocker.patch.object(pykube.KubeConfig, 'from_file', return_value=cfg),
             pykube_from_env=mocker.patch.object(pykube.KubeConfig, 'from_env', return_value=cfg),
@@ -399,7 +399,7 @@ def login_mocks(mocker):
     except ImportError:
         pass
     else:
-        kwargs.update(
+        kwargs |= dict(
             client_in_cluster=mocker.patch.object(kubernetes.config, 'load_incluster_config'),
             client_from_file=mocker.patch.object(kubernetes.config, 'load_kube_config'),
         )
@@ -498,7 +498,7 @@ def _with_module_absent(name: str):
         yield
     finally:
         sys.meta_path.remove(finder)
-        sys.modules.update(preserved)
+        sys.modules |= preserved
 
         # Verify if it works and that we didn't break the importing machinery.
         mod_after = importlib.import_module(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import logging
 import re
 import sys
 import time
-from typing import Set
 from unittest.mock import AsyncMock, Mock
 
 import aiohttp.web
@@ -739,7 +738,7 @@ def _no_asyncio_pending_tasks(loop: asyncio.AbstractEventLoop):
         pytest.fail(f"Unattended asyncio tasks detected: {remains!r}")
 
 
-def _get_all_tasks() -> Set[asyncio.Task]:
+def _get_all_tasks() -> set[asyncio.Task]:
     """Similar to `asyncio.all_tasks`, but for all event loops at once."""
     i = 0
     while True:

--- a/tests/diffs/test_calculation.py
+++ b/tests/diffs/test_calculation.py
@@ -138,7 +138,7 @@ def test_custom_mappings_are_recursed():
     class SampleMapping(collections.abc.Mapping):
         def __init__(self, data=(), **kwargs) -> None:
             super().__init__()
-            self._items = dict(data, **kwargs)
+            self._items = dict(data) | kwargs
         def __len__(self) -> int: return len(self._items)
         def __iter__(self): return iter(self._items)
         def __getitem__(self, item: str) -> str: return self._items[item]

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -3,7 +3,8 @@ import collections
 import re
 import subprocess
 import time
-from typing import Any, Optional, Sequence
+from collections.abc import Sequence
+from typing import Any, Optional
 
 import astpath
 import pytest

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -3,7 +3,7 @@ import collections
 import re
 import subprocess
 import time
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Optional, Sequence
 
 import astpath
 import pytest
@@ -127,8 +127,8 @@ class E2EParser:
     the whole example (which can have side-effects). Some snippets are still
     executed: e.g. values of E2E configs or values of some decorators' kwargs.
     """
-    configs: Dict[str, Any]
-    xml2ast: Dict[etree._Element, ast.AST]
+    configs: dict[str, Any]
+    xml2ast: dict[etree._Element, ast.AST]
     xtree: etree._Element
 
     def __init__(self, path: str) -> None:
@@ -187,11 +187,11 @@ class E2EParser:
         return self.configs.get('E2E_ALLOW_TRACEBACKS')
 
     @property
-    def success_counts(self) -> Optional[Dict[str, int]]:
+    def success_counts(self) -> Optional[dict[str, int]]:
         return self.configs.get('E2E_SUCCESS_COUNTS')
 
     @property
-    def failure_counts(self) -> Optional[Dict[str, int]]:
+    def failure_counts(self) -> Optional[dict[str, int]]:
         return self.configs.get('E2E_FAILURE_COUNTS')
 
     @property

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -27,7 +27,8 @@ async def test_daemon_exits_gracefully_and_instantly_on_resource_deletion(
 
     # 1st stage: trigger termination due to resource deletion.
     mocker.resetall()
-    event_object.setdefault('metadata', {}).update({'deletionTimestamp': '...'})
+    event_object.setdefault('metadata', {})
+    event_object['metadata'] |= {'deletionTimestamp': '...'}
     await simulate_cycle(event_object)
 
     # Check that the daemon has exited near-instantly, with no delays.
@@ -134,7 +135,8 @@ async def test_daemon_exits_instantly_via_cancellation_with_backoff(
 
     # 1st stage: trigger termination due to resource deletion. Wait for backoff.
     mocker.resetall()
-    event_object.setdefault('metadata', {}).update({'deletionTimestamp': '...'})
+    event_object.setdefault('metadata', {})
+    event_object['metadata'] |= {'deletionTimestamp': '...'}
     await simulate_cycle(event_object)
 
     assert k8s_mocked.sleep.call_count == 1
@@ -178,7 +180,8 @@ async def test_daemon_exits_slowly_via_cancellation_with_backoff(
 
     # 1st stage: trigger termination due to resource deletion. Wait for backoff.
     mocker.resetall()
-    event_object.setdefault('metadata', {}).update({'deletionTimestamp': '...'})
+    event_object.setdefault('metadata', {})
+    event_object['metadata'] |= {'deletionTimestamp': '...'}
     await simulate_cycle(event_object)
 
     assert k8s_mocked.sleep.call_count == 1
@@ -232,7 +235,8 @@ async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
 
     # 1st stage: trigger termination due to resource deletion. Wait for backoff.
     mocker.resetall()
-    event_object.setdefault('metadata', {}).update({'deletionTimestamp': '...'})
+    event_object.setdefault('metadata', {})
+    event_object['metadata'] |= {'deletionTimestamp': '...'}
     await simulate_cycle(event_object)
 
     assert k8s_mocked.sleep.call_count == 1

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 import freezegun
 import pytest

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -26,7 +26,7 @@ async def test_1st_step_stores_progress_by_patching(
     event_body = {
         'metadata': {'finalizers': [settings.persistence.finalizer]},
     }
-    event_body['metadata'].update(deletion_ts)
+    event_body['metadata'] |= deletion_ts
     cause_mock.reason = cause_type
 
     await process_resource_event(
@@ -86,7 +86,7 @@ async def test_2nd_step_finishes_the_handlers(caplog,
             name2: {'started': '1979-01-01T00:00:00'},
         }}}
     }
-    event_body['metadata'].update(deletion_ts)
+    event_body['metadata'] |= deletion_ts
     cause_mock.reason = cause_type
 
     await process_resource_event(

--- a/tests/logging/test_configuration.py
+++ b/tests/logging/test_configuration.py
@@ -1,5 +1,5 @@
 import logging.handlers
-from typing import Collection
+from collections.abc import Collection
 
 import pytest
 

--- a/tests/persistence/test_essences.py
+++ b/tests/persistence/test_essences.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import pytest
 
 from kopf._cogs.configs.diffbase import AnnotationsDiffBaseStorage, \
@@ -11,7 +9,7 @@ ALL_STORAGES = [AnnotationsDiffBaseStorage, StatusDiffBaseStorage]
 
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_removes_resource_references(
-        cls: Type[DiffBaseStorage],
+        cls: type[DiffBaseStorage],
 ):
     body = Body({'apiVersion': 'group/version', 'kind': 'Kind'})
     storage = cls()
@@ -34,7 +32,7 @@ def test_get_essence_removes_resource_references(
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_removes_system_fields_and_cleans_parents(
         field: str,
-        cls: Type[DiffBaseStorage],
+        cls: type[DiffBaseStorage],
 ):
     body = Body({'metadata': {field: 'x'}})
     storage = cls()
@@ -57,7 +55,7 @@ def test_get_essence_removes_system_fields_and_cleans_parents(
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_removes_system_fields_but_keeps_extra_fields(
         field: str,
-        cls: Type[DiffBaseStorage],
+        cls: type[DiffBaseStorage],
 ):
     body = Body({'metadata': {field: 'x', 'other': 'y'}})
     storage = cls()
@@ -71,7 +69,7 @@ def test_get_essence_removes_system_fields_but_keeps_extra_fields(
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_removes_garbage_annotations_and_cleans_parents(
         annotation: str,
-        cls: Type[DiffBaseStorage],
+        cls: type[DiffBaseStorage],
 ):
     body = Body({'metadata': {'annotations': {annotation: 'x'}}})
     storage = cls()
@@ -85,7 +83,7 @@ def test_get_essence_removes_garbage_annotations_and_cleans_parents(
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_removes_garbage_annotations_but_keeps_others(
         annotation: str,
-        cls: Type[DiffBaseStorage],
+        cls: type[DiffBaseStorage],
 ):
     body = Body({'metadata': {'annotations': {annotation: 'x', 'other': 'y'}}})
     storage = cls()
@@ -106,7 +104,7 @@ def test_get_essence_removes_garbage_annotations_but_keeps_others(
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_keeps_annotations_mentioning_kopf_but_not_from_other_operators(
         prefix: str,
-        cls: Type[DiffBaseStorage],
+        cls: type[DiffBaseStorage],
 ):
     annotation = f'{prefix}/to-be-removed'
     body = Body({'metadata': {'annotations': {annotation: 'x'}}})
@@ -123,7 +121,7 @@ def test_get_essence_keeps_annotations_mentioning_kopf_but_not_from_other_operat
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_removes_other_operators_annotations_by_domain(
         prefix: str,
-        cls: Type[DiffBaseStorage],
+        cls: type[DiffBaseStorage],
 ):
     annotation = f'{prefix}/to-be-removed'
     body = Body({'metadata': {'annotations': {annotation: 'x', 'other': 'y'}}})
@@ -138,7 +136,7 @@ def test_get_essence_removes_other_operators_annotations_by_domain(
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_removes_other_operators_annotations_by_marker(
         prefix: str,
-        cls: Type[DiffBaseStorage],
+        cls: type[DiffBaseStorage],
 ):
     marker = f'{prefix}/kopf-managed'
     annotation = f'{prefix}/to-be-removed'
@@ -150,7 +148,7 @@ def test_get_essence_removes_other_operators_annotations_by_marker(
 
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_removes_status_and_cleans_parents(
-        cls: Type[DiffBaseStorage],
+        cls: type[DiffBaseStorage],
 ):
     body = Body({'status': {'kopf': {'progress': 'x', 'anything': 'y'}, 'other': 'z'}})
     storage = cls()
@@ -160,7 +158,7 @@ def test_get_essence_removes_status_and_cleans_parents(
 
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_removes_status_but_keeps_extra_fields(
-        cls: Type[DiffBaseStorage],
+        cls: type[DiffBaseStorage],
 ):
     body = Body({'status': {'kopf': {'progress': 'x', 'anything': 'y'}, 'other': 'z'}})
     storage = cls()
@@ -170,7 +168,7 @@ def test_get_essence_removes_status_but_keeps_extra_fields(
 
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_get_essence_clones_body(
-        cls: Type[DiffBaseStorage],
+        cls: type[DiffBaseStorage],
 ):
     body = Body({'spec': {'depth': {'field': 'x'}}})
     storage = cls()

--- a/tests/persistence/test_storing_of_diffbase.py
+++ b/tests/persistence/test_storing_of_diffbase.py
@@ -1,5 +1,4 @@
 import json
-from typing import Type
 
 import pytest
 
@@ -79,7 +78,7 @@ def test_status_storage_with_field():
 
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_fetching_from_empty_body_returns_none(
-        cls: Type[DiffBaseStorage]):
+        cls: type[DiffBaseStorage]):
     storage = cls()
     body = Body({})
     data = storage.fetch(body=body)
@@ -174,7 +173,7 @@ def test_storing_to_status_storage_populates_keys(cls):
 
 @pytest.mark.parametrize('cls', STATUS_POPULATING_STORAGES)
 def test_storing_to_status_storage_overwrites_old_content(
-        cls: Type[DiffBaseStorage]):
+        cls: type[DiffBaseStorage]):
     storage = cls(field='status.my-operator.diff-base')
     patch = Patch()
     body = Body({})

--- a/tests/persistence/test_storing_of_progress.py
+++ b/tests/persistence/test_storing_of_progress.py
@@ -1,5 +1,4 @@
 import json
-from typing import Type
 
 import pytest
 
@@ -116,7 +115,7 @@ def test_smart_storage_with_prefix():
 
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_fetching_from_empty_body_returns_none(
-        cls: Type[ProgressStorage]):
+        cls: type[ProgressStorage]):
     storage = cls()
     body = Body({})
     data = storage.fetch(body=body, key=HandlerId('id1'))
@@ -125,7 +124,7 @@ def test_fetching_from_empty_body_returns_none(
 
 @pytest.mark.parametrize('cls', ALL_STORAGES)
 def test_purging_already_empty_body_does_nothing(
-        cls: Type[ProgressStorage]):
+        cls: type[ProgressStorage]):
     storage = cls()
     patch = Patch()
     body = Body({})

--- a/tests/registries/test_matching_for_changing.py
+++ b/tests/registries/test_matching_for_changing.py
@@ -70,8 +70,8 @@ def handler_factory(registry, selector):
 ])
 def cause_no_diff(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(**kwargs)
     return cause
 
@@ -84,8 +84,8 @@ def cause_no_diff(request, cause_factory):
 ])
 def cause_with_diff(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(**kwargs)
     return cause
 
@@ -100,8 +100,8 @@ def cause_with_diff(request, cause_factory):
 ])
 def cause_any_diff(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(**kwargs)
     return cause
 

--- a/tests/registries/test_matching_for_indexing.py
+++ b/tests/registries/test_matching_for_indexing.py
@@ -41,8 +41,8 @@ def handler_factory(registry, selector):
 ])
 def cause_no_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(cls=WatchingCause, **kwargs)
     return cause
 
@@ -52,8 +52,8 @@ def cause_no_field(request, cause_factory):
 ])
 def cause_with_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(cls=WatchingCause, **kwargs)
     return cause
 
@@ -65,8 +65,8 @@ def cause_with_field(request, cause_factory):
 ])
 def cause_any_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(cls=WatchingCause, **kwargs)
     return cause
 

--- a/tests/registries/test_matching_for_spawning.py
+++ b/tests/registries/test_matching_for_spawning.py
@@ -48,8 +48,8 @@ def handler_factory(registry, selector):
 ])
 def cause_no_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(cls=SpawningCause, **kwargs)
     return cause
 
@@ -59,8 +59,8 @@ def cause_no_field(request, cause_factory):
 ])
 def cause_with_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(cls=SpawningCause, **kwargs)
     return cause
 
@@ -72,8 +72,8 @@ def cause_with_field(request, cause_factory):
 ])
 def cause_any_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(cls=SpawningCause, **kwargs)
     return cause
 

--- a/tests/registries/test_matching_for_watching.py
+++ b/tests/registries/test_matching_for_watching.py
@@ -41,8 +41,8 @@ def handler_factory(registry, selector):
 ])
 def cause_no_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(cls=WatchingCause, **kwargs)
     return cause
 
@@ -52,8 +52,8 @@ def cause_no_field(request, cause_factory):
 ])
 def cause_with_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(cls=WatchingCause, **kwargs)
     return cause
 
@@ -65,8 +65,8 @@ def cause_with_field(request, cause_factory):
 ])
 def cause_any_field(request, cause_factory):
     kwargs = copy.deepcopy(request.param)
-    kwargs['body'].update({'metadata': {'labels': {'known': 'value'},
-                                        'annotations': {'known': 'value'}}})
+    kwargs['body'] |= {'metadata': {'labels': {'known': 'value'},
+                                    'annotations': {'known': 'value'}}}
     cause = cause_factory(cls=WatchingCause, **kwargs)
     return cause
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -23,7 +23,7 @@ async def test_http_user_agent_version(
     mocker.patch('kopf._cogs.helpers.versions.version', version)
 
     @authenticated
-    async def get_it(url: str, *, context: APIContext) -> Dict[str, Any]:
+    async def get_it(url: str, *, context: APIContext) -> dict[str, Any]:
         response = await context.session.get(url)
         return await response.json()
 


### PR DESCRIPTION
A follow-up for the Python 3.8 deprecation, in order to catch up the syntax features.

* #1164