### PR TITLE
feat: Add support for removing fields from diff

### DIFF
--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -91,7 +91,7 @@ class DiffBaseStorage(conventions.StorageKeyMarkingConvention,
                 try:
                     dicts.remove(essence, ignored_field)
                 except TypeError:
-                    # If the field is not present or does not support item deletion, just skip it.
+                    # If the field does not support item deletion, just skip it.
                     pass
 
         return cast(bodies.BodyEssence, essence)

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -31,6 +31,7 @@ class DiffBaseStorage(conventions.StorageKeyMarkingConvention,
             *,
             body: bodies.Body,
             extra_fields: Iterable[dicts.FieldSpec] | None = None,
+            ignored_fields: Iterable[dicts.FieldSpec] | None = None,
     ) -> bodies.BodyEssence:
         """
         Extract only the relevant fields for the state comparisons.
@@ -83,6 +84,16 @@ class DiffBaseStorage(conventions.StorageKeyMarkingConvention,
         dicts.cherrypick(src=body, dst=essence, fields=extra_fields, picker=copy.deepcopy)
 
         self.remove_empty_stanzas(cast(bodies.BodyEssence, essence))
+
+        # Remove ignored fields if specified
+        if ignored_fields:
+            for ignored_field in ignored_fields:
+                try:
+                    dicts.remove(essence, ignored_field)
+                except TypeError:
+                    # If the field is not present or does not support item deletion, just skip it.
+                    pass
+
         return cast(bodies.BodyEssence, essence)
 
     @abc.abstractmethod
@@ -111,12 +122,12 @@ class AnnotationsDiffBaseStorage(conventions.StorageKeyFormingConvention, DiffBa
             *,
             prefix: str = 'kopf.zalando.org',
             key: str = 'last-handled-configuration',
-            ignored_fields: Iterable[dicts.FieldSpec] = None,
+            ignored_fields: Iterable[dicts.FieldSpec] | None = None,
             v1: bool = True,  # will be switched to False a few releases later
     ) -> None:
         super().__init__(prefix=prefix, v1=v1)
         self.key = key
-        self._ignored_fields = ignored_fields if ignored_fields else []
+        self._ignored_fields = ignored_fields
 
     def build(
             self,
@@ -124,15 +135,11 @@ class AnnotationsDiffBaseStorage(conventions.StorageKeyFormingConvention, DiffBa
             body: bodies.Body,
             extra_fields: Iterable[dicts.FieldSpec] | None = None,
     ) -> bodies.BodyEssence:
-        essence = super().build(body=body, extra_fields=extra_fields)
-
-        # Remove ignored fields if specified
-        for f in self._ignored_fields:
-            try:
-                dicts.remove(essence, f)
-            except TypeError:
-                # If the field is not present or does not support item deletion, just skip it.
-                pass
+        essence = super().build(
+            body=body,
+            extra_fields=extra_fields,
+            ignored_fields=self._ignored_fields
+        )
 
         self.remove_annotations(essence, set(self.make_keys(self.key, body=body)))
         self.remove_empty_stanzas(essence)
@@ -171,13 +178,13 @@ class StatusDiffBaseStorage(DiffBaseStorage):
             *,
             name: str = 'kopf',
             field: dicts.FieldSpec = 'status.{name}.last-handled-configuration',
-            ignored_fields: Iterable[dicts.FieldSpec] = None,
+            ignored_fields: Iterable[dicts.FieldSpec] | None = None,
     ) -> None:
         super().__init__()
         self._name = name
         real_field = field.format(name=self._name) if isinstance(field, str) else field
         self._field = dicts.parse_field(real_field)
-        self._ignored_fields = ignored_fields if ignored_fields else []
+        self._ignored_fields = ignored_fields
 
     @property
     def field(self) -> dicts.FieldPath:
@@ -194,15 +201,11 @@ class StatusDiffBaseStorage(DiffBaseStorage):
             body: bodies.Body,
             extra_fields: Iterable[dicts.FieldSpec] | None = None,
     ) -> bodies.BodyEssence:
-        essence = super().build(body=body, extra_fields=extra_fields)
-
-        # Remove ignored fields if specified
-        for f in self._ignored_fields:
-            try:
-                dicts.remove(essence, f)
-            except TypeError:
-                # If the field is not present or does not support item deletion, just skip it.
-                pass
+        essence = super().build(
+            body=body,
+            extra_fields=extra_fields,
+            ignored_fields=self._ignored_fields
+        )
 
         # Work around an issue with mypy not treating TypedDicts as MutableMappings.
         essence_dict = cast(dict[Any, Any], essence)

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -111,12 +111,12 @@ class AnnotationsDiffBaseStorage(conventions.StorageKeyFormingConvention, DiffBa
             *,
             prefix: str = 'kopf.zalando.org',
             key: str = 'last-handled-configuration',
-            remove_fields: Iterable[str] = None,
+            ignored_fields: Iterable[str] = None,
             v1: bool = True,  # will be switched to False a few releases later
     ) -> None:
         super().__init__(prefix=prefix, v1=v1)
         self.key = key
-        self._remove_fields = list(remove_fields) if remove_fields else []
+        self._ignored_fields = list(ignored_fields) if ignored_fields else []
 
     def build(
             self,
@@ -126,8 +126,8 @@ class AnnotationsDiffBaseStorage(conventions.StorageKeyFormingConvention, DiffBa
     ) -> bodies.BodyEssence:
         essence = super().build(body=body, extra_fields=extra_fields)
 
-        # Remove extra fields if specified
-        for path in self._remove_fields:
+        # Remove ignored fields if specified
+        for path in self._ignored_fields:
             d = essence
             keys = path.split('.')
             for k in keys[:-1]:
@@ -174,13 +174,13 @@ class StatusDiffBaseStorage(DiffBaseStorage):
             *,
             name: str = 'kopf',
             field: dicts.FieldSpec = 'status.{name}.last-handled-configuration',
-            remove_fields: Iterable[str] = None,
+            ignored_fields: Iterable[str] = None,
     ) -> None:
         super().__init__()
         self._name = name
         real_field = field.format(name=self._name) if isinstance(field, str) else field
         self._field = dicts.parse_field(real_field)
-        self._remove_fields = list(remove_fields) if remove_fields else []
+        self._ignored_fields = list(ignored_fields) if ignored_fields else []
 
     @property
     def field(self) -> dicts.FieldPath:
@@ -199,8 +199,8 @@ class StatusDiffBaseStorage(DiffBaseStorage):
     ) -> bodies.BodyEssence:
         essence = super().build(body=body, extra_fields=extra_fields)
 
-        # Remove extra fields if specified
-        for path in self._remove_fields:
+        # Remove ignored fields if specified
+        for path in self._ignored_fields:
             d = essence
             keys = path.split('.')
             for k in keys[:-1]:

--- a/tests/persistence/test_essences.py
+++ b/tests/persistence/test_essences.py
@@ -181,7 +181,7 @@ def test_get_essence_clones_body(
 
 
 @pytest.mark.parametrize('cls', ALL_STORAGES)
-def test_status_storage_removes_fields(
+def test_status_storage_removes_ignored_fields(
         cls: type[DiffBaseStorage]):
     body = Body({
         'a': {
@@ -196,7 +196,7 @@ def test_status_storage_removes_fields(
             'i': 'j',
         }
     })
-    storage = cls(remove_fields=['a.b', 'a.e.f.g', 'h', 'k.l.m'])
+    storage = cls(ignored_fields=['a.b', 'a.e.f.g', 'h', 'k.l.m'])
     essence = storage.build(body=body)
 
     assert 'a' in essence

--- a/tests/persistence/test_essences.py
+++ b/tests/persistence/test_essences.py
@@ -178,3 +178,33 @@ def test_get_essence_clones_body(
     assert essence['spec'] is not body['spec']
     assert essence['spec']['depth'] is not body['spec']['depth']
     assert essence['spec']['depth']['field'] == 'x'
+
+
+@pytest.mark.parametrize('cls', ALL_STORAGES)
+def test_status_storage_removes_fields(
+        cls: type[DiffBaseStorage]):
+    body = Body({
+        'a': {
+            'b': {
+                'c': 'd',
+            },
+            'e': {
+                'f': 'g',
+            }
+        },
+        'h': {
+            'i': 'j',
+        }
+    })
+    storage = cls(remove_fields=['a.b', 'a.e.f.g', 'h', 'k.l.m'])
+    essence = storage.build(body=body)
+
+    assert 'a' in essence
+    assert 'e' in essence['a']
+    assert 'f' in essence['a']['e']
+
+    assert 'b' not in essence['a']
+    # 'f' is the inner-most field with a string value 'g', removing field 'g' in 'a.e.f.g' should have no effect
+    assert 'g' == essence['a']['e']['f']
+    assert 'h' not in essence
+    assert 'k' not in essence

--- a/tests/persistence/test_storing_of_diffbase.py
+++ b/tests/persistence/test_storing_of_diffbase.py
@@ -65,11 +65,21 @@ def test_annotations_storage_with_prefix_and_key():
     assert storage.prefix == 'my-operator.my-company.com'
     assert storage.key == 'diff-base'
 
+def test_annotations_storage_with_remove_fields():
+    storage = AnnotationsDiffBaseStorage(
+        remove_fields=['a.b', 'a.e.f.g', 'h', 'k.l.m']
+    )
+    assert storage._remove_fields == ['a.b', 'a.e.f.g', 'h', 'k.l.m']
 
 def test_status_storage_with_field():
     storage = StatusDiffBaseStorage(field='status.my-operator.diff-base')
     assert storage.field == ('status', 'my-operator', 'diff-base')
 
+def test_status_storage_with_remove_fields():
+    storage = StatusDiffBaseStorage(
+        remove_fields=['a.b', 'a.e.f.g', 'h', 'k.l.m']
+    )
+    assert storage._remove_fields == ['a.b', 'a.e.f.g', 'h', 'k.l.m']
 
 #
 # Common behaviour.

--- a/tests/persistence/test_storing_of_diffbase.py
+++ b/tests/persistence/test_storing_of_diffbase.py
@@ -65,21 +65,21 @@ def test_annotations_storage_with_prefix_and_key():
     assert storage.prefix == 'my-operator.my-company.com'
     assert storage.key == 'diff-base'
 
-def test_annotations_storage_with_remove_fields():
+def test_annotations_storage_with_ignored_fields():
     storage = AnnotationsDiffBaseStorage(
-        remove_fields=['a.b', 'a.e.f.g', 'h', 'k.l.m']
+        ignored_fields=['a.b', 'a.e.f.g', 'h', 'k.l.m']
     )
-    assert storage._remove_fields == ['a.b', 'a.e.f.g', 'h', 'k.l.m']
+    assert storage._ignored_fields == ['a.b', 'a.e.f.g', 'h', 'k.l.m']
 
 def test_status_storage_with_field():
     storage = StatusDiffBaseStorage(field='status.my-operator.diff-base')
     assert storage.field == ('status', 'my-operator', 'diff-base')
 
-def test_status_storage_with_remove_fields():
+def test_status_storage_with_ignored_fields():
     storage = StatusDiffBaseStorage(
-        remove_fields=['a.b', 'a.e.f.g', 'h', 'k.l.m']
+        ignored_fields=['a.b', 'a.e.f.g', 'h', 'k.l.m']
     )
-    assert storage._remove_fields == ['a.b', 'a.e.f.g', 'h', 'k.l.m']
+    assert storage._ignored_fields == ['a.b', 'a.e.f.g', 'h', 'k.l.m']
 
 #
 # Common behaviour.

--- a/tests/persistence/test_storing_of_diffbase.py
+++ b/tests/persistence/test_storing_of_diffbase.py
@@ -65,21 +65,11 @@ def test_annotations_storage_with_prefix_and_key():
     assert storage.prefix == 'my-operator.my-company.com'
     assert storage.key == 'diff-base'
 
-def test_annotations_storage_with_ignored_fields():
-    storage = AnnotationsDiffBaseStorage(
-        ignored_fields=['a.b', 'a.e.f.g', 'h', 'k.l.m']
-    )
-    assert storage._ignored_fields == ['a.b', 'a.e.f.g', 'h', 'k.l.m']
 
 def test_status_storage_with_field():
     storage = StatusDiffBaseStorage(field='status.my-operator.diff-base')
     assert storage.field == ('status', 'my-operator', 'diff-base')
 
-def test_status_storage_with_ignored_fields():
-    storage = StatusDiffBaseStorage(
-        ignored_fields=['a.b', 'a.e.f.g', 'h', 'k.l.m']
-    )
-    assert storage._ignored_fields == ['a.b', 'a.e.f.g', 'h', 'k.l.m']
 
 #
 # Common behaviour.


### PR DESCRIPTION
related: https://github.com/nolar/kopf/issues/1087

This PR solves [this comment](https://github.com/nolar/kopf/issues/1087#issuecomment-2186077417) from the previously mentioned issue.

[trivy-dojo-report-operator](https://github.com/telekom-mms/trivy-dojo-report-operator)'s `VulnerabilityReport` resources can get very big and cause issues. Having the ability to remove a couple of fields from the diff solves it.

Acknowledgement: Thanks to @baracoder for suggesting the core idea behind this approach!
