### PR TITLE
Fix finalizer race condition by switching to strategic merge patch

### DIFF
--- a/kopf/_cogs/structs/finalizers.py
+++ b/kopf/_cogs/structs/finalizers.py
@@ -29,8 +29,7 @@ def block_deletion(
         finalizer: str,
 ) -> None:
     if not is_deletion_blocked(body=body, finalizer=finalizer):
-        finalizers = body.get('metadata', {}).get('finalizers', [])
-        patch.setdefault('metadata', {}).setdefault('finalizers', list(finalizers))
+        patch.setdefault('metadata', {}).setdefault('finalizers', [])
         patch['metadata']['finalizers'].append(finalizer)
 
 
@@ -41,7 +40,5 @@ def allow_deletion(
         finalizer: str,
 ) -> None:
     if is_deletion_blocked(body=body, finalizer=finalizer):
-        finalizers = body.get('metadata', {}).get('finalizers', [])
-        patch.setdefault('metadata', {}).setdefault('finalizers', list(finalizers))
-        if finalizer in patch['metadata']['finalizers']:
-            patch['metadata']['finalizers'].remove(finalizer)
+        patch.setdefault('metadata', {}).setdefault('$deleteFromPrimitiveList/finalizers', [])
+        patch['metadata']['$deleteFromPrimitiveList/finalizers'].append(finalizer)

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -37,7 +37,7 @@ async def test_daemon_exits_gracefully_and_instantly_on_resource_deletion(
 
     assert looptime == 0
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['$deleteFromPrimitiveList/finalizers'] == [finalizer]
 
 
 async def test_daemon_exits_gracefully_and_instantly_on_operator_exiting(
@@ -147,7 +147,7 @@ async def test_daemon_exits_instantly_on_cancellation_with_backoff(
 
     assert looptime == 1.23  # i.e. no additional sleeps happened
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['$deleteFromPrimitiveList/finalizers'] == [finalizer]
 
     # Cleanup.
     await dummy.wait_for_daemon_done()
@@ -206,7 +206,7 @@ async def test_daemon_exits_slowly_on_cancellation_with_backoff(
 
     assert looptime == 1.23 + 4.56  # i.e. not additional sleeps happened
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['$deleteFromPrimitiveList/finalizers'] == [finalizer]
 
 
 async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
@@ -253,7 +253,7 @@ async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
 
     assert looptime == 1000 + 4.56
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['$deleteFromPrimitiveList/finalizers'] == [finalizer]
     assert_logs(["Daemon 'fn' did not exit in time. Leaving it orphaned."])
 
     # Cleanup.

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -115,4 +115,4 @@ async def test_2nd_step_finishes_the_handlers(caplog,
     # Finalizers could be removed for resources being deleted on the 2nd step.
     # The logic can vary though: either by deletionTimestamp, or by reason==DELETE.
     if deletion_ts and deletion_ts['deletionTimestamp']:
-        assert patch['metadata']['finalizers'] == []
+        assert patch['metadata']['$deleteFromPrimitiveList/finalizers'] == [settings.persistence.finalizer]

--- a/tests/reactor/test_patching_inconsistencies.py
+++ b/tests/reactor/test_patching_inconsistencies.py
@@ -96,8 +96,10 @@ async def test_patching_without_inconsistencies(
                  id='response-status-undeleted'),
 
     # True-positive inconsistencies for K8s-managed fields with possible false-positives.
+    # NB: finalizers are excluded -- with strategic merge patch, the partial list in the patch
+    # won't match the full list in the response, and the directives ($deleteFromPrimitiveList)
+    # are cleaned up before the check. So finalizer inconsistencies are no longer detectable.
     pytest.param({'metadata': {'annotations': {'x': 'y'}}}, {'metadata': {}}, id='true-annotations'),
-    pytest.param({'metadata': {'finalizers': ['x', 'y']}}, {'metadata': {}}, id='true-finalizers'),
     pytest.param({'metadata': {'labels': {'x': 'y'}}}, {'metadata': {}}, id='true-labels'),
 
 ])

--- a/tests/test_finalizers.py
+++ b/tests/test_finalizers.py
@@ -36,7 +36,7 @@ def test_append_finalizers_to_others():
     body = {'metadata': {'finalizers': ['other1', 'other2']}}
     patch = {}
     block_deletion(body=body, patch=patch, finalizer='fin')
-    assert patch == {'metadata': {'finalizers': ['other1', 'other2', 'fin']}}
+    assert patch == {'metadata': {'finalizers': ['fin']}}
 
 
 def test_append_finalizers_to_empty():
@@ -60,7 +60,7 @@ def test_remove_finalizers_keeps_others(finalizer):
     body = {'metadata': {'finalizers': ['other1', finalizer, 'other2']}}
     patch = {}
     allow_deletion(body=body, patch=patch, finalizer='fin')
-    assert patch == {'metadata': {'finalizers': ['other1', 'other2']}}
+    assert patch == {'metadata': {'$deleteFromPrimitiveList/finalizers': ['fin']}}
 
 
 def test_remove_finalizers_when_absent():


### PR DESCRIPTION
## Summary

- Fixes #1106 — finalizer race condition when multiple controllers manage finalizers on the same resource
- Switches all K8s API patch calls from `application/merge-patch+json` to `application/strategic-merge-patch+json`
- `block_deletion()` now adds only the Kopf finalizer to the patch (strategic merge merges it into the existing list atomically)
- `allow_deletion()` now uses the `$deleteFromPrimitiveList/finalizers` directive to remove only the Kopf finalizer without touching others

## Background

With JSON merge patch, arrays are replaced wholesale. When Kopf removed its finalizer, it copied the full finalizers list, removed its own, and patched — overwriting any concurrent changes by other controllers. This caused `"Forbidden: no new finalizers can be added if the object is being deleted"` errors when multiple controllers operated on the same resource.

Strategic merge patch is safe for all existing behavior: metadata maps (labels, annotations) merge by key in both patch types, and CRD spec/status list fields default to atomic (replace) unless the CRD author explicitly opts into merge.

## Test plan

- [x] `tests/test_finalizers.py` — updated assertions for new patch structure (17 passed)
- [x] `tests/k8s/test_patching.py` — added content-type verification and directive cleanup test (22 passed)
- [x] `tests/handling/daemons/test_daemon_termination.py` — updated finalizer payload assertions (12 passed)
- [x] `tests/handling/test_multistep.py` — updated deletion-step assertion (24 passed)
- [x] `tests/reactor/test_patching_inconsistencies.py` — removed inapplicable finalizer inconsistency test case
- [x] Full broader test suite: 2072 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)