### PR TITLE
Work around changes in Click 8.2.0

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -34,8 +34,8 @@ exit code and output are available to the test (for additional assertions).
 
         assert runner.exit_code == 0
         assert runner.exception is None
-        assert 'And here we are!' in runner.stdout
-        assert 'Deleted, really deleted' in runner.stdout
+        assert 'And here we are!' in runner.output
+        assert 'Deleted, really deleted' in runner.output
 
 .. note::
     The operator runs against the cluster which is currently authenticated ---

--- a/examples/09-testing/test_example_09.py
+++ b/examples/09-testing/test_example_09.py
@@ -51,5 +51,5 @@ def test_resource_lifecycle():
     assert runner.exit_code == 0
 
     # There are usually more than these messages, but we only check for the certain ones.
-    assert '[default/kopf-example-1] Creation is in progress:' in runner.stdout
-    assert '[default/kopf-example-1] Something was logged here.' in runner.stdout
+    assert '[default/kopf-example-1] Creation is in progress:' in runner.output
+    assert '[default/kopf-example-1] Something was logged here.' in runner.output

--- a/examples/10-builtins/test_example_10.py
+++ b/examples/10-builtins/test_example_10.py
@@ -19,10 +19,10 @@ def test_pods_reacted():
     assert runner.exception is None
     assert runner.exit_code == 0
 
-    assert f'[default/{name}] Creation is in progress:' in runner.stdout
-    assert f'[default/{name}] === Pod killing happens in 30s.' in runner.stdout
-    assert f'[default/{name}] Deletion is in progress:' in runner.stdout
-    assert f'[default/{name}] === Pod killing is cancelled!' in runner.stdout
+    assert f'[default/{name}] Creation is in progress:' in runner.output
+    assert f'[default/{name}] === Pod killing happens in 30s.' in runner.output
+    assert f'[default/{name}] Deletion is in progress:' in runner.output
+    assert f'[default/{name}] === Pod killing is cancelled!' in runner.output
 
 
 def _create_pod():

--- a/examples/11-filtering-handlers/test_example_11.py
+++ b/examples/11-filtering-handlers/test_example_11.py
@@ -54,19 +54,19 @@ def test_handler_filtering():
     assert runner.exit_code == 0
 
     # Check for correct log lines (to indicate correct handlers were executed).
-    assert '[default/kopf-example-1] Label is matching.' in runner.stdout
-    assert '[default/kopf-example-1] Label is present.' in runner.stdout
-    assert '[default/kopf-example-1] Label is absent.' in runner.stdout
-    assert '[default/kopf-example-1] Label callback matching.' in runner.stdout
-    assert '[default/kopf-example-1] Annotation is matching.' in runner.stdout
-    assert '[default/kopf-example-1] Annotation is present.' in runner.stdout
-    assert '[default/kopf-example-1] Annotation is absent.' in runner.stdout
-    assert '[default/kopf-example-1] Annotation callback mismatch.' not in runner.stdout
-    assert '[default/kopf-example-1] Filter satisfied.' in runner.stdout
-    assert '[default/kopf-example-1] Filter not satisfied.' not in runner.stdout
-    assert '[default/kopf-example-1] Field value is satisfied.' in runner.stdout
-    assert '[default/kopf-example-1] Field value is not satisfied.' not in runner.stdout
-    assert '[default/kopf-example-1] Field presence is satisfied.' in runner.stdout
-    assert '[default/kopf-example-1] Field presence is not satisfied.' not in runner.stdout
-    assert '[default/kopf-example-1] Field change is satisfied.' in runner.stdout
-    assert '[default/kopf-example-1] Field daemon is satisfied.' in runner.stdout
+    assert '[default/kopf-example-1] Label is matching.' in runner.output
+    assert '[default/kopf-example-1] Label is present.' in runner.output
+    assert '[default/kopf-example-1] Label is absent.' in runner.output
+    assert '[default/kopf-example-1] Label callback matching.' in runner.output
+    assert '[default/kopf-example-1] Annotation is matching.' in runner.output
+    assert '[default/kopf-example-1] Annotation is present.' in runner.output
+    assert '[default/kopf-example-1] Annotation is absent.' in runner.output
+    assert '[default/kopf-example-1] Annotation callback mismatch.' not in runner.output
+    assert '[default/kopf-example-1] Filter satisfied.' in runner.output
+    assert '[default/kopf-example-1] Filter not satisfied.' not in runner.output
+    assert '[default/kopf-example-1] Field value is satisfied.' in runner.output
+    assert '[default/kopf-example-1] Field value is not satisfied.' not in runner.output
+    assert '[default/kopf-example-1] Field presence is satisfied.' in runner.output
+    assert '[default/kopf-example-1] Field presence is not satisfied.' not in runner.output
+    assert '[default/kopf-example-1] Field change is satisfied.' in runner.output
+    assert '[default/kopf-example-1] Field daemon is satisfied.' in runner.output

--- a/kopf/_kits/runner.py
+++ b/kopf/_kits/runner.py
@@ -38,7 +38,7 @@ class KopfRunner(_AbstractKopfRunner):
 
         assert runner.exit_code == 0
         assert runner.exception is None
-        assert 'And here we are!' in runner.stdout
+        assert 'And here we are!' in runner.output
 
     All the args & kwargs are passed directly to Click's invocation method.
     See: `click.testing.CliRunner`.

--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -29,7 +29,10 @@ class CLIControls:
     loop: Optional[asyncio.AbstractEventLoop] = None
 
 
-class LogFormatParamType(click.Choice):
+# With Click>=8.2.0, that should be `click.Choice[LogFormat]`, but it is good for now, too.
+# TODO: when Python 3.9 is dropped, upgrade dependencies to click>=8.2.0, and remake the class here.
+#       see: https://github.com/nolar/kopf/pull/1174
+class LogFormatParamType(click.Choice):  # type: ignore
 
     def __init__(self) -> None:
         super().__init__(choices=[v.name.lower() for v in loggers.LogFormat])

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -67,18 +67,18 @@ def test_all_examples_are_runnable(mocker, settings, with_crd, exampledir, caplo
     # There are usually more than these messages, but we only check for the certain ones.
     # This just shows us that the operator is doing something, it is alive.
     if e2e.has_mandatory_on_delete:
-        assert '[default/kopf-example-1] Adding the finalizer' in runner.stdout
+        assert '[default/kopf-example-1] Adding the finalizer' in runner.output
     if e2e.has_on_create:
-        assert '[default/kopf-example-1] Creation is in progress:' in runner.stdout
+        assert '[default/kopf-example-1] Creation is in progress:' in runner.output
     if e2e.has_mandatory_on_delete:
-        assert '[default/kopf-example-1] Deletion is in progress:' in runner.stdout
+        assert '[default/kopf-example-1] Deletion is in progress:' in runner.output
     if e2e.has_changing_handlers:
-        assert '[default/kopf-example-1] Deleted, really deleted' in runner.stdout
+        assert '[default/kopf-example-1] Deleted, really deleted' in runner.output
     if not e2e.allow_tracebacks:
-        assert 'Traceback (most recent call last):' not in runner.stdout
+        assert 'Traceback (most recent call last):' not in runner.output
 
     # Verify that once a handler succeeds, it is never re-executed again.
-    handler_names = re.findall(r"'(.+?)' succeeded", runner.stdout)
+    handler_names = re.findall(r"'(.+?)' succeeded", runner.output)
     if e2e.success_counts is not None:
         checked_names = [name for name in handler_names if name in e2e.success_counts]
         name_counts = collections.Counter(checked_names)
@@ -88,7 +88,7 @@ def test_all_examples_are_runnable(mocker, settings, with_crd, exampledir, caplo
         assert set(name_counts.values()) == {1}
 
     # Verify that once a handler fails, it is never re-executed again.
-    handler_names = re.findall(r"'(.+?)' failed (?:permanently|with an exception. Will stop.)", runner.stdout)
+    handler_names = re.findall(r"'(.+?)' failed (?:permanently|with an exception. Will stop.)", runner.output)
     if e2e.failure_counts is not None:
         checked_names = [name for name in handler_names if name in e2e.failure_counts]
         name_counts = collections.Counter(checked_names)


### PR DESCRIPTION
Click 8.2.0 has been released 2 days ago: 2025-05-10. It has introduced a few changes that are irrelevant for Kopf, but broke the CI end2end tests:

* https://click.palletsprojects.com/en/stable/changes/

Specifically:

> Keep stdout and stderr streams independent in CliRunner. Always collect stderr output and never raise an exception. Add a new output stream to simulate what the user sees in its terminal. Removes the mix_stderr parameter in CliRunner.

Hence, switch from `.stdout` to `.output` in the end2end tests. The expected logs go to stderr, but they were previously visible in `.stdout`, so I used whatever worked.

> Choice is now generic and supports any iterable value. This allows you to use enums and other non-str values.

This failed the mypy checks. The proper fix would be to remake `LogFormatParamType` to inhert from `click.Choice[loggers.LogFormat]` (the enum). But this requires the strict dependency for `click>=8.2.0` for Kopf, since the type was not a generic in 8.1.x and before. However, Click 8.2.0 also drops the support for the yet-alive Python 3.9, which should be supported in Kopf till October 2025. So, I cannot make Kopf depend on `click>=8.2.0` yet.

Therefore, suppress the line for the time being. Get back to that line when Python 3.9 is dropped from Kopf.