### PR TITLE
Refactor for stricter checks of Nones vs. False-eval values

### DIFF
--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -48,7 +48,7 @@ from kopf._cogs.configs import conventions
 from kopf._cogs.structs import bodies, dicts, ids, patches
 
 
-class ProgressRecord(TypedDict, total=True):
+class ProgressRecord(TypedDict, total=False):
     """ A single record stored for persistence of a single handler. """
     started: str | None
     stopped: str | None

--- a/kopf/_core/actions/execution.py
+++ b/kopf/_core/actions/execution.py
@@ -91,7 +91,7 @@ class HandlerState(Protocol):
 
     The implementation and detailed fields are in `progression.HandlerState`.
     """
-    started: datetime.datetime | None
+    started: datetime.datetime
     retries: int
 
     @property
@@ -255,7 +255,7 @@ async def execute_handler_once(
             handler=handler,
             cause=cause,
             retry=state.retries,
-            started=state.started or datetime.datetime.now(datetime.timezone.utc),  # "or" is for type-checking.
+            started=state.started,
             runtime=state.runtime,
             settings=settings,
             lifecycle=lifecycle,  # just a default for the sub-handlers, not used directly.

--- a/kopf/_core/actions/progression.py
+++ b/kopf/_core/actions/progression.py
@@ -111,8 +111,8 @@ class HandlerState(execution.HandlerState):
         return cls(
             active=self.active,
             purpose=self.purpose,
-            started=self.started if self.started else now,
-            stopped=self.stopped if self.stopped else now if outcome.final else None,
+            started=self.started if self.started is not None else now,
+            stopped=self.stopped if self.stopped is not None else now if outcome.final else None,
             delayed=now + datetime.timedelta(seconds=outcome.delay) if outcome.delay is not None else None,
             success=bool(outcome.final and outcome.exception is None),
             failure=bool(outcome.final and outcome.exception is not None),

--- a/kopf/_core/actions/progression.py
+++ b/kopf/_core/actions/progression.py
@@ -39,9 +39,8 @@ class HandlerState(execution.HandlerState):
     but not participating in the current handling cycle.
     """
 
-    # Some fields may overlap the base class's fields, but this is fine (the types are the same).
-    active: bool | None = None  # is it used in done/delays [T]? or only in counters/purges [F]?
-    started: datetime.datetime | None = None  # None means this information was lost.
+    active: bool  # whether it is used in done/delays [T] or only in counters/purges [F].
+    started: datetime.datetime
     stopped: datetime.datetime | None = None  # None means it is still running (e.g. delayed).
     delayed: datetime.datetime | None = None  # None means it is finished (succeeded/failed).
     purpose: str | None = None  # None is a catch-all marker for upgrades/rollbacks.
@@ -129,7 +128,7 @@ class HandlerState(execution.HandlerState):
         return cls(
             active=self.active,
             purpose=self.purpose,
-            started=self.started if self.started is not None else now,
+            started=self.started,
             stopped=self.stopped if self.stopped is not None else now if outcome.final else None,
             delayed=now + datetime.timedelta(seconds=outcome.delay) if outcome.delay is not None else None,
             success=bool(outcome.final and outcome.exception is None),

--- a/kopf/_core/actions/progression.py
+++ b/kopf/_core/actions/progression.py
@@ -52,6 +52,24 @@ class HandlerState(execution.HandlerState):
     subrefs: Collection[ids.HandlerId] = ()  # ids of actual sub-handlers of all levels deep.
     _origin: progress.ProgressRecord | None = None  # to check later if it has actually changed.
 
+    @property
+    def finished(self) -> bool:
+        return bool(self.success or self.failure)
+
+    @property
+    def sleeping(self) -> bool:
+        ts = self.delayed
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        return not self.finished and ts is not None and ts > now
+
+    @property
+    def awakened(self) -> bool:
+        return bool(not self.finished and not self.sleeping)
+
+    @property
+    def runtime(self) -> datetime.timedelta:
+        return datetime.datetime.now(tz=datetime.timezone.utc) - self.started
+
     @classmethod
     def from_scratch(cls, *, purpose: str | None = None) -> "HandlerState":
         return cls(

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -186,7 +186,7 @@ async def stop_daemons(
     for daemon in list(daemons.values()):
         logger = daemon.logger
         stopper = daemon.stopper
-        age = (now - (stopper.when or now))
+        age = (now - (stopper.when if stopper.when is not None else now))
 
         handler = daemon.handler
         match handler:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -320,7 +320,7 @@ def version_api(resp_mocker, aresponses, hostname, resource):
 def stream(fake_vault, resp_mocker, aresponses, hostname, resource, version_api):
     """ A mock for the stream of events as if returned by K8s client. """
 
-    def feed(*args, namespace=None):
+    def feed(*args, namespace: str | None):
         for arg in args:
 
             # Prepare the stream response pre-rendered (for simplicity, no actual streaming).
@@ -345,7 +345,7 @@ def stream(fake_vault, resp_mocker, aresponses, hostname, resource, version_api)
             aresponses.add(hostname, list_url, 'get', list_resp, match_querystring=True)
 
     # TODO: One day, find a better way to terminate a ``while-true`` reconnection cycle.
-    def close(*, namespace=None):
+    def close(*, namespace: str | None):
         """
         A way to stop the stream from reconnecting: say it that the resource version is gone
         (we know a priori that it stops on this condition, and escalates to `infinite_stream`).

--- a/tests/reactor/conftest.py
+++ b/tests/reactor/conftest.py
@@ -48,7 +48,7 @@ async def watcher_in_background(settings, resource, worker_spy, stream):
         pass
 
     # Prevent any real streaming for the very beginning, before it even starts.
-    stream.feed([])
+    stream.feed([], namespace=None)
 
     # Spawn a watcher in the background.
     coro = watcher(

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -56,8 +56,8 @@ async def test_watchevent_demultiplexing(worker_mock, timer, resource, processor
     settings.batching.batch_window = 100  # should not be involved, fail if it is
 
     # Inject the events of unique objects - to produce a few streams/workers.
-    stream.feed(events)
-    stream.close()
+    stream.feed(events, namespace=None)
+    stream.close(namespace=None)
 
     # Run the watcher (near-instantly and test-blocking).
     with timer:
@@ -132,8 +132,8 @@ async def test_watchevent_batching(settings, resource, processor, timer,
     settings.batching.batch_window = 0.3  # the time period being tested (make bigger than overhead)
 
     # Inject the events of unique objects - to produce a few streams/workers.
-    stream.feed(events)
-    stream.close()
+    stream.feed(events, namespace=None)
+    stream.close(namespace=None)
 
     # Run the watcher (near-instantly and test-blocking).
     with timer:
@@ -179,7 +179,9 @@ async def test_watchevent_batching(settings, resource, processor, timer,
 
 ])
 @pytest.mark.usefixtures('watcher_in_background')
-async def test_garbage_collection_of_streams(settings, stream, events, unique, worker_spy):
+async def test_garbage_collection_of_streams(
+        settings, stream, events, unique, worker_spy, namespace
+):
 
     # Override the default timeouts to make the tests faster.
     settings.batching.exit_timeout = 100  # should exit instantly, fail if it didn't
@@ -188,8 +190,8 @@ async def test_garbage_collection_of_streams(settings, stream, events, unique, w
     settings.watching.reconnect_backoff = 1.0  # to prevent src depletion
 
     # Inject the events of unique objects - to produce a few streams/workers.
-    stream.feed(events)
-    stream.close()
+    stream.feed(events, namespace=None)
+    stream.close(namespace=None)
 
     # Give it a moment to populate the streams and spawn all the workers.
     # Intercept and remember _any_ seen dict of streams for further checks.


### PR DESCRIPTION
This is a refactoring extracted from the PR with `looptime` — a preparation for proper handling of certain time-based situations, separating the wall-clock time from the event-loop time. These changes are unrelated to the timing things directly, and can be considered as a separate refactoring (among others) with no changes in behaviour.

* #881 

PS: The changeset is from Nov-Dec'2022, adjusted to the codebase of Jan'2026.