### PR TITLE
chore(logging): update log level when retrying

### DIFF
--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -104,7 +104,7 @@ async def request(
                 logger.error(f"Request attempt {idx} failed; escalating: {what} -> {e!r}")
                 raise
             else:
-                logger.error(f"Request attempt {idx} failed; will retry: {what} -> {e!r}")
+                logger.warning(f"Request attempt {idx} failed; will retry: {what} -> {e!r}")
                 await asyncio.sleep(backoff)  # non-awakable! but still cancellable.
         else:
             if retry > 1:


### PR DESCRIPTION
Use log level `WARNING` (instead of `ERROR`) when a request to the Kubernetes API fails **and will be retried**.  Reporting these cases as WARNING seems appropriate as the request _could_ still be successful.