### PR TITLE
Select resources to handle via a callable selector

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -265,6 +265,13 @@ They can filter by any kwarg data, e.g. by a :kwarg:`reason` of this invocation,
 remembered :kwarg:`memo` values, etc. However, it is highly recommended that
 the filters do not modify the state of the operator -- keep it for handlers.
 
+There is a subtle difference between callable filters and resource selectors
+(see :doc:`resources`): the callable filter applies to all events
+coming from a live watch stream identified by a resource kind and a namespace
+(or by a resource kind only for watch streams of cluster-wide operators);
+the callable resource selector decides whether to start the watch-stream
+for that resource kind at all, which can help reduce the load on the API.
+
 
 Callback helpers
 ================

--- a/kopf/on.py
+++ b/kopf/on.py
@@ -142,9 +142,10 @@ def probe(  # lgtm[py/similar-function]
 
 def validate(  # lgtm[py/similar-function]
         # Resource type specification:
-        __group_or_groupversion_or_name: str | references.Marker | None = None,
-        __version_or_name: str | references.Marker | None = None,
-        __name: str | references.Marker | None = None,
+        arg1: str | references.Marker | Callable[[references.Resource], bool] | None = None,
+        arg2: str | references.Marker | None = None,
+        arg3: str | references.Marker | None = None,
+        /,
         *,
         group: str | None = None,
         version: str | None = None,
@@ -183,7 +184,7 @@ def validate(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
         selector = references.Selector(
-            __group_or_groupversion_or_name, __version_or_name, __name,
+            arg1, arg2, arg3,
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
@@ -202,9 +203,10 @@ def validate(  # lgtm[py/similar-function]
 
 def mutate(  # lgtm[py/similar-function]
         # Resource type specification:
-        __group_or_groupversion_or_name: str | references.Marker | None = None,
-        __version_or_name: str | references.Marker | None = None,
-        __name: str | references.Marker | None = None,
+        arg1: str | references.Marker | Callable[[references.Resource], bool] | None = None,
+        arg2: str | references.Marker | None = None,
+        arg3: str | references.Marker | None = None,
+        /,
         *,
         group: str | None = None,
         version: str | None = None,
@@ -243,7 +245,7 @@ def mutate(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
         selector = references.Selector(
-            __group_or_groupversion_or_name, __version_or_name, __name,
+            arg1, arg2, arg3,
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
@@ -262,9 +264,10 @@ def mutate(  # lgtm[py/similar-function]
 
 def resume(  # lgtm[py/similar-function]
         # Resource type specification:
-        __group_or_groupversion_or_name: str | references.Marker | None = None,
-        __version_or_name: str | references.Marker | None = None,
-        __name: str | references.Marker | None = None,
+        arg1: str | references.Marker | Callable[[references.Resource], bool] | None = None,
+        arg2: str | references.Marker | None = None,
+        arg3: str | references.Marker | None = None,
+        /,
         *,
         group: str | None = None,
         version: str | None = None,
@@ -300,7 +303,7 @@ def resume(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
         selector = references.Selector(
-            __group_or_groupversion_or_name, __version_or_name, __name,
+            arg1, arg2, arg3,
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
@@ -319,9 +322,10 @@ def resume(  # lgtm[py/similar-function]
 
 def create(  # lgtm[py/similar-function]
         # Resource type specification:
-        __group_or_groupversion_or_name: str | references.Marker | None = None,
-        __version_or_name: str | references.Marker | None = None,
-        __name: str | references.Marker | None = None,
+        arg1: str | references.Marker | Callable[[references.Resource], bool] | None = None,
+        arg2: str | references.Marker | None = None,
+        arg3: str | references.Marker | None = None,
+        /,
         *,
         group: str | None = None,
         version: str | None = None,
@@ -356,7 +360,7 @@ def create(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
         selector = references.Selector(
-            __group_or_groupversion_or_name, __version_or_name, __name,
+            arg1, arg2, arg3,
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
@@ -375,9 +379,10 @@ def create(  # lgtm[py/similar-function]
 
 def update(  # lgtm[py/similar-function]
         # Resource type specification:
-        __group_or_groupversion_or_name: str | references.Marker | None = None,
-        __version_or_name: str | references.Marker | None = None,
-        __name: str | references.Marker | None = None,
+        arg1: str | references.Marker | Callable[[references.Resource], bool] | None = None,
+        arg2: str | references.Marker | None = None,
+        arg3: str | references.Marker | None = None,
+        /,
         *,
         group: str | None = None,
         version: str | None = None,
@@ -414,7 +419,7 @@ def update(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
         selector = references.Selector(
-            __group_or_groupversion_or_name, __version_or_name, __name,
+            arg1, arg2, arg3,
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
@@ -433,9 +438,10 @@ def update(  # lgtm[py/similar-function]
 
 def delete(  # lgtm[py/similar-function]
         # Resource type specification:
-        __group_or_groupversion_or_name: str | references.Marker | None = None,
-        __version_or_name: str | references.Marker | None = None,
-        __name: str | references.Marker | None = None,
+        arg1: str | references.Marker | Callable[[references.Resource], bool] | None = None,
+        arg2: str | references.Marker | None = None,
+        arg3: str | references.Marker | None = None,
+        /,
         *,
         group: str | None = None,
         version: str | None = None,
@@ -471,7 +477,7 @@ def delete(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
         selector = references.Selector(
-            __group_or_groupversion_or_name, __version_or_name, __name,
+            arg1, arg2, arg3,
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
@@ -490,9 +496,10 @@ def delete(  # lgtm[py/similar-function]
 
 def field(  # lgtm[py/similar-function]
         # Resource type specification:
-        __group_or_groupversion_or_name: str | references.Marker | None = None,
-        __version_or_name: str | references.Marker | None = None,
-        __name: str | references.Marker | None = None,
+        arg1: str | references.Marker | Callable[[references.Resource], bool] | None = None,
+        arg2: str | references.Marker | None = None,
+        arg3: str | references.Marker | None = None,
+        /,
         *,
         group: str | None = None,
         version: str | None = None,
@@ -529,7 +536,7 @@ def field(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
         selector = references.Selector(
-            __group_or_groupversion_or_name, __version_or_name, __name,
+            arg1, arg2, arg3,
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
@@ -548,9 +555,10 @@ def field(  # lgtm[py/similar-function]
 
 def index(  # lgtm[py/similar-function]
         # Resource type specification:
-        __group_or_groupversion_or_name: str | references.Marker | None = None,
-        __version_or_name: str | references.Marker | None = None,
-        __name: str | references.Marker | None = None,
+        arg1: str | references.Marker | Callable[[references.Resource], bool] | None = None,
+        arg2: str | references.Marker | None = None,
+        arg3: str | references.Marker | None = None,
+        /,
         *,
         group: str | None = None,
         version: str | None = None,
@@ -585,7 +593,7 @@ def index(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id)
         selector = references.Selector(
-            __group_or_groupversion_or_name, __version_or_name, __name,
+            arg1, arg2, arg3,
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
@@ -602,9 +610,10 @@ def index(  # lgtm[py/similar-function]
 
 def event(  # lgtm[py/similar-function]
         # Resource type specification:
-        __group_or_groupversion_or_name: str | references.Marker | None = None,
-        __version_or_name: str | references.Marker | None = None,
-        __name: str | references.Marker | None = None,
+        arg1: str | references.Marker | Callable[[references.Resource], bool] | None = None,
+        arg2: str | references.Marker | None = None,
+        arg3: str | references.Marker | None = None,
+        /,
         *,
         group: str | None = None,
         version: str | None = None,
@@ -635,7 +644,7 @@ def event(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
         selector = references.Selector(
-            __group_or_groupversion_or_name, __version_or_name, __name,
+            arg1, arg2, arg3,
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
@@ -652,9 +661,10 @@ def event(  # lgtm[py/similar-function]
 
 def daemon(  # lgtm[py/similar-function]
         # Resource type specification:
-        __group_or_groupversion_or_name: str | references.Marker | None = None,
-        __version_or_name: str | references.Marker | None = None,
-        __name: str | references.Marker | None = None,
+        arg1: str | references.Marker | Callable[[references.Resource], bool] | None = None,
+        arg2: str | references.Marker | None = None,
+        arg3: str | references.Marker | None = None,
+        /,
         *,
         group: str | None = None,
         version: str | None = None,
@@ -693,7 +703,7 @@ def daemon(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
         selector = references.Selector(
-            __group_or_groupversion_or_name, __version_or_name, __name,
+            arg1, arg2, arg3,
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )
@@ -714,9 +724,10 @@ def daemon(  # lgtm[py/similar-function]
 
 def timer(  # lgtm[py/similar-function]
         # Resource type specification:
-        __group_or_groupversion_or_name: str | references.Marker | None = None,
-        __version_or_name: str | references.Marker | None = None,
-        __name: str | references.Marker | None = None,
+        arg1: str | references.Marker | Callable[[references.Resource], bool] | None = None,
+        arg2: str | references.Marker | None = None,
+        arg3: str | references.Marker | None = None,
+        /,
         *,
         group: str | None = None,
         version: str | None = None,
@@ -755,7 +766,7 @@ def timer(  # lgtm[py/similar-function]
         real_field = dicts.parse_field(field) or None  # to not store tuple() as a no-field case.
         real_id = registries.generate_id(fn=fn, id=id, suffix=".".join(real_field or []))
         selector = references.Selector(
-            __group_or_groupversion_or_name, __version_or_name, __name,
+            arg1, arg2, arg3,
             group=group, version=version,
             kind=kind, plural=plural, singular=singular, shortcut=shortcut, category=category,
         )

--- a/tests/references/test_selector_parsing.py
+++ b/tests/references/test_selector_parsing.py
@@ -118,6 +118,20 @@ def test_three_args(group, version, name):
     assert selector.any_name == name
 
 
+def test_callable_arg():
+    fn = lambda _: False
+    selector = Selector(fn)
+    assert selector.fn is fn
+    assert selector.group is None
+    assert selector.version is None
+    assert selector.plural is None
+
+
+def test_callable_with_extra_args():
+    with pytest.raises(TypeError, match="cannot have any other selectors") as err:
+        Selector(lambda _: False, 'name1')
+
+
 def test_too_many_args():
     with pytest.raises(TypeError) as err:
         Selector('group1', 'version1', 'name1', 'etc')
@@ -222,21 +236,21 @@ def test_kwarg_any_name():
 
 @pytest.mark.parametrize('kwargs', [
     {kwarg1: 'name1', kwarg2: 'name2'}
-    for kwarg1 in ['kind', 'plural', 'singular', 'shortcut', 'category', 'any_name']
-    for kwarg2 in ['kind', 'plural', 'singular', 'shortcut', 'category', 'any_name']
+    for kwarg1 in ['kind', 'plural', 'singular', 'shortcut', 'category', 'any_name', 'fn']
+    for kwarg2 in ['kind', 'plural', 'singular', 'shortcut', 'category', 'any_name', 'fn']
     if kwarg1 != kwarg2
 ])
 def test_conflicting_names_with_only_kwargs(kwargs):
     with pytest.raises(TypeError) as err:
         Selector(**kwargs)
-    assert "Ambiguous resource specification with names" in str(err.value)
+    assert "Ambiguous resource specification with" in str(err.value)
 
 
 @pytest.mark.parametrize('kwarg', ['kind', 'plural', 'singular', 'shortcut', 'category'])
 def test_conflicting_name_with_positional_name(kwarg):
     with pytest.raises(TypeError) as err:
         Selector('name1', **{kwarg: 'name2'})
-    assert "Ambiguous resource specification with names" in str(err.value)
+    assert "Ambiguous resource specification with" in str(err.value)
 
 
 @pytest.mark.parametrize('kwarg', ['kind', 'plural', 'singular', 'shortcut', 'category'])


### PR DESCRIPTION
Example:

```python
import kopf

def kex_selector(resource: kopf.Resource) -> bool:
    return resource.plural == 'kopfexamples' and resource.preferred

@kopf.on.event(kex_selector)
def fn(**_):
    pass
```

TODOs:

- [x] Tests.

Closes #1187, closes #1194 (supersedes it), closes #1013.