### PR TITLE
Drop Python 3.9 from CI, require Python 3.10+

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "pypy-3.9", "pypy-3.10" ]
+        python-version: [ "pypy-3.9", "pypy-3.10", "pypy-3.11" ]
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
         include:
           - install-extras: "uvloop"
             python-version: "3.13"
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "pypy-3.9", "pypy-3.10", "pypy-3.11" ]
+        python-version: [ "pypy-3.10", "pypy-3.11" ]
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
         include:
           - install-extras: "uvloop"
             python-version: "3.13"
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "pypy-3.9", "pypy-3.10", "pypy-3.11" ]
+        python-version: [ "pypy-3.10", "pypy-3.11" ]
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         install-extras: [ "", "full-auth" ]
-        python-version: [ "pypy-3.9", "pypy-3.10" ]
+        python-version: [ "pypy-3.9", "pypy-3.10", "pypy-3.11" ]
     name: Python ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -80,7 +80,7 @@ If you use PyCharm, create a Run/Debug Configuration as follows:
 * Mode: `module name`
 * Module name: `kopf`
 * Arguments: `run examples/01-minimal/example.py --verbose`
-* Python Interpreter: anything with Python>=3.9
+* Python Interpreter: anything with Python>=3.10
 
 Stop the console operator, and start the IDE debug session.
 Put a breakpoint in the used operator script on the first line of the function.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ That easy! For more features, see the [documentation](https://kopf.readthedocs.i
 
 ## Usage
 
-Python 3.9+ is required:
+Python 3.10+ is required:
 [CPython](https://www.python.org/) and [PyPy](https://www.pypy.org/)
 are officially supported and tested; other Python implementations can work too.
 

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -10,7 +10,7 @@ But normally, the operators are usually deployed directly to the clusters.
 Docker image
 ============
 
-First of all, the operator must be packaged as a docker image with Python 3.9 or newer:
+First of all, the operator must be packaged as a docker image with Python 3.10 or newer:
 
 .. code-block:: dockerfile
     :caption: Dockerfile

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,7 +6,7 @@ Installation
 
 Prerequisites:
 
-* Python >= 3.9 (CPython and PyPy are officially tested and supported).
+* Python >= 3.10 (CPython and PyPy are officially tested and supported).
 
 To install Kopf::
 

--- a/docs/walkthrough/prerequisites.rst
+++ b/docs/walkthrough/prerequisites.rst
@@ -6,7 +6,7 @@ We need a running Kubernetes cluster and some tools for our experiments.
 If you have a cluster already preconfigured, you can skip this section.
 Otherwise, let's install minikube locally (e.g. for MacOS):
 
-* Python >= 3.9 (running in a venv is recommended, though is not necessary).
+* Python >= 3.10 (running in a venv is recommended, though is not necessary).
 * `Install kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
 * :doc:`Install minikube </minikube>` (a local Kubernetes cluster)
 * :doc:`Install Kopf </install>`

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
@@ -53,7 +52,7 @@ setup(
         ],
     },
 
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     setup_requires=[
         'setuptools_scm',
     ],


### PR DESCRIPTION
Python 3.9 is end-of life as of October 2025 — it is time to move on:

<img width="827" height="368" alt="image" src="https://github.com/user-attachments/assets/465e4a13-0faf-4ec6-a9a4-f65a1958ead9" />

The syntax rewrites are in:

* #1191 