### PR TITLE
Convert to Python 3.9: convert most internal mappings to dicts

### DIFF
--- a/docs/kwargs.rst
+++ b/docs/kwargs.rst
@@ -352,7 +352,7 @@ See more: :doc:`admission`.
 User information
 ----------------
 
-``userinfo`` (``Mapping[str, Any]``) is information about the user that
+``userinfo`` (``dict[str, Any]``) is information about the user that
 sends the API request to Kubernetes.
 
 It usually contains the keys ``'username'``, ``'uid'``, ``'groups'``,
@@ -372,10 +372,10 @@ For rudimentary authentication and authorization, Kopf passes the information
 from the admission requests to the admission handlers as-is,
 without any additional interpretation.
 
-``headers`` (``Mapping[str, str]``) contains all HTTPS request headers,
+``headers`` (``dict[str, str]``) contains all HTTPS request headers,
 including ``Authorization: Basic ...``, ``Authorization: Bearer ...``.
 
-``sslpeer`` (``Mapping[str, Any]``) contains the SSL peer information
+``sslpeer`` (``dict[str, Any]``) contains the SSL peer information
 as returned by :func:`ssl.SSLSocket.getpeercert`. It is ``None`` if no valid
 SSL client certificate was provided (e.g. by apiservers talking to webhooks),
 or if the SSL protocol could not verify the provided certificate against its CA.

--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -4,7 +4,7 @@ import itertools
 import json
 import ssl
 import urllib.parse
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator
 from typing import Any
 
 import aiohttp
@@ -48,7 +48,7 @@ async def request(
         *,
         settings: configuration.OperatorSettings,
         payload: object | None = None,
-        headers: Mapping[str, str] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: aiohttp.ClientTimeout | None = None,
         context: auth.APIContext | None = None,  # injected by the decorator
         logger: typedefs.Logger,
@@ -136,7 +136,7 @@ async def get(
         *,
         settings: configuration.OperatorSettings,
         payload: object | None = None,
-        headers: Mapping[str, str] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: aiohttp.ClientTimeout | None = None,
         logger: typedefs.Logger,
 ) -> Any:
@@ -158,7 +158,7 @@ async def post(
         *,
         settings: configuration.OperatorSettings,
         payload: object | None = None,
-        headers: Mapping[str, str] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: aiohttp.ClientTimeout | None = None,
         logger: typedefs.Logger,
 ) -> Any:
@@ -180,7 +180,7 @@ async def patch(
         *,
         settings: configuration.OperatorSettings,
         payload: object | None = None,
-        headers: Mapping[str, str] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: aiohttp.ClientTimeout | None = None,
         logger: typedefs.Logger,
 ) -> Any:
@@ -202,7 +202,7 @@ async def delete(
         *,
         settings: configuration.OperatorSettings,
         payload: object | None = None,
-        headers: Mapping[str, str] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: aiohttp.ClientTimeout | None = None,
         logger: typedefs.Logger,
 ) -> Any:
@@ -224,7 +224,7 @@ async def stream(
         *,
         settings: configuration.OperatorSettings,
         payload: object | None = None,
-        headers: Mapping[str, str] | None = None,
+        headers: dict[str, str] | None = None,
         timeout: aiohttp.ClientTimeout | None = None,
         stopper: aiotasks.Future | None = None,
         logger: typedefs.Logger,

--- a/kopf/_cogs/clients/scanning.py
+++ b/kopf/_cogs/clients/scanning.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import Collection, Mapping
+from collections.abc import Collection
 
 from kopf._cogs.clients import api, errors
 from kopf._cogs.configs import configuration
@@ -11,8 +11,8 @@ async def read_version(
         *,
         settings: configuration.OperatorSettings,
         logger: typedefs.Logger,
-) -> Mapping[str, str]:
-    rsp: Mapping[str, str] = await api.get('/version', settings=settings, logger=logger)
+) -> dict[str, str]:
+    rsp: dict[str, str] = await api.get('/version', settings=settings, logger=logger)
     return rsp
 
 

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -41,7 +41,7 @@ All timestamps are strings in ISO8601 format in UTC (no explicit ``Z`` suffix).
 import abc
 import copy
 import json
-from collections.abc import Collection, Mapping
+from collections.abc import Collection
 from typing import Any, TypedDict, cast
 
 from kopf._cogs.configs import conventions
@@ -316,7 +316,7 @@ class StatusProgressStorage(ProgressStorage):
             key: ids.HandlerId,
             body: bodies.Body,
     ) -> ProgressRecord | None:
-        container: Mapping[ids.HandlerId, ProgressRecord]
+        container: dict[ids.HandlerId, ProgressRecord]
         container = dicts.resolve(body, self.field, {})
         return container.get(key, None)
 

--- a/kopf/_cogs/structs/bodies.py
+++ b/kopf/_cogs/structs/bodies.py
@@ -49,6 +49,7 @@ from typing import Any, Literal, TypeAlias, TypedDict, cast
 from kopf._cogs.structs import dicts, references
 
 # Make sure every kwarg has a corresponding same-named type in the root package.
+# Usually, they are "live views" into dicts, so they are not dicts themselves.
 Labels: TypeAlias = Mapping[str, str]
 Annotations: TypeAlias = Mapping[str, str]
 
@@ -182,7 +183,7 @@ class Status(dicts.MappingView[str, Any]):
 
 class Body(dicts.ReplaceableMappingView[str, Any]):
 
-    def __init__(self, __src: Mapping[str, Any]) -> None:
+    def __init__(self, __src: RawBody | BodyEssence) -> None:
         super().__init__(__src)
         self._meta = Meta(self)
         self._spec = Spec(self)

--- a/kopf/_cogs/structs/bodies.py
+++ b/kopf/_cogs/structs/bodies.py
@@ -116,14 +116,14 @@ class RawEvent(TypedDict, total=True):
 
 
 class MetaEssence(TypedDict, total=False):
-    labels: Labels
-    annotations: Annotations
+    labels: dict[str, str]
+    annotations: dict[str, str]
 
 
 class BodyEssence(TypedDict, total=False):
     metadata: MetaEssence
-    spec: Mapping[str, Any]
-    status: Mapping[str, Any]
+    spec: dict[str, Any]
+    status: dict[str, Any]
 
 
 #

--- a/kopf/_cogs/structs/bodies.py
+++ b/kopf/_cogs/structs/bodies.py
@@ -68,8 +68,8 @@ class RawMeta(TypedDict, total=False):
     uid: str
     name: str
     namespace: str
-    labels: Labels
-    annotations: Annotations
+    labels: dict[str, str]
+    annotations: dict[str, str]
     finalizers: list[str]
     resourceVersion: str
     deletionTimestamp: str
@@ -81,15 +81,15 @@ class RawBody(TypedDict, total=False):
     apiVersion: str
     kind: str
     metadata: RawMeta
-    spec: Mapping[str, Any]
-    status: Mapping[str, Any]
+    spec: dict[str, Any]
+    status: dict[str, Any]
 
 
 # A special payload for type==ERROR (this is not a connection or client error).
 class RawError(TypedDict, total=False):
     apiVersion: str     # usually: Literal['v1']
     kind: str           # usually: Literal['Status']
-    metadata: Mapping[Any, Any]
+    metadata: dict[Any, Any]
     code: int
     reason: str
     status: str

--- a/kopf/_cogs/structs/credentials.py
+++ b/kopf/_cogs/structs/credentials.py
@@ -34,7 +34,7 @@ import os
 import random
 import ssl
 import tempfile
-from collections.abc import AsyncIterable, AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterable, AsyncIterator, Callable
 from typing import NewType, TypeVar, cast
 
 import aiohttp
@@ -239,7 +239,7 @@ class Vault(AsyncIterable[tuple[VaultKey, KubeContext]]):
 
     def __init__(
             self,
-            __src: Mapping[str, object] | None = None,
+            __src: dict[str, object] | None = None,
     ) -> None:
         super().__init__()
         self._current = {}
@@ -446,7 +446,7 @@ class Vault(AsyncIterable[tuple[VaultKey, KubeContext]]):
 
     async def populate(
             self,
-            __src: Mapping[str, object],
+            __src: dict[str, object],
     ) -> None:
         """
         Add newly retrieved credentials.
@@ -525,7 +525,7 @@ class Vault(AsyncIterable[tuple[VaultKey, KubeContext]]):
 
     def _update_converted(
             self,
-            __src: Mapping[str, object],
+            __src: dict[str, object],
     ) -> None:
         for key, info in __src.items():
             key = VaultKey(str(key))

--- a/kopf/_cogs/structs/dicts.py
+++ b/kopf/_cogs/structs/dicts.py
@@ -64,7 +64,7 @@ def resolve_obj(
                 case collections.abc.Mapping():
                     result = result[key]
                 case thirdparty.KubernetesModel():
-                    attrmap: Mapping[str, str] = getattr(result, 'attribute_map', {})
+                    attrmap: dict[str, str] = getattr(result, 'attribute_map', {})
                     attrs = [attr for attr, schema_key in attrmap.items() if schema_key == key]
                     key = attrs[0] if attrs else key
                     result = getattr(result, key)

--- a/kopf/_cogs/structs/patches.py
+++ b/kopf/_cogs/structs/patches.py
@@ -66,7 +66,7 @@ class Patch(dict[str, Any]):
 
     def __init__(
         self,
-        src: collections.abc.MutableMapping[str, Any] | None = None,
+        src: dict[str, Any] | None = None,
         /,
         body: bodies.RawBody | None = None,
         fns: Iterable[PatchFn] = (),

--- a/kopf/_cogs/structs/references.py
+++ b/kopf/_cogs/structs/references.py
@@ -199,7 +199,7 @@ class Resource:
             namespace: Namespace = None,
             name: str | None = None,
             subresource: str | None = None,
-            params: Mapping[str, str] | None = None,
+            params: dict[str, str] | None = None,
     ) -> str:
         """
         Build a URL to be used with K8s API.

--- a/kopf/_cogs/structs/references.py
+++ b/kopf/_cogs/structs/references.py
@@ -4,7 +4,7 @@ import enum
 import fnmatch
 import re
 import urllib.parse
-from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, MutableMapping
+from collections.abc import Callable, Collection, Iterable, Iterator, Mapping
 from typing import NewType
 
 # A namespace specification with globs, negations, and some minimal syntax; see `match_namespace()`.
@@ -439,7 +439,7 @@ class Backbone(Mapping[Selector, Resource]):
 
     def __init__(self) -> None:
         super().__init__()
-        self._items: MutableMapping[Selector, Resource] = {}
+        self._items: dict[Selector, Resource] = {}
         self._revised = asyncio.Condition()
         self.selectors = [
             NAMESPACES, EVENTS, CRDS,

--- a/kopf/_cogs/structs/reviews.py
+++ b/kopf/_cogs/structs/reviews.py
@@ -1,13 +1,13 @@
 """
 Admission reviews: requests & responses, also the webhook server protocols.
 """
-from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any, Literal, Protocol, TypedDict
 
 from kopf._cogs.structs import bodies
 
-Headers = Mapping[str, str]
-SSLPeer = Mapping[str, Any]
+Headers = dict[str, str]
+SSLPeer = dict[str, Any]
 
 Operation = Literal['CREATE', 'UPDATE', 'DELETE', 'CONNECT']
 
@@ -126,8 +126,8 @@ class WebhookFn(Protocol):
             request: Request,
             *,
             webhook: str | None = None,
-            headers: Mapping[str, str] | None = None,
-            sslpeer: Mapping[str, Any] | None = None,
+            headers: Headers | None = None,
+            sslpeer: SSLPeer | None = None,
     ) -> Awaitable[Response]:
         ...
 

--- a/kopf/_core/actions/execution.py
+++ b/kopf/_core/actions/execution.py
@@ -113,7 +113,7 @@ class Cause(invocation.Kwargable):
     logger: typedefs.Logger
 
     @property
-    def _kwargs(self) -> Mapping[str, Any]:
+    def _kwargs(self) -> dict[str, Any]:
         # Similar to `dataclasses.asdict()`, but not recursive for other dataclasses.
         return {field.name: getattr(self, field.name) for field in dataclasses.fields(self)}
 

--- a/kopf/_core/actions/execution.py
+++ b/kopf/_core/actions/execution.py
@@ -12,8 +12,7 @@ import contextlib
 import dataclasses
 import datetime
 import enum
-from collections.abc import AsyncIterator, Callable, Collection, \
-                            Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import AsyncIterator, Callable, Collection, Iterable, Mapping, Sequence
 from contextvars import ContextVar
 from typing import Any, AsyncContextManager, NewType, Protocol, TypeVar
 
@@ -177,7 +176,7 @@ async def execute_handlers_once(
         state: State,
         extra_context: ExtraContext = no_extra_context,
         default_errors: ErrorsMode = ErrorsMode.TEMPORARY,
-) -> Mapping[ids.HandlerId, Outcome]:
+) -> dict[ids.HandlerId, Outcome]:
     """
     Call the next handler(s) from the chain of the handlers.
 
@@ -193,7 +192,7 @@ async def execute_handlers_once(
     handlers_plan = lifecycle(handlers_todo, state=state, **cause.kwargs)
 
     # Execute all planned (selected) handlers in one event reaction cycle, even if there are a few.
-    outcomes: MutableMapping[ids.HandlerId, Outcome] = {}
+    outcomes: dict[ids.HandlerId, Outcome] = {}
     for handler in handlers_plan:
         outcome = await execute_handler_once(
             settings=settings,

--- a/kopf/_core/actions/invocation.py
+++ b/kopf/_core/actions/invocation.py
@@ -10,7 +10,7 @@ import contextlib
 import contextvars
 import functools
 import inspect
-from collections.abc import Callable, Coroutine, Iterable, Iterator, Mapping
+from collections.abc import Callable, Coroutine, Iterable, Iterator
 from typing import Any, TypeAlias, TypeVar, final
 
 from kopf._cogs.configs import configuration
@@ -38,35 +38,35 @@ class Kwargable:
     """
 
     @property
-    def _kwargs(self) -> Mapping[str, Any]:
+    def _kwargs(self) -> dict[str, Any]:
         return {}
 
     @property
-    def _sync_kwargs(self) -> Mapping[str, Any]:
+    def _sync_kwargs(self) -> dict[str, Any]:
         return self._kwargs
 
     @property
-    def _async_kwargs(self) -> Mapping[str, Any]:
+    def _async_kwargs(self) -> dict[str, Any]:
         return self._kwargs
 
     @property
-    def _super_kwargs(self) -> Mapping[str, Any]:
+    def _super_kwargs(self) -> dict[str, Any]:
         return {}
 
     @final
     @property
-    def kwargs(self) -> Mapping[str, Any]:
-        return dict(self._kwargs) | dict(self._super_kwargs)
+    def kwargs(self) -> dict[str, Any]:
+        return self._kwargs | self._super_kwargs
 
     @final
     @property
-    def sync_kwargs(self) -> Mapping[str, Any]:
-        return dict(self._sync_kwargs) | dict(self._super_kwargs)
+    def sync_kwargs(self) -> dict[str, Any]:
+        return self._sync_kwargs | self._super_kwargs
 
     @final
     @property
-    def async_kwargs(self) -> Mapping[str, Any]:
-        return dict(self._async_kwargs) | dict(self._super_kwargs)
+    def async_kwargs(self) -> dict[str, Any]:
+        return self._async_kwargs | self._super_kwargs
 
 
 @contextlib.contextmanager
@@ -92,7 +92,7 @@ async def invoke(
         *,
         settings: configuration.OperatorSettings | None = None,
         kwargsrc: Kwargable | None = None,
-        kwargs: Mapping[str, Any] | None = None,  # includes param, retry, started, runtime, etc.
+        kwargs: dict[str, Any] | None = None,  # includes param, retry, started, runtime, etc.
 ) -> Any:
     """
     Invoke a single function, but safely for the main asyncio process.

--- a/kopf/_core/actions/loggers.py
+++ b/kopf/_core/actions/loggers.py
@@ -135,6 +135,7 @@ class ObjectLogger(typedefs.LoggerAdapter):
             ),
         ))
 
+    # Typed with MutableMapping[] to match the parent's signature.
     def process(
             self,
             msg: str,

--- a/kopf/_core/actions/loggers.py
+++ b/kopf/_core/actions/loggers.py
@@ -142,7 +142,7 @@ class ObjectLogger(typedefs.LoggerAdapter):
     ) -> tuple[str, MutableMapping[str, Any]]:
         # Native logging overwrites the message's extra with the adapter's extra.
         # We merge them, so that both message's & adapter's extras are available.
-        kwargs["extra"] = (self.extra or {}) | kwargs.get('extra', {})
+        kwargs["extra"] = dict(self.extra or {}) | dict(kwargs.get('extra') or {})
         return msg, kwargs
 
 

--- a/kopf/_core/actions/progression.py
+++ b/kopf/_core/actions/progression.py
@@ -296,7 +296,7 @@ class State(execution.State):
 
     def with_outcomes(
             self,
-            outcomes: Mapping[ids.HandlerId, execution.Outcome],
+            outcomes: dict[ids.HandlerId, execution.Outcome],
     ) -> "State":
         unknown_ids = [handler_id for handler_id in outcomes if handler_id not in self]
         if unknown_ids:
@@ -423,7 +423,7 @@ class State(execution.State):
 
 def deliver_results(
         *,
-        outcomes: Mapping[ids.HandlerId, execution.Outcome],
+        outcomes: dict[ids.HandlerId, execution.Outcome],
         patch: patches.Patch,
 ) -> None:
     """

--- a/kopf/_core/actions/progression.py
+++ b/kopf/_core/actions/progression.py
@@ -178,7 +178,7 @@ class HandlerState(execution.HandlerState):
             subrefs=None if not self.subrefs else list(sorted(self.subrefs)),
         )
 
-    def as_in_storage(self) -> Mapping[str, Any]:
+    def as_in_storage(self) -> dict[str, Any]:
         # Nones are not stored by Kubernetes, so we filter them out for comparison.
         return {key: val for key, val in self.for_storage().items() if val is not None}
 

--- a/kopf/_core/actions/progression.py
+++ b/kopf/_core/actions/progression.py
@@ -368,7 +368,7 @@ class State(execution.State):
         )
 
     @property
-    def extras(self) -> Mapping[str, StateCounters]:
+    def extras(self) -> dict[str, StateCounters]:
         purposes = {
             handler_state.purpose for handler_state in self._states.values()
             if handler_state.purpose is not None and handler_state.purpose != self.purpose

--- a/kopf/_core/actions/progression.py
+++ b/kopf/_core/actions/progression.py
@@ -230,7 +230,7 @@ class State(execution.State):
     reflect the changes in the object's status. A new state is created every
     time some changes/outcomes are merged into the current state.
     """
-    _states: Mapping[ids.HandlerId, HandlerState]
+    _states: dict[ids.HandlerId, HandlerState]
 
     # Eliminate even the smallest microsecond-scale deviations by using the shared base time.
     # The deviations can come from UTC wall-clock time slowly moving during the run (CPU overhead).
@@ -238,7 +238,7 @@ class State(execution.State):
 
     def __init__(
             self,
-            __src: Mapping[ids.HandlerId, HandlerState],
+            __src: dict[ids.HandlerId, HandlerState],
             *,
             basetime: datetime.datetime,
             purpose: str | None = None,

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -207,7 +207,7 @@ def find_resource(
 def build_response(
         *,
         request: reviews.Request,
-        outcomes: Mapping[ids.HandlerId, execution.Outcome],
+        outcomes: dict[ids.HandlerId, execution.Outcome],
         warnings: Collection[str],
         jsonpatch: patches.JSONPatch,
 ) -> reviews.Response:

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -451,7 +451,7 @@ class MatchExpression(TypedDict, total=False):
     values: Collection[str] | None
 
 
-def _build_labels_selector(labels: filters.MetaFilter | None) -> Mapping[str, Any] | None:
+def _build_labels_selector(labels: filters.MetaFilter | None) -> dict[str, Any] | None:
     # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements
     exprs: Collection[MatchExpression] = [
         {'key': key, 'operator': 'Exists'} if val is filters.MetaFilterToken.PRESENT else

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -6,7 +6,7 @@ import json
 import logging
 import re
 import urllib.parse
-from collections.abc import Collection, Iterable, Mapping
+from collections.abc import Collection, Iterable
 from typing import Any, AsyncContextManager, Literal, TypedDict
 
 from kopf._cogs.aiokits import aiovalues
@@ -94,8 +94,8 @@ async def serve_admission_request(
         request: reviews.Request,
         *,
         # Optional for webhook servers that can recognise this information:
-        headers: Mapping[str, str] | None = None,
-        sslpeer: Mapping[str, Any] | None = None,
+        headers: reviews.Headers | None = None,
+        sslpeer: reviews.SSLPeer | None = None,
         webhook: ids.HandlerId | None = None,
         reason: causes.WebhookType | None = None,  # TODO: undocumented: requires typing clarity!
         # Injected by partial() from spawn_tasks():

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -25,7 +25,7 @@ import asyncio
 import dataclasses
 import sys
 import warnings
-from collections.abc import Collection, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Collection, Iterable, MutableMapping, Sequence
 
 from kopf._cogs.aiokits import aiotasks, aiotime, aiotoggles
 from kopf._cogs.configs import configuration
@@ -73,7 +73,7 @@ async def spawn_daemons(
         *,
         settings: configuration.OperatorSettings,
         handlers: Sequence[handlers_.SpawningHandler],
-        daemons: MutableMapping[ids.HandlerId, Daemon],
+        daemons: dict[ids.HandlerId, Daemon],
         cause: causes.SpawningCause,
         memory: DaemonsMemory,
 ) -> Collection[float]:
@@ -118,7 +118,7 @@ async def match_daemons(
         *,
         settings: configuration.OperatorSettings,
         handlers: Sequence[handlers_.SpawningHandler],
-        daemons: MutableMapping[ids.HandlerId, Daemon],
+        daemons: dict[ids.HandlerId, Daemon],
 ) -> Collection[float]:
     """
     Re-match the running daemons with the filters, and stop those mismatching.
@@ -142,7 +142,7 @@ async def match_daemons(
 async def pause_daemons(
         *,
         settings: configuration.OperatorSettings,
-        daemons: MutableMapping[ids.HandlerId, Daemon],
+        daemons: dict[ids.HandlerId, Daemon],
         operator_paused: aiotoggles.ToggleSet | None,  # None for tests
 ) -> Collection[float]:
     """
@@ -182,7 +182,7 @@ async def pause_daemons(
 async def stop_daemons(
         *,
         settings: configuration.OperatorSettings,
-        daemons: Mapping[ids.HandlerId, Daemon],
+        daemons: dict[ids.HandlerId, Daemon],
         reason: stoppers.DaemonStoppingReason = stoppers.DaemonStoppingReason.RESOURCE_DELETED,
 ) -> Collection[float]:
     """
@@ -447,7 +447,7 @@ async def _wait_for_instant_exit(
 async def _runner(
         *,
         settings: configuration.OperatorSettings,
-        daemons: MutableMapping[ids.HandlerId, Daemon],
+        daemons: dict[ids.HandlerId, Daemon],
         handler: handlers_.SpawningHandler,
         memory: DaemonsMemory,
         cause: causes.DaemonCause,

--- a/kopf/_core/engines/indexing.py
+++ b/kopf/_core/engines/indexing.py
@@ -198,7 +198,7 @@ class OperatorIndexers(dict[ids.HandlerId, OperatorIndexer]):
     def replace(
             self,
             body: bodies.Body,
-            outcomes: Mapping[ids.HandlerId, execution.Outcome],
+            outcomes: dict[ids.HandlerId, execution.Outcome],
     ) -> None:
         """ Interpret the indexing results and apply them to the indices. """
         key = self.make_key(body)

--- a/kopf/_core/engines/peering.py
+++ b/kopf/_core/engines/peering.py
@@ -39,7 +39,7 @@ import getpass
 import logging
 import os
 import random
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from typing import Any, NewType, NoReturn, cast
 
 import iso8601
@@ -121,7 +121,7 @@ async def process_peering_event(
         return
 
     # Find if we are still the highest priority operator.
-    pairs = cast(Mapping[str, Mapping[str, Any]], body.get('status', {}))
+    pairs = cast(dict[str, dict[str, Any]], body.get('status', {}))
     peers = [Peer(identity=Identity(opid), **opinfo) for opid, opinfo in pairs.items()]
     dead_peers = [peer for peer in peers if peer.is_dead]
     live_peers = [peer for peer in peers if not peer.is_dead and peer.identity != identity]

--- a/kopf/_core/engines/probing.py
+++ b/kopf/_core/engines/probing.py
@@ -2,7 +2,6 @@ import asyncio
 import datetime
 import logging
 import urllib.parse
-from collections.abc import MutableMapping
 
 import aiohttp.web
 
@@ -34,7 +33,7 @@ async def health_reporter(
     is cancelled or fails). Once it stops responding for any reason,
     Kubernetes will assume the pod is not alive anymore, and will restart it.
     """
-    probing_container: MutableMapping[ids.HandlerId, execution.Result] = {}
+    probing_container: dict[ids.HandlerId, execution.Result] = {}
     probing_timestamp: datetime.datetime | None = None
     probing_max_age = datetime.timedelta(seconds=10.0)
     probing_lock = asyncio.Lock()
@@ -61,7 +60,7 @@ async def health_reporter(
                         memo=memo,
                     )
                     probing_container.clear()
-                    probing_container.update(activity_results)
+                    probing_container |= activity_results
                     probing_timestamp = datetime.datetime.now(datetime.timezone.utc)
 
         return aiohttp.web.json_response(probing_container)

--- a/kopf/_core/intents/causes.py
+++ b/kopf/_core/intents/causes.py
@@ -106,14 +106,14 @@ class BaseCause(execution.Cause):
     memo: ephemera.AnyMemo
 
     @property
-    def _kwargs(self) -> Mapping[str, Any]:
+    def _kwargs(self) -> dict[str, Any]:
         kwargs = dict(super()._kwargs)
         del kwargs['indices']
         return kwargs
 
     @property
-    def _super_kwargs(self) -> Mapping[str, Any]:
-        return self.indices
+    def _super_kwargs(self) -> dict[str, Any]:
+        return dict(self.indices)
 
 
 @dataclasses.dataclass
@@ -129,7 +129,7 @@ class ResourceCause(BaseCause):
     body: bodies.Body
 
     @property
-    def _kwargs(self) -> Mapping[str, Any]:
+    def _kwargs(self) -> dict[str, Any]:
         return dict(
             super()._kwargs,
             spec=self.body.spec,
@@ -159,7 +159,7 @@ class WebhookCause(ResourceCause):
     diff: diffs.Diff | None = None
 
     @property
-    def _kwargs(self) -> Mapping[str, Any]:
+    def _kwargs(self) -> dict[str, Any]:
         kwargs = dict(super()._kwargs)
         del kwargs['reason']
         del kwargs['webhook']
@@ -193,7 +193,7 @@ class SpawningCause(ResourceCause):
     reset: bool
 
     @property
-    def _kwargs(self) -> Mapping[str, Any]:
+    def _kwargs(self) -> dict[str, Any]:
         kwargs = dict(super()._kwargs)
         del kwargs['reset']
         return kwargs
@@ -214,7 +214,7 @@ class ChangingCause(ResourceCause):
     new: bodies.BodyEssence | None = None
 
     @property
-    def _kwargs(self) -> Mapping[str, Any]:
+    def _kwargs(self) -> dict[str, Any]:
         kwargs = dict(super()._kwargs)
         del kwargs['initial']
         return kwargs
@@ -247,18 +247,18 @@ class DaemonCause(ResourceCause):
     stopper: stoppers.DaemonStopper  # a signaller for the termination and its reason.
 
     @property
-    def _kwargs(self) -> Mapping[str, Any]:
+    def _kwargs(self) -> dict[str, Any]:
         kwargs = dict(super()._kwargs)
         del kwargs['stopper']
         return kwargs
 
     @property
-    def _sync_kwargs(self) -> Mapping[str, Any]:
-        return dict(super()._sync_kwargs, stopped=self.stopper.sync_waiter)
+    def _sync_kwargs(self) -> dict[str, Any]:
+        return super()._sync_kwargs | dict(stopped=self.stopper.sync_waiter)
 
     @property
-    def _async_kwargs(self) -> Mapping[str, Any]:
-        return dict(super()._async_kwargs, stopped=self.stopper.async_waiter)
+    def _async_kwargs(self) -> dict[str, Any]:
+        return super()._async_kwargs | dict(stopped=self.stopper.async_waiter)
 
 
 def detect_watching_cause(

--- a/kopf/_core/intents/causes.py
+++ b/kopf/_core/intents/causes.py
@@ -21,7 +21,6 @@ could execute on the yet-existing object (and its children, if created).
 """
 import dataclasses
 import enum
-from collections.abc import Mapping
 from typing import Any
 
 from kopf._cogs.configs import configuration
@@ -148,8 +147,8 @@ class WebhookCause(ResourceCause):
     dryrun: bool
     reason: WebhookType | None  # None means "all" or expects the webhook id
     webhook: ids.HandlerId | None  # None means "all"
-    headers: Mapping[str, str]
-    sslpeer: Mapping[str, Any]
+    headers: reviews.Headers
+    sslpeer: reviews.SSLPeer
     userinfo: reviews.UserInfo
     warnings: list[str]  # mutable!
     operation: reviews.Operation | None  # None if not provided for some reason

--- a/kopf/_core/intents/registries.py
+++ b/kopf/_core/intents/registries.py
@@ -14,8 +14,7 @@ of the handlers to be executed on each reaction cycle.
 import abc
 import enum
 import functools
-from collections.abc import Callable, Collection, Container, Iterable, \
-                            Iterator, Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Collection, Container, Iterable, Iterator, Mapping, Sequence
 from types import FunctionType, MethodType
 from typing import Any, Generic, TypeVar, cast
 
@@ -397,7 +396,7 @@ def prematch(
         cause: causes.ResourceCause,
 ) -> bool:
     # Kwargs are lazily evaluated on the first _actual_ use, and shared for all filters since then.
-    kwargs: MutableMapping[str, Any] = {}
+    kwargs: dict[str, Any] = {}
     return (
         _matches_resource(handler, cause.resource) and
         _matches_subresource(handler, cause) and
@@ -413,7 +412,7 @@ def match(
         cause: causes.ResourceCause,
 ) -> bool:
     # Kwargs are lazily evaluated on the first _actual_ use, and shared for all filters since then.
-    kwargs: MutableMapping[str, Any] = {}
+    kwargs: dict[str, Any] = {}
     return (
         _matches_resource(handler, cause.resource) and
         _matches_subresource(handler, cause) and
@@ -448,7 +447,7 @@ def _matches_subresource(
 def _matches_labels(
         handler: handlers.ResourceHandler,
         cause: causes.ResourceCause,
-        kwargs: MutableMapping[str, Any],
+        kwargs: dict[str, Any],
 ) -> bool:
     return (not handler.labels or
             _matches_metadata(pattern=handler.labels,
@@ -459,7 +458,7 @@ def _matches_labels(
 def _matches_annotations(
         handler: handlers.ResourceHandler,
         cause: causes.ResourceCause,
-        kwargs: MutableMapping[str, Any],
+        kwargs: dict[str, Any],
 ) -> bool:
     return (not handler.annotations or
             _matches_metadata(pattern=handler.annotations,
@@ -471,7 +470,7 @@ def _matches_metadata(
         *,
         pattern: filters.MetaFilter,  # from the handler
         content: Mapping[str, str],  # from the body
-        kwargs: MutableMapping[str, Any],
+        kwargs: dict[str, Any],
         cause: causes.ResourceCause,
 ) -> bool:
     for key, value in pattern.items():
@@ -481,7 +480,7 @@ def _matches_metadata(
             continue
         elif callable(value):
             if not kwargs:
-                kwargs.update(cause.kwargs)
+                kwargs |= cause.kwargs
             if value(content.get(key, None), **kwargs):
                 continue
             else:
@@ -498,13 +497,13 @@ def _matches_metadata(
 def _matches_field_values(
         handler: handlers.ResourceHandler,
         cause: causes.ResourceCause,
-        kwargs: MutableMapping[str, Any],
+        kwargs: dict[str, Any],
 ) -> bool:
     if not handler.field:
         return True
 
     if not kwargs:
-        kwargs.update(cause.kwargs)
+        kwargs |= cause.kwargs
 
     absent = _UNSET.token  # or any other identifyable object
     if isinstance(cause, causes.ChangingCause):
@@ -528,7 +527,7 @@ def _matches_field_values(
 def _matches_field_changes(
         handler: handlers.ResourceHandler,
         cause: causes.ResourceCause,
-        kwargs: MutableMapping[str, Any],
+        kwargs: dict[str, Any],
 ) -> bool:
     if not isinstance(handler, handlers.ChangingHandler):
         return True
@@ -538,7 +537,7 @@ def _matches_field_changes(
         return True
 
     if not kwargs:
-        kwargs.update(cause.kwargs)
+        kwargs |= cause.kwargs
 
     absent = _UNSET.token  # or any other identifyable object
     old = dicts.resolve(cause.old, handler.field, absent)
@@ -564,12 +563,12 @@ def _matches_field_changes(
 def _matches_filter_callback(
         handler: handlers.ResourceHandler,
         cause: causes.ResourceCause,
-        kwargs: MutableMapping[str, Any],
+        kwargs: dict[str, Any],
 ) -> bool:
     if handler.when is None:
         return True
     if not kwargs:
-        kwargs.update(cause.kwargs)
+        kwargs |= cause.kwargs
     return handler.when(**kwargs)
 
 

--- a/kopf/_core/intents/registries.py
+++ b/kopf/_core/intents/registries.py
@@ -469,7 +469,7 @@ def _matches_annotations(
 def _matches_metadata(
         *,
         pattern: filters.MetaFilter,  # from the handler
-        content: Mapping[str, str],  # from the body
+        content: Mapping[str, str],  # from the body; can be live views on dicts (labels & co)
         kwargs: dict[str, Any],
         cause: causes.ResourceCause,
 ) -> bool:

--- a/kopf/_core/reactor/inventory.py
+++ b/kopf/_core/reactor/inventory.py
@@ -19,7 +19,7 @@ must be kept together with their owning modules rather than mirrored in structs.
 """
 import copy
 import dataclasses
-from collections.abc import Iterator, MutableMapping
+from collections.abc import Iterator
 
 from kopf._cogs.structs import bodies, ephemera, patches
 from kopf._core.actions import throttlers
@@ -62,7 +62,7 @@ class ResourceMemories(admission.MemoGetter, daemons.DaemonsMemoriesIterator):
     are handled in parallel though), so the same key will not be added/deleted
     in the background during the operation, so the locking is not needed.
     """
-    _items: MutableMapping[str, ResourceMemory]
+    _items: dict[str, ResourceMemory]
 
     def __init__(self) -> None:
         super().__init__()

--- a/kopf/_core/reactor/orchestration.py
+++ b/kopf/_core/reactor/orchestration.py
@@ -27,7 +27,7 @@ import dataclasses
 import functools
 import itertools
 import logging
-from collections.abc import Collection, Container, Iterable, MutableMapping
+from collections.abc import Collection, Container, Iterable
 from typing import Any, NamedTuple, Protocol
 
 from kopf._cogs.aiokits import aiotasks, aiotoggles
@@ -91,7 +91,7 @@ class Ensemble:
         return {toggle for key, toggle in self.conflicts_found.items() if key in keys}
 
     def del_keys(self, keys: Container[EnsembleKey]) -> None:
-        d: MutableMapping[EnsembleKey, Any]
+        d: dict[EnsembleKey, Any]
         for d in [self.watcher_tasks, self.peering_tasks, self.pinging_tasks]:
             for key in set(d):
                 if key in keys:

--- a/kopf/_core/reactor/orchestration.py
+++ b/kopf/_core/reactor/orchestration.py
@@ -66,7 +66,7 @@ class Ensemble:
     #       ToggleSet is used because it is the closest equivalent of such a primitive.
     operator_indexed: aiotoggles.ToggleSet
 
-    # Multidimentional pausing: for every namespace, and a few for the whole cluster (for CRDs).
+    # Multidimensional pausing: for every namespace, and a few for the whole cluster (for CRDs).
     operator_paused: aiotoggles.ToggleSet
     peering_missing: aiotoggles.Toggle
     conflicts_found: dict[EnsembleKey, aiotoggles.Toggle] = dataclasses.field(default_factory=dict)

--- a/kopf/_core/reactor/queueing.py
+++ b/kopf/_core/reactor/queueing.py
@@ -26,7 +26,6 @@ import asyncio
 import contextlib
 import enum
 import logging
-from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, NamedTuple, NewType, Protocol
 
 from kopf._cogs.aiokits import aiotasks, aiotoggles
@@ -70,7 +69,6 @@ class Stream(NamedTuple):
 
 ObjectUid = NewType('ObjectUid', str)
 ObjectRef = tuple[references.Resource, ObjectUid]
-Streams = MutableMapping[ObjectRef, Stream]
 
 
 def get_uid(raw_event: bodies.RawEvent) -> ObjectUid:
@@ -172,7 +170,7 @@ async def watcher(
     signaller = asyncio.Condition()
     scheduler = aiotasks.Scheduler(limit=settings.queueing.worker_limit,
                                    exception_handler=exception_handler)
-    streams: Streams = {}
+    streams: dict[ObjectRef, Stream] = {}
 
     try:
         # Either use the existing object's queue, or create a new one together with the per-object job.
@@ -267,7 +265,7 @@ async def worker(
         processor: WatchStreamProcessor,
         resource_indexed: aiotoggles.Toggle | None = None,  # None for tests & observation
         operator_indexed: aiotoggles.ToggleSet | None = None,  # None for tests & observation
-        streams: Streams,
+        streams: dict[ObjectRef, Stream],
         key: ObjectRef,
 ) -> None:
     """
@@ -376,7 +374,7 @@ async def _wait_for_depletion(
         signaller: asyncio.Condition,
         scheduler: aiotasks.Scheduler,
         settings: configuration.OperatorSettings,
-        streams: Streams,
+        streams: dict[ObjectRef, Stream],
 ) -> None:
 
     # Notify all the workers to finish now. Wake them up if they are waiting in the queue-getting.

--- a/tests/handling/test_activity_triggering.py
+++ b/tests/handling/test_activity_triggering.py
@@ -1,5 +1,3 @@
-from collections.abc import Mapping
-
 import freezegun
 import pytest
 
@@ -16,8 +14,7 @@ from kopf._core.intents.registries import OperatorRegistry
 
 def test_activity_error_exception():
     outcome = Outcome(final=True)
-    outcomes: Mapping[HandlerId, Outcome]
-    outcomes = {HandlerId('id'): outcome}
+    outcomes: dict[HandlerId, Outcome] = {HandlerId('id'): outcome}
     error = ActivityError("message", outcomes=outcomes)
     assert str(error) == "message"
     assert error.outcomes == outcomes


### PR DESCRIPTION
An extended follow-up for:

* #1164
* #1165

Here, minimize the usage of `Mapping` & `MutableMapping` and reduce them to the built-in generic `dict`.

Excluded from the conversion:

* Generic type declarations that implement the interface of Mapping/MutableMapping.
* Live views into the underlying dicts, such as Body/Spec/Meta/Labels/Annotations.
* All user-facing public API routines that accept dict-like values, such as object/label/metadata manipulation.
* All user-facing public API types that are **not** promised to be dicts, though can be de-facto dicts.
  * Except for the webhook HTTP headers & SSL peer info, which are now promised to be dicts.

---

The `Iterable` / `Iterator` / `Container` / `Collection` / `Sequence` generics are NOT converted or narrowed down to their concrete types, even internally. While the conversion of mappings to dicts simplifies the codebase, the conversion of these generics would do the opposite — it will complicate the codebase. We need to know the bare minimum behaviour that we can use in a routine, and allow the callers of this routine to inject any possible containers they prefer on their side. 

Such distinction is of little significance for the only two types of mappings: readonly vs. mutable — we can ignore it, we use dicts in all cases anyway. (Except for the "live views" on bodies for a bit of syntax sugar.)