### PR TITLE
Refactor test mocks to use named args/kwargs instead of indexed ones

### DIFF
--- a/tests/admission/test_admission_manager.py
+++ b/tests/admission/test_admission_manager.py
@@ -56,8 +56,8 @@ async def test_creation_is_attempted(
     )
 
     assert k8s_mocked.post.call_count == 1
-    assert k8s_mocked.post.call_args_list[0][1]['url'].startswith('/apis/admissionregistration.k8s.io/')
-    assert k8s_mocked.post.call_args_list[0][1]['payload']['metadata']['name'] == 'xyz'
+    assert k8s_mocked.post.call_args_list[0].kwargs['url'].startswith('/apis/admissionregistration.k8s.io/')
+    assert k8s_mocked.post.call_args_list[0].kwargs['payload']['metadata']['name'] == 'xyz'
 
 
 @pytest.mark.parametrize('reason', set(WebhookType))
@@ -80,8 +80,8 @@ async def test_creation_ignores_if_exists_already(
     )
 
     assert k8s_mocked.post.call_count == 1
-    assert k8s_mocked.post.call_args_list[0][1]['url'].startswith('/apis/admissionregistration.k8s.io/')
-    assert k8s_mocked.post.call_args_list[0][1]['payload']['metadata']['name'] == 'xyz'
+    assert k8s_mocked.post.call_args_list[0].kwargs['url'].startswith('/apis/admissionregistration.k8s.io/')
+    assert k8s_mocked.post.call_args_list[0].kwargs['payload']['metadata']['name'] == 'xyz'
 
 
 @pytest.mark.parametrize('error', {APIError, APIForbiddenError, APIUnauthorizedError})
@@ -106,8 +106,8 @@ async def test_creation_escalates_on_errors(
         )
 
     assert k8s_mocked.post.call_count == 1
-    assert k8s_mocked.post.call_args_list[0][1]['url'].startswith('/apis/admissionregistration.k8s.io/')
-    assert k8s_mocked.post.call_args_list[0][1]['payload']['metadata']['name'] == 'xyz'
+    assert k8s_mocked.post.call_args_list[0].kwargs['url'].startswith('/apis/admissionregistration.k8s.io/')
+    assert k8s_mocked.post.call_args_list[0].kwargs['payload']['metadata']['name'] == 'xyz'
 
 
 @pytest.mark.parametrize('reason', set(WebhookType))
@@ -138,20 +138,20 @@ async def test_patching_on_changes(
     )
 
     assert k8s_mocked.patch.call_count == 3
-    assert k8s_mocked.patch.call_args_list[0][1]['url'].startswith('/apis/admissionregistration.k8s.io/')
-    assert k8s_mocked.patch.call_args_list[0][1]['url'].endswith('/xyz')
-    assert k8s_mocked.patch.call_args_list[1][1]['url'].startswith('/apis/admissionregistration.k8s.io/')
-    assert k8s_mocked.patch.call_args_list[1][1]['url'].endswith('/xyz')
-    assert k8s_mocked.patch.call_args_list[2][1]['url'].startswith('/apis/admissionregistration.k8s.io/')
-    assert k8s_mocked.patch.call_args_list[2][1]['url'].endswith('/xyz')
+    assert k8s_mocked.patch.call_args_list[0].kwargs['url'].startswith('/apis/admissionregistration.k8s.io/')
+    assert k8s_mocked.patch.call_args_list[0].kwargs['url'].endswith('/xyz')
+    assert k8s_mocked.patch.call_args_list[1].kwargs['url'].startswith('/apis/admissionregistration.k8s.io/')
+    assert k8s_mocked.patch.call_args_list[1].kwargs['url'].endswith('/xyz')
+    assert k8s_mocked.patch.call_args_list[2].kwargs['url'].startswith('/apis/admissionregistration.k8s.io/')
+    assert k8s_mocked.patch.call_args_list[2].kwargs['url'].endswith('/xyz')
 
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert patch['webhooks']
     assert patch['webhooks'][0]['clientConfig']['url'].startswith('https://hostname1/')
     assert patch['webhooks'][0]['rules']
     assert patch['webhooks'][0]['rules'][0]['resources'] == ['kopfexamples']
 
-    patch = k8s_mocked.patch.call_args_list[1][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[1].kwargs['payload']
     assert patch['webhooks']
     assert patch['webhooks'][0]['clientConfig']['url'].startswith('https://hostname2/')
     assert patch['webhooks'][0]['rules']
@@ -185,7 +185,7 @@ async def test_patching_purges_non_permanent_webhooks(
     )
 
     assert k8s_mocked.patch.call_count == 2
-    patch = k8s_mocked.patch.call_args_list[-1][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[-1].kwargs['payload']
     assert not patch['webhooks']
 
 
@@ -216,7 +216,7 @@ async def test_patching_leaves_permanent_webhooks(
     )
 
     assert k8s_mocked.patch.call_count == 2
-    patch = k8s_mocked.patch.call_args_list[-1][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[-1].kwargs['payload']
     assert patch['webhooks'][0]['clientConfig']['url'].startswith('https://hostname/')
     assert patch['webhooks'][0]['rules']
     assert patch['webhooks'][0]['rules'][0]['resources'] == ['kopfexamples']

--- a/tests/admission/test_serving_kwargs_passthrough.py
+++ b/tests/admission/test_serving_kwargs_passthrough.py
@@ -22,7 +22,7 @@ async def test_dryrun_passed(
         memories=memories, memobase=object(), indices=indices,
     )
     assert mock.call_count == 1
-    assert mock.call_args[1]['dryrun'] == dryrun
+    assert mock.call_args.kwargs['dryrun'] == dryrun
 
 
 async def test_headers_passed(
@@ -40,7 +40,7 @@ async def test_headers_passed(
         memories=memories, memobase=object(), indices=indices,
     )
     assert mock.call_count == 1
-    assert mock.call_args[1]['headers'] == headers
+    assert mock.call_args.kwargs['headers'] == headers
 
 
 async def test_headers_not_passed_but_injected(
@@ -57,7 +57,7 @@ async def test_headers_not_passed_but_injected(
         memories=memories, memobase=object(), indices=indices,
     )
     assert mock.call_count == 1
-    assert mock.call_args[1]['headers'] == {}
+    assert mock.call_args.kwargs['headers'] == {}
 
 
 async def test_sslpeer_passed(
@@ -75,7 +75,7 @@ async def test_sslpeer_passed(
         memories=memories, memobase=object(), indices=indices,
     )
     assert mock.call_count == 1
-    assert mock.call_args[1]['sslpeer'] == sslpeer
+    assert mock.call_args.kwargs['sslpeer'] == sslpeer
 
 
 async def test_sslpeer_not_passed_but_injected(
@@ -92,7 +92,7 @@ async def test_sslpeer_not_passed_but_injected(
         memories=memories, memobase=object(), indices=indices,
     )
     assert mock.call_count == 1
-    assert mock.call_args[1]['sslpeer'] == {}
+    assert mock.call_args.kwargs['sslpeer'] == {}
 
 
 async def test_userinfo_passed(
@@ -111,7 +111,7 @@ async def test_userinfo_passed(
         memories=memories, memobase=object(), indices=indices,
     )
     assert mock.call_count == 1
-    assert mock.call_args[1]['userinfo'] == userinfo
+    assert mock.call_args.kwargs['userinfo'] == userinfo
 
 
 async def test_subresource_passed(
@@ -129,4 +129,4 @@ async def test_subresource_passed(
         memories=memories, memobase=object(), indices=indices,
     )
     assert mock.call_count == 1
-    assert mock.call_args[1]['subresource'] == 'xyz'
+    assert mock.call_args.kwargs['subresource'] == 'xyz'

--- a/tests/admission/test_webhook_ngrok.py
+++ b/tests/admission/test_webhook_ngrok.py
@@ -30,10 +30,10 @@ async def test_ngrok_tunnel(
     assert pyngrok_mock.conf.get_default.return_value.ngrok_path == '/bin/ngrok'
     assert pyngrok_mock.conf.get_default.return_value.region == 'xx'
     assert pyngrok_mock.ngrok.set_auth_token.called
-    assert pyngrok_mock.ngrok.set_auth_token.call_args_list[0][0][0] == 'xyz'
+    assert pyngrok_mock.ngrok.set_auth_token.call_args_list[0].args[0] == 'xyz'
     assert pyngrok_mock.ngrok.connect.called
-    assert pyngrok_mock.ngrok.connect.call_args_list[0][0][0] == '54321'
-    assert pyngrok_mock.ngrok.connect.call_args_list[0][1]['bind_tls'] == True
+    assert pyngrok_mock.ngrok.connect.call_args_list[0].args[0] == '54321'
+    assert pyngrok_mock.ngrok.connect.call_args_list[0].kwargs['bind_tls'] == True
     assert pyngrok_mock.ngrok.disconnect.called
 
     await asyncio.get_running_loop().shutdown_asyncgens()

--- a/tests/apis/test_api_requests.py
+++ b/tests/apis/test_api_requests.py
@@ -24,11 +24,11 @@ async def test_raw_requests_work(
     )
     assert isinstance(response, aiohttp.ClientResponse)  # unparsed!
     assert mock.call_count == 1
-    assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
-    assert mock.call_args[0][0].method.lower() == method
-    assert mock.call_args[0][0].path == '/url'
-    assert mock.call_args[0][0].data == {'fake': 'payload'}
-    assert mock.call_args[0][0].headers['fake'] == 'headers'  # and other system headers
+    assert isinstance(mock.call_args.args[0], aiohttp.web.BaseRequest)
+    assert mock.call_args.args[0].method.lower() == method
+    assert mock.call_args.args[0].path == '/url'
+    assert mock.call_args.args[0].data == {'fake': 'payload'}
+    assert mock.call_args.args[0].headers['fake'] == 'headers'  # and other system headers
 
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
@@ -59,8 +59,8 @@ async def test_relative_urls_are_prepended_with_server(
     mock = resp_mocker(return_value=aiohttp.web.json_response({}))
     aresponses.add(hostname, '/url', method, mock)
     await request(method, '/url', settings=settings, logger=logger)
-    assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
-    assert str(mock.call_args[0][0].url) == f'http://{hostname}/url'
+    assert isinstance(mock.call_args.args[0], aiohttp.web.BaseRequest)
+    assert str(mock.call_args.args[0].url) == f'http://{hostname}/url'
 
 
 @pytest.mark.parametrize('method', ['get', 'post', 'patch', 'delete'])
@@ -71,8 +71,8 @@ async def test_absolute_urls_are_passed_through(
     aresponses.add(hostname, '/url', method, mock)
     aresponses.add('fakehost.localdomain', '/url', method, mock)
     await request(method, 'http://fakehost.localdomain/url', settings=settings, logger=logger)
-    assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
-    assert str(mock.call_args[0][0].url) == 'http://fakehost.localdomain/url'
+    assert isinstance(mock.call_args.args[0], aiohttp.web.BaseRequest)
+    assert str(mock.call_args.args[0].url) == 'http://fakehost.localdomain/url'
 
 
 @pytest.mark.parametrize('fn, method', [
@@ -95,11 +95,11 @@ async def test_parsing_in_requests(
     )
     assert response == {'fake': 'result'}  # parsed!
     assert mock.call_count == 1
-    assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
-    assert mock.call_args[0][0].method.lower() == method
-    assert mock.call_args[0][0].path == '/url'
-    assert mock.call_args[0][0].data == {'fake': 'payload'}
-    assert mock.call_args[0][0].headers['fake'] == 'headers'  # and other system headers
+    assert isinstance(mock.call_args.args[0], aiohttp.web.BaseRequest)
+    assert mock.call_args.args[0].method.lower() == method
+    assert mock.call_args.args[0].path == '/url'
+    assert mock.call_args.args[0].data == {'fake': 'payload'}
+    assert mock.call_args.args[0].headers['fake'] == 'headers'  # and other system headers
 
 
 @pytest.mark.parametrize('method', ['get'])  # the only supported method at the moment
@@ -124,11 +124,11 @@ async def test_parsing_in_streams(
 
     assert items == [{'fake': 'result1'}, {'fake': 'result2'}]
     assert mock.call_count == 1
-    assert isinstance(mock.call_args[0][0], aiohttp.web.BaseRequest)
-    assert mock.call_args[0][0].method.lower() == method
-    assert mock.call_args[0][0].path == '/url'
-    assert mock.call_args[0][0].data == {'fake': 'payload'}
-    assert mock.call_args[0][0].headers['fake'] == 'headers'  # and other system headers
+    assert isinstance(mock.call_args.args[0], aiohttp.web.BaseRequest)
+    assert mock.call_args.args[0].method.lower() == method
+    assert mock.call_args.args[0].path == '/url'
+    assert mock.call_args.args[0].data == {'fake': 'payload'}
+    assert mock.call_args.args[0].headers['fake'] == 'headers'  # and other system headers
 
 
 @pytest.mark.parametrize('fn, method', [

--- a/tests/apis/test_error_retries.py
+++ b/tests/apis/test_error_retries.py
@@ -158,7 +158,7 @@ async def test_backoffs_as_lists(
         await request('get', '/url', settings=settings, logger=logger)
 
     assert mock.call_count == exp_calls
-    all_sleeps = [call[0][0] for call in sleep.call_args_list]
+    all_sleeps = [call.args[0] for call in sleep.call_args_list]
     assert all_sleeps == backoffs
 
 
@@ -174,7 +174,7 @@ async def test_backoffs_as_floats(
         await request('get', '/url', settings=settings, logger=logger)
 
     assert mock.call_count == 2
-    all_sleeps = [call[0][0] for call in sleep.call_args_list]
+    all_sleeps = [call.args[0] for call in sleep.call_args_list]
     assert all_sleeps == [5.0]
 
 
@@ -203,7 +203,7 @@ async def test_backoffs_as_iterables(
         await request('get', '/url', settings=settings, logger=logger)
 
     assert mock.call_count == 8
-    all_sleeps = [call[0][0] for call in sleep.call_args_list]
+    all_sleeps = [call.args[0] for call in sleep.call_args_list]
     assert all_sleeps == [1, 2, 3, 1, 2, 3]
 
 
@@ -239,7 +239,7 @@ async def test_retry_after_overrides_backoffs_when_enforced(
     ])
 
     assert mock.call_count == 4
-    all_sleeps = [call[0][0] for call in sleep.call_args_list]
+    all_sleeps = [call.args[0] for call in sleep.call_args_list]
     assert all_sleeps == [10, 10, 10]  # enforced retry-after
 
 
@@ -274,5 +274,5 @@ async def test_retry_after_overrides_backoffs_when_longer(
     ])
 
     assert mock.call_count == 4
-    all_sleeps = [call[0][0] for call in sleep.call_args_list]
+    all_sleeps = [call.args[0] for call in sleep.call_args_list]
     assert all_sleeps == [10, 10, 15]  # never smaller than retry-after

--- a/tests/authentication/test_login_kubeconfig.py
+++ b/tests/authentication/test_login_kubeconfig.py
@@ -28,7 +28,7 @@ def test_has_no_kubeconfig_when_nothing_is_provided(mocker, envs):
     result = has_kubeconfig()
     assert result is False
     assert exists_mock.call_count == 1
-    assert exists_mock.call_args_list[0][0][0].endswith('/.kube/config')
+    assert exists_mock.call_args_list[0].args[0].endswith('/.kube/config')
 
 
 @pytest.mark.parametrize('envs', [{'KUBECONFIG': 'x'}], ids=['set'])
@@ -38,7 +38,7 @@ def test_has_kubeconfig_when_envvar_is_set_but_no_homedir(mocker, envs):
     result = has_kubeconfig()
     assert result is True
     assert exists_mock.call_count == 1
-    assert exists_mock.call_args_list[0][0][0].endswith('/.kube/config')
+    assert exists_mock.call_args_list[0].args[0].endswith('/.kube/config')
 
 
 @pytest.mark.parametrize('envs', [{}, {'KUBECONFIG': ''}], ids=['absent', 'empty'])
@@ -48,7 +48,7 @@ def test_has_kubeconfig_when_homedir_exists_but_no_envvar(mocker, envs):
     result = has_kubeconfig()
     assert result is True
     assert exists_mock.call_count == 1
-    assert exists_mock.call_args_list[0][0][0].endswith('/.kube/config')
+    assert exists_mock.call_args_list[0].args[0].endswith('/.kube/config')
 
 
 @pytest.mark.parametrize('envs', [{}, {'KUBECONFIG': ''}], ids=['absent', 'empty'])
@@ -59,9 +59,9 @@ def test_homedir_is_used_if_it_exists(tmpdir, mocker, envs):
     mocker.patch.dict(os.environ, envs, clear=True)
     credentials = login_with_kubeconfig()
     assert exists_mock.call_count == 1
-    assert exists_mock.call_args_list[0][0][0].endswith('/.kube/config')
+    assert exists_mock.call_args_list[0].args[0].endswith('/.kube/config')
     assert open_mock.call_count == 1
-    assert open_mock.call_args_list[0][0][0].endswith('/.kube/config')
+    assert open_mock.call_args_list[0].args[0].endswith('/.kube/config')
     assert credentials is not None
 
 
@@ -73,7 +73,7 @@ def test_homedir_is_ignored_if_it_is_absent(tmpdir, mocker, envs):
     mocker.patch.dict(os.environ, envs, clear=True)
     credentials = login_with_kubeconfig()
     assert exists_mock.call_count == 1
-    assert exists_mock.call_args_list[0][0][0].endswith('/.kube/config')
+    assert exists_mock.call_args_list[0].args[0].endswith('/.kube/config')
     assert open_mock.call_count == 0
     assert credentials is None
 

--- a/tests/authentication/test_login_serviceaccount.py
+++ b/tests/authentication/test_login_serviceaccount.py
@@ -11,7 +11,7 @@ def test_has_no_serviceaccount_when_special_file_is_absent(mocker):
     result = has_service_account()
     assert result is False
     assert exists_mock.call_count == 1
-    assert exists_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
+    assert exists_mock.call_args_list[0].args[0] == SA_TOKEN_PATH
 
 
 def test_has_serviceaccount_when_special_file_exists(mocker):
@@ -19,7 +19,7 @@ def test_has_serviceaccount_when_special_file_exists(mocker):
     result = has_service_account()
     assert result is True
     assert exists_mock.call_count == 1
-    assert exists_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
+    assert exists_mock.call_args_list[0].args[0] == SA_TOKEN_PATH
 
 
 def test_serviceaccount_with_all_absent_files(mocker):
@@ -29,7 +29,7 @@ def test_serviceaccount_with_all_absent_files(mocker):
     credentials = login_with_service_account()
     assert credentials is None
     assert exists_mock.call_count == 1
-    assert exists_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
+    assert exists_mock.call_args_list[0].args[0] == SA_TOKEN_PATH
     assert not open_mock.called
 
 
@@ -44,12 +44,12 @@ def test_serviceaccount_with_all_present_files(mocker):
     assert credentials.token == 'tkn'
     assert credentials.ca_path == CA_PATH
     assert exists_mock.call_count == 3
-    assert exists_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
-    assert exists_mock.call_args_list[1][0][0] == NAMESPACE_PATH
-    assert exists_mock.call_args_list[2][0][0] == CA_PATH
+    assert exists_mock.call_args_list[0].args[0] == SA_TOKEN_PATH
+    assert exists_mock.call_args_list[1].args[0] == NAMESPACE_PATH
+    assert exists_mock.call_args_list[2].args[0] == CA_PATH
     assert open_mock.call_count == 2
-    assert open_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
-    assert open_mock.call_args_list[1][0][0] == NAMESPACE_PATH
+    assert open_mock.call_args_list[0].args[0] == SA_TOKEN_PATH
+    assert open_mock.call_args_list[1].args[0] == NAMESPACE_PATH
     # NB: the order is irrelevant and can be changed if needed.
 
 
@@ -65,8 +65,8 @@ def test_serviceaccount_with_only_the_token_file(mocker):
     assert credentials.token == 'tkn'
     assert credentials.ca_path is None
     assert exists_mock.call_count == 3
-    assert exists_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
-    assert exists_mock.call_args_list[1][0][0] == NAMESPACE_PATH
-    assert exists_mock.call_args_list[2][0][0] == CA_PATH
+    assert exists_mock.call_args_list[0].args[0] == SA_TOKEN_PATH
+    assert exists_mock.call_args_list[1].args[0] == NAMESPACE_PATH
+    assert exists_mock.call_args_list[2].args[0] == CA_PATH
     assert open_mock.call_count == 1
-    assert open_mock.call_args_list[0][0][0] == SA_TOKEN_PATH
+    assert open_mock.call_args_list[0].args[0] == SA_TOKEN_PATH

--- a/tests/cli/test_options.py
+++ b/tests/cli/test_options.py
@@ -18,7 +18,7 @@ def test_options_passed_to_preload(invoke, options, envvars, kwarg, value, prelo
     result = invoke(['run'] + options, env=envvars)
     assert result.exit_code == 0
     assert preload.called
-    assert preload.call_args[1][kwarg] == value
+    assert preload.call_args.kwargs[kwarg] == value
 
 
 @pytest.mark.parametrize('kwarg, value, options, envvars', [
@@ -56,4 +56,4 @@ def test_options_passed_to_realrun(invoke, options, envvars, kwarg, value, prelo
     result = invoke(['run'] + options, env=envvars)
     assert result.exit_code == 0
     assert real_run.called
-    assert real_run.call_args[1][kwarg] == value
+    assert real_run.call_args.kwargs[kwarg] == value

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -21,7 +21,7 @@ class DaemonDummy:
         self.mock = MagicMock()
 
     async def wait_for_daemon_done(self) -> None:
-        stopped = self.mock.call_args[1]['stopped']
+        stopped = self.mock.call_args.kwargs['stopped']
         await stopped.wait()
         while stopped.reason is None or not stopped.reason & stopped.reason.DONE:
             await asyncio.sleep(0)  # give control back to asyncio event loop
@@ -74,7 +74,7 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
 
         # Do the same as k8s does: merge the patches into the object.
         for call in k8s_mocked.patch.call_args_list:
-            _merge_dicts(call[1]['payload'], event_object)
+            _merge_dicts(call.kwargs['payload'], event_object)
 
     return _simulate_cycle
 

--- a/tests/handling/daemons/test_daemon_filtration.py
+++ b/tests/handling/daemons/test_daemon_filtration.py
@@ -59,4 +59,4 @@ async def test_daemon_filtration_mismatched(
     await asyncio.sleep(123)  # give it enough time to do something when nothing is expected
 
     assert spawn_daemons.called
-    assert spawn_daemons.call_args_list[0][1]['handlers'] == []
+    assert spawn_daemons.call_args_list[0].kwargs['handlers'] == []

--- a/tests/handling/daemons/test_daemon_rematching.py
+++ b/tests/handling/daemons/test_daemon_rematching.py
@@ -28,5 +28,5 @@ async def test_running_daemon_is_stopped_when_mismatches(
     await dummy.wait_for_daemon_done()
 
     assert looptime == 0
-    stopped = dummy.mock.call_args[1]['stopped']
+    stopped = dummy.mock.call_args.kwargs['stopped']
     assert DaemonStoppingReason.FILTERS_MISMATCH in stopped.reason

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -37,7 +37,7 @@ async def test_daemon_exits_gracefully_and_instantly_on_resource_deletion(
 
     assert looptime == 0
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['metadata']['finalizers'] == []
 
 
 async def test_daemon_exits_gracefully_and_instantly_on_operator_exiting(
@@ -139,7 +139,7 @@ async def test_daemon_exits_instantly_on_cancellation_with_backoff(
 
     assert looptime == 1.23  # i.e. the slept through the whole backoff time
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['status']['kopf']['dummy']
 
     # 2nd cycle: cancelling after the backoff is reached. Wait for cancellation timeout.
     mocker.resetall()
@@ -147,7 +147,7 @@ async def test_daemon_exits_instantly_on_cancellation_with_backoff(
 
     assert looptime == 1.23  # i.e. no additional sleeps happened
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['metadata']['finalizers'] == []
 
     # Cleanup.
     await dummy.wait_for_daemon_done()
@@ -186,7 +186,7 @@ async def test_daemon_exits_slowly_on_cancellation_with_backoff(
 
     assert looptime == 1.23
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['status']['kopf']['dummy']
 
     # 2nd cycle: cancelling after the backoff is reached. Wait for cancellation timeout.
     mocker.resetall()
@@ -194,7 +194,7 @@ async def test_daemon_exits_slowly_on_cancellation_with_backoff(
 
     assert looptime == 1.23 + 4.56  # i.e. it really spent all the timeout
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['status']['kopf']['dummy']
 
     # 3rd cycle: the daemon has exited, the resource should be unblocked from actual deletion.
     mocker.resetall()
@@ -206,7 +206,7 @@ async def test_daemon_exits_slowly_on_cancellation_with_backoff(
 
     assert looptime == 1.23 + 4.56  # i.e. not additional sleeps happened
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['metadata']['finalizers'] == []
 
 
 async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
@@ -243,7 +243,7 @@ async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
 
     assert looptime == 4.56
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['status']['kopf']['dummy']
 
     # 2rd cycle: the daemon has exited, the resource should be unblocked from actual deletion.
     mocker.resetall()
@@ -253,7 +253,7 @@ async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
 
     assert looptime == 1000 + 4.56
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0][1]['payload']['metadata']['finalizers'] == []
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['metadata']['finalizers'] == []
     assert_logs(["Daemon 'fn' did not exit in time. Leaving it orphaned."])
 
     # Cleanup.

--- a/tests/handling/daemons/test_timer_filtration.py
+++ b/tests/handling/daemons/test_timer_filtration.py
@@ -56,4 +56,4 @@ async def test_timer_filtration_mismatched(
     await asyncio.sleep(123)  # give it enough time to do something when nothing is expected
 
     assert spawn_daemons.called
-    assert spawn_daemons.call_args_list[0][1]['handlers'] == []
+    assert spawn_daemons.call_args_list[0].kwargs['handlers'] == []

--- a/tests/handling/test_atomicity_of_now.py
+++ b/tests/handling/test_atomicity_of_now.py
@@ -76,4 +76,4 @@ async def test_consistent_awakening(registry, settings, resource, k8s_mocked, mo
     # Without "now"-time consistency, neither sleep() would be called, nor a patch applied.
     # Verify that the patch was actually applied, so that the reaction cycle continues.
     assert k8s_mocked.patch.called
-    assert 'dummy' in k8s_mocked.patch.call_args_list[-1][1]['payload']['status']['kopf']
+    assert 'dummy' in k8s_mocked.patch.call_args_list[-1].kwargs['payload']['status']['kopf']

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -40,7 +40,7 @@ async def test_create(registry, settings, handlers, resource, cause_mock, event_
     assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert 'metadata' in patch
     assert 'annotations' in patch['metadata']
     assert LAST_SEEN_ANNOTATION in patch['metadata']['annotations']
@@ -79,7 +79,7 @@ async def test_update(registry, settings, handlers, resource, cause_mock, event_
     assert k8s_mocked.patch.call_count == 1
     assert not event_queue.empty()
 
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert 'metadata' in patch
     assert 'annotations' in patch['metadata']
     assert LAST_SEEN_ANNOTATION in patch['metadata']['annotations']

--- a/tests/handling/test_consistency.py
+++ b/tests/handling/test_consistency.py
@@ -59,9 +59,9 @@ async def test_preexisting_consistency(
         handlers.resume_mock if cause_reason == Reason.RESUME else
         None  # and fail
     )
-    assert handlers.event_mock.call_args_list[0][1]['_time'] == 0  # called instantly
-    assert handlers.index_mock.call_args_list[0][1]['_time'] == 0  # called instantly
-    assert changing_mock.call_args_list[0][1]['_time'] == 0  # called instantly
+    assert handlers.event_mock.call_args_list[0].kwargs['_time'] == 0  # called instantly
+    assert handlers.index_mock.call_args_list[0].kwargs['_time'] == 0  # called instantly
+    assert changing_mock.call_args_list[0].kwargs['_time'] == 0  # called instantly
 
 
 @pytest.mark.parametrize('cause_reason', HANDLER_REASONS)
@@ -102,9 +102,9 @@ async def test_past_consistency(
         handlers.resume_mock if cause_reason == Reason.RESUME else
         None  # and fail
     )
-    assert handlers.event_mock.call_args_list[0][1]['_time'] == 100  # called instantly
-    assert handlers.index_mock.call_args_list[0][1]['_time'] == 100  # called instantly
-    assert changing_mock.call_args_list[0][1]['_time'] == 100  # called instantly
+    assert handlers.event_mock.call_args_list[0].kwargs['_time'] == 100  # called instantly
+    assert handlers.index_mock.call_args_list[0].kwargs['_time'] == 100  # called instantly
+    assert changing_mock.call_args_list[0].kwargs['_time'] == 100  # called instantly
 
 
 @pytest.mark.parametrize('cause_reason', HANDLER_REASONS)
@@ -144,9 +144,9 @@ async def test_future_consistency(
         handlers.resume_mock if cause_reason == Reason.RESUME else
         None  # and fail
     )
-    assert handlers.event_mock.call_args_list[0][1]['_time'] == 0  # called instantly
-    assert handlers.index_mock.call_args_list[0][1]['_time'] == 0  # called instantly
-    assert changing_mock.call_args_list[0][1]['_time'] == 123  # called after the deemed consistency
+    assert handlers.event_mock.call_args_list[0].kwargs['_time'] == 0  # called instantly
+    assert handlers.index_mock.call_args_list[0].kwargs['_time'] == 0  # called instantly
+    assert changing_mock.call_args_list[0].kwargs['_time'] == 123  # called after the deemed consistency
 
 
 @pytest.mark.parametrize('cause_reason', HANDLER_REASONS)
@@ -172,8 +172,8 @@ async def test_no_consistency_wait_without_changing_handlers(
     assert looptime == 0  # zero means it did not sleep, as expected
     assert watching_handlers.event_mock.call_count == 1
     assert watching_handlers.index_mock.call_count == 1
-    assert watching_handlers.event_mock.call_args_list[0][1]['_time'] == 0  # called instantly
-    assert watching_handlers.index_mock.call_args_list[0][1]['_time'] == 0  # called instantly
+    assert watching_handlers.event_mock.call_args_list[0].kwargs['_time'] == 0  # called instantly
+    assert watching_handlers.index_mock.call_args_list[0].kwargs['_time'] == 0  # called instantly
 
 
 @pytest.mark.parametrize('cause_reason', HANDLER_REASONS)
@@ -203,8 +203,8 @@ async def test_stream_pressure_awakening_prevents_change_handlers(
     assert looptime == 123  # means: it has slept until awakened, but not until consistency
     assert handlers.event_mock.call_count == 1
     assert handlers.index_mock.call_count == 1
-    assert handlers.event_mock.call_args_list[0][1]['_time'] == 0  # called instantly
-    assert handlers.index_mock.call_args_list[0][1]['_time'] == 0  # called instantly
+    assert handlers.event_mock.call_args_list[0].kwargs['_time'] == 0  # called instantly
+    assert handlers.index_mock.call_args_list[0].kwargs['_time'] == 0  # called instantly
 
     changing_mock = (
         handlers.create_mock if cause_reason == Reason.CREATE else

--- a/tests/handling/test_delays.py
+++ b/tests/handling/test_delays.py
@@ -52,7 +52,7 @@ async def test_delayed_handlers_progress(
     assert k8s_mocked.patch.called
 
     fname = f'{cause_reason}_fn'
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert patch['status']['kopf']['progress'][fname]['delayed'] == delayed_iso
 
     assert_logs([
@@ -109,7 +109,7 @@ async def test_delayed_handlers_sleep(
 
     # The dummy patch is needed to trigger the further changes. The value is irrelevant.
     assert k8s_mocked.patch.called
-    assert 'dummy' in k8s_mocked.patch.call_args_list[-1][1]['payload']['status']['kopf']
+    assert 'dummy' in k8s_mocked.patch.call_args_list[-1].kwargs['payload']['status']['kopf']
 
     # The duration of sleep should be as expected.
     assert looptime == delay

--- a/tests/handling/test_error_handling.py
+++ b/tests/handling/test_error_handling.py
@@ -45,7 +45,7 @@ async def test_fatal_error_stops_handler(
     assert looptime == 0
     assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert patch['status']['kopf']['progress'] is not None
     assert patch['status']['kopf']['progress'][name1]['failure'] is True
     assert patch['status']['kopf']['progress'][name1]['message'] == 'oops'
@@ -89,7 +89,7 @@ async def test_retry_error_delays_handler(
     assert looptime == 0
     assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert patch['status']['kopf']['progress'] is not None
     assert patch['status']['kopf']['progress'][name1]['failure'] is False
     assert patch['status']['kopf']['progress'][name1]['success'] is False
@@ -134,7 +134,7 @@ async def test_arbitrary_error_delays_handler(
     assert looptime == 0
     assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert patch['status']['kopf']['progress'] is not None
     assert patch['status']['kopf']['progress'][name1]['failure'] is False
     assert patch['status']['kopf']['progress'][name1]['success'] is False

--- a/tests/handling/test_event_handling.py
+++ b/tests/handling/test_event_handling.py
@@ -31,7 +31,7 @@ async def test_handlers_called_always(
     assert handlers.event_mock.call_count == 1
     assert extrahandlers.event_mock.call_count == 1
 
-    event = handlers.event_mock.call_args_list[0][1]['event']
+    event = handlers.event_mock.call_args_list[0].kwargs['event']
     assert 'field' in event['object']
     assert event['object']['field'] == 'value'
     assert event['type'] == 'ev-type'

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -49,7 +49,7 @@ async def test_1st_step_stores_progress_by_patching(
     assert looptime == 0
     assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert patch['status']['kopf']['progress'] is not None
 
     assert patch['status']['kopf']['progress'][name1]['retries'] == 1
@@ -109,7 +109,7 @@ async def test_2nd_step_finishes_the_handlers(caplog,
     assert looptime == 0
     assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert patch['status']['kopf']['progress'] == {name1: None, name2: None}
 
     # Finalizers could be removed for resources being deleted on the 2nd step.

--- a/tests/handling/test_no_handlers.py
+++ b/tests/handling/test_no_handlers.py
@@ -46,7 +46,7 @@ async def test_skipped_with_no_handlers(
     assert k8s_mocked.patch.called
 
     # The patch must contain ONLY the last-seen update, and nothing else.
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert set(patch.keys()) == {'metadata'}
     assert set(patch['metadata'].keys()) == {'annotations'}
     assert set(patch['metadata']['annotations'].keys()) == {LAST_SEEN_ANNOTATION}

--- a/tests/handling/test_parametrization.py
+++ b/tests/handling/test_parametrization.py
@@ -31,7 +31,7 @@ async def test_parameter_is_passed_when_specified(resource, cause_mock, registry
     )
 
     assert mock.called
-    assert mock.call_args_list[0][1]['param'] == 123
+    assert mock.call_args_list[0].kwargs['param'] == 123
 
 
 async def test_parameter_is_passed_even_if_not_specified(resource, cause_mock, registry, settings):
@@ -57,4 +57,4 @@ async def test_parameter_is_passed_even_if_not_specified(resource, cause_mock, r
     )
 
     assert mock.called
-    assert mock.call_args_list[0][1]['param'] is None
+    assert mock.call_args_list[0].kwargs['param'] is None

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -55,7 +55,7 @@ async def test_timed_out_handler_fails(
     assert looptime == 0
     assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert patch['status']['kopf']['progress'] is not None
     assert patch['status']['kopf']['progress'][name1]['failure'] is True
 
@@ -104,7 +104,7 @@ async def test_retries_limited_handler_fails(
     assert looptime == 0
     assert k8s_mocked.patch.called
 
-    patch = k8s_mocked.patch.call_args_list[0][1]['payload']
+    patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
     assert patch['status']['kopf']['progress'] is not None
     assert patch['status']['kopf']['progress'][name1]['failure'] is True
 

--- a/tests/invocations/test_callbacks.py
+++ b/tests/invocations/test_callbacks.py
@@ -161,10 +161,10 @@ async def test_explicit_args_passed_properly(fn):
     assert mock.called
     assert mock.call_count == 1
 
-    assert len(mock.call_args[0]) == 0
-    assert len(mock.call_args[1]) >= 2  # also the magic kwargs
-    assert mock.call_args[1]['kw1'] == 300
-    assert mock.call_args[1]['kw2'] == 400
+    assert len(mock.call_args.args) == 0
+    assert len(mock.call_args.kwargs) >= 2  # also the magic kwargs
+    assert mock.call_args.kwargs['kw1'] == 300
+    assert mock.call_args.kwargs['kw2'] == 400
 
 
 @fns
@@ -195,5 +195,5 @@ async def test_special_kwargs_added(fn, resource):
     assert mock.call_count == 1
 
     # Only check that kwargs are passed at all. The exact kwargs per cause are tested separately.
-    assert 'logger' in mock.call_args[1]
-    assert 'resource' in mock.call_args[1]
+    assert 'logger' in mock.call_args.kwargs
+    assert 'resource' in mock.call_args.kwargs

--- a/tests/k8s/test_creating.py
+++ b/tests/k8s/test_creating.py
@@ -24,7 +24,7 @@ async def test_simple_body_with_arguments(
     assert post_mock.called
     assert post_mock.call_count == 1
 
-    data = post_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    data = post_mock.call_args_list[0].args[0].data  # [callidx][args/kwargs][argidx]
     if resource.namespaced:
         assert data == {'x': 'y', 'metadata': {'name': 'name1', 'namespace': 'ns'}}
     else:
@@ -48,7 +48,7 @@ async def test_full_body_with_identifiers(
     assert post_mock.called
     assert post_mock.call_count == 1
 
-    data = post_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    data = post_mock.call_args_list[0].args[0].data  # [callidx][args/kwargs][argidx]
     assert data == {'x': 'y', 'metadata': {'name': 'name1', 'namespace': namespace}}
 
 

--- a/tests/k8s/test_events.py
+++ b/tests/k8s/test_events.py
@@ -33,7 +33,7 @@ async def test_posting(
     assert post_mock.called
     assert post_mock.call_count == 1
 
-    req = post_mock.call_args_list[0][0][0]  # [callidx][args/kwargs][argidx]
+    req = post_mock.call_args_list[0].args[0]  # [callidx][args/kwargs][argidx]
     assert req.method == 'POST'
 
     data = req.data
@@ -149,7 +149,7 @@ async def test_message_is_cut_to_max_length(
         logger=logger,
     )
 
-    data = post_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    data = post_mock.call_args_list[0].args[0].data  # [callidx][args/kwargs][argidx]
     assert len(data['message']) <= 1024  # max supported API message length
     assert '...' in data['message']
     assert data['message'].startswith('start')

--- a/tests/k8s/test_patching.py
+++ b/tests/k8s/test_patching.py
@@ -50,7 +50,7 @@ async def test_without_subresources(
     assert patch_mock.called
     assert patch_mock.call_count == 1
 
-    data = patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    data = patch_mock.call_args_list[0].args[0].data  # [callidx][args/kwargs][argidx]
     assert data == {'x': 'y'}
 
 
@@ -72,9 +72,9 @@ async def test_status_as_subresource_with_combined_payload(
     assert status_patch_mock.called
     assert status_patch_mock.call_count == 1
 
-    data = object_patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    data = object_patch_mock.call_args_list[0].args[0].data  # [callidx][args/kwargs][argidx]
     assert data == {'spec': {'x': 'y'}}
-    data = status_patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    data = status_patch_mock.call_args_list[0].args[0].data  # [callidx][args/kwargs][argidx]
     assert data == {'status': {'s': 't'}}
 
     assert reconstructed == STATUS_RESPONSE  # ignore the body response if status was patched
@@ -97,7 +97,7 @@ async def test_status_as_subresource_with_object_fields_only(
     assert object_patch_mock.call_count == 1
     assert not status_patch_mock.called
 
-    data = object_patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    data = object_patch_mock.call_args_list[0].args[0].data  # [callidx][args/kwargs][argidx]
     assert data == {'spec': {'x': 'y'}}
 
     assert reconstructed == OBJECT_RESPONSE  # ignore the status response if status was not patched
@@ -120,7 +120,7 @@ async def test_status_as_subresource_with_status_fields_only(
     assert status_patch_mock.called
     assert status_patch_mock.call_count == 1
 
-    data = status_patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    data = status_patch_mock.call_args_list[0].args[0].data  # [callidx][args/kwargs][argidx]
     assert data == {'status': {'s': 't'}}
 
     assert reconstructed == STATUS_RESPONSE  # ignore the body response if status was patched
@@ -142,7 +142,7 @@ async def test_status_as_body_field_with_combined_payload(
     assert object_patch_mock.call_count == 1
     assert not status_patch_mock.called
 
-    data = object_patch_mock.call_args_list[0][0][0].data  # [callidx][args/kwargs][argidx]
+    data = object_patch_mock.call_args_list[0].args[0].data  # [callidx][args/kwargs][argidx]
     assert data == {'spec': {'x': 'y'}, 'status': {'s': 't'}}
 
     assert reconstructed == OBJECT_RESPONSE  # ignore the status response if status was not patched

--- a/tests/peering/test_keepalive.py
+++ b/tests/peering/test_keepalive.py
@@ -28,8 +28,8 @@ async def test_background_task_runs(mocker, settings, namespaced_peering_resourc
 
     assert randint_mock.call_count == 3  # only to be sure that we test the right thing
     assert sleep_mock.call_count == 3
-    assert sleep_mock.call_args_list[0][0][0] == 33 - 7
-    assert sleep_mock.call_args_list[1][0][0] == 33 - 5
-    assert sleep_mock.call_args_list[2][0][0] == 33 - 9
+    assert sleep_mock.call_args_list[0].args[0] == 33 - 7
+    assert sleep_mock.call_args_list[1].args[0] == 33 - 5
+    assert sleep_mock.call_args_list[2].args[0] == 33 - 9
 
     assert touch_mock.call_count == 4  # 3 updates + 1 clean-up

--- a/tests/peering/test_peer_patching.py
+++ b/tests/peering/test_peer_patching.py
@@ -24,7 +24,7 @@ async def test_cleaning_peers_purges_them(
                 namespace=peering_namespace)
 
     assert patch_mock.called
-    patch = await patch_mock.call_args_list[0][0][0].json()
+    patch = await patch_mock.call_args_list[0].args[0].json()
     assert set(patch['status']) == {'id1'}
     assert patch['status']['id1'] is None
 
@@ -43,7 +43,7 @@ async def test_touching_a_peer_stores_it(
                 namespace=peering_namespace)
 
     assert patch_mock.called
-    patch = await patch_mock.call_args_list[0][0][0].json()
+    patch = await patch_mock.call_args_list[0].args[0].json()
     assert set(patch['status']) == {'id1'}
     assert patch['status']['id1']['priority'] == 0
     assert patch['status']['id1']['lastseen'] == '2020-12-31T23:59:59.123456+00:00'
@@ -64,7 +64,7 @@ async def test_expiring_a_peer_purges_it(
                 namespace=peering_namespace, lifetime=0)
 
     assert patch_mock.called
-    patch = await patch_mock.call_args_list[0][0][0].json()
+    patch = await patch_mock.call_args_list[0].args[0].json()
     assert set(patch['status']) == {'id1'}
     assert patch['status']['id1'] is None
 

--- a/tests/posting/test_poster.py
+++ b/tests/posting/test_poster.py
@@ -46,16 +46,16 @@ async def test_poster_polls_and_posts(mocker, settings):
         await poster(event_queue=event_queue, backbone=backbone, settings=settings)
 
     assert post.call_count == 2
-    assert post.call_args_list[0][1]['url'] == '/api/v1/namespaces/ns1/events'
-    assert post.call_args_list[0][1]['payload']['type'] == 'type1'
-    assert post.call_args_list[0][1]['payload']['reason'] == 'reason1'
-    assert post.call_args_list[0][1]['payload']['message'] == 'message1'
-    assert post.call_args_list[0][1]['payload']['involvedObject'] == REF1
-    assert post.call_args_list[1][1]['url'] == '/api/v1/namespaces/ns2/events'
-    assert post.call_args_list[1][1]['payload']['type'] == 'type2'
-    assert post.call_args_list[1][1]['payload']['reason'] == 'reason2'
-    assert post.call_args_list[1][1]['payload']['message'] == 'message2'
-    assert post.call_args_list[1][1]['payload']['involvedObject'] == REF2
+    assert post.call_args_list[0].kwargs['url'] == '/api/v1/namespaces/ns1/events'
+    assert post.call_args_list[0].kwargs['payload']['type'] == 'type1'
+    assert post.call_args_list[0].kwargs['payload']['reason'] == 'reason1'
+    assert post.call_args_list[0].kwargs['payload']['message'] == 'message1'
+    assert post.call_args_list[0].kwargs['payload']['involvedObject'] == REF1
+    assert post.call_args_list[1].kwargs['url'] == '/api/v1/namespaces/ns2/events'
+    assert post.call_args_list[1].kwargs['payload']['type'] == 'type2'
+    assert post.call_args_list[1].kwargs['payload']['reason'] == 'reason2'
+    assert post.call_args_list[1].kwargs['payload']['message'] == 'message2'
+    assert post.call_args_list[1].kwargs['payload']['involvedObject'] == REF2
 
 
 def test_queueing_fails_with_no_queue(event_queue_loop):

--- a/tests/reactor/test_consistency_tracking.py
+++ b/tests/reactor/test_consistency_tracking.py
@@ -55,21 +55,21 @@ async def test_consistency_tracking_in_the_watcher(
     processed.clear()
     await processed.wait()
     assert processor.call_count == 1
-    assert processor.call_args[1]['raw_event']['object']['metadata']['resourceVersion'] == '1'
-    assert processor.call_args[1]['consistency_time'] is None
+    assert processor.call_args.kwargs['raw_event']['object']['metadata']['resourceVersion'] == '1'
+    assert processor.call_args.kwargs['consistency_time'] is None
 
     # Stage 2: simulate an event with an INCONSISTENT ResourceVersion, which should be ignored.
     processor.return_value = None
     processed.clear()
     await processed.wait()
     assert processor.call_count == 2
-    assert processor.call_args[1]['raw_event']['object']['metadata']['resourceVersion'] == '2'
-    assert processor.call_args[1]['consistency_time'] == 3.45
+    assert processor.call_args.kwargs['raw_event']['object']['metadata']['resourceVersion'] == '2'
+    assert processor.call_args.kwargs['consistency_time'] == 3.45
 
     # Stage 3: simulate an event with a CONSISTENT ResourceVersion, which should be fully processed.
     processor.return_value = None
     processed.clear()
     await processed.wait()
     assert processor.call_count == 3
-    assert processor.call_args[1]['raw_event']['object']['metadata']['resourceVersion'] == '3'
-    assert processor.call_args[1]['consistency_time'] is None
+    assert processor.call_args.kwargs['raw_event']['object']['metadata']['resourceVersion'] == '3'
+    assert processor.call_args.kwargs['consistency_time'] is None

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -129,8 +129,8 @@ async def test_garbage_collection_of_streams(
     # Intercept and remember _any_ seen dict of streams for further checks.
     while worker_spy.call_count < unique:
         await asyncio.sleep(0)  # give control to the loop
-    streams = worker_spy.call_args_list[-1][1]['streams']
-    signaller: asyncio.Condition = worker_spy.call_args_list[0][1]['signaller']
+    streams = worker_spy.call_args_list[-1].kwargs['streams']
+    signaller: asyncio.Condition = worker_spy.call_args_list[0].kwargs['signaller']
 
     # The mutable(!) streams dict is now populated with the objects' streams.
     assert len(streams) != 0  # usually 1, but can be 2+ if it is fast enough.

--- a/tests/testing/test_runner.py
+++ b/tests/testing/test_runner.py
@@ -33,8 +33,8 @@ def test_registry_and_settings_are_propagated(mocker):
     assert runner.exit_code == 0
     assert runner.exception is None
     assert operator_mock.called
-    assert operator_mock.call_args[1]['registry'] is registry
-    assert operator_mock.call_args[1]['settings'] is settings
+    assert operator_mock.call_args.kwargs['registry'] is registry
+    assert operator_mock.call_args.kwargs['settings'] is settings
 
 
 def test_exception_from_runner_suppressed_with_no_reraise():

--- a/tests/utilities/aiotasks/test_scheduler.py
+++ b/tests/utilities/aiotasks/test_scheduler.py
@@ -43,11 +43,11 @@ async def test_task_spawning_and_graceful_finishing(looptime):
 
     await flag1.wait()
     assert looptime == 0
-    assert mock.call_args_list[0][0][0] == 'started'
+    assert mock.call_args_list[0].args[0] == 'started'
 
     await flag2.wait()
     assert looptime == 123
-    assert mock.call_args_list[1][0][0] == 'finished'
+    assert mock.call_args_list[1].args[0] == 'finished'
 
     await scheduler.close()
 
@@ -63,11 +63,11 @@ async def test_task_spawning_and_cancellation(looptime):
 
     await flag1.wait()
     assert looptime == 0
-    assert mock.call_args_list[0][0][0] == 'started'
+    assert mock.call_args_list[0].args[0] == 'started'
 
     await scheduler.close()
     assert looptime == 0
-    assert mock.call_args_list[1][0][0] == 'cancelled'
+    assert mock.call_args_list[1].args[0] == 'cancelled'
 
 
 async def test_no_tasks_are_accepted_after_closing():
@@ -108,7 +108,7 @@ async def test_exceptions_are_reported():
     await scheduler.wait()
     await scheduler.close()
     assert exception_handler.call_count == 1
-    assert exception_handler.call_args[0][0] is exception
+    assert exception_handler.call_args.args[0] is exception
 
 
 async def test_tasks_are_parallel_if_limit_is_not_reached(looptime):


### PR DESCRIPTION
The named `.args` and `.kwargs` are available since Python 3.8, our minimum now is 3.10. It was forgotten in the upgrade, but it is a good time now to finish it — for readability. Especially since LLMs follow the existing patterns and reproduce the old style unless refactored.
