### PR TITLE
Cease posting the logs as k8s events out-of-the-box

### DIFF
--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -72,7 +72,7 @@ class PostingSettings:
     (``kopf.info()``, ``kopf.warn()``, ``kopf.exception()``).
     """
 
-    loggers: bool = True
+    loggers: bool = False
     """
     Should the log messages from the loggers be posted as K8s Events.
 

--- a/tests/handling/subhandling/test_subhandling.py
+++ b/tests/handling/subhandling/test_subhandling.py
@@ -38,6 +38,7 @@ async def test_1st_level(registry, settings, resource, cause_mock, event_type,
         async def sub1b(**_):
             sub1b_mock(**kwargs)
 
+    settings.posting.loggers = True
     event_queue = asyncio.Queue()
     await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
@@ -113,6 +114,7 @@ async def test_2nd_level(registry, settings, resource, cause_mock, event_type,
             def sub1b2b(**kwargs):
                 sub1b2b_mock(**kwargs)
 
+    settings.posting.loggers = True
     event_queue = asyncio.Queue()
     await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -20,6 +20,7 @@ async def test_create(registry, settings, handlers, resource, cause_mock, event_
                       assert_logs, k8s_mocked):
     cause_mock.reason = Reason.CREATE
 
+    settings.posting.loggers = True
     event_queue = asyncio.Queue()
     await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
@@ -59,6 +60,7 @@ async def test_update(registry, settings, handlers, resource, cause_mock, event_
                       assert_logs, k8s_mocked):
     cause_mock.reason = Reason.UPDATE
 
+    settings.posting.loggers = True
     event_queue = asyncio.Queue()
     await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
@@ -100,6 +102,7 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
     finalizer = settings.persistence.finalizer
     event_body = {'metadata': {'deletionTimestamp': '...', 'finalizers': [finalizer]}}
 
+    settings.posting.loggers = True
     event_queue = asyncio.Queue()
     await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
@@ -139,6 +142,7 @@ async def test_gone(registry, settings, handlers, resource, cause_mock, event_ty
                     assert_logs, k8s_mocked):
     cause_mock.reason = Reason.GONE
 
+    settings.posting.loggers = True
     event_queue = asyncio.Queue()
     await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
@@ -169,6 +173,7 @@ async def test_free(registry, settings, handlers, resource, cause_mock, event_ty
                     assert_logs, k8s_mocked):
     cause_mock.reason = Reason.FREE
 
+    settings.posting.loggers = True
     event_queue = asyncio.Queue()
     await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,
@@ -198,6 +203,7 @@ async def test_noop(registry, settings, handlers, resource, cause_mock, event_ty
                     assert_logs, k8s_mocked):
     cause_mock.reason = Reason.NOOP
 
+    settings.posting.loggers = True
     event_queue = asyncio.Queue()
     await process_resource_event(
         lifecycle=kopf.lifecycles.all_at_once,

--- a/tests/posting/test_log2k8s.py
+++ b/tests/posting/test_log2k8s.py
@@ -22,6 +22,7 @@ async def test_posting_normal_levels(settings, caplog, logstream, logfn, event_t
     logger = ObjectLogger(body=OBJ1, settings=settings)
     logger_fn = getattr(logger, logfn)
 
+    settings.posting.loggers = True
     logger_fn("hello %s", "world")
 
     assert event_queue.qsize() == 1
@@ -45,6 +46,7 @@ async def test_posting_above_config(settings, caplog, logstream, logfn, event_ty
     logger = ObjectLogger(body=OBJ1, settings=settings)
     logger_fn = getattr(logger, logfn)
 
+    settings.posting.loggers = True
     settings.posting.level = min_levelno
     logger_fn("hello %s", "world")
     settings.posting.level = min_levelno + 1
@@ -68,6 +70,7 @@ async def test_skipping_hidden_levels(settings, caplog, logstream, logfn,
     logger = ObjectLogger(body=OBJ1, settings=settings)
     logger_fn = getattr(logger, logfn)
 
+    settings.posting.loggers = True
     logger_fn("hello %s", "world")
     logger.info("must be here")
 
@@ -88,6 +91,7 @@ async def test_skipping_below_config(settings, caplog, logstream, logfn,
     logger = ObjectLogger(body=OBJ1, settings=settings)
     logger_fn = getattr(logger, logfn)
 
+    settings.posting.loggers = True
     settings.posting.level = 666
     logger_fn("hello %s", "world")
     settings.posting.level = 0
@@ -104,12 +108,14 @@ async def test_skipping_below_config(settings, caplog, logstream, logfn,
     'error',
     'critical',
 ])
+@pytest.mark.parametrize('flag', [True, False])
 async def test_skipping_when_disabled(settings, caplog, logstream, logfn,
-                                      event_queue, event_queue_loop):
+                                      event_queue, event_queue_loop, flag):
 
     logger = LocalObjectLogger(body=OBJ1, settings=settings)
     logger_fn = getattr(logger, logfn)
 
+    settings.posting.loggers = flag
     settings.posting.enabled = False
     settings.posting.level = 0
     logger_fn("hello %s", "world")
@@ -125,12 +131,14 @@ async def test_skipping_when_disabled(settings, caplog, logstream, logfn,
     'error',
     'critical',
 ])
+@pytest.mark.parametrize('flag', [True, False])
 async def test_skipping_when_local_with_all_levels(settings, caplog, logstream, logfn,
-                                                   event_queue, event_queue_loop):
+                                                   event_queue, event_queue_loop, flag):
 
     logger = LocalObjectLogger(body=OBJ1, settings=settings)
     logger_fn = getattr(logger, logfn)
 
+    settings.posting.loggers = flag
     logger_fn("hello %s", "world")
 
     assert event_queue.qsize() == 0

--- a/tests/posting/test_loggers_setting.py
+++ b/tests/posting/test_loggers_setting.py
@@ -17,8 +17,8 @@ def _settings_via_contextvar(settings_via_contextvar):
     pass
 
 
-async def test_loggers_setting_default_is_true(settings):
-    assert settings.posting.loggers  # for backwards compatibility
+async def test_loggers_setting_default_is_false(settings):
+    assert not settings.posting.loggers
 
 
 async def test_loggers_setting_true_posts_loggers(settings, event_queue, event_queue_loop, caplog):


### PR DESCRIPTION
In line with the goal of preparing Kopf to run on large cluster with high-load activity, disable the automatic posting of log messages as k8s events to relevant resources. Such posting creates unnecessary load on Kubernetes API servers with little or no benefit. These events include mainly the handler successes/failures and are of little interest. Logs should remain just the logs by default, i.e. out of the box. They should not map to k8s events. For k8s events, there are explicitly posting routines.

This change is slightly backwards incompatible (changes the existing behaviour), but no major release is needed.

**To revert:** If needed, the operator can enable this functionality by setting `settings.posting.loggers = True` in an on-startup handler.

```python
import kopf

@kopf.on.startup
def configure(settings, **_):
    settings.posting.loggers = True
```

**Not affected:** The explicit event posting via `kopf.event()`, `kopf.info()`, `kopf.warn()`, `kopf.exception()` remains unaffected (controlled by `settings.posting.enabled = True` by default). Related:

* #1215 
* #1186 