### PR TITLE
Fix the problem of hanging index handler at startup when worker_limit is less than number of resources

### DIFF
--- a/tests/handling/indexing/test_blocking_until_indexed.py
+++ b/tests/handling/indexing/test_blocking_until_indexed.py
@@ -41,13 +41,13 @@ async def test_reporting_on_resource_readiness(
 
 
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
-async def test_blocking_when_operator_is_not_ready(
+async def test_blocking_when_operator_is_not_ready_post_indexing(
         resource, settings, registry, indexers, caplog, event_type, handlers, looptime):
+    """Post-indexing events (resource_indexed=None) block until operator is ready."""
     caplog.set_level(logging.DEBUG)
 
     operator_indexed = ToggleSet(all)
     resource_listed = await operator_indexed.make_toggle()
-    resource_indexed = await operator_indexed.make_toggle()
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(process_resource_event(
             lifecycle=all_at_once,
@@ -60,7 +60,7 @@ async def test_blocking_when_operator_is_not_ready(
             raw_event={'type': event_type, 'object': {}},
             event_queue=asyncio.Queue(),
             operator_indexed=operator_indexed,
-            resource_indexed=resource_indexed,
+            resource_indexed=None,
         ), timeout=1.23)
     assert looptime == 1.23
     assert operator_indexed.is_off()
@@ -69,8 +69,9 @@ async def test_blocking_when_operator_is_not_ready(
 
 
 @pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
-async def test_unblocking_once_operator_is_ready(
+async def test_unblocking_once_operator_is_ready_post_indexing(
         resource, settings, registry, indexers, caplog, event_type, handlers, looptime):
+    """Post-indexing events (resource_indexed=None) unblock once operator is ready."""
     caplog.set_level(logging.DEBUG)
 
     async def delayed_readiness(delay: float):
@@ -79,8 +80,35 @@ async def test_unblocking_once_operator_is_ready(
 
     operator_indexed = ToggleSet(all)
     resource_listed = await operator_indexed.make_toggle()
-    resource_indexed = await operator_indexed.make_toggle()
     asyncio.create_task(delayed_readiness(1.23))
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=ResourceMemories(),
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': {}},
+        event_queue=asyncio.Queue(),
+        operator_indexed=operator_indexed,
+        resource_indexed=None,
+    )
+    assert looptime == 1.23
+    assert operator_indexed.is_on()
+    assert set(operator_indexed) == {resource_listed}
+    assert handlers.event_mock.called
+
+
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_no_blocking_during_initial_indexing(
+        resource, settings, registry, indexers, caplog, event_type, handlers, looptime):
+    """Initial indexing (resource_indexed is set) does NOT block even with pending toggles."""
+    caplog.set_level(logging.DEBUG)
+
+    operator_indexed = ToggleSet(all)
+    resource_listed = await operator_indexed.make_toggle()
+    resource_indexed = await operator_indexed.make_toggle()
     await process_resource_event(
         lifecycle=all_at_once,
         registry=registry,
@@ -94,7 +122,36 @@ async def test_unblocking_once_operator_is_ready(
         operator_indexed=operator_indexed,
         resource_indexed=resource_indexed,
     )
-    assert looptime == 1.23
-    assert operator_indexed.is_on()
+    assert looptime == 0
+    assert operator_indexed.is_off()  # resource_listed is still pending
     assert set(operator_indexed) == {resource_listed}
+    assert handlers.event_mock.called
+
+
+@pytest.mark.parametrize('event_type', EVENT_TYPES_WHEN_EXISTS)
+async def test_initial_indexing_drops_toggle_without_waiting(
+        resource, settings, registry, indexers, caplog, event_type, handlers, looptime):
+    """Initial indexing drops its toggle immediately without waiting for operator readiness."""
+    caplog.set_level(logging.DEBUG)
+
+    operator_indexed = ToggleSet(all)
+    resource_listed = await operator_indexed.make_toggle()
+    resource_indexed = await operator_indexed.make_toggle()
+    assert set(operator_indexed) == {resource_listed, resource_indexed}
+
+    await process_resource_event(
+        lifecycle=all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=indexers,
+        memories=ResourceMemories(),
+        memobase=Memo(),
+        raw_event={'type': event_type, 'object': {}},
+        event_queue=asyncio.Queue(),
+        operator_indexed=operator_indexed,
+        resource_indexed=resource_indexed,
+    )
+    assert looptime == 0
+    assert set(operator_indexed) == {resource_listed}  # resource_indexed was dropped
     assert handlers.event_mock.called


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping maintainers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
The changes introduced in [this commit](https://github.com/nolar/kopf/pull/661/changes/1d657e2b1e1669466d68e783cc6d23819cd130ed)
 caused the operator to hang indefinitely during startup when:

- An in-memory index is used, and
- worker_limit is set lower than the number of resources that need to be indexed.

In this scenario, the indexing process can never fully complete, which blocks the operator from progressing past initialization.

This PR fixes the issue by ensuring the indexing phase can complete even when the worker limit is lower than the total number of resources.