### PR TITLE
Fix the test failures in Python 3.13 due to not accepting name=… in tests

### DIFF
--- a/tests/utilities/aiotasks/test_coro_cancellation.py
+++ b/tests/utilities/aiotasks/test_coro_cancellation.py
@@ -12,7 +12,9 @@ async def f(mock):
     return mock()
 
 
-def factory(loop, coro_or_mock, context=None):
+# Kwargs are accepted to match the signatures, but are unused/not passed through due to no need.
+# Usually those are `name` & `context`, as in `asyncio.create_task(…)`.
+def factory(loop, coro_or_mock, **_):
     coro = coro_or_mock._mock_wraps if isinstance(coro_or_mock, AsyncMock) else coro_or_mock
     return asyncio.Task(coro, loop=loop)
 


### PR DESCRIPTION
A follow-up for: 

* #1164
* #1165

A minor issue shown only in tests because of how a fixture for the mock of the task factory was made:

It was not accepting the `name=…` kwargs, which is used in multiple places. And as such, it was failing in the test that was explicitly targeting the case where `coro.close()` does not exit.

