### PR TITLE
Reduce the API PATCHes by ceasing to write the handler progress to the status stanza

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -408,11 +408,11 @@ used when fetching, i.e. the first storage has precedence):
             kopf.StatusProgressStorage(field='status.my-operator'),
         ])
 
-The default storage is at both annotations and status, with annotations having
-precedence over the status (this is done as a transitioning solution
-from status-only storage in the past to annotations-only storage in the future).
-The annotations are ``kopf.zalando.org/{id}``,
-the status fields are ``status.kopf.progress.{id}``.
+The default storage is in annotations, plus read-only from the status stanza,
+with annotations having precedence over the status. That was a transitioning
+solution from the original status-only storage only (Mar'20–Mar'26; v0.27–1.44).
+The annotations are ``kopf.zalando.org/{id}`` (read-write),
+the status fields are ``status.kopf.progress.{id}`` (read-only).
 It is an equivalent of:
 
 .. code-block:: python

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -370,6 +370,17 @@ class StatusProgressStorage(ProgressStorage):
         return essence
 
 
+# Not very proper OOP-wise, but we use it only internally (not exported), so it is fine.
+# It should end the transitioning phase of Mar'20–Mar'26 by not writing to status anymore
+# because this increases the number of API PATCH requests "out of the box" with no need.
+class NoWriteStatusProgressStorage(StatusProgressStorage):
+    def store(self, **_: Any) -> None:
+        pass
+
+    def touch(self, **_: Any) -> None:
+        pass
+
+
 class MultiProgressStorage(ProgressStorage):
 
     def __init__(
@@ -443,5 +454,5 @@ class SmartProgressStorage(MultiProgressStorage):
     ) -> None:
         super().__init__([
             AnnotationsProgressStorage(v1=v1, prefix=prefix, verbose=verbose, touch_key=touch_key),
-            StatusProgressStorage(name=name, field=field, touch_field=touch_field),
+            NoWriteStatusProgressStorage(name=name, field=field, touch_field=touch_field),
         ])

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -142,7 +142,7 @@ async def test_daemon_exits_instantly_on_cancellation_with_backoff(
 
     assert looptime == 1.23  # i.e. the slept through the whole backoff time
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['metadata']['annotations']['kopf.zalando.org/touch-dummy']
 
     # 2nd cycle: cancelling after the backoff is reached. Wait for cancellation timeout.
     mocker.resetall()
@@ -192,7 +192,7 @@ async def test_daemon_exits_slowly_on_cancellation_with_backoff(
 
     assert looptime == 1.23
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['metadata']['annotations']['kopf.zalando.org/touch-dummy']
 
     # 2nd cycle: cancelling after the backoff is reached. Wait for cancellation timeout.
     mocker.resetall()
@@ -200,7 +200,7 @@ async def test_daemon_exits_slowly_on_cancellation_with_backoff(
 
     assert looptime == 1.23 + 4.56  # i.e. it really spent all the timeout
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['metadata']['annotations']['kopf.zalando.org/touch-dummy']
 
     # 3rd cycle: the daemon has exited, the resource should be unblocked from actual deletion.
     mocker.resetall()
@@ -252,7 +252,7 @@ async def test_daemon_is_abandoned_due_to_cancellation_timeout_reached(
 
     assert looptime == 4.56
     assert k8s_mocked.patch.call_count == 1
-    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['status']['kopf']['dummy']
+    assert k8s_mocked.patch.call_args_list[0].kwargs['payload']['metadata']['annotations']['kopf.zalando.org/touch-dummy']
 
     # 2rd cycle: the daemon has exited, the resource should be unblocked from actual deletion.
     mocker.resetall()

--- a/tests/handling/test_atomicity_of_now.py
+++ b/tests/handling/test_atomicity_of_now.py
@@ -76,4 +76,4 @@ async def test_consistent_awakening(registry, settings, resource, k8s_mocked, mo
     # Without "now"-time consistency, neither sleep() would be called, nor a patch applied.
     # Verify that the patch was actually applied, so that the reaction cycle continues.
     assert k8s_mocked.patch.called
-    assert 'dummy' in k8s_mocked.patch.call_args_list[-1].kwargs['payload']['status']['kopf']
+    assert 'kopf.zalando.org/touch-dummy' in k8s_mocked.patch.call_args_list[-1].kwargs['payload']['metadata']['annotations']

--- a/tests/handling/test_multistep.py
+++ b/tests/handling/test_multistep.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 import pytest
 
@@ -50,16 +51,18 @@ async def test_1st_step_stores_progress_by_patching(
     assert k8s_mocked.patch.called
 
     patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
-    assert patch['status']['kopf']['progress'] is not None
+    assert patch['metadata']['annotations']  # not empty at least
+    progress1 = json.loads(patch['metadata']['annotations'][f"kopf.zalando.org/{name1}"])
+    progress2 = json.loads(patch['metadata']['annotations'][f"kopf.zalando.org/{name2}"])
 
-    assert patch['status']['kopf']['progress'][name1]['retries'] == 1
-    assert patch['status']['kopf']['progress'][name1]['success'] is True
+    assert progress1['retries'] == 1
+    assert progress1['success'] is True
 
-    assert patch['status']['kopf']['progress'][name2]['retries'] == 0
-    assert patch['status']['kopf']['progress'][name2]['success'] is False
+    assert progress2['retries'] == 0
+    assert progress2['success'] is False
 
-    assert patch['status']['kopf']['progress'][name1]['started']
-    assert patch['status']['kopf']['progress'][name2]['started']
+    assert progress1['started']
+    assert progress2['started']
 
     # Premature removal of finalizers can prevent the 2nd step for deletion handlers.
     # So, the finalizers must never be removed on the 1st step.
@@ -80,12 +83,22 @@ async def test_2nd_step_finishes_the_handlers(caplog,
 
     event_type = None if cause_type == Reason.RESUME else 'irrelevant'
     event_body = {
-        'metadata': {'finalizers': [settings.persistence.finalizer],
-                     'resourceVersion': '1234567890'},
-        'status': {'kopf': {'progress': {
-            name1: {'started': '1979-01-01T00:00:00Z', 'success': True},
-            name2: {'started': '1979-01-01T00:00:00Z'},
-        }}}
+        'metadata': {
+            'finalizers': [settings.persistence.finalizer],
+            'resourceVersion': '1234567890',
+            'annotations': {
+                f'kopf.zalando.org/{name1}': json.dumps({
+                    'started': '1979-01-01T00:00:00Z', 'success': True,
+                }),
+                f'kopf.zalando.org/{name2}': json.dumps({
+                    'started': '1979-01-01T00:00:00Z'
+                }),
+            },
+        },
+        # 'status': {'kopf': {'progress': {
+        #     name1: {'started': '1979-01-01T00:00:00Z', 'success': True},
+        #     name2: {'started': '1979-01-01T00:00:00Z'},
+        # }}}
     }
     event_body['metadata'] |= deletion_ts
     cause_mock.reason = cause_type
@@ -111,7 +124,8 @@ async def test_2nd_step_finishes_the_handlers(caplog,
     assert k8s_mocked.patch.called
 
     patch1 = k8s_mocked.patch.call_args_list[0].kwargs['payload']
-    assert patch1['status']['kopf']['progress'] == {name1: None, name2: None}
+    assert patch1['metadata']['annotations'][f'kopf.zalando.org/{name1}'] is None
+    assert patch1['metadata']['annotations'][f'kopf.zalando.org/{name2}'] is None
 
     # Finalizers could be removed for resources being deleted on the 2nd step.
     # The logic can vary though: either by deletionTimestamp, or by reason==DELETE.

--- a/tests/handling/test_retrying_limits.py
+++ b/tests/handling/test_retrying_limits.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 import freezegun
 import pytest
@@ -56,8 +57,9 @@ async def test_timed_out_handler_fails(
     assert k8s_mocked.patch.called
 
     patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
-    assert patch['status']['kopf']['progress'] is not None
-    assert patch['status']['kopf']['progress'][name1]['failure'] is True
+    assert patch['metadata']['annotations']  # not empty at least
+    progress = json.loads(patch['metadata']['annotations'][f"kopf.zalando.org/{name1}"])
+    assert progress['failure'] is True
 
     assert_logs([
         "Handler .+ has timed out after",
@@ -105,8 +107,9 @@ async def test_retries_limited_handler_fails(
     assert k8s_mocked.patch.called
 
     patch = k8s_mocked.patch.call_args_list[0].kwargs['payload']
-    assert patch['status']['kopf']['progress'] is not None
-    assert patch['status']['kopf']['progress'][name1]['failure'] is True
+    assert patch['metadata']['annotations']  # not empty at least
+    progress = json.loads(patch['metadata']['annotations'][f"kopf.zalando.org/{name1}"])
+    assert progress['failure'] is True
 
     assert_logs([
         r"Handler .+ has exceeded \d+ retries",

--- a/tests/persistence/test_states.py
+++ b/tests/persistence/test_states.py
@@ -27,7 +27,7 @@ ZERO_DELTA = datetime.timedelta(seconds=0)
 
 # Use only the status-populating storages, to keep the tests with their original assertions.
 # The goal is to test the states, not the storages. The storages are tested in test_storages.py.
-@pytest.fixture(params=[StatusProgressStorage, SmartProgressStorage])
+@pytest.fixture(params=[StatusProgressStorage])
 def storage(request):
     return request.param()
 


### PR DESCRIPTION
**Background:** The transitioning from the status stanza to annotations started in #331, 23653ffd859d6a1263d9e17d0ca1c545c452756b, version 0.27 in March 2020. Now is March 2026 — 6 years was enough for all operators to execute the handling at least once, so that the progress is moved to annotations. It is time to stop writing to the status stanza.

**Problem:** This has become critical only now, after the recent introduction of JSON-patches via `patch.fns` (for atomicity of the finalizer addition/removal in the first place) — we have increased the number of API PATCH operations from max 2 to max 4 per cycle: merge/json x yes/no(status-as-a-subresource). That is too many. In most cases for "out of the box" operators, the status is updated ONLY for the internal progress of handlers, which is anyway duplicated in annotations as the primary storage.

* #1253 
* #1252

**Scope:** All new writes are suppressed. However, the deletion of the existing fields will continue — in case the framework/operator is upgraded in the middle of the handling, so that we remove the remaining status fields and leave no garbage after us.

**Not affected:** Users CAN add their payloads, such as handler results, or direct patches in the status fields — these cases cannot prevent the 4x PATCHes. But for the default case, we can prevent it and reduce the load on the clusters.

The cases with custom storages are not affected. The cases with the explicitly configured status storage are not affected either. Only the "smart" storage is affeced by redefining what "smart" is. Users CAN configure their operators to write to the status stanza if they want it — by using the copy of the smart storage before the change.