### PR TITLE
Migrate all API tests from aresponses to KMock

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -40,3 +40,29 @@ exit code and output are available to the test (for additional assertions).
 .. note::
     The operator runs against the cluster which is currently authenticated ---
     same as if would be executed with ``kopf run``.
+
+
+Mock server
+===========
+
+KMock is a supplimentary project to run a local mock server for any HTTP API, and for Kubernetes API in particular — with extended supported of Kubernetes API endpoints, resource discovery, and implicit in-memory object persistence.
+
+Use KMock when you need to run a very lightweight simulation of the Kubernetes API without deploying the heavy Kubernetes cluster nearby, for example when migrating to/from Kopf.
+
+.. code-block:: python
+
+    import kmock
+    import requests
+
+    def test_object_patching(kmock: kmock.KubernetesEmulator) -> None:
+        kmock.objects['kopf.dev/v1/kopfexamples', 'ns1', 'name1'] = {'spec': 123}
+        requests.patch(str(kmock.url) + '/kopf.dev/v1/namespaces/ns1/name1', json={'spec': 456})
+        assert len(kmock.requests) == 1
+        assert kmock.requests[0].method == 'patch'
+        assert kmock.objects['kopf.dev/v1/kopfexamples', 'ns1', 'name1'] == {'spec': 456}
+
+KMock's detailed documentation is out of scope of Kopf's documentation. The project and its documentation can be found at:
+
+* https://kmock.readthedocs.io/
+* https://github.com/nolar/kmock
+* https://pypi.org/project/kmock/

--- a/kopf/_kits/webhooks.py
+++ b/kopf/_kits/webhooks.py
@@ -173,7 +173,7 @@ class WebhookServer(webhacks.WebhookContextManager):
                 # multi-threaded sockets are not really used -- high load is not expected for webhooks.
                 addr = self.addr or None  # None is aiohttp's "any interface"
                 port = self.port or self._allocate_free_port()
-                site = aiohttp.web.TCPSite(runner, addr, port, ssl_context=context, reuse_port=True)
+                site = aiohttp.web.TCPSite(runner, addr, port, ssl_context=context, reuse_port=True, reuse_address=True)
                 await site.start()
 
                 # Log with the actual URL: normalised, with hostname/port set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,11 @@ lint = [
     "pyngrok",
     "uvloop",
 ]
+dev = [
+    {include-group = "docs"},
+    {include-group = "lint"},
+    {include-group = "test"},
+]
 
 [tool.setuptools.packages.find]
 # The star is for the versions.py, which is gitignored in docker builds (somewhy).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,13 +72,13 @@ docs = [
     "furo",
 ]
 test = [
-    "aresponses",
     "astpath[xpath]",
     "certbuilder",
     "certvalidator",
     "codecov",
     "coverage>=7.12.0",
     "freezegun",
+    "kmock>=0.3",
     "looptime>=0.7",
     "lxml",
     "pyngrok",

--- a/tests/apis/test_api_requests.py
+++ b/tests/apis/test_api_requests.py
@@ -7,13 +7,13 @@ import pytest
 from kopf._cogs.clients.api import delete, get, patch, post, request, stream
 from kopf._cogs.clients.errors import APIError
 
+pytestmark = pytest.mark.usefixtures('fake_vault')
+
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
-async def test_raw_requests_work(
-        resp_mocker, aresponses, hostname, method, settings, logger):
+async def test_raw_requests_work(kmock, method, settings, logger):
+    api = kmock[method, '/url'] << {}
 
-    mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    aresponses.add(hostname, '/url', method, mock)
     response = await request(
         method=method,
         url='/url',
@@ -23,56 +23,43 @@ async def test_raw_requests_work(
         logger=logger,
     )
     assert isinstance(response, aiohttp.ClientResponse)  # unparsed!
-    assert mock.call_count == 1
-    assert isinstance(mock.call_args.args[0], aiohttp.web.BaseRequest)
-    assert mock.call_args.args[0].method.lower() == method
-    assert mock.call_args.args[0].path == '/url'
-    assert mock.call_args.args[0].data == {'fake': 'payload'}
-    assert mock.call_args.args[0].headers['fake'] == 'headers'  # and other system headers
+    assert len(api) == 1
+    assert api[0].method.lower() == method
+    assert api[0].url.path == '/url'
+    assert api[0].data == {'fake': 'payload'}
+    assert api[0].headers['fake'] == 'headers'  # and other system headers
 
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
-async def test_raw_requests_are_not_parsed(
-        resp_mocker, aresponses, hostname, method, settings, logger):
-
-    mock = resp_mocker(return_value=aresponses.Response(text='BAD JSON!'))
-    aresponses.add(hostname, '/url', method, mock)
+async def test_raw_requests_are_not_parsed(kmock, method, settings, logger):
+    kmock[method, '/url'] << b'BAD JSON!'
     response = await request(method, '/url', settings=settings, logger=logger)
     assert isinstance(response, aiohttp.ClientResponse)
 
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
-async def test_server_errors_escalate(
-        resp_mocker, aresponses, hostname, method, settings, logger):
-
-    mock = resp_mocker(return_value=aiohttp.web.json_response({}, status=666, reason='oops'))
-    aresponses.add(hostname, '/url', method, mock)
+async def test_server_errors_escalate(kmock, method, settings, logger):
+    kmock[method, '/url'] << {} << 666
     with pytest.raises(APIError) as err:
         await request(method, '/url', settings=settings, logger=logger)
     assert err.value.status == 666
 
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
-async def test_relative_urls_are_prepended_with_server(
-        resp_mocker, aresponses, hostname, method, settings, logger):
-
-    mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    aresponses.add(hostname, '/url', method, mock)
+async def test_relative_urls_are_prepended_with_server(kmock, fake_vault, method, settings, logger):
+    kmock[method, '/url'] << {}
     await request(method, '/url', settings=settings, logger=logger)
-    assert isinstance(mock.call_args.args[0], aiohttp.web.BaseRequest)
-    assert str(mock.call_args.args[0].url) == f'http://{hostname}/url'
+    assert len(kmock) == 1
+    assert kmock[0].url.host == kmock.url.host
 
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
-async def test_absolute_urls_are_passed_through(
-        resp_mocker, aresponses, hostname, method, settings, logger):
-
-    mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    aresponses.add(hostname, '/url', method, mock)
-    aresponses.add('fakehost.localdomain', '/url', method, mock)
-    await request(method, 'http://fakehost.localdomain/url', settings=settings, logger=logger)
-    assert isinstance(mock.call_args.args[0], aiohttp.web.BaseRequest)
-    assert str(mock.call_args.args[0].url) == 'http://fakehost.localdomain/url'
+@pytest.mark.kmock(hostnames=['fakehost.fakedomain.tld'])
+async def test_absolute_urls_are_passed_through(kmock, fake_vault, method, settings, logger):
+    kmock[method, '/url'] << {}
+    await request(method, 'http://fakehost.fakedomain.tld/url', settings=settings, logger=logger)
+    assert len(kmock) == 1
+    assert kmock[0].url.host == 'fakehost.fakedomain.tld'
 
 
 @pytest.mark.parametrize('fn, method', [
@@ -81,11 +68,8 @@ async def test_absolute_urls_are_passed_through(
     (patch, 'patch'),
     (delete, 'delete'),
 ])
-async def test_parsing_in_requests(
-        resp_mocker, aresponses, hostname, fn, method, settings, logger):
-
-    mock = resp_mocker(return_value=aiohttp.web.json_response({'fake': 'result'}))
-    aresponses.add(hostname, '/url', method, mock)
+async def test_parsing_in_requests(kmock, fn, method, settings, logger):
+    api = kmock[method, '/url'] << {'fake': 'result'}
     response = await fn(
         url='/url',
         payload={'fake': 'payload'},
@@ -94,23 +78,16 @@ async def test_parsing_in_requests(
         logger=logger,
     )
     assert response == {'fake': 'result'}  # parsed!
-    assert mock.call_count == 1
-    assert isinstance(mock.call_args.args[0], aiohttp.web.BaseRequest)
-    assert mock.call_args.args[0].method.lower() == method
-    assert mock.call_args.args[0].path == '/url'
-    assert mock.call_args.args[0].data == {'fake': 'payload'}
-    assert mock.call_args.args[0].headers['fake'] == 'headers'  # and other system headers
+    assert len(api) == 1
+    assert api[0].method.lower() == method
+    assert api[0].url.path == '/url'
+    assert api[0].data == {'fake': 'payload'}
+    assert api[0].headers['fake'] == 'headers'  # and other system headers
 
 
 @pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
-async def test_parsing_in_streams(
-        resp_mocker, aresponses, hostname, method, settings, logger):
-
-    mock = resp_mocker(return_value=aresponses.Response(text=textwrap.dedent("""
-        {"fake": "result1"}
-        {"fake": "result2"}
-    """)))
-    aresponses.add(hostname, '/url', method, mock)
+async def test_parsing_in_streams(kmock, method, settings, logger):
+    kmock[method, '/url'] << {"fake": "result1"} << {"fake": "result2"}
 
     items = []
     async for item in stream(
@@ -123,12 +100,11 @@ async def test_parsing_in_streams(
         items.append(item)
 
     assert items == [{'fake': 'result1'}, {'fake': 'result2'}]
-    assert mock.call_count == 1
-    assert isinstance(mock.call_args.args[0], aiohttp.web.BaseRequest)
-    assert mock.call_args.args[0].method.lower() == method
-    assert mock.call_args.args[0].path == '/url'
-    assert mock.call_args.args[0].data == {'fake': 'payload'}
-    assert mock.call_args.args[0].headers['fake'] == 'headers'  # and other system headers
+    assert len(kmock) == 1
+    assert kmock[0].method.lower() == method
+    assert kmock[0].url.path == '/url'
+    assert kmock[0].data == {'fake': 'payload'}
+    assert kmock[0].headers['fake'] == 'headers'  # and other system headers
 
 
 @pytest.mark.parametrize('fn, method', [
@@ -137,15 +113,8 @@ async def test_parsing_in_streams(
     (patch, 'patch'),
     (delete, 'delete'),
 ])
-async def test_direct_timeout_in_requests(
-        resp_mocker, aresponses, hostname, fn, method, settings, logger, looptime):
-
-    async def serve_slowly():
-        await asyncio.sleep(10)
-        return aiohttp.web.json_response({})
-
-    mock = resp_mocker(side_effect=serve_slowly)
-    aresponses.add(hostname, '/url', method, mock)
+async def test_direct_timeout_in_requests(kmock, fn, method, settings, logger, looptime):
+    kmock[method, '/url'] << (lambda: asyncio.sleep(10)) << {}
 
     with pytest.raises(asyncio.TimeoutError):
         timeout = aiohttp.ClientTimeout(total=1.23)
@@ -156,10 +125,6 @@ async def test_direct_timeout_in_requests(
 
     assert looptime == 1.23
 
-    # Let the server request finish and release all resources (tasks).
-    # TODO: Remove when fixed: https://github.com/aio-libs/aiohttp/issues/7551
-    await asyncio.sleep(1.0)
-
 
 @pytest.mark.parametrize('fn, method', [
     (get, 'get'),
@@ -167,15 +132,8 @@ async def test_direct_timeout_in_requests(
     (patch, 'patch'),
     (delete, 'delete'),
 ])
-async def test_settings_timeout_in_requests(
-        resp_mocker, aresponses, hostname, fn, method, settings, logger, looptime):
-
-    async def serve_slowly():
-        await asyncio.sleep(10)
-        return aiohttp.web.json_response({})
-
-    mock = resp_mocker(side_effect=serve_slowly)
-    aresponses.add(hostname, '/url', method, mock)
+async def test_settings_timeout_in_requests(kmock, fn, method, settings, logger, looptime):
+    kmock[method, '/url'] << (lambda: asyncio.sleep(10)) << {}
 
     with pytest.raises(asyncio.TimeoutError):
         settings.networking.request_timeout = 1.23
@@ -186,21 +144,11 @@ async def test_settings_timeout_in_requests(
 
     assert looptime == 1.23
 
-    # Let the server request finish and release all resources (tasks).
-    # TODO: Remove when fixed: https://github.com/aio-libs/aiohttp/issues/7551
-    await asyncio.sleep(1.0)
-
 
 @pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
-async def test_direct_timeout_in_streams(
-        resp_mocker, aresponses, hostname, method, settings, logger, looptime):
+async def test_direct_timeout_in_streams(kmock, method, settings, logger, looptime):
 
-    async def serve_slowly():
-        await asyncio.sleep(10)
-        return "{}"
-
-    mock = resp_mocker(side_effect=serve_slowly)
-    aresponses.add(hostname, '/url', method, mock)
+    kmock[method, '/url'] << (lambda: asyncio.sleep(10)) << {}
 
     with pytest.raises(asyncio.TimeoutError):
         timeout = aiohttp.ClientTimeout(total=1.23)
@@ -212,21 +160,10 @@ async def test_direct_timeout_in_streams(
 
     assert looptime == 1.23
 
-    # Let the server request finish and release all resources (tasks).
-    # TODO: Remove when fixed: https://github.com/aio-libs/aiohttp/issues/7551
-    await asyncio.sleep(1.0)
-
 
 @pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
-async def test_settings_timeout_in_streams(
-        resp_mocker, aresponses, hostname, method, settings, logger, looptime):
-
-    async def serve_slowly():
-        await asyncio.sleep(10)
-        return "{}"
-
-    mock = resp_mocker(side_effect=serve_slowly)
-    aresponses.add(hostname, '/url', method, mock)
+async def test_settings_timeout_in_streams(kmock, method, settings, logger, looptime):
+    kmock[method, '/url'] << (lambda: asyncio.sleep(10)) << {}
 
     with pytest.raises(asyncio.TimeoutError):
         settings.networking.request_timeout = 1.23
@@ -238,37 +175,24 @@ async def test_settings_timeout_in_streams(
 
     assert looptime == 1.23
 
-    # Let the server request finish and release all resources (tasks).
-    # TODO: Remove when fixed: https://github.com/aio-libs/aiohttp/issues/7551
-    await asyncio.sleep(1.0)
-
 
 @pytest.mark.parametrize('delay, expected_times, expected_items', [
     pytest.param(0, [], [], id='instant-none'),
     pytest.param(2, [1], [{'fake': 'result1'}], id='fast-single'),
     pytest.param(9, [1, 4], [{'fake': 'result1'}, {'fake': 'result2'}], id='inf-double'),
 ])
-@pytest.mark.parametrize('initial', [True, False], ids=['slow-headers', 'fast-headers'])
+@pytest.mark.parametrize('initial', [None, b''], ids=['slow-headers', 'fast-headers'])
 @pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
 async def test_stopper_in_streams(
-        resp_mocker, aresponses, hostname, method, delay, initial, settings, logger, looptime,
+        kmock, method, delay, initial, settings, logger, looptime,
         expected_items, expected_times):
-
-    async def stream_slowly(request: aiohttp.web.Request) -> aiohttp.web.StreamResponse:
-        response = aiohttp.web.StreamResponse()
-        await asyncio.sleep(1 if initial else 0)  # before the http headers are sent
-        await response.prepare(request)
-        try:
-            await asyncio.sleep(0 if initial else 1)  # after the headers are sent
-            await response.write(b'{"fake": "result1"}\n')
-            await asyncio.sleep(3)
-            await response.write(b'{"fake": "result2"}\n')
-            await response.write_eof()
-        except ConnectionError:
-            pass  # the client side sometimes disconnects earlier, ignore it
-        return response
-
-    aresponses.add(hostname, '/url', method, stream_slowly)
+    kmock[method, '/url'] << (
+        initial,  # prepare and send the headers before the sleep
+        lambda: asyncio.sleep(1),
+        {"fake": "result1"},
+        lambda: asyncio.sleep(3),
+        {"fake": "result2"},
+    )
 
     stopper = asyncio.Future()
     asyncio.get_running_loop().call_later(delay, stopper.set_result, None)
@@ -281,6 +205,3 @@ async def test_stopper_in_streams(
 
     assert items == expected_items
     assert times == expected_times
-
-    # Give the response some time to be cancelled and its tasks closed. That is aiohttp's issue.
-    await asyncio.sleep(30)

--- a/tests/apis/test_error_retries.py
+++ b/tests/apis/test_error_retries.py
@@ -6,6 +6,8 @@ import pytest
 from kopf._cogs.clients.api import request
 from kopf._cogs.clients.errors import APIError
 
+pytestmark = pytest.mark.usefixtures('fake_vault')
+
 
 @pytest.fixture(autouse=True)
 def sleep(mocker):
@@ -19,7 +21,7 @@ def request_fn(mocker):
 
 
 async def test_regular_errors_escalate_without_retries(
-        assert_logs, settings, logger, resp_mocker, aresponses, hostname, request_fn):
+        assert_logs, settings, logger, request_fn):
     request_fn.side_effect = Exception("boo")
 
     settings.networking.error_backoffs = [1, 2, 3]
@@ -34,40 +36,30 @@ async def test_regular_errors_escalate_without_retries(
 # All client errors except explicitly retryable (403, 429).
 @pytest.mark.parametrize('status', [400, 404, 409, 499, 666, 999])
 async def test_permanent_errors_escalate_without_retries(
-        assert_logs, settings, logger, resp_mocker, aresponses, hostname, status):
-    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
-    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response({}, status=status, reason='oops'))
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+        assert_logs, settings, logger, kmock, status):
+    kmock['get /url'] << {} << status
 
     settings.networking.error_backoffs = [1, 2, 3]
     with pytest.raises(APIError) as err:
         await request('get', '/url', settings=settings, logger=logger)
 
     assert err.value.status == status
-    assert mock.call_count == 1
+    assert len(kmock) == 1
     assert_logs(prohibited=["attempt", "escalating", "retry"])
 
 
 # All server errors, certain client errors (403, 429).
 @pytest.mark.parametrize('status', [403, 429, 500, 503, 599])
 async def test_temporary_errors_escalate_with_retries(
-        assert_logs, settings, logger, resp_mocker, aresponses, hostname, status):
-    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
-    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response({}, status=status, reason='oops'))
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+        assert_logs, settings, logger, kmock, status):
+    kmock['get /url'] << {} << status
 
     settings.networking.error_backoffs = [0, 0, 0]
     with pytest.raises(APIError) as err:
         await request('get', '/url', settings=settings, logger=logger)
 
     assert err.value.status == status
-    assert mock.call_count == 4
+    assert len(kmock) == 4
     assert_logs([
         "attempt #1/4 failed; will retry",
         "attempt #2/4 failed; will retry",
@@ -76,8 +68,7 @@ async def test_temporary_errors_escalate_with_retries(
     ])
 
 
-async def test_connection_errors_escalate_with_retries(
-        assert_logs, settings, logger, resp_mocker, aresponses, hostname, request_fn):
+async def test_connection_errors_escalate_with_retries(assert_logs, settings, logger, request_fn):
     request_fn.side_effect = aiohttp.ClientConnectionError()
 
     settings.networking.error_backoffs = [0, 0, 0]
@@ -93,8 +84,7 @@ async def test_connection_errors_escalate_with_retries(
     ])
 
 
-async def test_timeout_errors_escalate_with_retries(
-        assert_logs, settings, logger, resp_mocker, aresponses, hostname, request_fn):
+async def test_timeout_errors_escalate_with_retries(assert_logs, settings, logger, request_fn):
     request_fn.side_effect = asyncio.TimeoutError()
 
     settings.networking.error_backoffs = [0, 0, 0]
@@ -110,22 +100,15 @@ async def test_timeout_errors_escalate_with_retries(
     ])
 
 
-async def test_retried_until_succeeded(
-        assert_logs, settings, logger, resp_mocker, aresponses, hostname):
-    mock = resp_mocker(side_effect=[
-        aiohttp.web.json_response({}, status=505, reason='oops'),
-        aiohttp.web.json_response({}, status=505, reason='oops'),
-        aiohttp.web.json_response({}),
-    ])
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+async def test_retried_until_succeeded(assert_logs, settings, logger, kmock):
+    api1 = kmock['get /url'][:2] << {} << 505
+    api2 = kmock['get /url'] << {}
 
     settings.networking.error_backoffs = [0, 0, 0]
     await request('get', '/url', settings=settings, logger=logger)
 
-    assert mock.call_count == 3  # 2 failures, 1 success; limited to 4 attempts.
+    assert len(api1) == 2  # 2 failures, 1 success
+    assert len(api2) == 1  # 1 success; the other one is not requested
     assert_logs([
         "attempt #1/4 failed; will retry",
         "attempt #2/4 failed; will retry",
@@ -143,58 +126,36 @@ async def test_retried_until_succeeded(
     ([1, 2], 3),
 ])
 @pytest.mark.parametrize('status', [429, 500])
-async def test_backoffs_as_lists(
-        assert_logs, settings, logger, resp_mocker, aresponses, hostname, sleep,
-        backoffs, exp_calls, status):
-    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
-    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response({}, status=status, reason='oops'))
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+async def test_backoffs_as_lists(settings, logger, kmock, sleep, backoffs, exp_calls, status):
+    kmock['get /url'][:4] << {} << status
 
     settings.networking.error_backoffs = backoffs
     with pytest.raises(APIError):
         await request('get', '/url', settings=settings, logger=logger)
 
-    assert mock.call_count == exp_calls
+    assert len(kmock) == exp_calls
     all_sleeps = [call.args[0] for call in sleep.call_args_list]
     assert all_sleeps == backoffs
 
 
-async def test_backoffs_as_floats(
-        assert_logs, settings, logger, resp_mocker, aresponses, hostname, sleep):
-    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
-    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response({}, status=500, reason='oops'))
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+async def test_backoffs_as_floats(settings, logger, kmock, sleep):
+    kmock['get /url'] << {} << 500
 
     settings.networking.error_backoffs = 5.0
     with pytest.raises(APIError):
         await request('get', '/url', settings=settings, logger=logger)
 
-    assert mock.call_count == 2
+    assert len(kmock) == 2
     all_sleeps = [call.args[0] for call in sleep.call_args_list]
     assert all_sleeps == [5.0]
 
 
-async def test_backoffs_as_iterables(
-        assert_logs, settings, logger, resp_mocker, aresponses, hostname, sleep):
+async def test_backoffs_as_iterables(settings, logger, kmock, sleep):
+    kmock['get /url'][:8] << {} << 500
 
     class Itr:
         def __iter__(self):
             return iter([1, 2, 3])
-
-    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
-    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response({}, status=500, reason='oops'))
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
 
     settings.networking.error_backoffs = Itr()  # to be reused on every attempt
     with pytest.raises(APIError):
@@ -202,7 +163,7 @@ async def test_backoffs_as_iterables(
     with pytest.raises(APIError):
         await request('get', '/url', settings=settings, logger=logger)
 
-    assert mock.call_count == 8
+    assert len(kmock) == 8
     all_sleeps = [call.args[0] for call in sleep.call_args_list]
     assert all_sleeps == [1, 2, 3, 1, 2, 3]
 
@@ -213,15 +174,8 @@ async def test_backoffs_as_iterables(
     pytest.param({}, {'kind': 'Status', 'details': {'retryAfterSeconds': 10}}, id='old-style'),
 ])
 async def test_retry_after_overrides_backoffs_when_enforced(
-        assert_logs, settings, logger, resp_mocker, aresponses, hostname, sleep, headers, payload):
-
-    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
-    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response(payload, status=429, headers=headers))
-    aresponses.add(hostname, '/url', 'get', mock)
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+        assert_logs, settings, logger, kmock, sleep, headers, payload):
+    kmock['get /url'] << 429 << kmock.headers(headers) << payload
 
     settings.networking.enforce_retry_after = True
     settings.networking.error_backoffs = [5, 10, 15]
@@ -238,7 +192,7 @@ async def test_retry_after_overrides_backoffs_when_enforced(
         "attempt #4/4 failed; escalating",
     ])
 
-    assert mock.call_count == 4
+    assert len(kmock) == 4
     all_sleeps = [call.args[0] for call in sleep.call_args_list]
     assert all_sleeps == [10, 10, 10]  # enforced retry-after
 
@@ -247,16 +201,9 @@ async def test_retry_after_overrides_backoffs_when_enforced(
     pytest.param({'Retry-After': '10'}, {}, id='new-style'),
     pytest.param({}, {'kind': 'Status', 'details': {'retryAfterSeconds': 10}}, id='old-style'),
 ])
-async def test_retry_after_overrides_backoffs_when_longer(
-        assert_logs, settings, logger, resp_mocker, aresponses, hostname, sleep, headers, payload):
-
-    # side_effect instead of return_value -- to generate a new response on every call, not reuse it.
-    mock = resp_mocker(side_effect=lambda: aiohttp.web.json_response(payload, status=429, headers=headers))
-    aresponses.add(hostname, '/url', 'get', mock)
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
-    aresponses.add(hostname, '/url', 'get', mock)  # repeat=N would copy the mock, lose all counts
+async def test_retry_after_overrides_backoffs_when_longer(caplog,
+        assert_logs, settings, logger, kmock, sleep, headers, payload):
+    kmock['get /url'] << 429 << kmock.headers(headers) << payload
 
     settings.networking.error_backoffs = [5, 10, 15]
     with pytest.raises(APIError):
@@ -273,6 +220,6 @@ async def test_retry_after_overrides_backoffs_when_longer(
         "Overriding the backoff 15s with the retry-after 10s",
     ])
 
-    assert mock.call_count == 4
+    assert len(kmock) == 4
     all_sleeps = [call.args[0] for call in sleep.call_args_list]
     assert all_sleeps == [10, 10, 15]  # never smaller than retry-after

--- a/tests/authentication/test_reauthentication.py
+++ b/tests/authentication/test_reauthentication.py
@@ -13,12 +13,8 @@ async def fn(
     return context, x + 100
 
 
-async def test_session_is_injected(
-        fake_vault, resp_mocker, aresponses, hostname, resource, namespace):
-
-    result = {}
-    get_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
-    aresponses.add(hostname, resource.get_url(namespace=namespace, name='xyz'), 'get', get_mock)
+async def test_session_is_injected(fake_vault, kmock, resource, namespace):
+    kmock['get', resource, kmock.namespace(namespace), kmock.name('xyz')] << {}
 
     context, result = await fn(1)
 
@@ -27,12 +23,8 @@ async def test_session_is_injected(
         assert result == 101
 
 
-async def test_session_is_passed_through(
-        fake_vault, resp_mocker, aresponses, hostname, resource, namespace):
-
-    result = {}
-    get_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
-    aresponses.add(hostname, resource.get_url(namespace=namespace, name='xyz'), 'get', get_mock)
+async def test_session_is_passed_through(fake_vault, kmock, resource, namespace):
+    kmock['get', resource, kmock.namespace(namespace), kmock.name('xyz')] << {}
 
     explicit_context = APIContext(ConnectionInfo(server='http://irrelevant/'))
     context, result = await fn(1, context=explicit_context)

--- a/tests/k8s/conftest.py
+++ b/tests/k8s/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _autouse_resp_mocker(resp_mocker, version_api):
+def _enforced_api_server(fake_vault, enforced_session, resource):
     pass
 
 

--- a/tests/k8s/test_creating.py
+++ b/tests/k8s/test_creating.py
@@ -1,4 +1,3 @@
-import aiohttp.web
 import pytest
 
 from kopf._cogs.clients.creating import create_obj
@@ -6,10 +5,8 @@ from kopf._cogs.clients.errors import APIError
 
 
 async def test_simple_body_with_arguments(
-        resp_mocker, aresponses, hostname, settings, resource, namespace, logger, caplog):
-
-    post_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    aresponses.add(hostname, resource.get_url(namespace=namespace), 'post', post_mock)
+        kmock, settings, resource, namespace, logger):
+    kmock['post', resource] << {}
 
     body = {'x': 'y'}
     await create_obj(
@@ -21,21 +18,18 @@ async def test_simple_body_with_arguments(
         body=body,
     )
 
-    assert post_mock.called
-    assert post_mock.call_count == 1
-
-    data = post_mock.call_args_list[0].args[0].data  # [callidx][args/kwargs][argidx]
+    assert len(kmock['post']) == 1
+    assert kmock['post'][0].resource == resource
+    assert kmock['post'][0].namespace == namespace
     if resource.namespaced:
-        assert data == {'x': 'y', 'metadata': {'name': 'name1', 'namespace': 'ns'}}
+        assert kmock['post'][0].data == {'x': 'y', 'metadata': {'name': 'name1', 'namespace': 'ns'}}
     else:
-        assert data == {'x': 'y', 'metadata': {'name': 'name1'}}
+        assert kmock['post'][0].data == {'x': 'y', 'metadata': {'name': 'name1'}}
 
 
 async def test_full_body_with_identifiers(
-        resp_mocker, aresponses, hostname, settings, resource, namespace, caplog, logger):
-
-    post_mock = resp_mocker(return_value=aiohttp.web.json_response({}))
-    aresponses.add(hostname, resource.get_url(namespace=namespace), 'post', post_mock)
+        kmock, settings, resource, namespace, logger):
+    kmock['post', resource] << {}
 
     body = {'x': 'y', 'metadata': {'name': 'name1', 'namespace': namespace}}
     await create_obj(
@@ -45,24 +39,19 @@ async def test_full_body_with_identifiers(
         body=body,
     )
 
-    assert post_mock.called
-    assert post_mock.call_count == 1
-
-    data = post_mock.call_args_list[0].args[0].data  # [callidx][args/kwargs][argidx]
-    assert data == {'x': 'y', 'metadata': {'name': 'name1', 'namespace': namespace}}
+    assert len(kmock['post']) == 1
+    assert kmock['post'][0].resource == resource
+    assert kmock['post'][0].namespace == namespace
+    assert kmock['post'][0].data == {'x': 'y', 'metadata': {'name': 'name1', 'namespace': namespace}}
 
 
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.
 @pytest.mark.parametrize('status', [400, 403, 404, 409, 500, 666])
 async def test_raises_api_errors(
-        resp_mocker, aresponses, hostname, settings, status, resource, namespace, logger,
+        kmock, settings, status, resource, namespace, logger,
         cluster_resource, namespaced_resource):
-
-    post_mock = resp_mocker(return_value=aresponses.Response(status=status, reason='oops'))
-    cluster_url = cluster_resource.get_url(namespace=None)
-    namespaced_url = namespaced_resource.get_url(namespace='ns')
-    aresponses.add(hostname, cluster_url, 'post', post_mock)
-    aresponses.add(hostname, namespaced_url, 'post', post_mock)
+    kmock['post', resource, kmock.clusterwide()] << status
+    kmock['post', resource, kmock.namespace('ns')] << status
 
     body = {'x': 'y'}
     with pytest.raises(APIError) as e:
@@ -74,4 +63,10 @@ async def test_raises_api_errors(
             name='name1',
             body=body,
         )
+
     assert e.value.status == status
+    assert len(kmock) == 1
+    if namespace is None:
+        assert kmock[0].resource == cluster_resource
+    else:
+        assert kmock[0].resource == namespaced_resource

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -1,45 +1,28 @@
-import aiohttp.web
 import pytest
 
 from kopf._cogs.clients.errors import APIError
 from kopf._cogs.clients.fetching import list_objs
-from kopf._cogs.structs.credentials import LoginError
 
 
-async def test_listing_works(
-        resp_mocker, aresponses, hostname, settings, logger, resource, namespace,
-        cluster_resource, namespaced_resource):
-
-    result = {'items': [{}, {}]}
-    list_mock = resp_mocker(return_value=aiohttp.web.json_response(result))
-    cluster_url = cluster_resource.get_url(namespace=None)
-    namespaced_url = namespaced_resource.get_url(namespace='ns')
-    aresponses.add(hostname, cluster_url, 'get', list_mock)
-    aresponses.add(hostname, namespaced_url, 'get', list_mock)
-
+async def test_listing_works(kmock, settings, logger, resource, namespace):
+    kmock[resource, kmock.namespace(namespace)] << {'items': [{}, {}]}
     items, resource_version = await list_objs(
         logger=logger,
         settings=settings,
         resource=resource,
         namespace=namespace,
     )
-    assert items == result['items']
-
-    assert list_mock.called
-    assert list_mock.call_count == 1
+    assert items == [{}, {}]
+    assert len(kmock['list']) == 1
 
 
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.
 @pytest.mark.parametrize('status', [400, 403, 500, 666])
 async def test_raises_direct_api_errors(
-        resp_mocker, aresponses, hostname, settings, logger, status, resource, namespace,
+        kmock, settings, logger, status, resource, namespace,
         cluster_resource, namespaced_resource):
-
-    list_mock = resp_mocker(return_value=aresponses.Response(status=status, reason='oops'))
-    cluster_url = cluster_resource.get_url(namespace=None)
-    namespaced_url = namespaced_resource.get_url(namespace='ns')
-    aresponses.add(hostname, cluster_url, 'get', list_mock)
-    aresponses.add(hostname, namespaced_url, 'get', list_mock)
+    kmock[cluster_resource, kmock.clusterwide()] << status
+    kmock[namespaced_resource, kmock.namespace('ns')] << status
 
     with pytest.raises(APIError) as e:
         await list_objs(

--- a/tests/reactor/test_patching_inconsistencies.py
+++ b/tests/reactor/test_patching_inconsistencies.py
@@ -1,4 +1,3 @@
-import aiohttp.web
 import pytest
 
 from kopf._cogs.structs.bodies import Body
@@ -40,13 +39,9 @@ from kopf._core.actions.loggers import LocalObjectLogger
 
 ])
 async def test_patching_without_inconsistencies(
-        resource, namespace, settings, assert_logs, version_api,
-        aresponses, hostname, resp_mocker,
-        patch, response):
-
-    url = resource.get_url(namespace=namespace, name='name1')
-    patch_mock = resp_mocker(return_value=aiohttp.web.json_response(response))
-    aresponses.add(hostname, url, 'patch', patch_mock)
+        kmock, resource, namespace, settings, assert_logs, patch, response):
+    kmock.objects[resource, namespace, 'name1'] = {}  # suppress 404s
+    kmock['patch', resource, kmock.namespace(namespace), kmock.name('name1')] << response
 
     body = Body({'metadata': {'namespace': namespace, 'name': 'name1'}})
     logger = LocalObjectLogger(body=body, settings=settings)
@@ -102,13 +97,9 @@ async def test_patching_without_inconsistencies(
 
 ])
 async def test_patching_with_inconsistencies(
-        resource, namespace, settings, assert_logs, version_api,
-        aresponses, hostname, resp_mocker,
-        patch, response):
-
-    url = resource.get_url(namespace=namespace, name='name1')
-    patch_mock = resp_mocker(return_value=aiohttp.web.json_response(response))
-    aresponses.add(hostname, url, 'patch', patch_mock)
+        kmock, resource, namespace, settings, assert_logs, patch, response):
+    kmock.objects[resource, namespace, 'name1'] = {}  # suppress 404s
+    kmock['patch', resource, kmock.namespace(namespace), kmock.name('name1')] << response
 
     body = Body({'metadata': {'namespace': namespace, 'name': 'name1'}})
     logger = LocalObjectLogger(body=body, settings=settings)
@@ -127,14 +118,10 @@ async def test_patching_with_inconsistencies(
 
 
 async def test_patching_with_disappearance(
-        resource, namespace, settings, assert_logs, version_api,
-        aresponses, hostname, resp_mocker):
+        kmock, resource, namespace, settings, assert_logs):
+    kmock['patch', resource, kmock.namespace(namespace), kmock.name('name1')] << 404
 
     patch = {'spec': {'x': 'y'}, 'status': {'s': 't'}}  # irrelevant
-    url = resource.get_url(namespace=namespace, name='name1')
-    patch_mock = resp_mocker(return_value=aresponses.Response(status=404, reason='oops'))
-    aresponses.add(hostname, url, 'patch', patch_mock)
-
     body = Body({'metadata': {'namespace': namespace, 'name': 'name1'}})
     logger = LocalObjectLogger(body=body, settings=settings)
     await patch_and_check(

--- a/tests/utilities/aiotasks/test_coro_cancellation.py
+++ b/tests/utilities/aiotasks/test_coro_cancellation.py
@@ -66,9 +66,10 @@ async def test_coro_is_awaited_via_a_task_with_no_warning(coromock_task_factory)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('default')
         mock = Mock()
-        coro = AsyncMock(wraps=f(mock))
-        del coro.close
-        await cancel_coro(coro)
+        coro = f(mock)
+        coromock = AsyncMock(wraps=coro, spec=coro)
+        del coromock.close
+        await cancel_coro(coromock)
 
         # The warnings come only from the garbage collection, so dereference it.
         del coro


### PR DESCRIPTION
Kmock is a Kubernetes Mock Server, but can mock any API and HTTP servers locally. It allows expressing any regular or weird (mis)behaviour of the server side as needed for local tests — and is much shorter and compact than the equivalent code with `aresponses`.

* https://kmock.readthedocs.io/
* https://github.com/nolar/kmock

It originally started as a couple of helper tools inside Kopf itself, but I later extracted it into a separate library (done in ≈2021; released in 2025 due to personal reasons).