### PR TITLE
Accept custom aiohttp sessions from login handlers

### DIFF
--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -61,6 +61,7 @@ from kopf._cogs.structs.bodies import (
 from kopf._cogs.structs.credentials import (
     LoginError,
     ConnectionInfo,
+    AiohttpSession,
 )
 from kopf._cogs.structs.dicts import (
     FieldSpec,
@@ -193,6 +194,7 @@ __all__ = [
     'login_with_service_account',
     'LoginError',
     'ConnectionInfo',
+    'AiohttpSession',
     'event', 'info', 'warn', 'exception',
     'spawn_tasks', 'run_tasks', 'operator', 'run',
     'adopt', 'label',

--- a/kopf/_cogs/clients/auth.py
+++ b/kopf/_cogs/clients/auth.py
@@ -1,9 +1,4 @@
-import base64
-import contextlib
 import functools
-import os
-import ssl
-import tempfile
 from collections.abc import Callable
 from contextvars import ContextVar
 from typing import Any, TypeVar, cast
@@ -97,7 +92,14 @@ class APIContext:
         # Generic aiohttp session based on the constructed credentials.
         match info:
             case credentials.ConnectionInfo():
-                self.session = self.make_aiohttp_session(info)
+                self.session = aiohttp.ClientSession(
+                    connector=aiohttp.TCPConnector(
+                        limit=0,
+                        ssl=info.as_ssl_context(),
+                    ),
+                    headers=info.as_http_headers(),
+                    auth=info.as_aiohttp_basic_auth(),
+                )
             case credentials.AiohttpSession():
                 self.session = info.aiohttp_session
             case _:
@@ -112,76 +114,6 @@ class APIContext:
         self.default_namespace = info.default_namespace
 
         self.responses = []
-
-    def make_aiohttp_session(self, info: credentials.ConnectionInfo) -> aiohttp.ClientSession:
-
-        # Some SSL data are not accepted directly, so we have to use temp files.
-        # Do not even create temporary files if there is no need. It can be a readonly filesystem.
-        with contextlib.ExitStack() as stack:
-
-            cert_path: str | bytes | os.PathLike[str] | os.PathLike[bytes] | None
-            if info.certificate_path:
-                cert_path = info.certificate_path
-            elif info.certificate_data:
-                cert_file = stack.enter_context(tempfile.NamedTemporaryFile(buffering=0))
-                cert_file.write(decode_to_pem(info.certificate_data).encode('ascii'))
-                cert_path = cert_file.name
-            else:
-                cert_path = None
-
-            pkey_path: str | bytes | os.PathLike[str] | os.PathLike[bytes] | None
-            if info.private_key_path:
-                pkey_path = info.private_key_path
-            elif info.private_key_data:
-                pkey_file = stack.enter_context(tempfile.NamedTemporaryFile(buffering=0))
-                pkey_file.write(decode_to_pem(info.private_key_data).encode('ascii'))
-                pkey_path = pkey_file.name
-            else:
-                pkey_path = None
-
-            # The SSL part (both client certificate auth and CA verification).
-            context: ssl.SSLContext
-            if cert_path and pkey_path:
-                context = ssl.create_default_context(
-                    purpose=ssl.Purpose.SERVER_AUTH,
-                    cafile=info.ca_path,
-                    cadata=decode_to_pem(info.ca_data) if info.ca_data is not None else None,
-                )
-                context.load_cert_chain(certfile=cert_path, keyfile=pkey_path)
-            else:
-                context = ssl.create_default_context(
-                    cafile=info.ca_path,
-                    cadata=decode_to_pem(info.ca_data) if info.ca_data is not None else None,
-                )
-
-        if info.insecure:
-            context.check_hostname = False
-            context.verify_mode = ssl.CERT_NONE
-
-        # The token auth part.
-        headers: dict[str, str] = {}
-        if info.scheme and info.token:
-            headers['Authorization'] = f'{info.scheme} {info.token}'
-        elif info.scheme:
-            headers['Authorization'] = f'{info.scheme}'
-        elif info.token:
-            headers['Authorization'] = f'Bearer {info.token}'
-
-        # The basic auth part.
-        auth: aiohttp.BasicAuth | None
-        if info.username and info.password:
-            auth = aiohttp.BasicAuth(info.username, info.password)
-        else:
-            auth = None
-
-        return aiohttp.ClientSession(
-            connector=aiohttp.TCPConnector(
-                limit=0,
-                ssl=context,
-            ),
-            headers=headers,
-            auth=auth,
-        )
 
     def flush_closed_responses(self) -> None:
         # There's no point keeping references to already closed responses.
@@ -207,13 +139,3 @@ class APIContext:
 
         # Closing is triggered by `Vault._flush_caches()` -- forward it to the actual session.
         await self.session.close()
-
-
-def decode_to_pem(data: str | bytes) -> str:
-    match data:
-        case str() if data.startswith('-----BEGIN '):
-            return data
-        case bytes() if data.startswith(b'-----BEGIN '):
-            return data.decode('ascii')
-        case _:
-            return base64.b64decode(data).decode('ascii')

--- a/kopf/_cogs/structs/credentials.py
+++ b/kopf/_cogs/structs/credentials.py
@@ -24,12 +24,16 @@ and nothing more than that:
     :func:`authentication` and :mod:`piggybacking`.
 """
 import asyncio
+import base64
 import collections
+import contextlib
 import dataclasses
 import datetime
 import inspect
 import os
 import random
+import ssl
+import tempfile
 from collections.abc import AsyncIterable, AsyncIterator, Callable, Mapping
 from typing import NewType, TypeVar, cast
 
@@ -87,6 +91,92 @@ class ConnectionInfo(KubeContext):
             raise ValueError("Both certificate path & data are set. Need only one.")
         if self.private_key_path and self.private_key_data:
             raise ValueError("Both private key path & data are set. Need only one.")
+
+    def as_aiohttp_basic_auth(self) -> aiohttp.BasicAuth | None:
+        """Make a basic auth for username/password, or ``None`` if absent."""
+        if self.username and self.password:
+            return aiohttp.BasicAuth(self.username, self.password)
+        else:
+            return None
+
+    def as_http_headers(self) -> dict[str, str]:
+        """
+        Make a dict with the ``Authorization`` header set to scheme+token,
+        or an empty dict if there are no tokens or schemes.
+        """
+        if self.scheme and self.token:
+            return {'Authorization': f'{self.scheme} {self.token}'}
+        elif self.scheme:
+            return {'Authorization': f'{self.scheme}'}
+        elif self.token:
+            return {'Authorization': f'Bearer {self.token}'}
+        else:
+            return {}
+
+    def as_ssl_context(self) -> ssl.SSLContext:
+        """
+        Make an SSL context with CA and client cert using Python's :mod:`ssl`.
+
+        .. warning::
+            It will store the :attr:`kopf.ConnectionInfo.certificate_data` and
+            :attr:`kopf.ConnectionInfo.private_key_data` into temporary files
+            for a brief moment of time until the SSL context is constructed,
+            since Python's :mod:`ssl` cannot load them from memory.
+        """
+        # Some SSL data are not accepted directly, so we have to use temp files.
+        # Do not even create temporary files if there is no need. It can be a readonly filesystem.
+        with contextlib.ExitStack() as stack:
+
+            cert_path: str | bytes | os.PathLike[str] | os.PathLike[bytes] | None
+            if self.certificate_path:
+                cert_path = self.certificate_path
+            elif self.certificate_data:
+                cert_file = stack.enter_context(tempfile.NamedTemporaryFile(buffering=0))
+                cert_file.write(self.__decode_to_pem(self.certificate_data).encode('ascii'))
+                cert_path = cert_file.name
+            else:
+                cert_path = None
+
+            pkey_path: str | bytes | os.PathLike[str] | os.PathLike[bytes] | None
+            if self.private_key_path:
+                pkey_path = self.private_key_path
+            elif self.private_key_data:
+                pkey_file = stack.enter_context(tempfile.NamedTemporaryFile(buffering=0))
+                pkey_file.write(self.__decode_to_pem(self.private_key_data).encode('ascii'))
+                pkey_path = pkey_file.name
+            else:
+                pkey_path = None
+
+            # The SSL part (both client certificate auth and CA verification).
+            context: ssl.SSLContext
+            if cert_path and pkey_path:
+                context = ssl.create_default_context(
+                    purpose=ssl.Purpose.SERVER_AUTH,
+                    cafile=self.ca_path,
+                    cadata=self.__decode_to_pem(self.ca_data) if self.ca_data is not None else None,
+                )
+                context.load_cert_chain(certfile=cert_path, keyfile=pkey_path)
+            else:
+                context = ssl.create_default_context(
+                    cafile=self.ca_path,
+                    cadata=self.__decode_to_pem(self.ca_data) if self.ca_data is not None else None,
+                )
+
+        if self.insecure:
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+
+        return context
+
+    @staticmethod
+    def __decode_to_pem(data: str | bytes) -> str:
+        match data:
+            case str() if data.startswith('-----BEGIN '):
+                return data
+            case bytes() if data.startswith(b'-----BEGIN '):
+                return data.decode('ascii')
+            case _:
+                return base64.b64decode(data).decode('ascii')
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/tests/authentication/test_connectioninfo.py
+++ b/tests/authentication/test_connectioninfo.py
@@ -1,4 +1,6 @@
 import datetime
+import pathlib
+import ssl
 
 import aiohttp
 import pytest
@@ -101,6 +103,55 @@ def test_conflicting_certificate_data_and_path():
 def test_conflicting_private_key_data_and_path():
     with pytest.raises(ValueError, match="Both private key path & data"):
         ConnectionInfo(server='', private_key_path='/path', private_key_data=b'data')
+
+
+def test_connection_info_as_aiohttp_basic_auth():
+    info = ConnectionInfo(
+        server='https://localhost',
+        username='username',
+        password='password',
+    )
+    assert info.as_aiohttp_basic_auth() == aiohttp.BasicAuth('username', 'password')
+    assert info.as_http_headers() == {}
+
+
+def test_connection_info_as_http_headers():
+    info = ConnectionInfo(
+        server='https://localhost',
+        scheme='Bearer',
+        token='xyz'
+    )
+    assert info.as_aiohttp_basic_auth() is None
+    assert info.as_http_headers() == {'Authorization': 'Bearer xyz'}
+
+
+def test_connection_info_as_ssl_context_when_insecure():
+    info = ConnectionInfo(
+        server='https://localhost',
+        insecure=True,
+    )
+    ssl_context = info.as_ssl_context()
+    ca = ssl_context.get_ca_certs()
+    assert ssl_context.verify_mode == ssl.CERT_NONE
+    assert ssl_context.check_hostname is False
+    assert ca  # at least some default CAs must be loaded, but we do not know which ones.
+
+
+def test_connection_info_as_ssl_context_when_defined():
+    info = ConnectionInfo(
+        server='https://localhost',
+        ca_path=pathlib.Path(__file__).parent / 'fixtures/ca.pem',
+        certificate_path=pathlib.Path(__file__).parent / 'fixtures/cert.pem',
+        private_key_path=pathlib.Path(__file__).parent / 'fixtures/pkey.pem',
+    )
+    ssl_context = info.as_ssl_context()
+    ca = ssl_context.get_ca_certs()
+    assert ssl_context.verify_mode == ssl.CERT_REQUIRED
+    assert ssl_context.check_hostname is True
+    assert ca[0]['issuer'] == ((('commonName', 'minikubeCA'),),)
+    assert ca[0]['subject'] == ((('commonName', 'minikubeCA'),),)
+    assert ca[0]['notAfter'] == 'May 19 09:18:36 2029 GMT'
+    assert ca[0]['notBefore'] == 'May 21 09:18:36 2019 GMT'
 
 
 async def test_creation_of_aiohttp_session():


### PR DESCRIPTION
You can, for example, inject extra headers, remove or replace the existing ones, add sophisticated authentication schemes, or set the networking parameters, such as timeouts or connection limits (for client-side rate-limiting).

Example:

```python
import aiohttp
import kopf

@kopf.on.login()
async def login_fn(**kwargs) -> kopf.AiohttpSession:
    credentials = kopf.login_via_client(logger=logger)
    headers = {
        'X-Custom-Header': 'helloworld',
        'User-Agent': f'myoperator/1.2.3 kopf/{kopf.__version__}',
    }
    session = aiohttp.ClientSession(
        connector=aiohttp.TCPConnector(
            limit_per_host=1, limit=1, keepalive_timeout=30,
            ssl=credentials.as_ssl_context(),
        ),
        headers=credentials.as_http_headers() | headers,
        auth=credentials.as_aiohttp_basic_auth(),
        trust_env=True,
    )
    return kopf.AiohttpSession(
        server=credentials.server,
        default_namespace=credentials.default_namespace,
        aiohttp_session=session,
    )
```

Docs:

* https://kopf.readthedocs.io/en/latest/authentication/#custom-http-sessions

Closes #1011, closes #909, related #1076 