### PR TITLE
Fix the types and token retrieval for kubernetes-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,15 @@ lint = [
     "import-linter",
     "isort",
     "pre-commit",
+    # All extras — for proper type-checks of imports (only for linting, not for testing!).
+    "kubernetes",
+    "kubernetes-asyncio",
+    "pykube-ng",
+    "oscrypto",
+    "certbuilder",
+    "certvalidator",
+    "pyngrok",
+    "uvloop",
 ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
#1010 introduced `kubernetes-asyncio`, which declares itself as typed (`py.typed` file exists), though many functions are not typed — neither directly nor in the `.pyi` files. As a result, in the local dev environment, it was causing the typing issues in Kopf.

It was not noticed when the PR was merged, since neither the extras, nor even the dependencies out of any extras, were installed. As such, the `ignore_missing_imports = true` config was in play in CI and it was green, but not in local dev environments.

These dependencies are necessary, since `# type: ignore` marks will otherwise behave differently in CI and in local dev. So, all these dependencies (all extras and a bit more) are now a part of the `lint` group.

As a side note: for reasons unknown, MyPy complains about one function, but is totally fine with an identical untyped function a few lines below. Anyway, we do not care as long as it works, so ignore the typing issues.