### PR TITLE
Consider a namespace deleted not earlier than all blockers/finalizers removed

### DIFF
--- a/tests/observation/test_revision_of_namespaces.py
+++ b/tests/observation/test_revision_of_namespaces.py
@@ -19,13 +19,39 @@ def test_bodies_for_additional_population(registry):
     assert insights.namespaces == {'ns1', 'ns2'}
 
 
-def test_bodies_for_deletion_via_timestamp(registry):
+def test_bodies_for_deletion_via_timestamp_without_conditions(registry):
     b1 = RawBody(metadata={'name': 'ns1'})
     b2 = RawBody(metadata={'name': 'ns1', 'deletionTimestamp': '...'})
     insights = Insights()
     revise_namespaces(insights=insights, namespaces=['ns*'], raw_bodies=[b1])
     revise_namespaces(insights=insights, namespaces=['ns*'], raw_bodies=[b2])
+    assert insights.namespaces == {'ns1'}
+
+
+def test_bodies_for_deletion_via_timestamp_with_true_conditions(registry, assert_logs):
+    b1 = RawBody(metadata={'name': 'ns1'})
+    b2 = RawBody(metadata={'name': 'ns1', 'deletionTimestamp': '...'},
+                 status={'conditions': [{'type': 'Whatever',
+                                         'status': 'True',
+                                         'reason': 'SomeReason',
+                                         'message': 'Some message'}]})
+    insights = Insights()
+    revise_namespaces(insights=insights, namespaces=['ns*'], raw_bodies=[b1])
+    revise_namespaces(insights=insights, namespaces=['ns*'], raw_bodies=[b2])
+    assert insights.namespaces == {'ns1'}
+    assert_logs(["Namespace 'ns1' termination pending: SomeReason: Some message"])
+
+
+def test_bodies_for_deletion_via_timestamp_with_false_conditions(registry, assert_logs):
+    b1 = RawBody(metadata={'name': 'ns1'})
+    b2 = RawBody(metadata={'name': 'ns1', 'deletionTimestamp': '...'},
+                 status={'conditions': [{'type': 'Whatever',
+                                         'status': 'False'}]})
+    insights = Insights()
+    revise_namespaces(insights=insights, namespaces=['ns*'], raw_bodies=[b1])
+    revise_namespaces(insights=insights, namespaces=['ns*'], raw_bodies=[b2])
     assert not insights.namespaces
+    assert_logs(prohibited=["Namespace '.*' termination pending:"])
 
 
 def test_bodies_ignored_for_mismatching(registry):
@@ -51,13 +77,39 @@ def test_events_for_additional_population(registry):
     assert insights.namespaces == {'ns1', 'ns2'}
 
 
-def test_events_for_deletion_via_timestamp(registry):
+def test_events_for_deletion_via_timestamp_without_conditions(registry):
     e1 = RawEvent(type=None, object=RawBody(metadata={'name': 'ns1'}))
     e2 = RawEvent(type=None, object=RawBody(metadata={'name': 'ns1', 'deletionTimestamp': '...'}))
     insights = Insights()
     revise_namespaces(insights=insights, namespaces=['ns*'], raw_events=[e1])
     revise_namespaces(insights=insights, namespaces=['ns*'], raw_events=[e2])
+    assert insights.namespaces == {'ns1'}
+
+
+def test_events_for_deletion_via_timestamp_with_true_conditions(registry, assert_logs):
+    e1 = RawEvent(type=None, object=RawBody(metadata={'name': 'ns1'}))
+    e2 = RawEvent(type=None, object=RawBody(metadata={'name': 'ns1', 'deletionTimestamp': '...'},
+                                            status={'conditions': [{'type': 'Whatever',
+                                                                    'status': 'True',
+                                                                    'reason': 'SomeReason',
+                                                                    'message': 'Some message'}]}))
+    insights = Insights()
+    revise_namespaces(insights=insights, namespaces=['ns*'], raw_events=[e1])
+    revise_namespaces(insights=insights, namespaces=['ns*'], raw_events=[e2])
+    assert insights.namespaces == {'ns1'}
+    assert_logs(["Namespace 'ns1' termination pending: SomeReason: Some message"])
+
+
+def test_events_for_deletion_via_timestamp_with_false_conditions(registry, assert_logs):
+    e1 = RawEvent(type=None, object=RawBody(metadata={'name': 'ns1'}))
+    e2 = RawEvent(type=None, object=RawBody(metadata={'name': 'ns1', 'deletionTimestamp': '...'},
+                                            status={'conditions': [{'type': 'Whatever',
+                                                                    'status': 'False'}]}))
+    insights = Insights()
+    revise_namespaces(insights=insights, namespaces=['ns*'], raw_events=[e1])
+    revise_namespaces(insights=insights, namespaces=['ns*'], raw_events=[e2])
     assert not insights.namespaces
+    assert_logs(prohibited=["Namespace '.*' termination pending:"])
 
 
 def test_events_for_deletion_via_event_type(registry):


### PR DESCRIPTION
Previously, when the namespace was only marked for deletion, Kopf considered it already deleted and stopped the watcher stream, which implicitly terminates all the related workers. As a result, the actual changes of objects in the deleted namespaces were not tracked or handled, including the removal of the finalizers.

As a side note: the DELETED event did not always arrive, so it was never a reliable criterion for stopping the watcher. This is why the mark-for-deletion was used in the first place.

Now, the namespace is considered deleted when these pre-requisites are satisfied:

- The namespace is marked for deletion (as before).
- There are conditions in the namespace status (at least one).
- There are no "True" conditions for the namespace (blockers).

The existence of any conditions is important, since at least initially comes a MODIFIED event with the `metadata.deletionTimestamp` but no conditions, which is briefly followed by another event with conditions. We should not stop the watcher on the first event until we know it is safe to stop the watcher.

Closes #1088, closes #1134 