### PR TITLE
Prevent handler retries if they are doomed to fail on the next run

### DIFF
--- a/kopf/_core/actions/execution.py
+++ b/kopf/_core/actions/execution.py
@@ -300,7 +300,7 @@ async def execute_handler_once(
         return Outcome(final=False, exception=e, delay=e.delay, subrefs=subrefs)
 
     # Same as permanent errors below, but with better logging for our internal cases.
-    except HandlerTimeoutError as e:
+    except (HandlerTimeoutError, HandlerRetriesError) as e:
         logger.error(f"{str(e) or repr(e)}")  # already formatted
         return Outcome(final=True, exception=e, subrefs=subrefs)
         # TODO: report the handling failure somehow (beside logs/events). persistent status?

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -88,7 +88,7 @@ def test_all_examples_are_runnable(mocker, settings, with_crd, exampledir, caplo
         assert set(name_counts.values()) == {1}
 
     # Verify that once a handler fails, it is never re-executed again.
-    handler_names = re.findall(r"'(.+?)' failed (?:permanently|with an exception. Will stop.)", runner.output)
+    handler_names = re.findall(r"'(.+?)' failed (?:permanently|with an exception and will stop)", runner.output)
     if e2e.failure_counts is not None:
         checked_names = [name for name in handler_names if name in e2e.failure_counts]
         name_counts = collections.Counter(checked_names)

--- a/tests/handling/daemons/test_daemon_errors.py
+++ b/tests/handling/daemons/test_daemon_errors.py
@@ -56,7 +56,7 @@ async def test_daemon_stopped_on_arbitrary_errors_with_mode_permanent(
     assert k8s_mocked.sleep.call_count == 0
 
     assert_logs([
-        "Daemon 'fn' failed with an exception. Will stop.",
+        "Daemon 'fn' failed with an exception and will stop now: boo!",
         "Daemon 'fn' has exited on its own",
     ], prohibited=[
         "Daemon 'fn' succeeded.",
@@ -122,7 +122,7 @@ async def test_daemon_retried_on_arbitrary_error_with_mode_temporary(
     assert k8s_mocked.sleep.call_args_list[0][0][0] == 1.0  # [call#][args/kwargs][arg#]
 
     assert_logs([
-        "Daemon 'fn' failed with an exception. Will retry.",
+        "Daemon 'fn' failed with an exception and will try again in 1.0 seconds: boo!",
         "Daemon 'fn' succeeded.",
         "Daemon 'fn' has exited on its own",
     ])
@@ -142,10 +142,9 @@ async def test_daemon_retried_until_retries_limit(
     await dummy.steps['called'].wait()
     await dummy.wait_for_daemon_done()
 
-    assert k8s_mocked.sleep.call_count == 3  # one for each retry
+    assert k8s_mocked.sleep.call_count == 2  # one between each retry (3 attempts - 2 sleeps)
     assert k8s_mocked.sleep.call_args_list[0][0][0] == 1.0  # [call#][args/kwargs][arg#]
     assert k8s_mocked.sleep.call_args_list[1][0][0] == 1.0  # [call#][args/kwargs][arg#]
-    assert k8s_mocked.sleep.call_args_list[2][0][0] == 1.0  # [call#][args/kwargs][arg#]
 
 
 async def test_daemon_retried_until_timeout(
@@ -162,7 +161,6 @@ async def test_daemon_retried_until_timeout(
     await dummy.steps['called'].wait()
     await dummy.wait_for_daemon_done()
 
-    assert k8s_mocked.sleep.call_count == 3  # one for each retry
+    assert k8s_mocked.sleep.call_count == 2  # one between each retry (3 attempts - 2 sleeps)
     assert k8s_mocked.sleep.call_args_list[0][0][0] == 1.0  # [call#][args/kwargs][arg#]
     assert k8s_mocked.sleep.call_args_list[1][0][0] == 1.0  # [call#][args/kwargs][arg#]
-    assert k8s_mocked.sleep.call_args_list[2][0][0] == 1.0  # [call#][args/kwargs][arg#]

--- a/tests/handling/daemons/test_timer_errors.py
+++ b/tests/handling/daemons/test_timer_errors.py
@@ -56,7 +56,7 @@ async def test_timer_stopped_on_arbitrary_errors_with_mode_permanent(
     assert k8s_mocked.sleep.call_args_list[0][0][0] == 1.0
 
     assert_logs([
-        "Timer 'fn' failed with an exception. Will stop.",
+        "Timer 'fn' failed with an exception and will stop now: boo!",
     ], prohibited=[
         "Timer 'fn' succeeded.",
     ])
@@ -122,7 +122,7 @@ async def test_timer_retried_on_arbitrary_error_with_mode_temporary(
     assert k8s_mocked.sleep.call_args_list[1][0][0] == 1.0  # interval
 
     assert_logs([
-        "Timer 'fn' failed with an exception. Will retry.",
+        "Timer 'fn' failed with an exception and will try again in 1.0 seconds: boo!",
         "Timer 'fn' succeeded.",
     ])
 
@@ -144,11 +144,10 @@ async def test_timer_retried_until_retries_limit(
     await dummy.steps['called'].wait()
     await dummy.wait_for_daemon_done()
 
-    assert k8s_mocked.sleep.call_count >= 4  # one for each retry
+    assert k8s_mocked.sleep.call_count >= 3  # one between each retry (3 attempts - 2 sleeps)
     assert k8s_mocked.sleep.call_args_list[0][0][0] == [1.0]  # delays
     assert k8s_mocked.sleep.call_args_list[1][0][0] == [1.0]  # delays
-    assert k8s_mocked.sleep.call_args_list[2][0][0] == [1.0]  # delays
-    assert k8s_mocked.sleep.call_args_list[3][0][0] == 1.0  # interval
+    assert k8s_mocked.sleep.call_args_list[2][0][0] == 1.0  # interval
 
 
 async def test_timer_retried_until_timeout(
@@ -168,8 +167,7 @@ async def test_timer_retried_until_timeout(
     await dummy.steps['called'].wait()
     await dummy.wait_for_daemon_done()
 
-    assert k8s_mocked.sleep.call_count >= 4  # one for each retry
+    assert k8s_mocked.sleep.call_count >= 3  # one between each retry (3 attempts - 2 sleeps)
     assert k8s_mocked.sleep.call_args_list[0][0][0] == [1.0]  # delays
     assert k8s_mocked.sleep.call_args_list[1][0][0] == [1.0]  # delays
-    assert k8s_mocked.sleep.call_args_list[2][0][0] == [1.0]  # delays
-    assert k8s_mocked.sleep.call_args_list[3][0][0] == 1.0  # interval
+    assert k8s_mocked.sleep.call_args_list[2][0][0] == 1.0  # interval

--- a/tests/handling/test_error_handling.py
+++ b/tests/handling/test_error_handling.py
@@ -145,5 +145,5 @@ async def test_arbitrary_error_delays_handler(
     assert patch['status']['kopf']['progress'][name1]['delayed']
 
     assert_logs([
-        "Handler .+ failed with an exception. Will retry.",
+        "Handler .+ failed with an exception and will try again in 60 seconds: oops",
     ])

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -71,7 +71,7 @@ async def test_errors_are_ignored(
 
     assert_logs([
         "Handler 'event_fn' is invoked.",
-        "Handler 'event_fn' failed with an exception. Will ignore.",
+        "Handler 'event_fn' failed with an exception and will ignore it: oops",
         "Handler 'event_fn2' is invoked.",
         "Handler 'event_fn2' succeeded.",
     ])


### PR DESCRIPTION
This is a refactoring extracted from the PR with `looptime` — a preparation for proper handling of certain time-based situations, separating the wall-clock time from the event-loop time. These changes are unrelated to the timing things directly, and can be considered as a little improvement instead.

* #881 

PS: The changeset is from Nov-Dec'2022, adjusted to the codebase of Jan'2026.