### PR TITLE
Require aiohttp>=3.11.0 for proxy support (released ~Nov'24)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "iso8601",              # 0.07 MB
     "pyyaml",               # 0.90 MB
     "click>=8.2.0",         # 0.60 MB
-    "aiohttp>=3.0.0",       # 7.80 MB
+    "aiohttp>=3.11.0",      # 7.80 MB
     "aiohttp>=3.9.0; python_version >= '3.12'",
 ]
 dynamic = ["version"]  # taken from git tags


### PR DESCRIPTION
The `proxy=` parameter was introduced only in [aiohttp 3.11.0](https://github.com/aio-libs/aiohttp/releases/tag/v3.11.0), so reqiure it as the minimal version, so that dependency resolvers can properly resolve the final setup.

aiohttp 3.11.0 was released in Nov'24, so 1+ years ago — this should be enough time to adapt a newer minor version in the operators.

Proxyies were introduced in:

* #1234 

Noticed in https://github.com/nolar/kopf/pull/1234#discussion_r2798494366