### PR TITLE
Behave safer with misconstructed NamespaceCondition

### DIFF
--- a/kopf/_core/reactor/observation.py
+++ b/kopf/_core/reactor/observation.py
@@ -347,5 +347,5 @@ def is_deleted(raw_event: bodies.RawEvent) -> bool:
 
 def get_blockers(raw_event: bodies.RawEvent) -> list[tuple[str | None, str | None]]:
     conditions = raw_event['object'].get('status', {}).get('conditions', [])
-    conditions = [cond for cond in conditions if cond['status'] == 'True']
-    return [(cond['reason'], cond['message']) for cond in conditions]
+    conditions = [cond for cond in conditions if cond.get('status') == 'True']
+    return [(cond.get('reason', ''), cond.get('message', '')) for cond in conditions]


### PR DESCRIPTION
While the schema clearly defines these fields as present in the namespace condition, it is always a good idea to be on a safer side by assuming that they are absent. For this particular case, their values are of no importance, they are passed through to logs. So, there is no need to fail if the fields are accidentally absent.

Schema: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#namespacecondition-v1-core

A follow-up for

* #1225 