### PR TITLE
Use Protocol for function typing

### DIFF
--- a/kopf/_core/intents/callbacks.py
+++ b/kopf/_core/intents/callbacks.py
@@ -27,7 +27,6 @@ class ActivityFn(Protocol):
         self,
         *,
         settings: configuration.OperatorSettings,
-        index: ephemera.Index[Any, Any],
         retry: int,
         started: datetime.datetime,
         runtime: datetime.timedelta,
@@ -165,7 +164,6 @@ class TimerFn(Protocol):
     def __call__(
         self,
         *,
-        index: ephemera.Index[Any, Any],
         annotations: bodies.Annotations,
         labels: bodies.Labels,
         body: bodies.Body,


### PR DESCRIPTION
Use [Python protocol](https://typing.python.org/en/latest/spec/protocol.html) rather than the [deprecated mypy extension](https://mypy.readthedocs.io/en/stable/additional_features.html#extended-callable-types).

This change makes it more compatible to users of other type checkers such as [ty](https://github.com/astral-sh/ty).