### PR TITLE
Switch to uv for python/venv management (only in CI)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,19 +16,20 @@ jobs:
     timeout-minutes: 7  # usually 5 mins with coverage
     steps:
       - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - run: pip install --group lint -e .
-      - run: pre-commit run --all-files
-      - run: mypy
+      - run: uv sync --group lint
+      - run: uv run pre-commit run --all-files
+      - run: uv run mypy
       - run: |
           # Separately, because the shared module name "example.py" causes naming conflicts.
           exit_codes=0
           for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
           do
             echo "Checking ${d}"
-            mypy --config-file= --ignore-missing-imports $d
+            uv run mypy --config-file= --ignore-missing-imports $d
             exit_codes=$[${exit_codes} + $?]
           done
           exit ${exit_codes}
@@ -47,14 +48,15 @@ jobs:
     timeout-minutes: 7  # usually 5 mins with coverage
     steps:
       - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      - run: pip install --group test -e .
-      - run: pip install -e .[${{ matrix.install-extras }}]
+      - run: uv sync --group test
+      - run: uv sync --group test --extra ${{ matrix.install-extras }}
         if: ${{ matrix.install-extras }}
-      - run: coverage run --branch --source=kopf -m pytest --color=yes --timeout=2
+      - run: uv run coverage run --branch --source=kopf -m pytest --color=yes --timeout=2
 
       - name: Publish coverage to Coveralls.io
         uses: coverallsapp/github-action@v2
@@ -62,6 +64,7 @@ jobs:
           parallel: true
           flag-name: ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
         if: success()
+        continue-on-error: true  # tends to fail with no code changes (e.g. only CI/docs)
       - name: Publish coverage to CodeCov.io
         uses: codecov/codecov-action@v5
         env:
@@ -87,17 +90,17 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - run: sudo apt-get update && sudo apt-get install libxml2-dev libxslt-dev
-      - run: pip install --upgrade pip wheel setuptools
 
-      - run: pip install --group test -e .
-      - run: pip install -e .[${{ matrix.install-extras }}]
+      - run: uv sync --group test
+      - run: uv sync --group test --extra ${{ matrix.install-extras }}
         if: ${{ matrix.install-extras }}
-      - run: pytest --color=yes --timeout=2 --no-cov
+      - run: uv run pytest --color=yes --timeout=2 --no-cov
 
   functional:
     strategy:
@@ -109,6 +112,7 @@ jobs:
     timeout-minutes: 10  # usually 4-5 mins
     steps:
       - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
@@ -116,8 +120,9 @@ jobs:
         with:
           version: ${{ matrix.k3s }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: pip install --group test -e . -r examples/requirements.txt
-      - run: pytest --color=yes --timeout=30 --only-e2e
+      - run: uv sync --group test
+      - run: uv pip install -r examples/requirements.txt
+      - run: uv run pytest --color=yes --timeout=30 --only-e2e
 
   coveralls-finish:
     name: Finalize coveralls.io

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,11 +16,11 @@ jobs:
       id-token: write  # for trusted publishing
     steps:
       - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - run: pip install --upgrade pip build
-      - run: python -m build  # includes sdist & wheel by default
+      - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip_existing: true

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -20,19 +20,20 @@ jobs:
     timeout-minutes: 7  # usually 5 mins with coverage
     steps:
       - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - run: pip install --group lint -e .
-      - run: pre-commit run --all-files
-      - run: mypy
+      - run: uv sync --group lint
+      - run: uv run pre-commit run --all-files
+      - run: uv run mypy
       - run: |
           # Separately, because the shared module name "example.py" causes naming conflicts.
           exit_codes=0
           for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
           do
             echo "Checking ${d}"
-            mypy --config-file= --ignore-missing-imports $d
+            uv run mypy --config-file= --ignore-missing-imports $d
             exit_codes=$[${exit_codes} + $?]
           done
           exit ${exit_codes}
@@ -51,14 +52,15 @@ jobs:
     timeout-minutes: 7  # usually 5 mins with coverage
     steps:
       - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      - run: pip install --group test -e .
-      - run: pip install -e .[${{ matrix.install-extras }}]
+      - run: uv sync --group test
+      - run: uv sync --group test --extra ${{ matrix.install-extras }}
         if: ${{ matrix.install-extras }}
-      - run: coverage run --branch --source=kopf -m pytest --color=yes --timeout=2
+      - run: uv run coverage run --branch --source=kopf -m pytest --color=yes --timeout=2
 
       - name: Publish coverage to Coveralls.io
         uses: coverallsapp/github-action@v2
@@ -66,6 +68,7 @@ jobs:
           parallel: true
           flag-name: ${{ matrix.python-version }}${{ matrix.install-extras && ' ' || '' }}${{ matrix.install-extras }}
         if: success()
+        continue-on-error: true  # tends to fail with no code changes (e.g. only CI/docs)
       - name: Publish coverage to CodeCov.io
         uses: codecov/codecov-action@v5
         env:
@@ -91,17 +94,17 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - run: sudo apt-get update && sudo apt-get install libxml2-dev libxslt-dev
-      - run: pip install --upgrade pip wheel setuptools
 
-      - run: pip install --group test -e .
-      - run: pip install -e .[${{ matrix.install-extras }}]
+      - run: uv sync --group test
+      - run: uv sync --group test --extra ${{ matrix.install-extras }}
         if: ${{ matrix.install-extras }}
-      - run: pytest --color=yes --timeout=2 --no-cov
+      - run: uv run pytest --color=yes --timeout=2 --no-cov
 
   functional:
     strategy:
@@ -113,6 +116,7 @@ jobs:
     timeout-minutes: 10  # usually 4-5 mins
     steps:
       - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
@@ -120,8 +124,9 @@ jobs:
         with:
           version: ${{ matrix.k3s }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: pip install --group test -e . -r examples/requirements.txt
-      - run: pytest --color=yes --timeout=30 --only-e2e
+      - run: uv sync --group test
+      - run: uv pip install -r examples/requirements.txt
+      - run: uv run pytest --color=yes --timeout=30 --only-e2e
 
   full-scale:
     strategy:
@@ -135,12 +140,14 @@ jobs:
       K8S: ${{ matrix.k8s }}
     steps:
       - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - run: tools/install-minikube.sh
-      - run: pip install --group test -e . -r examples/requirements.txt
-      - run: pytest --color=yes --timeout=30 --only-e2e
+      - run: uv sync --group test
+      - run: uv pip install -r examples/requirements.txt
+      - run: uv run pytest --color=yes --timeout=30 --only-e2e
 
   coveralls-finish:
     name: Finalize coveralls.io

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,12 @@ build:
   tools:
     python: "3"
   jobs:
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
     install:
-      - pip install --upgrade pip
-      - pip install --group docs -e .
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --group docs
 sphinx:
   configuration: docs/conf.py
   builder: "dirhtml"

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -34,23 +34,23 @@ Both variants are built for ``linux/amd64`` and ``linux/arm64`` platforms.
 Image tags
 ==========
 
-For a release such as ``1.42.5`` built with Python 3.14 (the default),
+For a release such as ``1.43.0`` built with Python 3.14 (the default),
 the following tags are available:
 
 * ``ghcr.io/nolar/kopf:latest`` --- the latest release with the default
   Python version and the default variant (slim).
-* ``ghcr.io/nolar/kopf:1.42.5`` --- a specific patch release.
-* ``ghcr.io/nolar/kopf:1.42`` --- the latest patch within a minor release.
+* ``ghcr.io/nolar/kopf:1.43.0`` --- a specific patch release.
+* ``ghcr.io/nolar/kopf:1.43`` --- the latest patch within a minor release.
 * ``ghcr.io/nolar/kopf:v1`` --- the latest release within a major version.
 
 To pin a specific Python version or variant, use the extended tag format:
 
-* ``ghcr.io/nolar/kopf:1.42.5-python3.13-alpine``
-* ``ghcr.io/nolar/kopf:1.42-python3.14-slim``
-* ``ghcr.io/nolar/kopf:v1-python3.13``
+* ``ghcr.io/nolar/kopf:1.43.0-python3.14-alpine``
+* ``ghcr.io/nolar/kopf:1.43-python3.14-slim``
+* ``ghcr.io/nolar/kopf:v1-python3.14``
 
-Tags without a variant suffix (e.g. ``1.42-python3.13``) point to the slim variant.
-Tags without a Python version (e.g. ``1.42.5``) point to the default Python version.
+Tags without a variant suffix (e.g. ``1.43-python3.14``) point to the slim variant.
+Tags without a Python version (e.g. ``1.43.0``) point to the default Python version.
 
 
 Kubeconfig security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
 
 [dependency-groups]
 docs = [
-    "sphinx>=9.0.0",
+    "sphinx>=9.0.0; python_version>='3.11'",  # TODO: remove when 3.10 is dropped (≈Oct'26)
     "sphinx-autobuild",
     "sphinx-autodoc-typehints",
     "sphinx-copybutton",


### PR DESCRIPTION
Not yet really to switch, but to check if it works in GitHub Actions and how much faster than pip/setuptools.

Preliminary results of the dependencies installation only:

| Type | pip | uv cache miss | uv cache hit | overall | saved,s | saved, % |
| ---- | --- | ------------- | -------- | ----- | ----- | ----- |
| cpython | 18s | 6s | 4s | 3m15s | 14s | 7.7% |
| +fullauth extra | 18s+7s = 25s | 5s | 3s+1s=4s | 3m15s | 21s | 11% |
| +uvloop extra | 17s+3s=20s | … | 1s+2s=3s | 3m15s | 14s | 7.5% |
| pypy | 7s+38s=45s | 23s | 15s | 3m15s | 30s | 15% |
| e2e | 19s | 4s+1s=5s | 2s | 4m40s | 17s | 6% |
| readthedocs | 5s+13s=18s | — | 2s+9s=11s | 1m15s | 7s | 10% |

Roughly, the speedup is 2-3x in the worst case (cache miss), 6-8x in the best case (cache hit).

The time is spent mostly on tests themselves (≈2m47s), but these seconds can be beneficial anyway — to not waste GitHub Actions runtime seconds.