### PR TITLE
Improve the readability & debuggability of Kubernetes API errors

### DIFF
--- a/kopf/_cogs/clients/errors.py
+++ b/kopf/_cogs/clients/errors.py
@@ -66,15 +66,21 @@ class APIError(Exception):
             payload: RawStatus | None,
             *,
             status: int,
+            headers: dict[str, str],
     ) -> None:
         message = payload.get('message') if payload else None
         super().__init__(message, payload)
         self._status = status
+        self._headers = headers
         self._payload = payload
 
     @property
     def status(self) -> int:
         return self._status
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return self._headers
 
     @property
     def code(self) -> int | None:
@@ -160,4 +166,4 @@ async def check_response(
         try:
             response.raise_for_status()
         except aiohttp.ClientResponseError as e:
-            raise cls(payload, status=response.status) from e
+            raise cls(payload, status=response.status, headers=dict(response.headers)) from e

--- a/tests/admission/test_admission_manager.py
+++ b/tests/admission/test_admission_manager.py
@@ -67,7 +67,7 @@ async def test_creation_ignores_if_exists_already(
 
     container = Container()
     mocker.patch.object(container, 'as_changed', return_value=aiter([]))
-    k8s_mocked.post.side_effect = APIConflictError({}, status=409)
+    k8s_mocked.post.side_effect = APIConflictError({}, status=409, headers={})
 
     settings.admission.managed = 'xyz'
     await configuration_manager(
@@ -92,7 +92,7 @@ async def test_creation_escalates_on_errors(
 
     container = Container()
     mocker.patch.object(container, 'as_changed', return_value=aiter([]))
-    k8s_mocked.post.side_effect = error({}, status=400)
+    k8s_mocked.post.side_effect = error({}, status=400, headers={})
 
     with pytest.raises(error):
         settings.admission.managed = 'xyz'

--- a/tests/k8s/test_errors.py
+++ b/tests/k8s/test_errors.py
@@ -19,7 +19,7 @@ def test_aiohttp_is_not_leaked_outside():
 
 
 def test_exception_without_payload():
-    exc = APIError(None, status=456)
+    exc = APIError(None, status=456, headers={'X-H': 'abc'})
     assert exc.status == 456
     assert exc.code is None
     assert exc.message is None
@@ -27,7 +27,7 @@ def test_exception_without_payload():
 
 
 def test_exception_with_payload():
-    exc = APIError({"message": "msg", "code": 123, "details": {"a": "b"}}, status=456)
+    exc = APIError({"message": "msg", "code": 123, "details": {"a": "b"}}, status=456, headers={'X-H': 'abc'})
     assert exc.status == 456
     assert exc.code == 123
     assert exc.message == "msg"

--- a/tests/k8s/test_errors.py
+++ b/tests/k8s/test_errors.py
@@ -19,19 +19,33 @@ def test_aiohttp_is_not_leaked_outside():
 
 
 def test_exception_without_payload():
-    exc = APIError(None, status=456, headers={'X-H': 'abc'})
+    exc = APIError(status=456, headers={'X-H': 'abc'})
     assert exc.status == 456
     assert exc.code is None
     assert exc.message is None
     assert exc.details is None
+    assert str(exc) == ""
+    assert repr(exc) == "APIError(status=456)"  # no headers!
 
 
-def test_exception_with_payload():
+def test_exception_with_dict_payload():
     exc = APIError({"message": "msg", "code": 123, "details": {"a": "b"}}, status=456, headers={'X-H': 'abc'})
     assert exc.status == 456
     assert exc.code == 123
     assert exc.message == "msg"
     assert exc.details == {"a": "b"}
+    assert str(exc) == "('msg', {'message': 'msg', 'code': 123, 'details': {'a': 'b'}})"
+    assert repr(exc) == "APIError('msg', {'message': 'msg', 'code': 123, 'details': {'a': 'b'}}, status=456)"
+
+
+def test_exception_with_text_payload():
+    exc = APIError("oops!", status=456, headers={'X-H': 'abc'})
+    assert exc.status == 456
+    assert exc.code is None
+    assert exc.message is None
+    assert exc.details is None
+    assert str(exc) == "oops!"
+    assert repr(exc) == "APIError('oops!', status=456)"  # no headers!
 
 
 @pytest.mark.parametrize('status', [200, 202, 300, 304])
@@ -63,7 +77,7 @@ async def test_no_error_on_success(
     (500, APIError),
     (666, APIError),
 ])
-async def test_error_with_payload(
+async def test_error_with_dict_payload(
         resp_mocker, aresponses, hostname, status, exctype):
 
     resp = aresponses.Response(
@@ -86,7 +100,7 @@ async def test_error_with_payload(
 
 
 @pytest.mark.parametrize('status', [400, 500, 666])
-async def test_error_with_nonjson_payload(
+async def test_error_with_text_payload(
         resp_mocker, aresponses, hostname, status):
 
     resp = aresponses.Response(
@@ -104,6 +118,7 @@ async def test_error_with_nonjson_payload(
     assert err.value.code is None
     assert err.value.message is None
     assert err.value.details is None
+    assert str(err.value) == "unparsable json"
 
 
 @pytest.mark.parametrize('status', [400, 500, 666])
@@ -125,3 +140,4 @@ async def test_error_with_parseable_nonk8s_payload(
     assert err.value.code is None
     assert err.value.message is None
     assert err.value.details is None
+    assert str(err.value) == ""

--- a/tests/k8s/test_watching_infinitely.py
+++ b/tests/k8s/test_watching_infinitely.py
@@ -75,7 +75,7 @@ async def test_too_many_requests_exception(
         "details": {
             "retryAfterSeconds": 1,
         }
-    }, status=429)
+    }, status=429, headers={})
     enforced_session.request = mocker.Mock(side_effect=exc)
     stream.feed([], namespace=namespace)
     stream.close(namespace=namespace)


### PR DESCRIPTION
Some API errors now return a non-JSON payload, such as HTTP 429 saying "Too many requests, please try later.". Such errors now render as `APIError(None, None)`, which makes it difficult to identify.

Now, two major things change:

* The http status will always be in the error repr in logs.
* The non-JSON payloads will also be shown in the repr.

Before:

```python
APIClientError(None, None)
```

After:

```python
APIClientError('Too many requests, please try again later.', status=429)
```

Some basic safety guards are used to prevent massive data leaks into the logs, but this is rudimentary: it is not our job to protect the data if it is already dumped to the client (us). But we do care about log size to a limited extent, so we cut the huge messages.

Related: #1195
