### PR TITLE
Restart the webhook server on renewal of externally provided SSL cert/keys

### DIFF
--- a/docs/admission.rst
+++ b/docs/admission.rst
@@ -567,10 +567,18 @@ This applies to all servers:
     @kopf.on.startup()
     def config(settings: kopf.OperatorSettings, **_):
         settings.admission.server = kopf.WebhookServer(
-            cafile='ca.pem',        # or cadata, or capath.
-            certfile='cert.pem',
-            pkeyfile='pkey.pem',
-            password='...')         # for the private key, if used.
+            cafile='/secrets/ca.pem',       # or cadata, or capath.
+            certfile='/secrets/cert.pem',
+            pkeyfile='/secrets/pkey.pem',
+            password='...',                 # for the private key, if used.
+            file_check_interval=60,
+        )
+
+You can use cert-manager or other externally provided certificate files
+at their known (mounted) locations without the full restart of the operator.
+Once any of the specified files changes, e.g. due to certificate or private key
+automated renewal, the webhook server will restart with the new certificate
+(at the latest after ``file_check_interval`` seconds, which defaults to 60s).
 
 .. note::
     ``cadump`` (output) can be used together with ``cafile``/``cadata`` (input),

--- a/tests/admission/test_webhook_server.py
+++ b/tests/admission/test_webhook_server.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 import ssl
@@ -99,6 +100,36 @@ async def test_webhookserver_serves(
                     assert text == '{"hello": "world"}'
                     assert resp.status == 200
             break  # do not sleep
+
+
+async def test_webhookserver_renews_certificate_files(tmp_path, responder, looptime):
+
+    # Generate different certificates.
+    certpath = tmp_path / 'cert.pem'
+    pkeypath = tmp_path / 'pkey.pem'
+    cert1, pkey1 = WebhookServer.build_certificate(['localhost', '127.0.0.1', 'hostA'])
+    cert2, pkey2 = WebhookServer.build_certificate(['localhost', '127.0.0.1', 'hostB'])
+    certpath.write_bytes(cert1)
+    pkeypath.write_bytes(pkey1)
+
+    # Schedule a delayed replacement of the files.
+    loop = asyncio.get_running_loop()
+    loop.call_later(5, certpath.write_bytes, cert2)
+    loop.call_later(5, pkeypath.write_bytes, pkey2)
+
+    # Run the server.
+    cabundles = []
+    server = WebhookServer(certfile=certpath, pkeyfile=pkeypath, file_check_interval=10)
+    async with server:
+        async for client_config in server(responder.fn):
+            cabundles.append(base64.b64decode(client_config['caBundle']))
+            if len(cabundles) >= 2:
+                break
+
+    assert looptime == 10
+    assert len(cabundles) == 2
+    assert cabundles[0] == cert1
+    assert cabundles[1] == cert2
 
 
 @pytest.mark.parametrize('code, error', [


### PR DESCRIPTION
A better approach than parsing the certificates with a self-made PEM/DER parser:

* #1216 

Here, we onl keep track of SSL-related files — CA file, cert file, pkey file — and wake up once any of them changes its content. Any change in any file means a new SSL content and a new listening server.

Note: the mounted secrets do not change their metadata (mtime, etc), so we have to re-read the full content for every check.

Unlike with the "notAfter" approach, we detect the file changes almost immediately (60s checkk interval by default), not closer to the cert expiration time. This also covers the forced renewals.

TODOs:

- [x] Tests
- [x] Docs

Closes #1135