### PR TITLE
Enable Python 3.14 and use it by default in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - run: pip install --group lint -e .
       - run: pre-commit run --all-files
       - run: mypy kopf --strict
@@ -38,10 +38,10 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         include:
           - install-extras: "uvloop"
-            python-version: "3.13"
+            python-version: "3.14"
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5  # usually 2-3 mins
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: nolar/setup-k3d-k3s@v1
         with:
           version: ${{ matrix.k3s }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - run: pip install --upgrade pip build
       - run: python -m build  # includes sdist & wheel by default
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - run: pip install --group lint -e .
       - run: pre-commit run --all-files
       - run: mypy kopf --strict
@@ -42,10 +42,10 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         include:
           - install-extras: "uvloop"
-            python-version: "3.13"
+            python-version: "3.14"
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5  # usually 2-3 mins
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: nolar/setup-k3d-k3s@v1
         with:
           version: ${{ matrix.k3s }}
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - run: tools/install-minikube.sh
       - run: pip install --group test -e . -r examples/requirements.txt
       - run: pytest --color=yes --timeout=30 --only-e2e

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
         files: '^examples/'
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py310-plus, --keep-mock]

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ We assume that when the operator is executed in the cluster, it must be packaged
 into a docker image with a CI/CD tool of your preference.
 
 ```dockerfile
-FROM python:3.13
+FROM python:3.14
 ADD . /src
 RUN pip install kopf
 CMD kopf run /src/handlers.py --verbose

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -16,7 +16,7 @@ First of all, the operator must be packaged as a docker image with Python 3.10 o
     :caption: Dockerfile
     :name: dockerfile
 
-    FROM python:3.13
+    FROM python:3.14
     RUN pip install kopf
     ADD . /src
     CMD kopf run /src/handlers.py --verbose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",

--- a/tests/testing/test_runner.py
+++ b/tests/testing/test_runner.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 
 from kopf._cogs.configs.configuration import OperatorSettings
@@ -10,22 +8,6 @@ from kopf.testing import KopfRunner
 @pytest.fixture(autouse=True)
 def no_config_needed(login_mocks):
     pass
-
-
-@pytest.fixture(autouse=True, params=['default', 'uvloop'])
-def _event_loop_policy(request):
-    original_policy = asyncio.get_event_loop_policy()
-    if request.param == 'default':
-        policy = asyncio.DefaultEventLoopPolicy()
-    elif request.param == 'uvloop':
-        uvloop = pytest.importorskip('uvloop')
-        policy = uvloop.EventLoopPolicy()
-    else:
-        raise RuntimeError(f"Unknown event loop type {request.param!r}")
-
-    asyncio.set_event_loop_policy(policy)
-    yield
-    asyncio.set_event_loop_policy(original_policy)
 
 
 def test_command_invocation_works():


### PR DESCRIPTION
Python 3.14 has been released a few weeks ago — it is time to enable it (and fix the issues/deprecations).

Related:

* #1189 
* #1190 
* #1191 

---

**FIXED.** ~BLOCKED~: The API tests are extremely slow in Python 3.14 (only 3.14, fast in 3.10-3.13) and fail the CI due to timeouts (5 mins). The cause is unknown.

This happens locally if the test are executed in sequence from the beginning, and does not happen if the API tests are executed selectively. Probably, some state accumulation that is not reset/cleared in Python 3.14 — likely in aresponses, likley with the monkey-patching of the dns resolver (as before) — but it is not proven yet.

To unblock, it requires either investigating & fixing the aresponses (or other causes), or finishing the kmock (99% finished since 2 years ago) and converting all tests to kmock — depending on what is easier & faster. Either way, it takes time, so Python 3.14 is currently on pause.

* https://github.com/nolar/kmock/pull/2

However, the code in this PR is fixed & prepared and should be **runnable in Python 3.14** (on your own risk). If needed (in case the CI fix takes too long), it can be extracted into a separate PR and released as is.

UPD: Extracted into and released as 1.39.0:

* #1199

UPD2: Fixed by suppressing the deprecation warnings from aresponses, and fixing the mock factory in Kopf. The switch to KMock was not necessary (though it is not cancelled, only postponed).