### PR TITLE
Upgrade to kmock 0.4 (replace `clusterwide()` with `namespace(None)`).

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ test = [
     "codecov",
     "coverage>=7.12.0",
     "freezegun",
-    "kmock>=0.3",
+    "kmock>=0.4",
     "looptime>=0.7",
     "lxml",
     "pyngrok",

--- a/tests/k8s/test_creating.py
+++ b/tests/k8s/test_creating.py
@@ -50,7 +50,7 @@ async def test_full_body_with_identifiers(
 async def test_raises_api_errors(
         kmock, settings, status, resource, namespace, logger,
         cluster_resource, namespaced_resource):
-    kmock['post', resource, kmock.clusterwide()] << status
+    kmock['post', resource, kmock.namespace(None)] << status
     kmock['post', resource, kmock.namespace('ns')] << status
 
     body = {'x': 'y'}

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -21,7 +21,7 @@ async def test_listing_works(kmock, settings, logger, resource, namespace):
 async def test_raises_direct_api_errors(
         kmock, settings, logger, status, resource, namespace,
         cluster_resource, namespaced_resource):
-    kmock[cluster_resource, kmock.clusterwide()] << status
+    kmock[cluster_resource, kmock.namespace(None)] << status
     kmock[namespaced_resource, kmock.namespace('ns')] << status
 
     with pytest.raises(APIError) as e:


### PR DESCRIPTION
Or else, it breaks all the CI jobs in all the PRs.