### PR TITLE
Parse proxy-url from kubeconfig or client libraries, pass to the session

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ exclude: |
   (?x)^(
     docs/.*\.xml|
     docs/.*\.png|
+    tests/authentication/_proxy_server.py|
     tests/authentication/fixtures/pkey.pem
   )
 repos:

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -42,6 +42,7 @@ or an instance of :class:`kopf.ConnectionInfo`:
     def login_fn(**kwargs):
         return kopf.ConnectionInfo(
             server='https://localhost',
+            proxy_url='http://localhost:8080',
             ca_path='/etc/ssl/ca.crt',
             ca_data=b'...',
             insecure=True,
@@ -80,6 +81,18 @@ for making the API calls, but not the ways of retrieving them. Specifically:
 * HTTP ``Authorization: Basic username:password``.
 * HTTP ``Authorization: Bearer token`` (or other schemes: Bearer, Digest, etc).
 * URL's default namespace for the cases when this is implied.
+* HTTP/HTTPS proxy url, possibly with credentials.
+
+.. note::
+    Proxy support is limited to what ``aiohttp`` supports__. Specifically,
+    it supports plain HTTP proxies, some limited HTTPS proxies, but not SOCKS5.
+    Would you need more sophisticated proxying or tunneling, implement it
+    as a custom HTTP session with a custom connector, for example using
+    `aiohttp_socks <https://github.com/romis2012/aiohttp-socks>`_
+    (Kopf claims no responsibility for the quality if this library;
+    do your own due diligence).
+
+__ https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support
 
 No matter how the endpoints or credentials are retrieved, they are directly
 mapped to TCP/SSL/HTTPS protocols in the API clients. It is the responsibility
@@ -94,7 +107,7 @@ or the same credentials via different libraries. All of the retrieved
 credentials will be used in random order with no specific priority.
 
 
-.. _auth-custom-session:
+.. _custom-http-sessions:
 
 Custom HTTP sessions
 ====================

--- a/kopf/_cogs/clients/auth.py
+++ b/kopf/_cogs/clients/auth.py
@@ -99,6 +99,7 @@ class APIContext:
                     ),
                     headers=info.as_http_headers(),
                     auth=info.as_aiohttp_basic_auth(),
+                    proxy=info.proxy_url,
                 )
             case credentials.AiohttpSession():
                 self.session = info.aiohttp_session

--- a/kopf/_cogs/structs/credentials.py
+++ b/kopf/_cogs/structs/credentials.py
@@ -81,6 +81,7 @@ class ConnectionInfo(KubeContext):
     private_key_path: str | bytes | os.PathLike[str] | os.PathLike[bytes] | None = None
     private_key_data: str | bytes | None = None
     default_namespace: str | None = None  # used for cluster objects' k8s-events.
+    proxy_url: str | None = None
     priority: int = 0
     expiration: datetime.datetime | None = None  # TZ-aware or TZ-naive (implies UTC)
 
@@ -184,7 +185,7 @@ class AiohttpSession(KubeContext):
     """
     A custom ``aiohttp`` session to use instead of the built-in one.
 
-    See: :ref:`auth-custom-session` for details.
+    See: :ref:`custom-http-sessions` for details.
     """
     aiohttp_session: aiohttp.ClientSession
 

--- a/kopf/_core/intents/piggybacking.py
+++ b/kopf/_core/intents/piggybacking.py
@@ -113,6 +113,7 @@ def login_via_client(
         token=token,
         certificate_path=config.cert_file,  # can be a temporary file
         private_key_path=config.key_file,  # can be a temporary file
+        proxy_url=config.proxy,
         priority=PRIORITY_OF_CLIENT,
     )
 
@@ -173,6 +174,7 @@ async def login_via_async_client(
         token=token,
         certificate_path=config.cert_file,  # can be a temporary file
         private_key_path=config.key_file,  # can be a temporary file
+        proxy_url=config.proxy,
         priority=PRIORITY_OF_ASYNC_CLIENT,
     )
 
@@ -223,6 +225,7 @@ def login_via_pykube(
         certificate_path=cert.filename() if cert else None,  # can be a temporary file
         private_key_path=pkey.filename() if pkey else None,  # can be a temporary file
         default_namespace=config.namespace,
+        proxy_url=config.cluster.get('proxy-url'),
         priority=PRIORITY_OF_PYKUBE,
     )
 
@@ -340,5 +343,6 @@ def login_with_kubeconfig(**_: Any) -> credentials.ConnectionInfo | None:
         password=user.get('password'),
         token=user.get('token') or provider_token,
         default_namespace=context.get('namespace'),
+        proxy_url=cluster.get('proxy-url'),
         priority=PRIORITY_OF_KUBECONFIG,
     )

--- a/tests/authentication/_proxy_server.py
+++ b/tests/authentication/_proxy_server.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Rudimentary HTTP CONNECT proxy server for tunneling HTTPS connections.
+Preserves client certificates by creating a transparent TCP tunnel.
+
+This is a testing tool itself, not a part of the package, so it is not tested.
+Start a proxy server, then add `proxy-url` to `~/.kube/config` (note HTTP):
+
+.. code-block: yaml
+
+    clusters:
+    - name: …
+      cluster:
+        server: …
+        proxy-url: http://127.0.0.1:8080
+
+Or via the CLI:
+
+    kubectl config get-contexts
+    cluster=k3d-k3s-default
+    kubectl config set-cluster $cluster --proxy-url=http://127.0.0.1:8080
+    kubectl config set-cluster $cluster --proxy-url=  # unset
+
+Written by AI (then adapted to the usage protocol). The prompt is:
+Write a simplistic proxy server in Python that serves the CONNECT requests only.
+Make it asyncio-based. Listen on 127.0.0.1:8080.
+"""
+import asyncio
+from typing import NamedTuple
+
+
+class ProxiedRequest(NamedTuple):
+    client_host: str
+    client_port: int
+    server_host: str
+    server_port: int
+
+
+class ProxyServer:
+    requests: list[ProxiedRequest]
+    host: str
+    port: int | None
+
+    def __init__(
+            self,
+            *,
+            host: str = '127.0.0.1',
+            port: int | None = None,
+    ) -> None:
+        super().__init__()
+        self.requests = []
+        self.host = host
+        self.port = port
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    async def run(self) -> None:
+        server = await asyncio.start_server(self.handle_client, self.host, self.port)
+        addr = server.sockets[0].getsockname()
+        self.host = addr[0]
+        self.port = addr[1]
+
+        print(f"[*] CONNECT Proxy Server listening on {addr[0]}:{addr[1]}")
+        print(f"[*] Press Ctrl+C to stop or cancel programmatically.")
+
+        async with server:
+            await server.serve_forever()
+
+    async def handle_client(self, reader, writer):
+        """Handle incoming client connection."""
+        addr = writer.get_extra_info('peername')
+        print(f"[+] Connection from {addr}")
+
+        try:
+            # Read the CONNECT request
+            request_line = await reader.readline()
+            request = request_line.decode('utf-8').strip()
+
+            if not request.startswith('CONNECT'):
+                print(f"[-] Non-CONNECT request from {addr}: {request}")
+                writer.write(b"HTTP/1.1 405 Method Not Allowed\r\n\r\n")
+                await writer.drain()
+                writer.close()
+                await writer.wait_closed()
+                return
+
+            # Parse CONNECT request: CONNECT host:port HTTP/1.1
+            parts = request.split()
+            if len(parts) < 2:
+                print(f"[-] Malformed CONNECT request from {addr}")
+                writer.write(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+                await writer.drain()
+                writer.close()
+                await writer.wait_closed()
+                return
+
+            target = parts[1]  # host:port
+
+            # Read and discard headers
+            while True:
+                header = await reader.readline()
+                if header == b'\r\n' or header == b'\n' or header == b'':
+                    break
+
+            # Parse target host and port
+            if ':' in target:
+                host, port_str = target.rsplit(':', 1)
+                try:
+                    port = int(port_str)
+                except ValueError:
+                    port = 443
+            else:
+                host = target
+                port = 443
+
+            print(f"[*] Connecting to {host}:{port}")
+
+            # Connect to the target server
+            try:
+                target_reader, target_writer = await asyncio.open_connection(host, port)
+            except Exception as e:
+                print(f"[-] Failed to connect to {host}:{port} - {e}")
+                writer.write(b"HTTP/1.1 502 Bad Gateway\r\n\r\n")
+                await writer.drain()
+                writer.close()
+                await writer.wait_closed()
+                return
+
+            # Send success response to client
+            writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            await writer.drain()
+
+            print(f"[+] Tunnel established: {addr} <-> {host}:{port}")
+            self.requests.append(ProxiedRequest(addr[0], addr[1], host, port))
+
+            # Run both directions concurrently
+            await asyncio.gather(
+                self.forward(reader, target_writer, "client->target"),
+                self.forward(target_reader, writer, "target->client"),
+                return_exceptions=True
+            )
+
+            print(f"[-] Tunnel closed: {addr} <-> {host}:{port}")
+
+        except Exception as e:
+            print(f"[-] Error handling client {addr}: {e}")
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    async def forward(self, src, dst, direction):
+        """Bidirectional data forwarding"""
+        try:
+            while True:
+                data = await src.read(8192)
+                if not data:
+                    break
+                dst.write(data)
+                await dst.drain()
+        except Exception as e:
+            print(f"[!] Error in {direction}: {e}")
+            raise
+        finally:
+            dst.close()
+            await dst.wait_closed()
+
+
+if __name__ == '__main__':
+    asyncio.run(ProxyServer(port=8080).run())

--- a/tests/authentication/test_connectioninfo.py
+++ b/tests/authentication/test_connectioninfo.py
@@ -31,6 +31,7 @@ def test_creation_with_minimal_fields():
     assert info.private_key_path is None
     assert info.private_key_data is None
     assert info.default_namespace is None
+    assert info.proxy_url is None
     assert info.priority == 0
     assert info.expiration is None
 
@@ -44,6 +45,7 @@ def test_creation_with_regular_fields():
         scheme='scheme',
         token='token',
         default_namespace='default',
+        proxy_url='https://username:password@localhost',
         priority=123,
         expiration=datetime.datetime.max,
     )
@@ -55,6 +57,7 @@ def test_creation_with_regular_fields():
     assert info.token == 'token'
     assert info.default_namespace == 'default'
     assert info.priority == 123
+    assert info.proxy_url == 'https://username:password@localhost'
     assert info.expiration == datetime.datetime.max
 
 

--- a/tests/authentication/test_login_kubeconfig.py
+++ b/tests/authentication/test_login_kubeconfig.py
@@ -141,6 +141,7 @@ def test_full_kubeconfig_reading_with_ssl_files(tmpdir, mocker):
           - name: clstr
             cluster:
               server: https://hostname:1234/
+              proxy-url: http://localhost:8080/
               certificate-authority: /pathA
               insecure-skip-tls-verify: true
           - name: hij
@@ -160,6 +161,7 @@ def test_full_kubeconfig_reading_with_ssl_files(tmpdir, mocker):
 
     assert credentials is not None
     assert credentials.server == 'https://hostname:1234/'
+    assert credentials.proxy_url == 'http://localhost:8080/'
     assert credentials.insecure == True
     assert credentials.scheme is None
     assert credentials.token == 'tkn'
@@ -190,6 +192,7 @@ def test_full_kubeconfig_reading_with_ssl_data(tmpdir, mocker):
           - name: clstr
             cluster:
               server: https://hostname:1234/
+              proxy-url: http://localhost:8080/
               certificate-authority-data: base64dataA
               insecure-skip-tls-verify: true
           - name: hij
@@ -209,6 +212,7 @@ def test_full_kubeconfig_reading_with_ssl_data(tmpdir, mocker):
 
     assert credentials is not None
     assert credentials.server == 'https://hostname:1234/'
+    assert credentials.proxy_url == 'http://localhost:8080/'
     assert credentials.insecure == True
     assert credentials.scheme is None
     assert credentials.token == 'tkn'


### PR DESCRIPTION
The schema of kubeconfig's clusters:

* https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/#Cluster

To test locally (MacOS):

```
brew install mitmproxy
```

Make `ca.pem` and `client.pem` from whatever certificates you use. This proxy cannot pass the client certificates through the connection. It accepts the client cert on the client<>mitm part, and presents its own client cert on the mitm<>server part. This is a limitation of the tool (probably).

```
mitmproxy --set ssl_verify_upstream_trusted_ca=ca.pem --set client_certs=client.pem
```

Add the mitm CA from `~/.mitmproxy/mitmproxy-ca-cert.pem` to the overall CA used by the client — because it fully substitues the SSL with its own CA on the client<>mitm part.

Add `proxy-url: http://127.0.0.1:8080` to the `~/.kube/config` for your current cluster, next to the `server: …` key.

TODOs:

- [x] Tests
- [x] Docs
- [x] Manual experiments (find a dev proxy server)

Closes #1076 