### PR TITLE
Patch finalizers atomically using json-patch relative to the freshest body state

### DIFF
--- a/kopf/_core/actions/application.py
+++ b/kopf/_core/actions/application.py
@@ -153,5 +153,14 @@ async def patch_and_check(
         # Which newer version to expect for consistency. If there was no patch or it has failed,
         # the patched body is None, so the version is None, meaning to wait for the last known one.
         resource_version = (resulting_body or {}).get('metadata', {}).get('resourceVersion')
+
+        # A workaround for Kubernetes behavior on the removal of the LAST finalizer on deletion:
+        # it does NOT increase the resourceVersion, and uses the last one from merge-patches.
+        # We should NEVER expect the consistent state — the object will be "gone" in an instant.
+        deletion_ongoing = bool((resulting_body or {}).get('metadata', {}).get('deletionTimestamp'))
+        deletion_blocked = bool((resulting_body or {}).get('metadata', {}).get('finalizers'))
+        if deletion_ongoing and not deletion_blocked:
+            resource_version = f"{resource_version}~which~never~arrives"
+
         return resource_version, remaining_patch
     return None, None

--- a/kopf/_core/reactor/processing.py
+++ b/kopf/_core/reactor/processing.py
@@ -308,6 +308,8 @@ async def process_resource_causes(
     # Never release the object (i.e., remove the finalizer) in the inconsistent state, always wait.
     consistency_is_required = changing_cause is not None
     consistency_is_achieved = consistency_time is None  # i.e. preexisting consistency
+    if changing_cause is not None and changing_cause.reason == causes.Reason.GONE:
+        consistency_is_achieved = True  # for the final goodbye log message
     if consistency_is_required and not consistency_is_achieved and not patch and consistency_time:
         loop = asyncio.get_running_loop()
         unslept = await aiotime.sleep(consistency_time - loop.time(), wakeup=stream_pressure)

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -71,6 +71,7 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
             raw_event={'type': 'irrelevant', 'object': event_object},
             event_queue=asyncio.Queue(),
             stream_pressure=stream_pressure,
+            no_throttling=True,
         )
 
         # Do the same as k8s does: merge the patches into the object.

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -120,7 +120,7 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
     assert not handlers.update_mock.called
     assert handlers.delete_mock.call_count == 1
 
-    assert k8s_mocked.patch.call_count == 1
+    assert k8s_mocked.patch.call_count == 2  # (1) annotations, (2) finalizers.
     assert not event_queue.empty()
 
     assert_logs([

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -168,6 +168,41 @@ async def test_gone(registry, settings, handlers, resource, cause_mock, event_ty
     ])
 
 
+# Happens on the removal of the very last finalizer on DELETED events (it arrives as not removed).
+async def test_gone_with_finalizer_not_removed_on_deleted_event(
+        registry, settings, handlers, resource, cause_mock,
+        assert_logs, k8s_mocked):
+    cause_mock.reason = Reason.GONE
+    finalizer = settings.persistence.finalizer
+    event_body = {'metadata': {'deletionTimestamp': '...', 'finalizers': [finalizer]}}
+
+    event_queue = asyncio.Queue()
+    await process_resource_event(
+        lifecycle=kopf.lifecycles.all_at_once,
+        registry=registry,
+        settings=settings,
+        resource=resource,
+        indexers=OperatorIndexers(),
+        memories=ResourceMemories(),
+        memobase=Memo(),
+        raw_event={'type': 'DELETED', 'object': event_body},
+        event_queue=event_queue,
+    )
+
+    assert not handlers.create_mock.called
+    assert not handlers.update_mock.called
+    assert not handlers.delete_mock.called
+
+    assert not k8s_mocked.patch.called
+    assert event_queue.empty()
+
+    assert_logs([
+        "Deleted, really deleted",
+    ], prohibited=[
+        "Removing the finalizer",
+    ])
+
+
 @pytest.mark.parametrize('event_type', EVENT_TYPES)
 async def test_free(registry, settings, handlers, resource, cause_mock, event_type,
                     assert_logs, k8s_mocked):

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -137,9 +137,10 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
 # Informational causes: just log, and do nothing else.
 #
 
+@pytest.mark.parametrize('consistency_time', [0, 100], ids=['now', 'future'])
 @pytest.mark.parametrize('event_type', EVENT_TYPES)
 async def test_gone(registry, settings, handlers, resource, cause_mock, event_type,
-                    assert_logs, k8s_mocked):
+                    assert_logs, k8s_mocked, consistency_time, looptime):
     cause_mock.reason = Reason.GONE
 
     settings.posting.loggers = True
@@ -154,6 +155,7 @@ async def test_gone(registry, settings, handlers, resource, cause_mock, event_ty
         memobase=Memo(),
         raw_event={'type': event_type, 'object': {}},
         event_queue=event_queue,
+        consistency_time=consistency_time,
     )
 
     assert not handlers.create_mock.called
@@ -163,6 +165,7 @@ async def test_gone(registry, settings, handlers, resource, cause_mock, event_ty
     assert not k8s_mocked.patch.called
     assert event_queue.empty()
 
+    assert looptime == 0
     assert_logs([
         "Deleted, really deleted",
     ])


### PR DESCRIPTION
**Prerequisites:**

* #1253

**Problem:**

With merge-patches (now), when we are adding/removing our own finalizer, we persist the whole list of other finalizers. If some of them were removed since our latest seen body state, we are re-adding them against the will of those operators. If some new finalizers were added by other operators, we will remove them against the will of those operators.

This is bad on its own. But this is especially critical when we re-add (restore) the finalizers of other operators when the object is marked for deletion — finalizers can only be removed in that case.

**Solution:**

Remove Kopf-managed finalizers from the merge-patch strategy, and apply them via the json-patch strategy. For this, we need the freshmost body to calculate the actual diffs (we need indexes of finalizers in the list).

To ensure that our inferred indexes match the actual state at the server, prepend the "test" operation on `metadata.resourceVersion`: if it passes, remove the finalizers as calculated. If it fails, conclude that there are newer changes pending, so postpone the patch till the next processing cycle (which arrives instantly).

Closes #1106 

TODOs:

- [x] Blocked by #1253 
- [x] Simulate it manually (patch with a client library in a handler to create a conflict, observe multi-cycle patching).
- [x] Unit tests
- [x] ~Maybe: docs on the `patch.ops`? _(Or only after bigger extension?)_~

---

**Previous attempts:**

1) First, AI has implemented this using stragegic merges — only to find out that strategic merges are not available for custom resources. This is inappropriate for a generalised framework. #1236 

2) Then it implemented it with JSON-patch as intended, but in a for-cycle inside `patch_obj()`, where it was refreshing the resource body via `GET` operations. Good, but three cons: (a) it would require extra RBAC permissions on the resources, despite we already have the watch-stream for this; (b) it will be busy patching that resource in the for-cycle, and will miss or delay the pending on-event handlers, thus violating one of the core promises; (c) it requires the same retrying cycle as we already have for generic API requests, but for failures of the json-patch specifically, so some extra settings (backoffs), etc. — extra complexity.

3) With human guidance, it reimplemented it to carry the remaining patch as a part of the consistency tracking machinery (now: only the resource_version + deemed deadline). Which worked as expected, but was overly complex (the human's fault, not the AI's). #1237

4) (This one; hand-made) After some digestion and meditation on (3), I have reimplemented the approach using the existing per-resource "memory". This simplified the solution significantly. And I have generalized it to manipulate any other list fields, not just finalizers (undocumented, but available to users).

All previous attempts are preserved just for history of learning to use AI. It was fun :-) 