### PR TITLE
Apply arbitrary resource transformations via json-patches

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,7 @@ Kopf: Kubernetes Operators Framework
    loading
    resources
    filters
+   patches
    results
    errors
    scopes

--- a/docs/kwargs.rst
+++ b/docs/kwargs.rst
@@ -176,15 +176,13 @@ after the handler. It is actively used internally by the framework itself,
 and is shared to the handlers for convenience _(since patching happens anyway
 in the framework, why make separate API calls for patching?)_.
 
-.. note::
-    Currently, it is just a dictionary, and the changes are applied
-    as ``application/merge-patch+json``: ``None`` values delete the fields,
-    other values override, dicts are merged.
+``patch`` also provides a ``fns`` property for appending transformation
+functions that operate on the raw resource body as a mutable dictionary.
+This is useful for list operations and other changes that depend
+on the current state of the resource.
 
-    In the future, at discretion of this framework, it can be converted
-    to JSON-patch (a list of add/change/remove operation), while keeping
-    the same Python mutable mapping protocol and remembering the changes
-    in the order they were made.
+See :doc:`patches` for details on both merge-patch and transformation
+functions.
 
 
 .. kwarg:: memo

--- a/docs/patches.rst
+++ b/docs/patches.rst
@@ -1,0 +1,126 @@
+========
+Patching
+========
+
+Handlers can modify the Kubernetes resource they are handling
+by using the :kwarg:`patch` keyword argument.
+There are two patching strategies available:
+the merge-patch dictionary for simple field changes,
+and transformation functions for operations that depend
+on the current state of the resource, such as list manipulations.
+
+The changes from both strategies are mixed with the framework's own
+modifications (such as progress storage, finalizer management,
+and handler result delivery) and applied together in the minimal number
+of API calls (depending on the resource definition).
+
+There can be from zero to four patches per one processing cycle,
+depending on whether the status is a subresource, and whether the patch
+is a mix of dictionary changes and transformation functions with actual changes.
+
+Alternatively, the operator developers can use any third-party
+Kubernetes client library to patch their resources directly
+inside the handlers instead of using the provided :kwarg:`patch` facility.
+
+
+Dictionary merge-patches
+========================
+
+The :kwarg:`patch` object behaves as a mutable dictionary.
+The changes accumulated in it are applied to the resource
+as a JSON merge-patch (``application/merge-patch+json``)
+after the handler finishes:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.create('kopfexamples')
+    def ensure_defaults(spec, patch, **_):
+        if 'greeting' not in spec:
+            patch.spec['greeting'] = 'hello'
+        patch.status['state'] = 'initialized'
+
+Setting a field to ``None`` deletes it from the resource.
+Nested dictionaries are merged recursively.
+Other values overwrite the existing ones:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.update('kopfexamples')
+    def cleanup_obsolete_fields(patch, **_):
+        patch.spec['obsoleteField'] = None  # deletes the field
+        patch.status['phase'] = 'updated'   # overwrites the value
+
+
+Transformation functions
+========================
+
+Some changes cannot be expressed as a merge-patch.
+In particular, list operations (appending to or removing from a list)
+require knowing the current state of the list to calculate the correct indices.
+For example, adding a finalizer requires knowing how many finalizers
+are already present; removing one requires knowing its position in the list.
+
+For these cases, the :kwarg:`patch` object provides the ``patch.fns`` property.
+Any function of type :type:`kopf.PatchFn` can be appended to ``patch.fns``
+(or inserted into the beginning or the middle of the list, if that matters).
+Each function accepts the raw resource body as a positional argument
+(a regular mutable dictionary) and mutates it in place; the dictionary being
+mutated is already a deep copy of the original body, so no need to worry:
+
+.. code-block:: python
+
+    import kopf
+
+    def add_finalizer(body):
+        finalizers = body.setdefault('metadata', {}).setdefault('finalizers', [])
+        if 'my-operator/cleanup' not in finalizers:
+            finalizers.append('my-operator/cleanup')
+
+    @kopf.on.create('kopfexamples')
+    def create_fn(patch, **_):
+        patch.fns.append(add_finalizer)
+
+The framework calls the transformation functions against the freshest seen
+resource body and computes a JSON diff (``application/json-patch+json``)
+relative to that body.
+The resulting JSON Patch operations are sent to the Kubernetes API
+with an optimistic concurrency check on the ``metadata.resourceVersion``.
+
+.. note::
+
+    The body passed to the transformation function is the latest version
+    of the resource known to the framework at the time the function is applied.
+    It may already reflect the results of earlier patch operations
+    in the same or previous processing cycles, so it is not necessarily
+    the body from the event that triggered the handler.
+
+The transformation functions can be called more than once across
+the same or several processing cycles --
+for instance, if the API server rejects the patch due to a conflict.
+The functions should therefore be safe to call repeatedly:
+they should check the current state before making changes
+rather than assuming a particular starting state.
+
+
+Arguments to transformation functions
+--------------------------------------
+
+The transformation function signature is a single positional argument
+for the body. If additional positional or keyword arguments are needed,
+use ``functools.partial``:
+
+.. code-block:: python
+
+    import functools
+    import kopf
+
+    def set_label(body, name, value):
+        body.setdefault('metadata', {}).setdefault('labels', {})[name] = value
+
+    @kopf.on.create('kopfexamples')
+    def create_fn(patch, **_):
+        patch.fns.append(functools.partial(set_label, name='my-label', value='my-value'))

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -82,6 +82,7 @@ from kopf._cogs.structs.ids import (
 )
 from kopf._cogs.structs.patches import (
     Patch,
+    PatchFn,
 )
 from kopf._cogs.structs.references import (
     Resource,
@@ -264,6 +265,7 @@ __all__ = [
     'HandlerId',
     'Reason',
     'Patch',
+    'PatchFn',
     'DaemonStopped',
     'DaemonStoppingReason',
     'SyncDaemonStopperChecker',  # deprecated

--- a/kopf/_cogs/clients/errors.py
+++ b/kopf/_cogs/clients/errors.py
@@ -133,6 +133,10 @@ class APIConflictError(APIClientError):
     pass
 
 
+class APIUnprocessableEntityError(APIClientError):
+    pass
+
+
 class APITooManyRequestsError(APIClientError):
     pass
 
@@ -179,6 +183,7 @@ async def check_response(
             APIForbiddenError if response.status == 403 else
             APINotFoundError if response.status == 404 else
             APIConflictError if response.status == 409 else
+            APIUnprocessableEntityError if response.status == 422 else
             APITooManyRequestsError if response.status == 429 else
             APIClientError if 400 <= response.status < 500 else
             APIServerError if 500 <= response.status < 600 else

--- a/kopf/_cogs/clients/patching.py
+++ b/kopf/_cogs/clients/patching.py
@@ -12,7 +12,7 @@ async def patch_obj(
         name: str | None,
         patch: patches.Patch,
         logger: typedefs.Logger,
-) -> bodies.RawBody | None:
+) -> tuple[bodies.RawBody | None, patches.Patch | None]:
     """
     Patch a resource of specific kind.
 
@@ -40,7 +40,7 @@ async def patch_obj(
     # partial or empty -- if the body/status patches are empty. This is fine: it is only used
     # to verify that the patched fields are matching the patch. No patch? No mismatch!
     try:
-        patched_body = bodies.RawBody()
+        patched_body: bodies.RawBody | None = None
 
         if body_patch:
             logger.debug(f"Merge-patching the resource with: {body_patch!r}")
@@ -56,16 +56,89 @@ async def patch_obj(
             # NB: we need the new resourceVersion, so we take the whole new patched body.
             logger.debug(f"Merge-patching the status with: {status_patch!r}")
             patched_body = await api.patch(
-                url=resource.get_url(namespace=namespace, name=name,
-                                     subresource='status' if as_subresource else None),
+                url=resource.get_url(namespace=namespace, name=name, subresource='status'),
                 headers={'Content-Type': 'application/merge-patch+json'},
                 payload=status_patch,
                 settings=settings,
                 logger=logger,
             )
 
-        return patched_body
+        # Only the callable transformations are left now, no dict-merge components left.
+        # If we fail at any stage below, we re-apply this whole patch. We cannot distinguish
+        # the "status" functions from the "main body" functions; some of them can be mixed.
+        remaining_patch = patches.Patch(fns=patch.fns)
+
+        # Calculate the JSON diffs to be applied and split into body + status (if a subresource).
+        # Use the latest known body for reference when calculating the item indexes in lists.
+        # Note: we apply transformations for the whole body atomically, and in the future (not yet)
+        # we want to get the ops from the functions, so we can only filter by path here.
+        fresh_body: bodies.RawBody | None = patched_body if patched_body else patch._original
+        ops: patches.JSONPatch = remaining_patch.as_json_patch(fresh_body)
+        body_ops: patches.JSONPatch
+        status_ops: patches.JSONPatch
+        if as_subresource:
+            body_ops = [op for op in ops
+                        if not(op['path'] == '/status' or op['path'].startswith('/status/'))]
+            status_ops = [op for op in ops
+                          if op['path'] == '/status' or op['path'].startswith('/status/')]
+        else:
+            body_ops = ops
+            status_ops = []
+
+        # Apply pending operations (finalizers) via JSON-patch with optimistic concurrency.
+        # If the resource version fails the test, we know there are newer changes pending,
+        # so we will get back to the handling cycle & this same patching almost immediately.
+        # NB: the patched_body=={} in tests' mocks, so check for emptiness, not just null-ness.
+        if body_ops:
+            resource_version = (fresh_body or {}).get('metadata', {}).get('resourceVersion')
+            test = patches.JSONPatchItem(op='test', path='/metadata/resourceVersion', value=resource_version)
+            ops = [test] + body_ops
+            logger.debug(f"JSON-patching the resource with: {ops!r}")
+            try:
+                patched_body = await api.patch(
+                    url=resource.get_url(namespace=namespace, name=name),
+                    headers={'Content-Type': 'application/json-patch+json'},
+                    payload=ops,
+                    settings=settings,
+                    logger=logger,
+                )
+            except errors.APIUnprocessableEntityError:
+                # NB: also detach from the current freshest body, persist only the patch fns.
+                logger.debug(
+                    "Could not apply the patch in full due to conflicts with newer changes. "
+                    f"Will try on the next cycle soon. Remaining: {remaining_patch!r}"
+                )
+                return patched_body, remaining_patch
+            else:
+                fresh_body = patched_body
+
+        # We DO NOT recalculate the diff against a newer body after the recent patch!
+        # The ops of both diffs are already non-conflicting, because we have split them so.
+        # If the body patch succeeds, we know the new fresh state. If it fails, we do not get here.
+        # If something jumps inbetween, we fail & postpone the whole JSON-patch to the next cycle.
+        if status_ops:
+            resource_version = (fresh_body or {}).get('metadata', {}).get('resourceVersion')
+            test = patches.JSONPatchItem(op='test', path='/metadata/resourceVersion', value=resource_version)
+            ops = [test] + status_ops
+            logger.debug(f"JSON-patching the status with: {ops!r}")
+            try:
+                patched_body = await api.patch(
+                    url=resource.get_url(namespace=namespace, name=name, subresource='status'),
+                    headers={'Content-Type': 'application/json-patch+json'},
+                    payload=ops,
+                    settings=settings,
+                    logger=logger,
+                )
+            except errors.APIUnprocessableEntityError:
+                # NB: also detach from the current freshest body, persist only the patch fns.
+                logger.debug(
+                    "Could not apply the patch in full due to conflicts with newer changes. "
+                    f"Will try on the next cycle soon. Remaining: {remaining_patch!r}"
+                )
+                return patched_body, remaining_patch
+
+        return patched_body, None
 
     except errors.APINotFoundError:
         logger.debug(f"Patching was skipped: the object does not exist anymore.")
-        return None
+        return None, None

--- a/kopf/_cogs/structs/patches.py
+++ b/kopf/_cogs/structs/patches.py
@@ -66,14 +66,25 @@ class Patch(dict[str, Any]):
 
     def __init__(
         self,
-        __src: collections.abc.MutableMapping[str, Any] | None = None,
-        body: bodies.RawBody | None = None
+        src: collections.abc.MutableMapping[str, Any] | None = None,
+        /,
+        body: bodies.RawBody | None = None,
     ) -> None:
-        super().__init__(__src or {})
+        super().__init__(src or {})
         self._meta = MetaPatch(self)
         self._spec = SpecPatch(self)
         self._status = StatusPatch(self)
         self._original = body
+
+    def __repr__(self) -> str:
+        texts: list[str] = []
+        if list(self):  # any keys at all?
+            texts += [super().__repr__()]
+        text = ", ".join(texts)
+        return f"{type(self).__name__}({text})"
+
+    def __bool__(self) -> bool:
+        return len(self) > 0
 
     @property
     def metadata(self) -> MetaPatch:

--- a/kopf/_core/actions/application.py
+++ b/kopf/_core/actions/application.py
@@ -49,7 +49,7 @@ async def apply(
         delays: Collection[float],
         logger: loggers.ObjectLogger,
         stream_pressure: asyncio.Event | None = None,  # None for tests
-) -> tuple[bool, str | None]:
+) -> tuple[bool, str | None, patches.Patch | None]:
     delay = min(delays) if delays else None
 
     # Delete dummies on occasion, but don't trigger special patching for them [discussable].
@@ -57,7 +57,7 @@ async def apply(
         settings.persistence.progress_storage.touch(body=body, patch=patch, value=None)
 
     # Actually patch if it was not empty originally or after the dummies removal.
-    resource_version = await patch_and_check(
+    resource_version, remaining_patch = await patch_and_check(
         settings=settings,
         resource=resource,
         logger=logger,
@@ -92,16 +92,16 @@ async def apply(
             value = datetime.datetime.now(datetime.timezone.utc).isoformat()
             touch = patches.Patch()
             settings.persistence.progress_storage.touch(body=body, patch=touch, value=value)
-            resource_version = await patch_and_check(
+            resource_version, _ = await patch_and_check(
                 settings=settings,
                 resource=resource,
                 logger=logger,
-                patch=touch,
+                patch=touch,  # NB: a minimal structure, nothing to remain
                 body=body,
             )
     elif not patch:  # no patch/touch and no delay
         applied = True
-    return applied, resource_version
+    return applied, resource_version, remaining_patch
 
 
 async def patch_and_check(
@@ -111,11 +111,11 @@ async def patch_and_check(
         body: bodies.Body,
         patch: patches.Patch,
         logger: typedefs.Logger,
-) -> str | None:  # patched resource version
+) -> tuple[str | None, patches.Patch | None]:  # (patched resource version, remaining patch)
     """
     Apply a patch and verify that it is applied correctly.
 
-    The inconsistencies are checked only against what was in the patch.
+    The inconsistencies are checked only against what was in the merge-patch.
     Other unexpected changes in the body are ignored, including the system
     fields, such as generations, resource versions, and other unrelated fields,
     such as other statuses, spec, labels, annotations, etc.
@@ -125,9 +125,11 @@ async def patch_and_check(
     whenever an empty list/dict is stored, such fields are completely removed.
     For normal fields (e.g. in spec/status), an empty list/dict is still
     a value and is persisted in the object and matches with the patch.
+
+    The JSON-patch transformation functions are currently also ignored.
     """
     if patch:
-        resulting_body = await patching.patch_obj(
+        resulting_body, remaining_patch = await patching.patch_obj(
             settings=settings,
             resource=resource,
             namespace=body.metadata.namespace,
@@ -135,6 +137,10 @@ async def patch_and_check(
             patch=patch,
             logger=logger,
         )
+
+        # Check inconsistencies ONLY for merge-patches. Background: added for "structural schemas"
+        # in K8s 1.16+ due to silent loss of the status changes when it is a subresource.
+        # JSON-patching inconsistencies are impossible — secured by the resourceVersion checks.
         inconsistencies = diffs.diff(patch, resulting_body, scope=diffs.DiffScope.LEFT)
         inconsistencies = diffs.Diff(
             diffs.DiffItem(op, field, old, new)
@@ -143,5 +149,9 @@ async def patch_and_check(
         )
         if inconsistencies and resulting_body is not None:
             logger.warning(f"Merge-patching finished with inconsistencies: {inconsistencies}")
-        return (resulting_body or {}).get('metadata', {}).get('resourceVersion')
-    return None
+
+        # Which newer version to expect for consistency. If there was no patch or it has failed,
+        # the patched body is None, so the version is None, meaning to wait for the last known one.
+        resource_version = (resulting_body or {}).get('metadata', {}).get('resourceVersion')
+        return resource_version, remaining_patch
+    return None, None

--- a/kopf/_core/actions/application.py
+++ b/kopf/_core/actions/application.py
@@ -127,7 +127,6 @@ async def patch_and_check(
     a value and is persisted in the object and matches with the patch.
     """
     if patch:
-        logger.debug(f"Patching with: {patch!r}")
         resulting_body = await patching.patch_obj(
             settings=settings,
             resource=resource,
@@ -142,9 +141,7 @@ async def patch_and_check(
             for op, field, old, new in inconsistencies
             if old or new or field not in KNOWN_INCONSISTENCIES
         )
-        if resulting_body is None:
-            logger.debug(f"Patching was skipped: the object does not exist anymore.")
-        elif inconsistencies:
-            logger.warning(f"Patching failed with inconsistencies: {inconsistencies}")
+        if inconsistencies and resulting_body is not None:
+            logger.warning(f"Merge-patching finished with inconsistencies: {inconsistencies}")
         return (resulting_body or {}).get('metadata', {}).get('resourceVersion')
     return None

--- a/kopf/_core/engines/peering.py
+++ b/kopf/_core/engines/peering.py
@@ -219,7 +219,7 @@ async def touch(
 
     patch = patches.Patch()
     patch |= {'status': {identity: None if peer.is_dead else peer.as_dict()}}
-    rsp = await patching.patch_obj(
+    rsp, remaining_patch = await patching.patch_obj(
         settings=settings,
         resource=resource,
         namespace=namespace,

--- a/kopf/_core/reactor/inventory.py
+++ b/kopf/_core/reactor/inventory.py
@@ -21,7 +21,7 @@ import copy
 import dataclasses
 from collections.abc import Iterator, MutableMapping
 
-from kopf._cogs.structs import bodies, ephemera
+from kopf._cogs.structs import bodies, ephemera, patches
 from kopf._core.actions import throttlers
 from kopf._core.engines import admission, daemons, indexing
 
@@ -37,6 +37,7 @@ class ResourceMemory:
     error_throttler: throttlers.Throttler = dataclasses.field(default_factory=throttlers.Throttler)
     indexing_memory: indexing.IndexingMemory = dataclasses.field(default_factory=indexing.IndexingMemory)
     daemons_memory: daemons.DaemonsMemory = dataclasses.field(default_factory=daemons.DaemonsMemory)
+    remaining_patch: patches.Patch | None = None  # None to save memory
 
     # For resuming handlers tracking and deciding on should they be called or not.
     noticed_by_listing: bool = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ test = [
     "codecov",
     "coverage>=7.12.0",
     "freezegun",
-    "kmock>=0.4",
+    "kmock>=0.5",
     "looptime>=0.7",
     "lxml",
     "pyngrok",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "python-json-logger",   # 0.05 MB
+    "jsonpatch",
     "iso8601",              # 0.07 MB
     "pyyaml",               # 0.90 MB
     "click>=8.2.0",         # 0.60 MB

--- a/tests/basic-structs/test_patch.py
+++ b/tests/basic-structs/test_patch.py
@@ -6,17 +6,20 @@ from kopf._cogs.structs.patches import Patch
 def test_patch_init_no_args():
     patch = Patch()
     assert dict(patch) == {}
+    assert len(patch.fns) == 0
 
 
 def test_patch_init_none_src():
     patch = Patch(None)
     assert dict(patch) == {}
+    assert len(patch.fns) == 0
 
 
 def test_patch_init_body_only():
     body = {'metadata': {'name': 'obj'}}
     patch = Patch(body=body)
     assert dict(patch) == {}
+    assert len(patch.fns) == 0
 
 
 def test_patch_init_body_stored_for_json_patch():
@@ -40,6 +43,16 @@ def test_patch_bool_with_dict_is_truthy():
     assert patch
 
 
+def test_patch_bool_with_fns_only_is_truthy():
+    patch = Patch(fns=[lambda body: None])
+    assert patch
+
+
+def test_patch_bool_with_dict_and_fns_is_truthy():
+    patch = Patch({'a': 'b'}, fns=[lambda body: None])
+    assert patch
+
+
 # === Patch.__repr__ ===
 
 
@@ -51,3 +64,60 @@ def test_patch_repr_empty():
 def test_patch_repr_dict_only():
     patch = Patch({'a': 'b'})
     assert repr(patch) == "Patch({'a': 'b'})"
+
+
+def test_patch_repr_fns_only():
+    patch = Patch(fns=[lambda body: None])
+    r = repr(patch)
+    assert r.startswith("Patch(fns=[")
+    assert r.endswith("])")
+
+
+def test_patch_repr_dict_and_fns():
+    patch = Patch({'a': 'b'}, fns=[lambda body: None])
+    r = repr(patch)
+    assert r.startswith("Patch({'a': 'b'}, fns=[")
+    assert r.endswith("])")
+
+
+# === Patch.fns property and inheritance ===
+
+
+def test_patch_fns_default_empty():
+    patch = Patch()
+    assert len(patch.fns) == 0
+
+
+def test_patch_fns_from_constructor():
+    fn1 = lambda body: None
+    fn2 = lambda body: None
+    patch = Patch(fns=[fn1, fn2])
+    assert list(patch.fns) == [fn1, fn2]
+
+
+def test_patch_inherits_fns_from_src_patch():
+    fn1 = lambda body: None
+    p1 = Patch(fns=[fn1])
+    p2 = Patch(p1)
+    assert list(p2.fns) == [fn1]
+
+
+def test_patch_combines_inherited_and_own_fns():
+    fn1 = lambda body: None
+    fn2 = lambda body: None
+    p1 = Patch(fns=[fn1])
+    p2 = Patch(p1, fns=[fn2])
+    assert list(p2.fns) == [fn1, fn2]
+
+
+def test_patch_no_fns_from_plain_dict():
+    p = Patch({'a': 'b'})
+    assert len(p.fns) == 0
+
+
+def test_patch_inherits_dict_and_fns():
+    fn1 = lambda body: None
+    p1 = Patch({'x': 'y'}, fns=[fn1])
+    p2 = Patch(p1)
+    assert p2['x'] == 'y'
+    assert list(p2.fns) == [fn1]

--- a/tests/basic-structs/test_patch.py
+++ b/tests/basic-structs/test_patch.py
@@ -1,0 +1,53 @@
+from kopf._cogs.structs.patches import Patch
+
+# === Patch.__init__ ===
+
+
+def test_patch_init_no_args():
+    patch = Patch()
+    assert dict(patch) == {}
+
+
+def test_patch_init_none_src():
+    patch = Patch(None)
+    assert dict(patch) == {}
+
+
+def test_patch_init_body_only():
+    body = {'metadata': {'name': 'obj'}}
+    patch = Patch(body=body)
+    assert dict(patch) == {}
+
+
+def test_patch_init_body_stored_for_json_patch():
+    body = {'abc': 456}
+    patch = Patch(body=body)
+    patch['abc'] = 789
+    ops = patch.as_json_patch()
+    assert ops == [{'op': 'replace', 'path': '/abc', 'value': 789}]
+
+
+# === Patch.__bool__ ===
+
+
+def test_patch_bool_empty_is_falsy():
+    patch = Patch()
+    assert not patch
+
+
+def test_patch_bool_with_dict_is_truthy():
+    patch = Patch({'a': 'b'})
+    assert patch
+
+
+# === Patch.__repr__ ===
+
+
+def test_patch_repr_empty():
+    patch = Patch()
+    assert repr(patch) == "Patch()"
+
+
+def test_patch_repr_dict_only():
+    patch = Patch({'a': 'b'})
+    assert repr(patch) == "Patch({'a': 'b'})"

--- a/tests/basic-structs/test_patch_fields.py
+++ b/tests/basic-structs/test_patch_fields.py
@@ -1,0 +1,196 @@
+from kopf._cogs.structs.patches import Patch
+
+# === spec ===
+
+
+def test_spec_set_creates_key():
+    patch = Patch()
+    patch.spec['replicas'] = 3
+    assert patch == {'spec': {'replicas': 3}}
+
+
+def test_spec_get_existing_key():
+    patch = Patch({'spec': {'replicas': 3}})
+    assert patch.spec['replicas'] == 3
+
+
+def test_spec_get_missing_key_with_default():
+    patch = Patch()
+    assert patch.spec.get('replicas', 42) == 42
+
+
+def test_spec_is_empty_initially():
+    patch = Patch()
+    assert dict(patch.spec) == {}
+    assert patch == {}
+
+
+def test_spec_set_multiple_keys():
+    patch = Patch()
+    patch.spec['replicas'] = 3
+    patch.spec['selector'] = {'app': 'test'}
+    assert patch == {'spec': {'replicas': 3, 'selector': {'app': 'test'}}}
+
+
+# === status ===
+
+
+def test_status_set_creates_key():
+    patch = Patch()
+    patch.status['ready'] = True
+    assert patch == {'status': {'ready': True}}
+
+
+def test_status_get_existing_key():
+    patch = Patch({'status': {'ready': True}})
+    assert patch.status['ready'] is True
+
+
+def test_status_get_missing_key_with_default():
+    patch = Patch()
+    assert patch.status.get('ready', False) is False
+
+
+def test_status_is_empty_initially():
+    patch = Patch()
+    assert dict(patch.status) == {}
+    assert patch == {}
+
+
+# === metadata ===
+
+
+def test_metadata_set_creates_key():
+    patch = Patch()
+    patch.metadata['name'] = 'obj'
+    assert patch == {'metadata': {'name': 'obj'}}
+
+
+def test_metadata_get_existing_key():
+    patch = Patch({'metadata': {'name': 'obj'}})
+    assert patch.metadata['name'] == 'obj'
+
+
+def test_metadata_get_missing_key_with_default():
+    patch = Patch()
+    assert patch.metadata.get('name', 'default') == 'default'
+
+
+def test_metadata_is_empty_initially():
+    patch = Patch()
+    assert dict(patch.metadata) == {}
+    assert patch == {}
+
+
+# === meta (alias for metadata) ===
+
+
+def test_meta_is_same_as_metadata():
+    patch = Patch()
+    assert patch.meta is patch.metadata
+
+
+def test_meta_set_reflects_in_patch():
+    patch = Patch()
+    patch.meta['name'] = 'obj'
+    assert patch == {'metadata': {'name': 'obj'}}
+
+
+# === labels ===
+
+
+def test_labels_set_creates_key():
+    patch = Patch()
+    patch.meta.labels['app'] = 'foo'
+    assert patch == {'metadata': {'labels': {'app': 'foo'}}}
+
+
+def test_labels_get_existing_key():
+    patch = Patch({'metadata': {'labels': {'app': 'foo'}}})
+    assert patch.meta.labels['app'] == 'foo'
+
+
+def test_labels_get_missing_key_with_default():
+    patch = Patch()
+    assert patch.meta.labels.get('app', 'default') == 'default'
+
+
+def test_labels_is_empty_initially():
+    patch = Patch()
+    assert dict(patch.meta.labels) == {}
+    assert patch == {}
+
+
+def test_labels_set_multiple():
+    patch = Patch()
+    patch.meta.labels['app'] = 'foo'
+    patch.meta.labels['env'] = 'prod'
+    assert patch == {'metadata': {'labels': {'app': 'foo', 'env': 'prod'}}}
+
+
+def test_labels_delete_via_none():
+    patch = Patch()
+    patch.meta.labels['app'] = None
+    assert patch == {'metadata': {'labels': {'app': None}}}
+
+
+# === annotations ===
+
+
+def test_annotations_set_creates_key():
+    patch = Patch()
+    patch.meta.annotations['key'] = 'value'
+    assert patch == {'metadata': {'annotations': {'key': 'value'}}}
+
+
+def test_annotations_get_existing_key():
+    patch = Patch({'metadata': {'annotations': {'key': 'value'}}})
+    assert patch.meta.annotations['key'] == 'value'
+
+
+def test_annotations_get_missing_key_with_default():
+    patch = Patch()
+    assert patch.meta.annotations.get('key', 'default') == 'default'
+
+
+def test_annotations_is_empty_initially():
+    patch = Patch()
+    assert dict(patch.meta.annotations) == {}
+    assert patch == {}
+
+
+def test_annotations_set_multiple():
+    patch = Patch()
+    patch.meta.annotations['a'] = '1'
+    patch.meta.annotations['b'] = '2'
+    assert patch == {'metadata': {'annotations': {'a': '1', 'b': '2'}}}
+
+
+# === cross-view consistency ===
+
+
+def test_spec_and_status_are_independent():
+    patch = Patch()
+    patch.spec['x'] = 1
+    patch.status['y'] = 2
+    assert patch == {'spec': {'x': 1}, 'status': {'y': 2}}
+
+
+def test_labels_and_annotations_coexist():
+    patch = Patch()
+    patch.meta.labels['app'] = 'foo'
+    patch.meta.annotations['note'] = 'bar'
+    assert patch == {'metadata': {'labels': {'app': 'foo'}, 'annotations': {'note': 'bar'}}}
+
+
+def test_all_views_coexist():
+    patch = Patch()
+    patch.meta['name'] = 'obj'
+    patch.meta.labels['app'] = 'foo'
+    patch.spec['replicas'] = 3
+    patch.status['ready'] = True
+    assert patch == {
+        'metadata': {'name': 'obj', 'labels': {'app': 'foo'}},
+        'spec': {'replicas': 3},
+        'status': {'ready': True},
+    }

--- a/tests/basic-structs/test_patch_fns.py
+++ b/tests/basic-structs/test_patch_fns.py
@@ -1,0 +1,71 @@
+import copy
+
+from kopf._cogs.structs.patches import Patch
+
+
+def test_patch_fns_empty_produces_no_ops():
+    patch = Patch()
+    body = {'metadata': {'resourceVersion': 'rv1'}, 'spec': {'x': 1}}
+    ops = patch.as_json_patch(body)
+    assert ops == []
+
+
+def test_patch_fns_noop_produces_no_ops():
+    patch = Patch(fns=[lambda body: None])
+    body = {'metadata': {'resourceVersion': 'rv1'}, 'spec': {'x': 1}}
+    ops = patch.as_json_patch(body)
+    assert ops == []
+
+
+def test_patch_fns_field_replacement():
+    def set_field(body):
+        body['spec']['x'] = 'new'
+
+    patch = Patch(fns=[set_field])
+    body = {'metadata': {'resourceVersion': 'rv1'}, 'spec': {'x': 'old'}}
+    ops = patch.as_json_patch(body)
+    assert ops == [{'op': 'replace', 'path': '/spec/x', 'value': 'new'}]
+
+
+def test_patch_fns_list_append():
+    def append_item(body):
+        body['metadata']['finalizers'].append('new-fin')
+
+    patch = Patch(fns=[append_item])
+    body = {'metadata': {'resourceVersion': 'rv1', 'finalizers': ['a', 'b']}}
+    ops = patch.as_json_patch(body)
+    assert ops == [{'op': 'add', 'path': '/metadata/finalizers/2', 'value': 'new-fin'}]
+
+
+def test_patch_fns_list_remove():
+    def remove_item(body):
+        body['metadata']['finalizers'].remove('b')
+
+    patch = Patch(fns=[remove_item])
+    body = {'metadata': {'resourceVersion': 'rv1', 'finalizers': ['a', 'b', 'c']}}
+    ops = patch.as_json_patch(body)
+    assert ops == [{'op': 'remove', 'path': '/metadata/finalizers/1'}]
+
+
+def test_patch_fns_multiple_patch_chained():
+    def add_field(body):
+        body['spec']['y'] = 2
+
+    def modify_field(body):
+        body['spec']['y'] = 3
+
+    patch = Patch(fns=[add_field, modify_field])
+    body = {'metadata': {'resourceVersion': 'rv1'}, 'spec': {'x': 1}}
+    ops = patch.as_json_patch(body)
+    assert ops == [{'op': 'add', 'path': '/spec/y', 'value': 3}]
+
+
+def test_patch_fns_does_not_mutate_original_body():
+    def set_field(body):
+        body['spec']['x'] = 'modified'
+
+    patch = Patch(fns=[set_field])
+    body = {'metadata': {'resourceVersion': 'rv1'}, 'spec': {'x': 'original'}}
+    body_before = copy.deepcopy(body)
+    patch.as_json_patch(body)
+    assert body == body_before

--- a/tests/basic-structs/test_patch_json.py
+++ b/tests/basic-structs/test_patch_json.py
@@ -5,8 +5,8 @@ def test_addition_of_the_key():
     body = {'abc': 456}
     patch = Patch(body=body)
     patch['xyz'] = 123
-    jsonpatch = patch.as_json_patch()
-    assert jsonpatch == [
+    ops = patch.as_json_patch()
+    assert ops == [
         {'op': 'add', 'path': '/xyz', 'value': 123},
     ]
 
@@ -15,8 +15,8 @@ def test_replacement_of_the_key():
     body = {'xyz': 456}
     patch = Patch(body=body)
     patch['xyz'] = 123
-    jsonpatch = patch.as_json_patch()
-    assert jsonpatch == [
+    ops = patch.as_json_patch()
+    assert ops == [
         {'op': 'replace', 'path': '/xyz', 'value': 123},
     ]
 
@@ -24,8 +24,8 @@ def test_replacement_of_the_key():
 def test_removal_of_the_key():
     patch = Patch()
     patch['xyz'] = None
-    jsonpatch = patch.as_json_patch()
-    assert jsonpatch == [
+    ops = patch.as_json_patch()
+    assert ops == [
         {'op': 'remove', 'path': '/xyz'},
     ]
 
@@ -34,8 +34,8 @@ def test_addition_of_the_subkey():
     body = {'xyz': {'def': 456}}
     patch = Patch(body=body)
     patch['xyz'] = {'abc': 123}
-    jsonpatch = patch.as_json_patch()
-    assert jsonpatch == [
+    ops = patch.as_json_patch()
+    assert ops == [
         {'op': 'add', 'path': '/xyz/abc', 'value': 123},
     ]
 
@@ -43,8 +43,8 @@ def test_replacement_of_the_subkey():
     body = {'xyz': {'abc': 456}}
     patch = Patch(body=body)
     patch['xyz'] = {'abc': 123}
-    jsonpatch = patch.as_json_patch()
-    assert jsonpatch == [
+    ops = patch.as_json_patch()
+    assert ops == [
         {'op': 'replace', 'path': '/xyz/abc', 'value': 123},
     ]
 
@@ -53,8 +53,8 @@ def test_addition_of_the_sub_subkey():
     body = {'xyz': {'uvw': 123}}
     patch = Patch(body=body)
     patch['xyz'] = {'abc': {'def': {'ghi': 456}}}
-    jsonpatch = patch.as_json_patch()
-    assert jsonpatch == [
+    ops = patch.as_json_patch()
+    assert ops == [
         {'op': 'add', 'path': '/xyz/abc', 'value': {'def': {'ghi': 456}}},
     ]
 
@@ -62,8 +62,8 @@ def test_addition_of_the_sub_subkey():
 def test_removal_of_the_subkey():
     patch = Patch()
     patch['xyz'] = {'abc': None}
-    jsonpatch = patch.as_json_patch()
-    assert jsonpatch == [
+    ops = patch.as_json_patch()
+    assert ops == [
         {'op': 'remove', 'path': '/xyz/abc'},
     ]
 
@@ -71,8 +71,8 @@ def test_removal_of_the_subkey():
 def test_escaping_of_key():
     patch = Patch()
     patch['~xyz/test'] = {'abc': None}
-    jsonpatch = patch.as_json_patch()
-    assert jsonpatch == [
+    ops = patch.as_json_patch()
+    assert ops == [
         {'op': 'remove', 'path': '/~0xyz~1test/abc'}
     ]
 
@@ -80,7 +80,7 @@ def test_escaping_of_key():
 def test_recursive_escape_of_key():
     patch = Patch()
     patch['x/y/~z'] = {'a/b/~0c': None}
-    jsonpatch = patch.as_json_patch()
-    assert jsonpatch == [
+    ops = patch.as_json_patch()
+    assert ops == [
         {'op': 'remove', 'path': '/x~1y~1~0z/a~1b~1~00c'},
     ]

--- a/tests/basic-structs/test_patch_json.py
+++ b/tests/basic-structs/test_patch_json.py
@@ -1,4 +1,64 @@
+import copy
+
+import pytest
+
 from kopf._cogs.structs.patches import Patch
+
+
+def test_error_when_no_body():
+    patch = Patch()
+    patch['xyz'] = 123
+    with pytest.raises(ValueError, match="Cannot build a JSON-patch without the original body"):
+        patch.as_json_patch()
+
+
+def test_no_error_when_no_body_is_needed():
+    patch = Patch()
+    ops = patch.as_json_patch()
+    assert ops == []
+
+
+def test_body_argument_overrides_original():
+    body1 = {'abc': 456}  # leads to ops=remove(abc) & op=add(xyz)
+    body2 = {'xyz': 789}  # leads to op=replace(xyz) only
+    patch = Patch(body=body1)
+    patch['abc'] = None
+    patch['xyz'] = 123
+    ops = patch.as_json_patch(body2)
+    assert ops == [
+        {'op': 'replace', 'path': '/xyz', 'value': 123},
+    ]
+
+
+def test_noop_empty_patch():
+    body = {'abc': 456}
+    patch = Patch(body=body)
+    ops = patch.as_json_patch()
+    assert ops == []
+
+
+def test_noop_merge_of_empty_dict():
+    body = {'xyz': {'abc': 456}}
+    patch = Patch(body=body)
+    patch['xyz'] = {}  # nothing to merge here
+    ops = patch.as_json_patch()
+    assert ops == []
+
+
+def test_noop_replacement_of_the_key():
+    body = {'xyz': 123}
+    patch = Patch(body=body)
+    patch['xyz'] = 123
+    ops = patch.as_json_patch()
+    assert ops == []
+
+
+def test_noop_removal_of_absent_key():
+    body = {'abc': 456}
+    patch = Patch(body=body)
+    patch['xyz'] = None
+    ops = patch.as_json_patch()
+    assert ops == []
 
 
 def test_addition_of_the_key():
@@ -22,7 +82,8 @@ def test_replacement_of_the_key():
 
 
 def test_removal_of_the_key():
-    patch = Patch()
+    body = {'xyz': 456}
+    patch = Patch(body=body)
     patch['xyz'] = None
     ops = patch.as_json_patch()
     assert ops == [
@@ -39,6 +100,7 @@ def test_addition_of_the_subkey():
         {'op': 'add', 'path': '/xyz/abc', 'value': 123},
     ]
 
+
 def test_replacement_of_the_subkey():
     body = {'xyz': {'abc': 456}}
     patch = Patch(body=body)
@@ -49,7 +111,17 @@ def test_replacement_of_the_subkey():
     ]
 
 
-def test_addition_of_the_sub_subkey():
+def test_addition_of_key_with_new_parent():
+    body = {}
+    patch = Patch(body=body)
+    patch['xyz'] = {'abc': 123}
+    ops = patch.as_json_patch()
+    assert ops == [
+        {'op': 'add', 'path': '/xyz', 'value': {'abc': 123}},
+    ]
+
+
+def test_addition_of_the_sub_subkey_with_existing_parent():
     body = {'xyz': {'uvw': 123}}
     patch = Patch(body=body)
     patch['xyz'] = {'abc': {'def': {'ghi': 456}}}
@@ -59,8 +131,9 @@ def test_addition_of_the_sub_subkey():
     ]
 
 
-def test_removal_of_the_subkey():
-    patch = Patch()
+def test_removal_of_the_subkey_and_remaining_parent():
+    body = {'xyz': {'abc': 456, 'other': '...'}}
+    patch = Patch(body=body)
     patch['xyz'] = {'abc': None}
     ops = patch.as_json_patch()
     assert ops == [
@@ -68,8 +141,56 @@ def test_removal_of_the_subkey():
     ]
 
 
+def test_removal_of_the_subkey_and_emptied_parent():
+    body = {'xyz': {'abc': 456}}
+    patch = Patch(body=body)
+    patch['xyz'] = {'abc': None}
+    ops = patch.as_json_patch()
+    assert ops == [
+        {'op': 'remove', 'path': '/xyz'},
+    ]
+
+
+def test_addition_of_list_value():
+    body = {'abc': 456}
+    patch = Patch(body=body)
+    patch['xyz'] = [1, 2, 3]
+    ops = patch.as_json_patch()
+    assert ops == [
+        {'op': 'add', 'path': '/xyz', 'value': [1, 2, 3]},
+    ]
+
+
+def test_replacement_of_list_value():
+    body = {'xyz': [1, 2, 3]}
+    patch = Patch(body=body)
+    patch['xyz'] = [4, 5]
+    ops = patch.as_json_patch()
+    # The jsonpatch library diffs lists element-by-element, not as a whole.
+    assert sorted(ops, key=lambda op: op['path']) == [
+        {'op': 'replace', 'path': '/xyz/0', 'value': 4},
+        {'op': 'replace', 'path': '/xyz/1', 'value': 5},
+        {'op': 'remove', 'path': '/xyz/2'},
+    ]
+
+
+def test_multiple_operations():
+    body = {'existing': 1, 'toremove': 2}
+    patch = Patch(body=body)
+    patch['existing'] = 99
+    patch['toremove'] = None
+    patch['newkey'] = 'hello'
+    ops = patch.as_json_patch()
+    assert sorted(ops, key=lambda op: op['path']) == [
+        {'op': 'replace', 'path': '/existing', 'value': 99},
+        {'op': 'add', 'path': '/newkey', 'value': 'hello'},
+        {'op': 'remove', 'path': '/toremove'},
+    ]
+
+
 def test_escaping_of_key():
-    patch = Patch()
+    body = {'~xyz/test': {'abc': '...', 'other': '...'}}
+    patch = Patch(body=body)
     patch['~xyz/test'] = {'abc': None}
     ops = patch.as_json_patch()
     assert ops == [
@@ -78,9 +199,19 @@ def test_escaping_of_key():
 
 
 def test_recursive_escape_of_key():
-    patch = Patch()
+    body = {'x/y/~z': {'a/b/~0c': '...', 'other': '...'}}
+    patch = Patch(body=body)
     patch['x/y/~z'] = {'a/b/~0c': None}
     ops = patch.as_json_patch()
     assert ops == [
         {'op': 'remove', 'path': '/x~1y~1~0z/a~1b~1~00c'},
     ]
+
+
+def test_does_not_mutate_original_body():
+    body = {'spec': {'x': 'original'}}
+    patch = Patch(body=body)
+    patch['spec'] = {'x': 'modified'}
+    body_before = copy.deepcopy(body)
+    patch.as_json_patch()
+    assert body == body_before

--- a/tests/handling/subhandling/test_subhandling.py
+++ b/tests/handling/subhandling/test_subhandling.py
@@ -69,7 +69,7 @@ async def test_1st_level(registry, settings, resource, cause_mock, event_type,
         "Handler 'fn/sub1b' succeeded",
         "Handler 'fn' succeeded",
         "Creation is processed",
-        "Patching with",
+        "Merge-patching",
     ])
 
 
@@ -157,5 +157,5 @@ async def test_2nd_level(registry, settings, resource, cause_mock, event_type,
         "Handler 'fn/sub1b' succeeded",
         "Handler 'fn' succeeded",
         "Creation is processed",
-        "Patching with",
+        "Merge-patching",
     ])

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -51,7 +51,7 @@ async def test_create(registry, settings, handlers, resource, cause_mock, event_
         "Handler 'create_fn' is invoked",
         "Handler 'create_fn' succeeded",
         "Creation is processed:",
-        "Patching with",
+        "Merge-patching",
     ])
 
 
@@ -91,7 +91,7 @@ async def test_update(registry, settings, handlers, resource, cause_mock, event_
         "Handler 'update_fn' is invoked",
         "Handler 'update_fn' succeeded",
         "Updating is processed:",
-        "Patching with",
+        "Merge-patching",
     ])
 
 
@@ -129,7 +129,7 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
         "Handler 'delete_fn' succeeded",
         "Deletion is processed:",
         "Removing the finalizer",
-        "Patching with",
+        "Merge-patching",
     ])
 
 

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -53,7 +53,7 @@ async def test_skipped_with_no_handlers(
 
     assert_logs([
         "(Creation|Updating|Resuming|Deletion) is in progress:",
-        "Patching with:",
+        "Merge-patching",
     ], prohibited=[
         "(Creation|Updating|Resuming|Deletion) is processed:",
     ])

--- a/tests/k8s/test_errors.py
+++ b/tests/k8s/test_errors.py
@@ -3,8 +3,9 @@ import pytest
 
 from kopf._cogs.clients.auth import APIContext, authenticated
 from kopf._cogs.clients.errors import APIClientError, APIConflictError, APIError, \
-                                      APIForbiddenError, APINotFoundError, APIServerError, \
-                                      APITooManyRequestsError, check_response
+                                      APIForbiddenError, APINotFoundError, \
+                                      APIServerError, APITooManyRequestsError, \
+                                      APIUnprocessableEntityError, check_response
 
 
 @authenticated
@@ -60,10 +61,12 @@ async def test_no_error_on_success(kmock, status):
     (403, APIForbiddenError),
     (404, APINotFoundError),
     (409, APIConflictError),
+    (422, APIUnprocessableEntityError),
     (429, APITooManyRequestsError),
     (400, APIClientError),
     (403, APIClientError),
     (404, APIClientError),
+    (422, APIClientError),
     (500, APIServerError),
     (503, APIServerError),
     (400, APIError),

--- a/tests/k8s/test_patching.py
+++ b/tests/k8s/test_patching.py
@@ -1,3 +1,39 @@
+"""
+We test these aspects:
+
+- If we skip the irrelevant patches: empty or not applicable (for status).
+- If the status patches are executed separately if it is a subresource.
+- If the patches are formed properly (ops-wise, content-changing).
+- If the patches contain the "test" op with the proper `resourceVersion`.
+  - Of the latest preceding patch, if any.
+  - Of the original body if no patches precede it.
+- If we react properly to the HTTP 422 failures of the "test" op.
+
+We have 0-4 patches:
+
+- merge-patch on the object
+- merge-patch on the status
+- json-patch on the object
+- json-patch on the status
+
+Each can be present or absent, depending on the setup:
+
+- is status a subresource: yes or no?
+- are fns present and change anything: yes or no?
+
+Instead of doing the full matrix, we focus only on the latest patch
+and the patch chronologically preceding it (for its resourceVersion),
+skipping the cases when 2+ patches precede it (affects nothing),
+and the cases when other patches follow it (tested in other functions).
+
+Those are "happy paths".
+
+Additionally, the JSON-patches can catch HTTP 422 and return
+different results (the remaining patches).
+
+Additionally, every of these patches can catch HTTP API errors
+(of which HTTP 404 is handled gracefully, while others escalate).
+"""
 import dataclasses
 
 import pytest
@@ -5,212 +41,539 @@ import pytest
 from kopf._cogs.clients.errors import APIError
 from kopf._cogs.clients.patching import patch_obj
 from kopf._cogs.structs.patches import Patch
+from kopf._cogs.structs.references import Resource
 
-OBJECT_RESPONSE = {'metadata': {'resourceVersion': 'xyz123', 'extra': '123'},
-                   'spec': {'x': 'y', 'extra': '123'},
-                   'status': {'extra': '123'}}
-STATUS_RESPONSE = {'metadata': {'resourceVersion': 'abc456', 'extra': '456'},
-                   'spec': {'x': 'y', 'extra': '456'},
-                   'status': {'extra': '456', 's': 't'}}
+# The key difference is the `resourceVersion` — we check that the proper one is used.
+# The empty status is present to ensure predictable json-patch diffs with one field only.
+OBJECT_MERGE_RESPONSE = {'metadata': {'resourceVersion': 'rv-object-merge'}, 'status': {}}
+STATUS_MERGE_RESPONSE = {'metadata': {'resourceVersion': 'rv-status-merge'}, 'status': {}}
+OBJECT_JSONP_RESPONSE = {'metadata': {'resourceVersion': 'rv-object-jsonp'}, 'status': {}}
+STATUS_JSONP_RESPONSE = {'metadata': {'resourceVersion': 'rv-status-jsonp'}, 'status': {}}
 
 
-async def test_without_subresources(kmock, settings, resource, namespace, logger, assert_logs):
-    kmock.objects[resource, namespace, 'name1'] = {}
-    patch = Patch({'x': 'y'})
-    await patch_obj(
-        logger=logger,
-        settings=settings,
-        resource=resource,
-        namespace=namespace,
-        name='name1',
-        patch=patch,
+@pytest.fixture()
+def resource():
+    # We do not care about namespaced/cluster-wide here, only on the subresource presence.
+    return Resource('kopf.dev', 'v1', 'kopfexamples', subresources=frozenset({'status'}))
+
+
+@pytest.fixture(autouse=True)
+def _endpoints(kmock, resource, namespace):
+
+    def set_body(body):
+        kmock.objects[resource, namespace, 'name1'] = dict(body)
+        return body
+
+    set_body({})  # suppress 404s in the emulator
+
+    # Every time the request is made, also update the stored body to the request's response,
+    # so that json-patches could be applied properly on the next requests, in particular:
+    # - the validity of he "test" operations on "/metadata/resourceVersion";
+    # - the existence of the metadata/spec/status stanzas for proper "add/replace" ops.
+    common = kmock['patch', resource, kmock.namespace(namespace), kmock.name('name1')]
+    common[{'Content-Type': 'application/merge-patch+json'}, kmock.subresource(None)] << (lambda: set_body(OBJECT_MERGE_RESPONSE))
+    common[{'Content-Type': 'application/merge-patch+json'}, kmock.subresource('status')] << (lambda: set_body(STATUS_MERGE_RESPONSE))
+    common[{'Content-Type': 'application/json-patch+json'}, kmock.subresource(None)] << (lambda: set_body(OBJECT_JSONP_RESPONSE))
+    common[{'Content-Type': 'application/json-patch+json'}, kmock.subresource('status')] << (lambda: set_body(STATUS_JSONP_RESPONSE))
+
+
+def _noop(body):
+    pass
+
+
+def _add_finalizer(body):
+    body.setdefault('metadata', {}).setdefault('finalizers', []).append('fin')
+
+
+def _add_status_field(body):
+    body.setdefault('status', {})['count'] = 1
+
+
+#
+# Test sequencing of patches and proper use of `resourceVersion` on each step.
+# Limit to max 2 patches per operation — there is no extra logic in 3+ patches.
+#
+async def test_empty_or_noop_patch_makes_no_api_calls(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    patch = Patch({}, body=original_body, fns=[_noop])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
     )
 
-    assert len(kmock) == 1
-    assert kmock[0].data == {'x': 'y'}
-    assert kmock.objects[resource, namespace, 'name1'] == {'x': 'y'}
+    assert result is None
+    assert remaining is None
+    assert len(kmock) == 0
 
+    assert_logs([
+    ], prohibited=[
+        "Merge-patching the resource with",
+        "Merge-patching the status with",
+        "JSON-patching the resource with",
+        "JSON-patching the status with",
+    ])
+
+
+async def test_object_merge_alone(caplog,
+        kmock, settings, resource, namespace, logger, assert_logs):
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch({'spec': {'x': 'y'}}, body=original_body, fns=[])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
+    assert result == OBJECT_MERGE_RESPONSE
+    assert remaining is None
+    assert len(kmock) == 1
+    assert kmock[0].subresource is None
+    assert kmock[0].data == {'spec': {'x': 'y'}}
     assert_logs([
         "Merge-patching the resource with",
     ], prohibited=[
         "Merge-patching the status with",
+        "JSON-patching the resource with",
+        "JSON-patching the status with",
     ])
 
 
-async def test_status_as_subresource_with_combined_payload(
+async def test_status_merge_alone(
         kmock, settings, resource, namespace, logger, assert_logs):
-    kmock.objects[resource, namespace, 'name1'] = {
-        'metadata': {'extra': '123'},
-        'spec': {'extra': '456'},
-        'status': {'extra': '789'},
-    }
-    resource = dataclasses.replace(resource, subresources=['status'])
-    patch = Patch({'spec': {'x': 'y'}, 'status': {'s': 't'}})
-    reconstructed = await patch_obj(
-        logger=logger,
-        settings=settings,
-        resource=resource,
-        namespace=namespace,
-        name='name1',
-        patch=patch,
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch({'status': {'x': 'y'}}, body=original_body, fns=[])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
     )
+    assert result == STATUS_MERGE_RESPONSE
+    assert remaining is None
+    assert len(kmock) == 1
+    assert kmock[0].subresource == 'status'
+    assert kmock[0].data == {'status': {'x': 'y'}}
+    assert_logs([
+        "Merge-patching the status with",
+    ], prohibited=[
+        "Merge-patching the resource with",
+        "JSON-patching the resource with",
+        "JSON-patching the status with",
+    ])
 
+
+async def test_status_merge_after_object_merge(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=original_body, fns=[])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
+    assert result == STATUS_MERGE_RESPONSE
+    assert remaining is None
+    assert len(kmock) == 2
+    assert kmock[0].subresource is None
+    assert kmock[1].subresource == 'status'
+    assert kmock[0].data == {'spec': {'x': 'y'}}  # status absent
+    assert kmock[1].data == {'status': {'x': 'y'}}  # spec absent
+    assert_logs([
+        "Merge-patching the resource with",
+        "Merge-patching the status with",
+    ], prohibited=[
+        "JSON-patching the resource with",
+        "JSON-patching the status with",
+    ])
+
+
+async def test_object_jsonp_alone(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch({}, body=original_body, fns=[_add_finalizer])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
+    assert result == OBJECT_JSONP_RESPONSE
+    assert remaining is None
+    assert len(kmock) == 1
+    assert kmock[0].subresource is None
+    assert kmock[0].data == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': 'rv0'},
+        {'op': 'add', 'path': '/metadata/finalizers', 'value': ['fin']},
+    ]
+    assert_logs([
+        "JSON-patching the resource with",
+    ], prohibited=[
+        "Merge-patching the resource with",
+        "Merge-patching the status with",
+        "JSON-patching the status with",
+    ])
+
+
+async def test_object_jsonp_after_object_merge(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch({'spec': {'x': 'y'}}, body=original_body, fns=[_add_finalizer])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
+    assert result == OBJECT_JSONP_RESPONSE
+    assert remaining is None
+    assert len(kmock) == 2
+    assert kmock[0].subresource is None
+    assert kmock[1].subresource is None
+    assert kmock[0].data == {'spec': {'x': 'y'}}
+    assert kmock[1].data == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': 'rv-object-merge'},
+        {'op': 'add', 'path': '/metadata/finalizers', 'value': ['fin']},
+    ]
+    assert_logs([
+        "Merge-patching the resource with",
+        "JSON-patching the resource with",
+    ], prohibited=[
+        "Merge-patching the status with",
+        "JSON-patching the status with",
+    ])
+
+
+async def test_object_jsonp_after_status_merge(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch({'status': {'x': 'y'}}, body=original_body, fns=[_add_finalizer])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
+    assert result == OBJECT_JSONP_RESPONSE
+    assert remaining is None
+    assert len(kmock) == 2
+    assert kmock[0].subresource == 'status'
+    assert kmock[1].subresource is None
+    assert kmock[0].data == {'status': {'x': 'y'}}
+    assert kmock[1].data == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': 'rv-status-merge'},
+        {'op': 'add', 'path': '/metadata/finalizers', 'value': ['fin']},
+    ]
+    assert_logs([
+        "Merge-patching the status with",
+        "JSON-patching the resource with",
+    ], prohibited=[
+        "Merge-patching the resource with",
+        "JSON-patching the status with",
+    ])
+
+
+async def test_status_jsonp_alone(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch({}, body=original_body, fns=[_add_status_field])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
+    assert result == STATUS_JSONP_RESPONSE
+    assert remaining is None
+    assert len(kmock) == 1
+    assert kmock[0].subresource == 'status'
+    assert kmock[0].data == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': 'rv0'},
+        {'op': 'add', 'path': '/status/count', 'value': 1},
+    ]
+    assert_logs([
+        "JSON-patching the status with",
+    ], prohibited=[
+        "Merge-patching the resource with",
+        "Merge-patching the status with",
+        "JSON-patching the resource with",
+    ])
+
+
+async def test_status_jsonp_after_object_merge(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch({'spec': {'x': 'y'}}, body=original_body, fns=[_add_status_field])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
+    assert result == STATUS_JSONP_RESPONSE
+    assert remaining is None
     assert len(kmock) == 2
     assert kmock[0].subresource is None
     assert kmock[1].subresource == 'status'
     assert kmock[0].data == {'spec': {'x': 'y'}}
-    assert kmock[1].data == {'status': {'s': 't'}}
-    assert reconstructed == {'metadata': {'extra': '123'},
-                             'spec': {'x': 'y', 'extra': '456'},
-                             'status': {'s': 't', 'extra': '789'}}
-    assert kmock.objects[resource, namespace, 'name1'] == reconstructed
-
+    assert kmock[1].data == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': 'rv-object-merge'},
+        {'op': 'add', 'path': '/status/count', 'value': 1},
+    ]
     assert_logs([
         "Merge-patching the resource with",
-        "Merge-patching the status with",
-    ])
-
-
-async def test_status_as_subresource_with_object_fields_only(
-        kmock, settings, resource, namespace, logger, assert_logs):
-    kmock.objects[resource, namespace, 'name1'] = {
-        'metadata': {'extra': '123'},
-        'spec': {'extra': '456'},
-        'status': {'extra': '789'}
-    }
-
-    resource = dataclasses.replace(resource, subresources=['status'])
-    patch = Patch({'spec': {'x': 'y'}})
-    reconstructed = await patch_obj(
-        logger=logger,
-        settings=settings,
-        resource=resource,
-        namespace=namespace,
-        name='name1',
-        patch=patch,
-    )
-
-    assert len(kmock) == 1
-    assert kmock[0].subresource is None
-    assert kmock[0].data == {'spec': {'x': 'y'}}
-    assert reconstructed == {'metadata': {'extra': '123'},
-                             'spec': {'x': 'y', 'extra': '456'},
-                             'status': {'extra': '789'}}
-    assert kmock.objects[resource, namespace, 'name1'] == reconstructed
-
-    assert_logs([
-        "Merge-patching the resource with",
+        "JSON-patching the status with",
     ], prohibited=[
         "Merge-patching the status with",
+        "JSON-patching the resource with",
     ])
 
 
-async def test_status_as_subresource_with_status_fields_only(
+async def test_status_jsonp_after_status_merge(
         kmock, settings, resource, namespace, logger, assert_logs):
-    kmock.objects[resource, namespace, 'name1'] = {
-        'metadata': {'extra': '123'},
-        'spec': {'extra': '456'},
-        'status': {'extra': '789'},
-    }
-
-    resource = dataclasses.replace(resource, subresources=['status'])
-    patch = Patch({'status': {'s': 't'}})
-    reconstructed = await patch_obj(
-        logger=logger,
-        settings=settings,
-        resource=resource,
-        namespace=namespace,
-        name='name1',
-        patch=patch,
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch({'status': {'x': 'y'}}, body=original_body, fns=[_add_status_field])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
     )
-
-    assert len(kmock) == 1
+    assert result == STATUS_JSONP_RESPONSE
+    assert remaining is None
+    assert len(kmock) == 2
     assert kmock[0].subresource == 'status'
-    assert kmock[0].data == {'status': {'s': 't'}}
-    assert reconstructed == {'metadata': {'extra': '123'},
-                             'spec': {'extra': '456'},
-                             'status': {'s': 't', 'extra': '789'}}
-    assert kmock.objects[resource, namespace, 'name1'] == reconstructed
-
+    assert kmock[1].subresource == 'status'
+    assert kmock[0].data == {'status': {'x': 'y'}}
+    assert kmock[1].data == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': 'rv-status-merge'},
+        {'op': 'add', 'path': '/status/count', 'value': 1},
+    ]
     assert_logs([
         "Merge-patching the status with",
+        "JSON-patching the status with",
     ], prohibited=[
         "Merge-patching the resource with",
+        "JSON-patching the resource with",
     ])
 
 
-async def test_status_as_body_field_with_combined_payload(
+async def test_status_jsonp_after_object_jsonp(
         kmock, settings, resource, namespace, logger, assert_logs):
-    kmock.objects[resource, namespace, 'name1'] = {
-        'metadata': {'extra': '123'},
-        'spec': {'extra': '456'},
-        'status': {'extra': '789'},
-    }
-
-    patch = Patch({'spec': {'x': 'y'}, 'status': {'s': 't'}})
-    reconstructed = await patch_obj(
-        logger=logger,
-        settings=settings,
-        resource=resource,
-        namespace=namespace,
-        name='name1',
-        patch=patch,
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch(body=original_body, fns=[_add_finalizer, _add_status_field])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
     )
+    assert result == STATUS_JSONP_RESPONSE
+    assert remaining is None
+    assert len(kmock) == 2
+    assert kmock[0].subresource is None
+    assert kmock[1].subresource == 'status'
+    assert kmock[0].data == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': 'rv0'},
+        {'op': 'add', 'path': '/metadata/finalizers', 'value': ['fin']},
+    ]
+    assert kmock[1].data == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': 'rv-object-jsonp'},
+        {'op': 'add', 'path': '/status/count', 'value': 1},
+    ]
+    assert_logs([
+        "JSON-patching the resource with",
+        "JSON-patching the status with",
+    ], prohibited=[
+        "Merge-patching the resource with",
+        "Merge-patching the status with",
+    ])
 
+
+# Not of direct interest (already tested implicitly), but worth checking the worst case: 4x patches.
+async def test_all_four_patches(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=original_body, fns=[_add_finalizer, _add_status_field])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
+    assert result == STATUS_JSONP_RESPONSE
+    assert remaining is None
+    assert len(kmock) == 4
+    assert kmock[0].subresource is None  # merge-patch
+    assert kmock[1].subresource == 'status'  # merge-patch
+    assert kmock[2].subresource is None  # json-patch
+    assert kmock[3].subresource == 'status'  # json-patch
+    assert kmock[0].data == {'spec': {'x': 'y'}}
+    assert kmock[1].data == {'status': {'x': 'y'}}
+    assert kmock[2].data == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': 'rv-status-merge'},
+        {'op': 'add', 'path': '/metadata/finalizers', 'value': ['fin']},
+    ]
+    assert kmock[3].data == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': 'rv-object-jsonp'},
+        {'op': 'add', 'path': '/status/count', 'value': 1},
+    ]
+    assert_logs([
+        "Merge-patching the resource with",
+        "Merge-patching the status with",
+        "JSON-patching the resource with",
+        "JSON-patching the status with",
+    ])
+
+
+#
+# Test status as a direct field (not a subresource): must not make extra API patches.
+#
+async def test_no_subresource_skips_status_merge(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    resource = dataclasses.replace(resource, subresources=frozenset())
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=original_body)
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
+    assert result == OBJECT_MERGE_RESPONSE
+    assert remaining is None
     assert len(kmock) == 1
     assert kmock[0].subresource is None
-    assert kmock[0].data == {'spec': {'x': 'y'}, 'status': {'s': 't'}}
-    assert reconstructed == {'metadata': {'extra': '123'},
-                             'spec': {'x': 'y', 'extra': '456'},
-                             'status': {'s': 't', 'extra': '789'}}
-    assert kmock.objects[resource, namespace, 'name1'] == reconstructed
-
+    assert kmock[0].data == {'spec': {'x': 'y'}, 'status': {'x': 'y'}}  # mixed!
     assert_logs([
         "Merge-patching the resource with",
     ], prohibited=[
         "Merge-patching the status with",
+        "JSON-patching the resource with",
+        "JSON-patching the status with",
     ])
 
 
-@pytest.mark.parametrize('status', [404])
-async def test_ignores_absent_objects(
-        kmock, settings, status, resource, namespace, logger, assert_logs,
-        cluster_resource, namespaced_resource):
-    kmock['patch', resource, kmock.name('name1')] << status
-
-    patch = {'x': 'y'}
-    result = await patch_obj(
-        logger=logger,
-        settings=settings,
-        resource=resource,
-        namespace=namespace,
-        name='name1',
-        patch=patch,
+async def test_no_subresource_skips_status_jsonp(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    resource = dataclasses.replace(resource, subresources=frozenset())
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    kmock.objects[resource, namespace, 'name1'] = original_body
+    patch = Patch(body=original_body, fns=[_add_finalizer, _add_status_field])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
     )
+    assert result == OBJECT_JSONP_RESPONSE
+    assert remaining is None
+    assert len(kmock) == 1
+    assert kmock[0].subresource is None
+    assert kmock[0].data[:1] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': 'rv0'},
+    ]
+    # The order of ops does not matter. What matters is the mix of status and metadata.
+    paths = {op['path'] for op in kmock[0].data[1:]}
+    assert paths == {'/metadata/finalizers', '/status/count'}  # mixed!
+    assert_logs([
+        "JSON-patching the resource with",
+    ], prohibited=[
+        "Merge-patching the resource with",
+        "Merge-patching the status with",
+        "JSON-patching the status with",
+    ])
 
+
+#
+# Test the remaining patches on HTTP 422 from JSON-patches.
+#
+async def test_422_in_object_jsonp_returns_the_remaining_patch(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    kmock[kmock.subresource(None), {'Content-Type': 'application/json-patch+json'}] ** 1 << 422
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=original_body, fns=[_add_finalizer, _add_status_field])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
+    assert result == STATUS_MERGE_RESPONSE  # we only need to see that it is not None
+    assert remaining is not None
+    assert remaining._original is None  # do not carry the body through cycles
+    assert list(remaining.fns) == [_add_finalizer, _add_status_field]
+    assert dict(remaining) == {}
+    assert len(kmock) == 3
+    assert kmock[0].subresource is None  # merge-patch
+    assert kmock[1].subresource == 'status'  # merge-patch
+    assert kmock[2].subresource is None  # json-patch
+    assert_logs([
+        "Merge-patching the resource with",
+        "Merge-patching the status with",
+        "JSON-patching the resource with",
+        "Could not apply the patch in full",
+    ], prohibited=[
+        "JSON-patching the status with",
+    ])
+
+
+async def test_422_in_status_jsonp_returns_the_remaining_patch(
+        kmock, settings, resource, namespace, logger, assert_logs):
+    kmock[kmock.subresource('status'), {'Content-Type': 'application/json-patch+json'}] ** 1 << 422
+    original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=original_body, fns=[_add_finalizer, _add_status_field])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
+    assert result == OBJECT_JSONP_RESPONSE  # we only need to see that it is not None
+    assert remaining is not None
+    assert remaining._original is None  # do not carry the body through cycles
+    assert list(remaining.fns) == [_add_finalizer, _add_status_field]
+    assert dict(remaining) == {}
+    assert len(kmock) == 4
+    assert kmock[0].subresource is None  # merge-patch
+    assert kmock[1].subresource == 'status'  # merge-patch
+    assert kmock[2].subresource is None  # json-patch
+    assert kmock[3].subresource == 'status'  # json-patch
+    assert_logs([
+        "Merge-patching the resource with",
+        "Merge-patching the status with",
+        "JSON-patching the resource with",
+        "JSON-patching the status with",
+        "Could not apply the patch in full",
+    ])
+
+
+#
+# Test API errors in every individual patch.
+#
+@pytest.mark.parametrize('exp_api_count, content_type, subresource', [
+    pytest.param(1, 'application/merge-patch+json', None),
+    pytest.param(2, 'application/merge-patch+json', 'status'),
+    pytest.param(3, 'application/json-patch+json', None),
+    pytest.param(4, 'application/json-patch+json', 'status'),
+])
+async def test_404_ignores_absent_objects(
+        kmock, settings, resource, namespace, logger, content_type, subresource,
+        cluster_resource, namespaced_resource, assert_logs, exp_api_count):
+    kmock[kmock.subresource(subresource), {'Content-Type': content_type}] ** 1 << 404
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body={}, fns=[_add_finalizer, _add_status_field])
+    result, remaining = await patch_obj(
+        logger=logger, settings=settings, resource=resource,
+        namespace=namespace, name='name1', patch=patch,
+    )
     assert result is None
-
+    assert remaining is None
+    assert len(kmock) == exp_api_count
     assert_logs([
         "Patching was skipped: the object does not exist anymore",
     ])
 
 
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.
+@pytest.mark.parametrize('exp_api_count, content_type, subresource', [
+    pytest.param(1, 'application/merge-patch+json', None),
+    pytest.param(2, 'application/merge-patch+json', 'status'),
+    pytest.param(3, 'application/json-patch+json', None),
+    pytest.param(4, 'application/json-patch+json', 'status'),
+])
 @pytest.mark.parametrize('status', [400, 403, 500, 666])
-async def test_raises_api_errors(
-        kmock, settings, status, resource, namespace, logger,
-        cluster_resource, namespaced_resource):
-    kmock.objects[resource, namespace, 'name1'] = {}  # suppress 404s
-    kmock['patch', resource, kmock.name('name1')] << status
-
-    patch = {'x': 'y'}
+async def test_api_errors_raised(
+        kmock, settings, status, resource, namespace, logger, content_type, subresource,
+        cluster_resource, namespaced_resource, exp_api_count):
+    kmock[kmock.subresource(subresource), {'Content-Type': content_type}] ** 1 << status
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body={}, fns=[_add_finalizer, _add_status_field])
     with pytest.raises(APIError) as e:
         await patch_obj(
-            logger=logger,
-            settings=settings,
-            resource=resource,
-            namespace=namespace,
-            name='name1',
-            patch=patch,
+            logger=logger, settings=settings, resource=resource,
+            namespace=namespace, name='name1', patch=patch,
         )
+    assert len(kmock) == exp_api_count
     assert e.value.status == status

--- a/tests/reactor/test_patching_inconsistencies.py
+++ b/tests/reactor/test_patching_inconsistencies.py
@@ -54,9 +54,9 @@ async def test_patching_without_inconsistencies(
     )
 
     assert_logs([
-        "Patching with:",
+        "Merge-patching",
     ], prohibited=[
-        "Patching failed with inconsistencies:",
+        "inconsistencies",
     ])
 
 
@@ -112,8 +112,8 @@ async def test_patching_with_inconsistencies(
     )
 
     assert_logs([
-        "Patching with:",
-        "Patching failed with inconsistencies:",
+        "Merge-patching",
+        "Merge-patching finished with inconsistencies:",
     ])
 
 
@@ -133,7 +133,7 @@ async def test_patching_with_disappearance(
     )
 
     assert_logs([
-        "Patching with:",
+        "Merge-patching",
         "Patching was skipped: the object does not exist anymore",
     ], prohibited=[
         "inconsistencies"


### PR DESCRIPTION
Add an ability for arbitrary transformations of the resource via the `patch.fns` functions, which accept the raw resource body (mutable dict) and modify it in place.

In the end, the json diff of the original and modified body is calculated and applied via the API as a JSON-patch operation (not a merge-patch as usual). The change is supposedly atomic, so the `resourceVersion` is checked on each such JSON-patch, to ensure that it patches against the same body that it was calculated against.

This is a preparational step for the "atomic finalizers" PR in the first place — but extracted as a documented user-exposed functionality (because why not).

* #1252
* Docs: https://docs.kopf.dev/en/latest/patches/

Eventually, all Kopf's internal operations can be migrated to JSON-patches (mainly, the diffbase/progress storages in annotations & statuses) — to keep it consistent and to minimize the number of patches "out of the box" — but the dict-patches (aka merge-patches) will be supported indefinitely.

Example:

```python
import kopf

def add_finalizer(body: kopf.RawBody) -> None:
    finalizers = body.setdefault('metadata', {}).setdefault('finalizers', [])
    if 'my-operator/cleanup' not in finalizers:
        finalizers.append('my-operator/cleanup')

@kopf.on.create('kopfexamples')
def create_fn(patch, **_):
    patch.fns.append(add_finalizer)
```


**BLOCKED by:**

* #1211 — it is easier to express tests with KMock's notation.