### PR TITLE
Switch to event loop's clock for all timing operations

### DIFF
--- a/kopf/_cogs/aiokits/aioenums.py
+++ b/kopf/_cogs/aiokits/aioenums.py
@@ -1,7 +1,6 @@
 import asyncio
 import enum
 import threading
-import time
 from collections.abc import Awaitable, Generator
 from typing import Generic, TypeVar
 
@@ -52,7 +51,7 @@ class FlagSetter(Generic[FlagReasonT]):
 
     def set(self, reason: FlagReasonT | None = None) -> None:
         reason = reason if reason is not None else self.reason  # to keep existing values
-        self.when = self.when if self.when is not None else time.monotonic()
+        self.when = self.when if self.when is not None else asyncio.get_running_loop().time()
         self.reason = reason if self.reason is None or reason is None else self.reason | reason
         self.sync_event.set()
         self.async_event.set()  # it is thread-safe: always called in operator's event loop.

--- a/kopf/_core/actions/progression.py
+++ b/kopf/_core/actions/progression.py
@@ -81,9 +81,9 @@ class HandlerState(execution.HandlerState):
     def from_storage(cls, __d: progress.ProgressRecord) -> "HandlerState":
         return cls(
             active=False,
-            started=_parse_iso8601(__d.get('started')) or datetime.datetime.now(datetime.timezone.utc),
-            stopped=_parse_iso8601(__d.get('stopped')),
-            delayed=_parse_iso8601(__d.get('delayed')),
+            started=parse_iso8601(__d.get('started')) or datetime.datetime.now(datetime.timezone.utc),
+            stopped=parse_iso8601(__d.get('stopped')),
+            delayed=parse_iso8601(__d.get('delayed')),
             purpose=__d.get('purpose') if __d.get('purpose') else None,
             retries=__d.get('retries') or 0,
             success=__d.get('success') or False,
@@ -95,9 +95,9 @@ class HandlerState(execution.HandlerState):
 
     def for_storage(self) -> progress.ProgressRecord:
         return progress.ProgressRecord(
-            started=None if self.started is None else _format_iso8601(self.started),
-            stopped=None if self.stopped is None else _format_iso8601(self.stopped),
-            delayed=None if self.delayed is None else _format_iso8601(self.delayed),
+            started=None if self.started is None else format_iso8601(self.started),
+            stopped=None if self.stopped is None else format_iso8601(self.stopped),
+            delayed=None if self.delayed is None else format_iso8601(self.delayed),
             purpose=None if self.purpose is None else str(self.purpose),
             retries=None if self.retries is None else int(self.retries),
             success=None if self.success is None else bool(self.success),
@@ -374,24 +374,24 @@ def deliver_results(
 
 
 @overload
-def _format_iso8601(val: None) -> None: ...
+def format_iso8601(val: None) -> None: ...
 
 
 @overload
-def _format_iso8601(val: datetime.datetime) -> str: ...
+def format_iso8601(val: datetime.datetime) -> str: ...
 
 
-def _format_iso8601(val: datetime.datetime | None) -> str | None:
+def format_iso8601(val: datetime.datetime | None) -> str | None:
     return None if val is None else val.isoformat(timespec='microseconds')
 
 
 @overload
-def _parse_iso8601(val: None) -> None: ...
+def parse_iso8601(val: None) -> None: ...
 
 
 @overload
-def _parse_iso8601(val: str) -> datetime.datetime: ...
+def parse_iso8601(val: str) -> datetime.datetime: ...
 
 
-def _parse_iso8601(val: str | None) -> datetime.datetime | None:
-    return None if val is None else iso8601.parse_date(val)  # always TZ-aware
+def parse_iso8601(val: str | None) -> datetime.datetime | None:
+    return None if val is None else iso8601.parse_date(val, default_timezone=None)

--- a/kopf/_core/reactor/processing.py
+++ b/kopf/_core/reactor/processing.py
@@ -14,7 +14,6 @@ But these internal changes are filtered out from the cause detection
 and therefore do not trigger the user-defined handlers.
 """
 import asyncio
-import time
 from collections.abc import Collection
 
 from kopf._cogs.aiokits import aiotoggles
@@ -329,7 +328,7 @@ async def process_spawning_cause(
     if memory.daemons_memory.live_fresh_body is None:
         memory.daemons_memory.live_fresh_body = cause.body
     if cause.reset:
-        memory.daemons_memory.idle_reset_time = time.monotonic()
+        memory.daemons_memory.idle_reset_time = asyncio.get_running_loop().time()
 
     if finalizers.is_deletion_ongoing(cause.body):
         stopping_delays = await daemons.stop_daemons(

--- a/tests/basic-structs/test_memories.py
+++ b/tests/basic-structs/test_memories.py
@@ -11,7 +11,7 @@ BODY: Body = {
 }
 
 
-def test_creation_with_defaults():
+async def test_creation_with_defaults():
     ResourceMemory()
 
 

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -99,15 +99,16 @@ async def background_daemon_killer(settings, memories, operator_paused):
 
 
 @pytest.fixture()
-def frozen_time():
+async def frozen_time():
     """
     A helper to simulate time movements to step over long sleeps/timeouts.
     """
-    # TODO LATER: Either freezegun should support the system clock, or find something else.
-    with freezegun.freeze_time("2020-01-01T00:00:00") as frozen:
+    with freezegun.freeze_time("2020-01-01 00:00:00") as frozen:
         # Use freezegun-supported time instead of system clocks -- for testing purposes only.
         # NB: Patch strictly after the time is frozen -- to use fake_time(), not real time().
-        with patch('time.monotonic', time.time), patch('time.perf_counter', time.time):
+        # NB: StdLib's event loops use time.monotonic(), but uvloop uses its own C-level time,
+        #     so patch the loop object directly instead of its implied underlying implementation.
+        with patch.object(asyncio.get_running_loop(), 'time', time.time):
             yield frozen
 
 

--- a/tests/handling/indexing/test_index_exclusion.py
+++ b/tests/handling/indexing/test_index_exclusion.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import logging
 
 import freezegun
@@ -30,9 +31,12 @@ EVENT_TYPES = EVENT_TYPES_WHEN_EXISTS + EVENT_TYPES_WHEN_GONE
 async def test_successes_are_removed_from_the_indexing_state(
         resource, namespace, settings, registry, memories, indexers, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
+
+    # Any "future" time works and affects nothing as long as it is the same
+    basetime = datetime.datetime.now(tz=datetime.timezone.utc)
     body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     record = ProgressRecord(success=True)
-    state = State({HandlerId('unrelated'): HandlerState.from_storage(record)})
+    state = State({HandlerId('unrelated'): HandlerState.from_storage(record, basetime=basetime)}, basetime=basetime)
     memory = await memories.recall(raw_body=body)
     memory.indexing_memory.indexing_state = state
     handlers.index_mock.side_effect = 123
@@ -56,9 +60,12 @@ async def test_successes_are_removed_from_the_indexing_state(
 async def test_temporary_failures_with_no_delays_are_reindexed(
         resource, namespace, settings, registry, memories, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
+
+    # Any "future" time works and affects nothing as long as it is the same
+    basetime = datetime.datetime.now(tz=datetime.timezone.utc)
     body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     record = ProgressRecord(delayed=None)
-    state = State({HandlerId('index_fn'): HandlerState.from_storage(record)})
+    state = State({HandlerId('index_fn'): HandlerState.from_storage(record, basetime=basetime)}, basetime=basetime)
     memory = await memories.recall(raw_body=body)
     memory.indexing_memory.indexing_state = state
     await process_resource_event(
@@ -81,9 +88,12 @@ async def test_temporary_failures_with_no_delays_are_reindexed(
 async def test_temporary_failures_with_expired_delays_are_reindexed(
         resource, namespace, settings, registry, memories, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
+
+    # Any "future" time works and affects nothing as long as it is the same
+    basetime = datetime.datetime.now(tz=datetime.timezone.utc)
     body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     record = ProgressRecord(delayed='2020-12-31T23:59:59.000000Z')
-    state = State({HandlerId('index_fn'): HandlerState.from_storage(record)})
+    state = State({HandlerId('index_fn'): HandlerState.from_storage(record, basetime=basetime)}, basetime=basetime)
     memory = await memories.recall(raw_body=body)
     memory.indexing_memory.indexing_state = state
     await process_resource_event(
@@ -105,9 +115,12 @@ async def test_temporary_failures_with_expired_delays_are_reindexed(
 async def test_permanent_failures_are_not_reindexed(
         resource, namespace, settings, registry, memories, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
+
+    # Any "future" time works and affects nothing as long as it is the same
+    basetime = datetime.datetime.now(tz=datetime.timezone.utc)
     body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
     record = ProgressRecord(failure=True)
-    state = State({HandlerId('index_fn'): HandlerState.from_storage(record)})
+    state = State({HandlerId('index_fn'): HandlerState.from_storage(record, basetime=basetime)}, basetime=basetime)
     memory = await memories.recall(raw_body=body)
     memory.indexing_memory.indexing_state = state
     await process_resource_event(

--- a/tests/handling/indexing/test_index_exclusion.py
+++ b/tests/handling/indexing/test_index_exclusion.py
@@ -82,7 +82,7 @@ async def test_temporary_failures_with_expired_delays_are_reindexed(
         resource, namespace, settings, registry, memories, indexers, index, caplog, event_type, handlers):
     caplog.set_level(logging.DEBUG)
     body = {'metadata': {'namespace': namespace, 'name': 'name1'}}
-    record = ProgressRecord(delayed='2020-12-31T23:59:59.000000')
+    record = ProgressRecord(delayed='2020-12-31T23:59:59.000000Z')
     state = State({HandlerId('index_fn'): HandlerState.from_storage(record)})
     memory = await memories.recall(raw_body=body)
     memory.indexing_memory.indexing_state = state

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -82,8 +82,8 @@ async def test_2nd_step_finishes_the_handlers(caplog,
     event_body = {
         'metadata': {'finalizers': [settings.persistence.finalizer]},
         'status': {'kopf': {'progress': {
-            name1: {'started': '1979-01-01T00:00:00', 'success': True},
-            name2: {'started': '1979-01-01T00:00:00'},
+            name1: {'started': '1979-01-01T00:00:00Z', 'success': True},
+            name2: {'started': '1979-01-01T00:00:00Z'},
         }}}
     }
     event_body['metadata'] |= deletion_ts

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -16,7 +16,7 @@ from kopf._core.reactor.processing import process_resource_event
 # The extrahandlers are needed to prevent the cycle ending and status purging.
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 @pytest.mark.parametrize('now, ts', [
-    ['2099-12-31T23:59:59', '2020-01-01T00:00:00'],
+    ['2099-12-31T23:59:59Z', '2020-01-01T00:00:00Z'],
 ], ids=['slow'])
 async def test_timed_out_handler_fails(
         registry, settings, handlers, extrahandlers, resource, cause_mock, cause_type,

--- a/tests/handling/test_timing_consistency.py
+++ b/tests/handling/test_timing_consistency.py
@@ -35,10 +35,10 @@ async def test_consistent_awakening(registry, settings, resource, k8s_mocked, mo
     """
 
     # Simulate that the object is scheduled to be awakened between the watch-event and sleep.
-    ts0 = iso8601.parse_date('2019-12-30T10:56:43')
-    tsA_triggered = "2019-12-30T10:56:42.999999"
-    ts0_scheduled = "2019-12-30T10:56:43.000000"
-    tsB_delivered = "2019-12-30T10:56:43.000001"
+    ts0 = iso8601.parse_date('2019-12-30T10:56:43Z')
+    tsA_triggered = "2019-12-30T10:56:42.999999Z"
+    ts0_scheduled = "2019-12-30T10:56:43.000000Z"
+    tsB_delivered = "2019-12-30T10:56:43.000001Z"
 
     # A dummy handler: it will not be selected for execution anyway, we just need to have it.
     @kopf.on.create(*resource, id='some-id')

--- a/tests/lifecycles/test_handler_selection.py
+++ b/tests/lifecycles/test_handler_selection.py
@@ -12,7 +12,7 @@ from kopf._core.actions.progression import State
     kopf.lifecycles.shuffled,
     kopf.lifecycles.asap,
 ])
-def test_with_empty_input(lifecycle):
+async def test_with_empty_input(lifecycle):
     state = State.from_scratch()
     handlers = []
     selected = lifecycle(handlers, state=state)
@@ -79,7 +79,7 @@ def test_shuffled_takes_them_all():
     assert set(selected) == {handler1, handler2, handler3}
 
 
-def test_asap_takes_the_first_one_when_no_retries(mocker):
+async def test_asap_takes_the_first_one_when_no_retries(mocker):
     handler1 = mocker.Mock(id='id1', spec_set=['id'])
     handler2 = mocker.Mock(id='id2', spec_set=['id'])
     handler3 = mocker.Mock(id='id3', spec_set=['id'])
@@ -92,7 +92,7 @@ def test_asap_takes_the_first_one_when_no_retries(mocker):
     assert selected[0] is handler1
 
 
-def test_asap_takes_the_least_retried(mocker):
+async def test_asap_takes_the_least_retried(mocker):
     handler1 = mocker.Mock(id='id1', spec_set=['id'])
     handler2 = mocker.Mock(id='id2', spec_set=['id'])
     handler3 = mocker.Mock(id='id3', spec_set=['id'])

--- a/tests/persistence/test_iso8601_times.py
+++ b/tests/persistence/test_iso8601_times.py
@@ -1,0 +1,43 @@
+import datetime
+
+import pytest
+
+from kopf._core.actions.progression import format_iso8601, parse_iso8601
+
+UTC = datetime.timezone.utc
+WEST11 = datetime.timezone(datetime.timedelta(hours=-11))
+EAST11 = datetime.timezone(datetime.timedelta(hours=11))
+
+
+@pytest.mark.parametrize('timestamp, expected', [
+    (None, None),
+    (datetime.datetime(2000, 1, 1), '2000-01-01T00:00:00.000000'),
+    (datetime.datetime(2000, 1, 1, 9, 8, 7, 654321), '2000-01-01T09:08:07.654321'),
+    (datetime.datetime(2000, 1, 1, tzinfo=UTC), '2000-01-01T00:00:00.000000+00:00'),
+    (datetime.datetime(2000, 1, 1, 9, 8, 7, 654321, tzinfo=UTC), '2000-01-01T09:08:07.654321+00:00'),
+    (datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=WEST11), '2000-01-01T00:00:00.000000-11:00'),
+    (datetime.datetime(2000, 1, 1, 9, 8, 7, 654321, tzinfo=WEST11), '2000-01-01T09:08:07.654321-11:00'),
+    (datetime.datetime(2000, 1, 1, 0, 0, 0, tzinfo=EAST11), '2000-01-01T00:00:00.000000+11:00'),
+    (datetime.datetime(2000, 1, 1, 9, 8, 7, 654321, tzinfo=EAST11), '2000-01-01T09:08:07.654321+11:00'),
+])
+def test_iso8601_formatting(timestamp, expected):
+    result = format_iso8601(timestamp)
+    assert result == expected
+
+
+@pytest.mark.parametrize('timestamp, expected', [
+    (None, None),
+    ('2000-01-01T00:00:00.000000', datetime.datetime(2000, 1, 1)),
+    ('2000-01-01T09:08:07.654321', datetime.datetime(2000, 1, 1, 9, 8, 7, 654321)),
+    ('2000-01-01T00:00:00.000000Z', datetime.datetime(2000, 1, 1, tzinfo=UTC)),
+    ('2000-01-01T09:08:07.654321Z', datetime.datetime(2000, 1, 1, 9, 8, 7, 654321, tzinfo=UTC)),
+    ('2000-01-01T00:00:00.000000+00:00', datetime.datetime(2000, 1, 1, tzinfo=UTC)),
+    ('2000-01-01T09:08:07.654321+00:00', datetime.datetime(2000, 1, 1, 9, 8, 7, 654321, tzinfo=UTC)),
+    ('2000-01-01T00:00:00.000000-11:00', datetime.datetime(2000, 1, 1, tzinfo=WEST11)),
+    ('2000-01-01T09:08:07.654321-11:00', datetime.datetime(2000, 1, 1, 9, 8, 7, 654321, tzinfo=WEST11)),
+    ('2000-01-01T00:00:00.000000+11:00', datetime.datetime(2000, 1, 1, tzinfo=EAST11)),
+    ('2000-01-01T09:08:07.654321+11:00', datetime.datetime(2000, 1, 1, 9, 8, 7, 654321, tzinfo=EAST11)),
+])
+def test_iso8601_parsing(timestamp, expected):
+    result = parse_iso8601(timestamp)
+    assert result == expected

--- a/tests/timing/test_throttling.py
+++ b/tests/timing/test_throttling.py
@@ -8,8 +8,8 @@ from kopf._core.actions.throttlers import Throttler, throttled
 
 
 @pytest.fixture(autouse=True)
-def clock(mocker):
-    return mocker.patch('time.monotonic', return_value=0)
+async def clock(mocker):
+    return mocker.patch.object(asyncio.get_running_loop(), 'time', return_value=0)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This is a refactoring extracted from the PR with `looptime` — a preparation for proper handling of certain time-based situations, separating the wall-clock time from the event-loop time. These changes are unrelated to the refactoring of tests per se, but are directly required to make those work. 

* #881 

Specifically, this PR switches all internal use of time from the wall clocks (`time.monotonic()`, `datetime.datetime.now()`, etc) to the event loop's internal clock (`loop.time()`). This covers both types of time usage:

1) time intervals and timeouts, as used strictly within a single runtime; 
2) timestamps in the persisted states of objects, as shared across several runtimes.

In particular, when it comes to the ISO 8601 timestamps, the ephemeral "base time" is used as a calculated `datetime` object at when the even loop's time was precisely zero — so that the movement of the event loop's time advances the measurements of the ISO 8601 time as expected, without the wall-clock time actually moving forwards.

**There are no changes to the behaviour of the operators, it is an internal refactoring only. The code changes are fully backward-compatible.**

PS: The changeset is from Nov-Dec'2022, adjusted to the codebase of Jan'2026.