### PR TITLE
refactor: just fix some typo - change function name from ochestrator to orchestrator (with r)

### DIFF
--- a/kopf/_core/reactor/orchestration.py
+++ b/kopf/_core/reactor/orchestration.py
@@ -101,7 +101,7 @@ class Ensemble:
                     del d[key]
 
 
-async def ochestrator(
+async def orchestrator(
         *,
         processor: ResourceWatchStreamProcessor,
         settings: configuration.OperatorSettings,

--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -328,7 +328,7 @@ async def spawn_tasks(
     else:
         tasks.append(aiotasks.create_guarded_task(
             name="multidimensional multitasker", flag=started_flag, logger=logger,
-            coro=orchestration.ochestrator(
+            coro=orchestration.orchestrator(
                 settings=settings,
                 insights=insights,
                 identity=identity,


### PR DESCRIPTION
I noticed some typo in 2 files - there was ochestrator instead of orchestrator (with r), so I fixed that
@nolar fyi