### PR TITLE
Package Kopf as a Docker image on GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__
+*.pyc
+.mypy_cache
+.pytest_cache
+tests/
+docs/
+examples/
+.github/
+.eggs/
+dist/
+build/
+*.egg-info
+.coverage
+htmlcov/
+.vscode
+.idea
+.claude/

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,108 @@
+# Build and publish Kopf Docker images to ghcr.io.
+# On PRs: build only (no push). On release tags: build and push with full tag matrix.
+name: Docker
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    tags:
+      - "[0-9]+.[0-9]+*"
+  workflow_dispatch: {}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  DEFAULT_PYTHON: "3.14"
+  DEFAULT_VARIANT: slim
+
+jobs:
+  docker:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14"]  # all versions starting with 3.14 as the first one
+        variant: [slim, alpine]
+    name: Python ${{ matrix.python-version }} ${{ matrix.variant }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute version
+        id: version
+        run: |
+          pip install setuptools-scm
+          VERSION=$(python -m setuptools_scm)
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
+          PATCH=$(echo "$VERSION" | cut -d. -f1-3 | cut -d+ -f1 | cut -da -f1 | cut -db -f1 | cut -dr -f1 | cut -dd -f1)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
+          echo "patch=$PATCH" >> "$GITHUB_OUTPUT"
+
+      - name: Compute tags
+        id: tags
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          IMAGE=$(echo "$IMAGE" | tr '[:upper:]' '[:lower:]')
+          PYTHON="${{ matrix.python-version }}"
+          VARIANT="${{ matrix.variant }}"
+          MAJOR="${{ steps.version.outputs.major }}"
+          MINOR="${{ steps.version.outputs.minor }}"
+          PATCH="${{ steps.version.outputs.patch }}"
+          IS_DEFAULT_PYTHON=${{ matrix.python-version == env.DEFAULT_PYTHON }}
+          IS_DEFAULT_VARIANT=${{ matrix.variant == env.DEFAULT_VARIANT }}
+
+          TAGS=""
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR="${{ github.event.pull_request.number }}"
+            TAGS="${IMAGE}:pr-${PR}-python${PYTHON}-${VARIANT}"
+          else
+            # Always: full version + python + variant
+            TAGS="${TAGS}${IMAGE}:${PATCH}-python${PYTHON}-${VARIANT}"
+            TAGS="${TAGS},${IMAGE}:${MINOR}-python${PYTHON}-${VARIANT}"
+            TAGS="${TAGS},${IMAGE}:v${MAJOR}-python${PYTHON}-${VARIANT}"
+
+            # Default variant: version + python (no variant suffix)
+            if [ "$IS_DEFAULT_VARIANT" = "true" ]; then
+              TAGS="${TAGS},${IMAGE}:${PATCH}-python${PYTHON}"
+              TAGS="${TAGS},${IMAGE}:${MINOR}-python${PYTHON}"
+              TAGS="${TAGS},${IMAGE}:v${MAJOR}-python${PYTHON}"
+            fi
+
+            # Default python + default variant: bare version tags + latest
+            if [ "$IS_DEFAULT_PYTHON" = "true" ] && [ "$IS_DEFAULT_VARIANT" = "true" ]; then
+              TAGS="${TAGS},${IMAGE}:${PATCH}"
+              TAGS="${TAGS},${IMAGE}:${MINOR}"
+              TAGS="${TAGS},${IMAGE}:v${MAJOR}"
+              TAGS="${TAGS},${IMAGE}:latest"
+            fi
+          fi
+
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+            VARIANT=${{ matrix.variant }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+ARG PYTHON_VERSION=3.14
+ARG VARIANT=slim
+
+#
+# Builder: install dependencies and build the package into a venv.
+# .git must be in context for setuptools-scm to determine the version.
+#
+FROM python:${PYTHON_VERSION}-${VARIANT} AS builder
+
+# Conditional build deps: alpine uses apk, slim/bookworm uses apt-get.
+RUN if command -v apk >/dev/null 2>&1; then \
+        apk add --no-cache gcc g++ make linux-headers git; \
+    else \
+        apt-get update && apt-get install -y --no-install-recommends gcc g++ make git \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+
+COPY . /src
+WORKDIR /src
+
+RUN python -m venv /opt/kopf \
+    && /opt/kopf/bin/pip install --no-cache-dir ".[full-auth,uvloop,dev]" \
+    && /opt/kopf/bin/pip install --no-cache-dir \
+        "oscrypto @ git+https://github.com/wbond/oscrypto.git@1547f535001ba568b239b8797465536759c742a3" \
+    && rm -rf /src
+
+#
+# Final: minimal image with the pre-built venv.
+#
+FROM python:${PYTHON_VERSION}-${VARIANT}
+
+COPY --from=builder /opt/kopf /opt/kopf
+ENV PATH="/opt/kopf/bin:$PATH"
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY docker/usage.txt /usr/local/share/kopf/usage.txt
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /app
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -150,6 +150,23 @@ CMD kopf run /src/handlers.py --verbose
 Where `handlers.py` is your Python script with the handlers
 (see `examples/*/example.py` for the examples).
 
+For quick experimentation, a pre-built image with all extras is available
+on GHCR — just mount your operator file and go:
+
+```bash
+# Minimize the credentials exposure.
+kubectl config view --minify --flatten > dev.kubeconfig
+
+# Run the operator locally, target a local cluster (host networking).
+docker run --rm -it --network=host \
+    -v ./handlers.py:/app/main.py:ro \
+    -v ./dev.kubeconfig:/root/.kube/config:ro \
+    ghcr.io/nolar/kopf
+```
+
+See the [Docker image documentation](https://kopf.readthedocs.io/en/latest/docker/)
+for more details.
+
 See `kopf run --help` for other ways of attaching the handlers.
 
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# Install extra dependencies from the mounted app directory.
+if [ -f /app/requirements.txt ]; then
+    pip install --no-cache-dir -r /app/requirements.txt
+fi
+if [ -f /app/pyproject.toml ]; then
+    pip install --no-cache-dir /app/
+fi
+
+# No CLI args: auto-detect or show help.
+if [ $# -eq 0 ]; then
+    if [ -f /app/main.py ]; then
+        exec kopf run -v /app/main.py
+    else
+        cat /usr/local/share/kopf/usage.txt
+        exit 1
+    fi
+fi
+
+# CLI args provided: pass through to kopf.
+exec kopf "$@"

--- a/docker/usage.txt
+++ b/docker/usage.txt
@@ -1,0 +1,40 @@
+
+Kopf Docker Image
+=================
+
+This image is for quick experimentation and ad-hoc operator development.
+For production, build your own image with `pip install kopf`.
+
+Usage
+-----
+
+Run an operator by mounting it at /app/main.py:
+
+    docker run --rm -it \
+        -v ./handler.py:/app/main.py:ro \
+        -v ~/.kube/config:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf
+
+Run an operator at a custom path:
+
+    docker run --rm -it \
+        -v ./src:/src:ro \
+        -v ~/.kube/config:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf run /src/handler.py
+
+Install extra dependencies via requirements.txt:
+
+    docker run --rm -it \
+        -v ./handler.py:/app/main.py:ro \
+        -v ./requirements.txt:/app/requirements.txt:ro \
+        -v ~/.kube/config:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf
+
+Install extra dependencies via pyproject.toml:
+
+    docker run --rm -it \
+        -v ./myproject:/app:ro \
+        -v ~/.kube/config:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf
+
+Documentation: https://kopf.readthedocs.io

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -1,0 +1,259 @@
+============
+Docker image
+============
+
+Kopf provides pre-built Docker images on the GitHub Container Registry (GHCR)
+with all extras pre-installed. These images are intended for quick experimentation
+and ad-hoc operator development. For production, it is recommended to build
+your own image with ``pip install kopf`` (see :doc:`deployment`).
+
+The images are available at:
+
+.. code-block:: text
+
+    ghcr.io/nolar/kopf
+
+Each image includes the ``kopf`` CLI, the ``full-auth`` extra (``pykube-ng``
+and ``kubernetes`` client libraries), ``uvloop`` for better async performance,
+and the ``dev`` extra (``oscrypto``, ``certbuilder``, ``certvalidator``,
+``pyngrok``) for development convenience.
+
+
+Image variants
+==============
+
+Images are published for each release in several variants:
+
+* **slim** (default) --- based on Debian, larger but with broader compatibility.
+* **alpine** --- based on Alpine Linux, smaller but may have issues
+  with some native dependencies.
+
+Both variants are built for ``linux/amd64`` and ``linux/arm64`` platforms.
+
+
+Image tags
+==========
+
+For a release such as ``1.42.5`` built with Python 3.14 (the default),
+the following tags are available:
+
+* ``ghcr.io/nolar/kopf:latest`` --- the latest release with the default
+  Python version and the default variant (slim).
+* ``ghcr.io/nolar/kopf:1.42.5`` --- a specific patch release.
+* ``ghcr.io/nolar/kopf:1.42`` --- the latest patch within a minor release.
+* ``ghcr.io/nolar/kopf:v1`` --- the latest release within a major version.
+
+To pin a specific Python version or variant, use the extended tag format:
+
+* ``ghcr.io/nolar/kopf:1.42.5-python3.13-alpine``
+* ``ghcr.io/nolar/kopf:1.42-python3.14-slim``
+* ``ghcr.io/nolar/kopf:v1-python3.13``
+
+Tags without a variant suffix (e.g. ``1.42-python3.13``) point to the slim variant.
+Tags without a Python version (e.g. ``1.42.5``) point to the default Python version.
+
+
+Quick start
+===========
+
+The simplest way to run an operator is to mount a single Python file
+at ``/app/main.py`` inside the container. The entrypoint will auto-detect it
+and run ``kopf run -v /app/main.py``:
+
+.. code-block:: bash
+
+    docker run --rm -it \
+        -v ./handler.py:/app/main.py:ro \
+        -v ~/.kube/config:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf
+
+The kubeconfig mount (``~/.kube/config``) gives the operator access
+to the Kubernetes cluster. Adjust the path as needed for your setup.
+
+
+Running a specific file
+=======================
+
+To run an operator from a custom path, pass the ``run`` command
+with the path explicitly:
+
+.. code-block:: bash
+
+    docker run --rm -it \
+        -v ./src:/src:ro \
+        -v ~/.kube/config:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf run -v /src/handler.py
+
+
+Extra dependencies
+==================
+
+If the operator needs additional Python packages, the entrypoint supports
+two mechanisms for automatic installation at startup.
+
+requirements.txt
+----------------
+
+Mount a ``requirements.txt`` file at ``/app/requirements.txt``.
+The entrypoint will run ``pip install -r /app/requirements.txt`` before
+starting the operator:
+
+.. code-block:: bash
+
+    docker run --rm -it \
+        -v ./handler.py:/app/main.py:ro \
+        -v ./requirements.txt:/app/requirements.txt:ro \
+        -v ~/.kube/config:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf
+
+pyproject.toml
+--------------
+
+Mount the entire project directory at ``/app/``. If a ``pyproject.toml`` is
+found, the entrypoint will run ``pip install /app/`` to install the project
+and its dependencies:
+
+.. code-block:: bash
+
+    docker run --rm -it \
+        -v ./myproject:/app:ro \
+        -v ~/.kube/config:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf
+
+
+Passing CLI options
+===================
+
+Any arguments passed to the container are forwarded directly to the ``kopf``
+CLI. For example, to run in verbose mode with a specific namespace:
+
+.. code-block:: bash
+
+    docker run --rm -it \
+        -v ./handler.py:/app/main.py:ro \
+        -v ~/.kube/config:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf run /app/main.py --verbose --namespace=default
+
+To see all available CLI options:
+
+.. code-block:: bash
+
+    docker run --rm ghcr.io/nolar/kopf run --help
+
+.. seealso::
+    :doc:`cli` for the full list of command-line options.
+
+
+Local clusters
+==============
+
+When the Kubernetes API server runs on the host machine (e.g. k3d, k3s, kind,
+minikube, or Docker Desktop Kubernetes), the container cannot reach it
+at ``127.0.0.1`` because that address refers to the container itself,
+not the host.
+
+The simplest solution is to use host networking, which shares the host's
+network stack with the container:
+
+.. code-block:: bash
+
+    docker run --rm -it --network host \
+        -v ./handler.py:/app/main.py:ro \
+        -v ~/.kube/config:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf
+
+With ``--network host``, the kubeconfig's ``127.0.0.1`` addresses work as-is.
+This mode is supported on Linux natively, and on macOS via Docker Desktop
+and OrbStack.
+
+If host networking is not an option, rewrite the server address in the
+kubeconfig to use ``host.docker.internal`` --- a special hostname that resolves
+to the host machine in Docker Desktop and OrbStack:
+
+.. code-block:: bash
+
+    kubectl config view --minify --flatten | \
+        sed 's|127\.0\.0\.1|host.docker.internal|' > dev.kubeconfig
+
+    docker run --rm -it \
+        -v ./handler.py:/app/main.py:ro \
+        -v ./dev.kubeconfig:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf
+
+On Linux without Docker Desktop, add ``--add-host host.docker.internal:host-gateway``
+to make the hostname resolve to the host.
+
+
+Using with Docker Compose
+=========================
+
+The image can be used in a Docker Compose setup for local development:
+
+.. code-block:: yaml
+
+    services:
+      operator:
+        image: ghcr.io/nolar/kopf
+        volumes:
+          - ./handler.py:/app/main.py:ro
+          - ~/.kube/config:/root/.kube/config:ro
+
+To target a local cluster (k3d, kind, etc.), use host networking:
+
+.. code-block:: yaml
+
+    services:
+      operator:
+        image: ghcr.io/nolar/kopf
+        network_mode: host
+        volumes:
+          - ./handler.py:/app/main.py:ro
+          - ~/.kube/config:/root/.kube/config:ro
+
+
+Kubeconfig security
+===================
+
+Mounting ``~/.kube/config`` directly into the container is convenient but may
+expose more credentials than necessary. The default kubeconfig often contains
+access tokens or client certificates for multiple clusters and contexts.
+
+For safer local development, create a minified copy that contains only
+the current context and review it before mounting:
+
+.. code-block:: bash
+
+    kubectl config view --minify --flatten > dev.kubeconfig
+    # Review dev.kubeconfig to ensure it contains only what you expect.
+
+Then mount the minified config instead:
+
+.. code-block:: bash
+
+    docker run --rm -it \
+        -v ./handler.py:/app/main.py:ro \
+        -v ./dev.kubeconfig:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf
+
+This limits the container to a single cluster and avoids accidentally leaking
+credentials for other clusters or service accounts. Remember to regenerate
+the file when switching contexts or after token rotation.
+
+
+Building your own image
+=======================
+
+For production deployments, it is recommended to build a custom image
+rather than relying on the pre-built one. This avoids startup-time dependency
+installation, ensures reproducible builds, and keeps the image minimal:
+
+.. code-block:: dockerfile
+
+    FROM python:3.14
+    RUN pip install kopf
+    COPY handler.py /src/handler.py
+    CMD ["kopf", "run", "/src/handler.py", "--verbose"]
+
+.. seealso::
+    :doc:`deployment` for the full deployment guide, including RBAC
+    and Kubernetes Deployment manifests.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,7 @@ Kopf: Kubernetes Operators Framework
    :maxdepth: 2
    :caption: Recipes:
 
+   docker
    deployment
    continuity
    idempotence

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,6 +6,9 @@ Prerequisites:
 
 * Python >= 3.10 (CPython and PyPy are officially tested and supported).
 
+Installing packages
+===================
+
 To install Kopf:
 
 .. code-block:: bash
@@ -25,6 +28,10 @@ If you want extra i/o performance under the hood, install it as (also see :ref:`
 .. code-block:: bash
 
     pip install kopf[uvloop]
+
+
+Example resources
+=================
 
 Unless you use the standalone mode,
 create a few Kopf-specific custom resources in the cluster:
@@ -48,3 +55,23 @@ You are ready to go:
     kopf --help
     kopf run --help
     kopf run examples/01-minimal/example.py
+
+
+Docker image
+============
+
+Alternatively, a pre-built Docker image with all extras is available for quick
+experimentation --- no local Python installation needed:
+
+.. code-block:: bash
+
+    # Minimize the credentials exposure.
+    kubectl config view --minify --flatten > dev.kubeconfig
+
+    # Run the operator locally, target a local cluster (host networking).
+    docker run --rm -it --network=host \
+        -v ./examples/01-minimal/example.py:/app/main.py:ro \
+        -v ./dev.kubeconfig:/root/.kube/config:ro \
+        ghcr.io/nolar/kopf
+
+See :doc:`docker` for image variants, tags, and more usage examples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,10 @@ lint = [
     "uvloop",
 ]
 
+[tool.setuptools.packages.find]
+# The star is for the versions.py, which is gitignored in docker builds (somewhy).
+include = ["kopf", "kopf.*"]
+
 [tool.setuptools_scm]
 version_file = "kopf/_cogs/helpers/versions.py"
 


### PR DESCRIPTION
## Summary

Build a docker image to use out of the box with only the operator code at hand. No need for virtualenv management anymore.

Example:

```shell
kubectl config view --minify --flatten > dev.kubeconfig

docker run --rm -it --network=host \
    -v ./examples/01-minimal/example.py:/app/main.py:ro \
    -v ./dev.kubeconfig:/root/.kube/config:ro \
    ghcr.io/nolar/kopf run /app/main.py --verbose --namespace=default
```

More examples in the [docs](https://kopf.readthedocs.io/en/latest/docker/).


## Changes

- Add a multi-stage `Dockerfile` with parameterized Python version and variant (slim/alpine), a smart entrypoint that auto-detects operator files and installs extra dependencies, and a GitHub Actions workflow to build and publish images to `ghcr.io/nolar/kopf`
- Build matrix: Python 3.14 x slim/alpine, platforms linux/amd64 + linux/arm64. Later, more Python versions will be maintained. But starting with the current 3.14 only.
- Add `docs/docker.rst` documentation page with usage examples (quick start, custom paths, extra deps, CLI options, Docker Compose)
- Add explicit `[tool.setuptools.packages.find]` to `pyproject.toml` to prevent setuptools auto-discovery from picking up `docker/` as a package

## Test plan

- [x] Local `python -m build` succeeds (sdist + wheel)
- [x] Local `docker build` succeeds (Python 3.14 slim)
- [x] `docker run --rm kopf:test --version` works
- [x] Entrypoint shows usage help when no operator file is found
- [x] `sphinx-build` succeeds with no new warnings
- [x] CI workflow builds all 2 matrix combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)