### PR TITLE
Retry on "too many requests" for all requests, obey the server's "retry-after"

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -658,6 +658,21 @@ on the next error.
     For errors in the framework, see :ref:`error-throttling`.
 
 
+Throttling of "too many requests"
+=================================
+
+When the API server responds with HTTP 429 "Too Many Requests", Kopf will retry
+as for usual errors. However, it will obey the server-suggested interval
+if it is longer than what Kopf would use otherwise from its own
+``settings.networking.error_backoffs``.
+
+``settings.networking.enforce_retry_after`` (boolean) tells Kopf what to do
+when its own backoff interval is longer than the server-requested interval.
+If ``True``, the server-provided interval will be used. If ``False`` (default),
+Kopf's longer backoff interval will be used. Either way, the backoff interval
+will never be shorter than what the server requested.
+
+
 .. _error-throttling:
 
 Throttling of unexpected errors

--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -96,7 +96,8 @@ async def request(
             raise
 
         # NOTE(vsaienko): during k8s upgrade API might throw 403 forbidden. Use retries for this exception as well.
-        except (aiohttp.ClientConnectionError, errors.APIServerError, asyncio.TimeoutError, errors.APIForbiddenError) as e:
+        except (aiohttp.ClientConnectionError, errors.APIServerError, asyncio.TimeoutError,
+                errors.APIForbiddenError, errors.APITooManyRequestsError) as e:
             if '[SSL: APPLICATION_DATA_AFTER_CLOSE_NOTIFY]' in str(e):  # for ClientOSError
                 logger.error(f"Request attempt {idx} failed; SSL closed; will re-authenticate: {what}")
                 raise errors.APISessionClosed("SSL data stream is closed.") from e

--- a/kopf/_cogs/clients/api.py
+++ b/kopf/_cogs/clients/api.py
@@ -69,7 +69,7 @@ async def request(
     backoffs = backoffs if isinstance(backoffs, collections.abc.Iterable) else [backoffs]
     count = len(backoffs) + 1 if isinstance(backoffs, collections.abc.Sized) else None
     backoff: float | None
-    for retry, backoff in enumerate(itertools.chain(backoffs, [None]), start=1):
+    for retry, backoff in enumerate(itertools.chain(backoffs, itertools.repeat(None)), start=1):
         idx = f"#{retry}/{count}" if count is not None else f"#{retry}"
         what = f"{method.upper()} {url}"
         try:
@@ -95,13 +95,29 @@ async def request(
                 raise errors.APISessionClosed("Session is closed.") from e
             raise
 
-        # NOTE(vsaienko): during k8s upgrade API might throw 403 forbidden. Use retries for this exception as well.
+        # During k8s upgrades, API might throw 403 Forbidden. Use retries for this error as well.
         except (aiohttp.ClientConnectionError, errors.APIServerError, asyncio.TimeoutError,
                 errors.APIForbiddenError, errors.APITooManyRequestsError) as e:
+
+            # If we are asked to retry later, do so, and obey the requested backoff.
+            if isinstance(e, errors.APITooManyRequestsError):
+                if e.headers and e.headers.get("Retry-After"):
+                    retry_after = int(float(e.headers["Retry-After"]))  # the new style
+                elif e.details and e.details.get("retryAfterSeconds"):
+                    retry_after = int(e.details["retryAfterSeconds"])  # the old style
+                else:
+                    retry_after = None
+
+                if retry_after is not None and backoff is not None:
+                    if settings.networking.enforce_retry_after or retry_after > backoff:
+                        logger.debug(f"Overriding the backoff {backoff}s "
+                                     f"with the retry-after {retry_after}s from the server: {what}")
+                        backoff = retry_after
+
             if '[SSL: APPLICATION_DATA_AFTER_CLOSE_NOTIFY]' in str(e):  # for ClientOSError
                 logger.error(f"Request attempt {idx} failed; SSL closed; will re-authenticate: {what}")
                 raise errors.APISessionClosed("SSL data stream is closed.") from e
-            elif backoff is None:  # i.e. the last or the only attempt.
+            elif backoff is None:  # the last or the only attempt.
                 logger.error(f"Request attempt {idx} failed; escalating: {what} -> {e!r}")
                 raise
             else:

--- a/kopf/_cogs/clients/errors.py
+++ b/kopf/_cogs/clients/errors.py
@@ -133,6 +133,10 @@ class APIConflictError(APIClientError):
     pass
 
 
+class APITooManyRequestsError(APIClientError):
+    pass
+
+
 class APISessionClosed(Exception):
     """
     A helper to escalate from inside the requests to cause re-authentication.
@@ -175,6 +179,7 @@ async def check_response(
             APIForbiddenError if response.status == 403 else
             APINotFoundError if response.status == 404 else
             APIConflictError if response.status == 409 else
+            APITooManyRequestsError if response.status == 429 else
             APIClientError if 400 <= response.status < 500 else
             APIServerError if 500 <= response.status < 600 else
             APIError

--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -376,6 +376,19 @@ class NetworkingSettings:
     For more information on the API errors retrying, see :doc:`api-retrying`.
     """
 
+    enforce_retry_after: bool = False
+    """
+    Should we obey the error backoffs if a retry-after is received from the API?
+
+    If ``True``, the retry-after is used always, regardless of the error backoff
+    of the current request attempt (e.g., for the HTTP 429 Too Many Requests).
+
+    If ``False``, the error backoff is used if longer than the retry-after.
+
+    Regardless of the setting, the retry-after is always the minimum backoff
+    (the request attempt never awaits shorter than what the server asked for).
+    """
+
 
 @dataclasses.dataclass
 class PersistenceSettings:

--- a/tests/k8s/test_errors.py
+++ b/tests/k8s/test_errors.py
@@ -3,8 +3,8 @@ import pytest
 
 from kopf._cogs.clients.auth import APIContext, authenticated
 from kopf._cogs.clients.errors import APIClientError, APIConflictError, APIError, \
-                                      APIForbiddenError, APINotFoundError, \
-                                      APIServerError, check_response
+                                      APIForbiddenError, APINotFoundError, APIServerError, \
+                                      APITooManyRequestsError, check_response
 
 
 @authenticated
@@ -68,6 +68,7 @@ async def test_no_error_on_success(
     (403, APIForbiddenError),
     (404, APINotFoundError),
     (409, APIConflictError),
+    (429, APITooManyRequestsError),
     (400, APIClientError),
     (403, APIClientError),
     (404, APIClientError),
@@ -99,7 +100,7 @@ async def test_error_with_dict_payload(
     assert err.value.details == {'a': 'b'}
 
 
-@pytest.mark.parametrize('status', [400, 500, 666])
+@pytest.mark.parametrize('status', [400, 429, 500, 666])
 async def test_error_with_text_payload(
         resp_mocker, aresponses, hostname, status):
 


### PR DESCRIPTION
When Kopf receives an HTTP 429 "Too Many Requests" from the server, retry and obey the proposed "retry-after" both in case of regular requests (e.g., gets or patches), so as streaming requests. Previously, only the streaming requests did the retry and obeyed the "retry-after" (only the old-style).

An additional config tells Kopf what to do when its own backoff internal is bigger than what the API asks for: either obey the "retry-after" regardless, or use the longer backoff interval (default). Either way, the backoff will never be smaller than what the server asks for.

Also, support the new-style error: when the "retry-after" comes in the headers rather than the payload. The payload is a non-JSON in this case, just a text "Too many requests, try later."

Example (in an artificially limited setup):

```
[2026-01-31 16:53:59,667] kopf._core.reactor.o [DEBUG   ] Overriding the backoff 1s with the retry-after 7s from the error: GET https://0.0.0.0:61502/apis
[2026-01-31 16:53:59,667] kopf._core.reactor.o [ERROR   ] Request attempt #1/9 failed; will retry: GET https://0.0.0.0:61502/apis -> APITooManyRequestsError('Too many requests, please try again later.', status=429)
```

Based on #1228. Closes #1195.