### PR TITLE
Check types in strict mode by default, with no CLI flags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,14 +21,14 @@ jobs:
           python-version: "3.14"
       - run: pip install --group lint -e .
       - run: pre-commit run --all-files
-      - run: mypy kopf --strict
+      - run: mypy
       - run: |
-          # Mypying the examples
+          # Separately, because the shared module name "example.py" causes naming conflicts.
           exit_codes=0
           for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
           do
             echo "Checking ${d}"
-            mypy $d
+            mypy --config-file= --ignore-missing-imports $d
             exit_codes=$[${exit_codes} + $?]
           done
           exit ${exit_codes}

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -25,14 +25,14 @@ jobs:
           python-version: "3.14"
       - run: pip install --group lint -e .
       - run: pre-commit run --all-files
-      - run: mypy kopf --strict
+      - run: mypy
       - run: |
-          # Mypying the examples
+          # Separately, because the shared module name "example.py" causes naming conflicts.
           exit_codes=0
           for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
           do
             echo "Checking ${d}"
-            mypy $d
+            mypy --config-file= --ignore-missing-imports $d
             exit_codes=$[${exit_codes} + $?]
           done
           exit ${exit_codes}

--- a/kopf/_kits/loops.py
+++ b/kopf/_kits/loops.py
@@ -47,7 +47,7 @@ def proper_loop(suggested_loop: asyncio.AbstractEventLoop | None = None) -> Iter
                 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
         try:
-            yield
+            yield None
 
         finally:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ test = [
 ]
 lint = [
     {include-group = "test"},
-    "mypy==1.19.0",
+    "mypy==1.19.1",
     "import-linter",
     "isort",
     "pre-commit",
@@ -119,6 +119,10 @@ lint = [
 version_file = "kopf/_cogs/helpers/versions.py"
 
 [tool.mypy]
+strict = true
+packages = ["kopf"]
+python_version = "3.10"
+exclude_gitignore = true
 warn_unused_configs = true
 ignore_missing_imports = true
 


### PR DESCRIPTION
Only `mypy` is enough now — easier for AI agents to type-check (similar to `pytest` with no CLI flags to run the tests).
