### PR TITLE
Postpone the initial timer/daemon delay by computable (e.g. random) time

### DIFF
--- a/docs/daemons.rst
+++ b/docs/daemons.rst
@@ -226,6 +226,28 @@ The start of the daemon will be delayed by 30 seconds after the resource
 creation (or operator startup). For example, this can be used to give some time
 for regular event-driven handlers to finish without producing too much activity.
 
+The ``initial_delay`` can also be a callable, which accepts the same arguments
+as the handler itself, and returns the delay in seconds:
+
+.. code-block:: python
+
+    import random
+    import kopf
+
+    def get_delay(body, **kwargs):
+        return random.randint(
+            body.get('spec', {}).get('minDelay', 0),
+            body.get('spec', {}).get('maxDelay', 60),
+        )
+
+    @kopf.daemon('kopfexamples', initial_delay=get_delay)
+    async def monitor_kex(stopped, **kwargs):
+        ...
+
+This is primarily intended for load balancing during operator restarts (e.g. by
+using a random delay). If you need more complex or periodic random timing,
+consider using a daemon with custom sleeps instead of a timer.
+
 
 Restarting
 ==========

--- a/docs/timers.rst
+++ b/docs/timers.rst
@@ -103,6 +103,28 @@ It is possible to postpone the invocations:
 This is similar to idling, except that it is applied only once per
 resource/operator lifecycle in the very beginning.
 
+The ``initial_delay`` can also be a callable, which accepts the same arguments
+as the handler itself, and returns the delay in seconds:
+
+.. code-block:: python
+
+    import random
+    import kopf
+
+    def get_delay(body, **kwargs):
+        return random.randint(
+            body.get('spec', {}).get('minDelay', 0),
+            body.get('spec', {}).get('maxDelay', 60),
+        )
+
+    @kopf.timer('kopfexamples', interval=1, initial_delay=get_delay)
+    def ping_kex(spec, **kwargs):
+        ...
+
+This is primarily intended for load balancing during operator restarts (e.g. by
+using a random delay). If you need more complex or periodic random timing,
+consider using a daemon with custom sleeps instead of a timer.
+
 
 Combined timing
 ===============

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -468,7 +468,8 @@ async def _daemon(
     body = cause.body
 
     if handler.initial_delay is not None:
-        await aiotime.sleep(handler.initial_delay, wakeup=cause.stopper.async_event)
+        delay = handler.initial_delay(**cause.kwargs) if callable(handler.initial_delay) else handler.initial_delay
+        await aiotime.sleep(delay, wakeup=cause.stopper.async_event)
 
     # Similar to activities (in-memory execution), but applies patches on every attempt.
     state = progression.State.from_scratch().with_handlers([handler])
@@ -537,7 +538,8 @@ async def _timer(
     body = cause.body
 
     if handler.initial_delay is not None:
-        await aiotime.sleep(handler.initial_delay, wakeup=stopper.async_event)
+        delay = handler.initial_delay(**cause.kwargs) if callable(handler.initial_delay) else handler.initial_delay
+        await aiotime.sleep(delay, wakeup=stopper.async_event)
 
     # Similar to activities (in-memory execution), but applies patches on every attempt.
     clock = asyncio.get_running_loop().time

--- a/kopf/_core/intents/callbacks.py
+++ b/kopf/_core/intents/callbacks.py
@@ -27,6 +27,7 @@ if not TYPE_CHECKING:  # pragma: nocover
     WebhookFn = Callable[..., invocation.SyncOrAsync[object | None]]
     DaemonFn = Callable[..., invocation.SyncOrAsync[object | None]]
     TimerFn = Callable[..., invocation.SyncOrAsync[object | None]]
+    DelayFn = Callable[..., float]  # strictly sync, no async!
     WhenFilterFn = Callable[..., bool]  # strictly sync, no async!
     MetaFilterFn = Callable[..., bool]  # strictly sync, no async!
 else:
@@ -194,6 +195,28 @@ else:
             KwArg(Any),
         ],
         invocation.SyncOrAsync[object | None]
+    ]
+
+    DelayFn = Callable[
+        [
+            NamedArg(ephemera.Index[Any, Any], "*"),
+            NamedArg(bodies.Annotations, "annotations"),
+            NamedArg(bodies.Labels, "labels"),
+            NamedArg(bodies.Body, "body"),
+            NamedArg(bodies.Meta, "meta"),
+            NamedArg(bodies.Spec, "spec"),
+            NamedArg(bodies.Status, "status"),
+            NamedArg(references.Resource, "resource"),
+            NamedArg(str | None, "uid"),
+            NamedArg(str | None, "name"),
+            NamedArg(str | None, "namespace"),
+            NamedArg(patches.Patch, "patch"),
+            NamedArg(typedefs.Logger, "logger"),
+            NamedArg(Any, "memo"),
+            DefaultNamedArg(Any, "param"),
+            KwArg(Any),
+        ],
+        float  # strictly sync, no async!
     ]
 
     WhenFilterFn = Callable[

--- a/kopf/_core/intents/handlers.py
+++ b/kopf/_core/intents/handlers.py
@@ -90,7 +90,7 @@ class ChangingHandler(ResourceHandler):
 @dataclasses.dataclass(frozen=True)
 class SpawningHandler(ResourceHandler):
     requires_finalizer: bool | None
-    initial_delay: float | None
+    initial_delay: float | callbacks.DelayFn | None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -668,7 +668,7 @@ def daemon(  # lgtm[py/similar-function]
         timeout: float | None = None,
         retries: int | None = None,
         backoff: float | None = None,
-        initial_delay: float | None = None,
+        initial_delay: float | callbacks.DelayFn | None = None,
         cancellation_backoff: float | None = None,
         cancellation_timeout: float | None = None,
         cancellation_polling: float | None = None,
@@ -731,7 +731,7 @@ def timer(  # lgtm[py/similar-function]
         retries: int | None = None,
         backoff: float | None = None,
         interval: float | None = None,
-        initial_delay: float | None = None,
+        initial_delay: float | callbacks.DelayFn | None = None,
         sharp: bool | None = None,
         idle: float | None = None,
         # Resource object specification:

--- a/tests/handling/daemons/test_daemon_spawning.py
+++ b/tests/handling/daemons/test_daemon_spawning.py
@@ -35,3 +35,23 @@ async def test_daemon_initial_delay_obeyed(
     await executed.wait()
 
     assert looptime == 5.0
+
+
+async def test_daemon_initial_delay_callable_obeyed(
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
+    caplog.set_level(logging.DEBUG)
+    executed = asyncio.Event()
+
+    def get_delay(body, **_):
+        return body.get('spec', {}).get('delay', 0.0)
+
+    @kopf.daemon(*resource, id='fn', initial_delay=get_delay)
+    async def fn(**kwargs):
+        dummy.mock(**kwargs)
+        executed.set()
+
+    await simulate_cycle({'spec': {'delay': 7.0}})
+    await executed.wait()
+
+    assert looptime == 7.0
+    assert dummy.mock.call_count == 1

--- a/tests/handling/daemons/test_timer_triggering.py
+++ b/tests/handling/daemons/test_timer_triggering.py
@@ -42,3 +42,26 @@ async def test_timer_initial_delay_obeyed(
 
     assert looptime == 6
     assert dummy.mock.call_count == 2
+
+
+async def test_timer_initial_delay_callable_obeyed(
+        resource, dummy, caplog, assert_logs, k8s_mocked, simulate_cycle, looptime):
+    caplog.set_level(logging.DEBUG)
+    trigger = asyncio.Condition()
+
+    def get_delay(body, **_):
+        return body.get('spec', {}).get('delay', 0.0)
+
+    @kopf.timer(*resource, id='fn', initial_delay=get_delay, interval=1.0)
+    async def fn(**kwargs):
+        dummy.mock(**kwargs)
+        async with trigger:
+            trigger.notify_all()
+
+    await simulate_cycle({'spec': {'delay': 3.0}})
+    async with trigger:
+        await trigger.wait()
+        await trigger.wait()
+
+    assert looptime == 4.0 # 3.0 delay + 1.0 interval
+    assert dummy.mock.call_count == 2


### PR DESCRIPTION
Example:

```python
    import random
    import kopf

    def get_delay(body, **kwargs):
        return random.randint(
            body.get('spec', {}).get('minDelay', 0),
            body.get('spec', {}).get('maxDelay', 60),
        )

    @kopf.daemon('kopfexamples', initial_delay=get_delay)
    async def monitor_kex(stopped, **kwargs):
        ...
```

The focus is ONLY on the initial delay when the operator starts/restarts. Everything after that, can be controlled by the daemon's internal logic.

Closes #1196 