### PR TITLE
Switch the docs to the "Furo" theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ extensions = [
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 html_static_path = ['_static']
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'furo'
 
 default_role = 'py:obj'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,8 @@ docs = [
     "sphinx>=9.0.0",
     "sphinx-autobuild",
     "sphinx-autodoc-typehints",
-    "sphinx_rtd_theme>=3.1.0rc1",
     "sphinx-llm>=0.1.4",
+    "furo",
 ]
 test = [
     "aresponses",


### PR DESCRIPTION
Pros:
(+) It looks cleaner.
(+) It utilises all the width (or more width).
(+) It has dark/light modes for those who care.
(+) It separates the main ToC on the left from the intra-page navigation on the right.

Cons: None.

Preview: https://kopf--1207.org.readthedocs.build/en/1207/
