### PR TITLE
Store the progress & diff base in file and sqlite storages [v1]

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -394,6 +394,23 @@ To store the state only in the status or any other field:
     def configure(settings: kopf.OperatorSettings, **_):
         settings.persistence.progress_storage = kopf.StatusProgressStorage(field='status.my-operator')
 
+To store the state in YAML files on a shared filesystem or pod volume,
+instead of on the Kubernetes object itself:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_):
+        settings.persistence.progress_storage = kopf.FileProgressStorage(path='/var/kopf-storage')
+
+Each Kubernetes resource gets its own file, named
+``{namespace}-{name}-{uid}.progress.yaml`` (or ``{name}-{uid}.progress.yaml``
+for cluster-scoped resources). The file contains a YAML mapping of handler IDs
+to their progress records. A small touch annotation is still written to the
+Kubernetes object to trigger watch events for delayed handler retries.
+
 To store in multiple places (stored in sync, but the first found state will be
 used when fetching, i.e. the first storage has precedence):
 
@@ -503,6 +520,21 @@ The default is an equivalent of:
 
 The stored content is a JSON-serialised essence of the object (i.e., only
 the important fields, with system fields and status stanza removed).
+
+To store the last-handled configuration in YAML files on a shared filesystem
+or pod volume, instead of on the Kubernetes object itself:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_):
+        settings.persistence.diffbase_storage = kopf.FileDiffBaseStorage(path='/var/kopf-storage')
+
+Each Kubernetes resource gets its own file, named
+``{namespace}-{name}-{uid}.diffbase.yaml`` (or ``{name}-{uid}.diffbase.yaml``
+for cluster-scoped resources). The file contains the YAML-encoded body essence.
 
 It is generally not a good idea to override this store unless multiple
 Kopf-based operators must handle the same resources, and they should not

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -411,6 +411,22 @@ for cluster-scoped resources). The file contains a YAML mapping of handler IDs
 to their progress records. A small touch annotation is still written to the
 Kubernetes object to trigger watch events for delayed handler retries.
 
+To store the state in a SQLite database:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_):
+        settings.persistence.progress_storage = kopf.SQLiteProgressStorage(path='/var/kopf/state.db')
+
+Each handler's progress record is stored as a separate row in a ``progress``
+table, keyed by the resource's namespace, name, uid, and handler id. The table
+is created automatically on first use. A small touch annotation is still written
+to the Kubernetes object to trigger watch events for delayed handler retries.
+Multiple storage types can share the same database file.
+
 To store in multiple places (stored in sync, but the first found state will be
 used when fetching, i.e. the first storage has precedence):
 
@@ -535,6 +551,21 @@ or pod volume, instead of on the Kubernetes object itself:
 Each Kubernetes resource gets its own file, named
 ``{namespace}-{name}-{uid}.diffbase.yaml`` (or ``{name}-{uid}.diffbase.yaml``
 for cluster-scoped resources). The file contains the YAML-encoded body essence.
+
+To store the last-handled configuration in a SQLite database:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_):
+        settings.persistence.diffbase_storage = kopf.SQLiteDiffBaseStorage(path='/var/kopf/state.db')
+
+Each resource's body essence is stored as a single row in a ``diffbase`` table,
+keyed by the resource's namespace, name, and uid. The table is created
+automatically on first use. Multiple storage types can share the same
+database file.
 
 It is generally not a good idea to override this store unless multiple
 Kopf-based operators must handle the same resources, and they should not

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -25,6 +25,7 @@ from kopf._cogs.configs.diffbase import (
     AnnotationsDiffBaseStorage,
     StatusDiffBaseStorage,
     FileDiffBaseStorage,
+    SQLiteDiffBaseStorage,
     MultiDiffBaseStorage,
 )
 from kopf._cogs.configs.progress import (
@@ -33,6 +34,7 @@ from kopf._cogs.configs.progress import (
     AnnotationsProgressStorage,
     StatusProgressStorage,
     FileProgressStorage,
+    SQLiteProgressStorage,
     MultiProgressStorage,
     SmartProgressStorage,
 )
@@ -236,12 +238,14 @@ __all__ = [
     'AnnotationsDiffBaseStorage',
     'StatusDiffBaseStorage',
     'FileDiffBaseStorage',
+    'SQLiteDiffBaseStorage',
     'MultiDiffBaseStorage',
     'ProgressRecord',
     'ProgressStorage',
     'AnnotationsProgressStorage',
     'StatusProgressStorage',
     'FileProgressStorage',
+    'SQLiteProgressStorage',
     'MultiProgressStorage',
     'SmartProgressStorage',
     'RawEventType',

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -24,6 +24,7 @@ from kopf._cogs.configs.diffbase import (
     DiffBaseStorage,
     AnnotationsDiffBaseStorage,
     StatusDiffBaseStorage,
+    FileDiffBaseStorage,
     MultiDiffBaseStorage,
 )
 from kopf._cogs.configs.progress import (
@@ -31,6 +32,7 @@ from kopf._cogs.configs.progress import (
     ProgressStorage,
     AnnotationsProgressStorage,
     StatusProgressStorage,
+    FileProgressStorage,
     MultiProgressStorage,
     SmartProgressStorage,
 )
@@ -233,11 +235,13 @@ __all__ = [
     'DiffBaseStorage',
     'AnnotationsDiffBaseStorage',
     'StatusDiffBaseStorage',
+    'FileDiffBaseStorage',
     'MultiDiffBaseStorage',
     'ProgressRecord',
     'ProgressStorage',
     'AnnotationsProgressStorage',
     'StatusProgressStorage',
+    'FileProgressStorage',
     'MultiProgressStorage',
     'SmartProgressStorage',
     'RawEventType',

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -284,6 +284,89 @@ class FileDiffBaseStorage(conventions.FileNamingConvention, DiffBaseStorage):
         filepath.write_text(yaml.safe_dump(dict(essence), default_flow_style=False), encoding='utf-8')
 
 
+class SQLiteDiffBaseStorage(conventions.SQLiteConvention, DiffBaseStorage):
+    """
+    Diff-base storage in a SQLite database file.
+
+    Each resource's body essence is stored as a single row, keyed by the
+    resource's namespace, name, and uid. The essence is stored as a JSON
+    string.
+
+    An example of the ``diffbase`` table contents:
+
+    .. code-block:: text
+
+        namespace | name   | uid   | essence
+        ----------+--------+-------+---------------------------------------
+        default   | my-app | uid1  | {"spec":{"replicas":3,"image":"..."}}
+
+    This storage does not write anything to the Kubernetes object itself.
+    Both the file and SQLite diff-base storages can share the same database
+    file when pointed to the same path.
+    """
+
+    _create_sql = (
+        'CREATE TABLE IF NOT EXISTS diffbase ('
+        'namespace TEXT NOT NULL, '
+        'name TEXT NOT NULL, '
+        'uid TEXT NOT NULL, '
+        'essence TEXT NOT NULL, '
+        'PRIMARY KEY (namespace, name, uid))'
+    )
+
+    def __init__(
+            self,
+            *,
+            path: str | pathlib.Path,
+            ignored_fields: Iterable[dicts.FieldSpec] | None = None,
+    ) -> None:
+        super().__init__(path=path, ignored_fields=ignored_fields)
+
+    def fetch(
+            self,
+            *,
+            body: bodies.Body,
+    ) -> bodies.BodyEssence | None:
+        namespace, name, uid = self._extract_keys(body)
+        if not name or not uid:
+            return None
+        conn = self._connect()
+        try:
+            cursor = self._try_execute(conn,
+                'SELECT essence FROM diffbase'
+                ' WHERE namespace=? AND name=? AND uid=?',
+                (namespace, name, uid))
+            if cursor is None:
+                return None
+            row = cursor.fetchone()
+        finally:
+            conn.close()
+        if row is None:
+            return None
+        return cast(bodies.BodyEssence, json.loads(row[0]))
+
+    def store(
+            self,
+            *,
+            body: bodies.Body,
+            patch: patches.Patch,
+            essence: bodies.BodyEssence,
+    ) -> None:
+        namespace, name, uid = self._extract_keys(body)
+        if not name or not uid:
+            return
+        encoded = json.dumps(dict(essence), separators=(',', ':'))
+        conn = self._connect()
+        try:
+            self._execute(conn,
+                'INSERT OR REPLACE INTO diffbase'
+                ' (namespace, name, uid, essence) VALUES (?, ?, ?, ?)',
+                (namespace, name, uid, encoded))
+            conn.commit()
+        finally:
+            conn.close()
+
+
 class MultiDiffBaseStorage(DiffBaseStorage):
 
     def __init__(

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -2,6 +2,7 @@ import abc
 import copy
 import json
 import pathlib
+import urllib.parse
 from collections.abc import Collection, Iterable
 from typing import Any, cast
 
@@ -260,14 +261,23 @@ class FileDiffBaseStorage(DiffBaseStorage):
         super().__init__(ignored_fields=ignored_fields)
         self._path = pathlib.Path(path)
 
+    @staticmethod
+    def _escape(value: str) -> str:
+        """Percent-encode a value for safe use in filenames."""
+        # urllib.parse.quote never encodes dots (unreserved in RFC 3986),
+        # so we replace them manually to prevent '..' path traversal.
+        return urllib.parse.quote(value, safe='-_~').replace('.', '%2E')
+
     def _build_filename(self, body: bodies.Body) -> pathlib.Path | None:
         namespace = body.get('metadata', {}).get('namespace')
         name = body.get('metadata', {}).get('name')
         uid = body.get('metadata', {}).get('uid')
         if not name or not uid:
             return None
-        prefix = f'{namespace}-' if namespace else ''
-        return self._path / f'{prefix}{name}-{uid}.diffbase.yaml'
+        safe_name = self._escape(name)
+        safe_uid = self._escape(uid)
+        prefix = f'{self._escape(namespace)}-' if namespace else ''
+        return self._path / f'{prefix}{safe_name}-{safe_uid}.diffbase.yaml'
 
     def fetch(
             self,

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -253,8 +253,8 @@ class FileDiffBaseStorage(conventions.FileNamingConvention, DiffBaseStorage):
 
     def __init__(
             self,
-            *,
             path: str | pathlib.Path,
+            *,
             ignored_fields: Iterable[dicts.FieldSpec] | None = None,
     ) -> None:
         super().__init__(path=path, file_suffix='diffbase', ignored_fields=ignored_fields)

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -41,8 +41,11 @@ All timestamps are strings in ISO8601 format in UTC (no explicit ``Z`` suffix).
 import abc
 import copy
 import json
+import pathlib
 from collections.abc import Collection, Mapping
 from typing import Any, TypedDict, cast
+
+import yaml
 
 from kopf._cogs.configs import conventions
 from kopf._cogs.structs import bodies, dicts, ids, patches
@@ -366,6 +369,129 @@ class StatusProgressStorage(ProgressStorage):
         essence_dict = cast(dict[Any, Any], essence)
         dicts.remove(essence_dict, self.field)
 
+        self.remove_empty_stanzas(essence)
+        return essence
+
+
+class FileProgressStorage(ProgressStorage):
+    """
+    State storage in YAML files on a shared filesystem or pod volume.
+
+    Each Kubernetes resource gets its own file, named after its namespace,
+    name, and uid. The file contains a YAML mapping of handler IDs to their
+    progress records.
+
+    An example file at ``/var/kopf/default-my-app-12345678-abcd.progress.yaml``:
+
+    .. code-block:: yaml
+
+        my_handler:
+          started: '2020-02-14T16:58:25.396364'
+          stopped: '2020-02-14T16:58:25.401844'
+          retries: 1
+          success: true
+        my_other_handler:
+          started: '2020-02-14T16:58:25.396421'
+          retries: 0
+
+    The progress data itself is stored in files, not on the Kubernetes object.
+    However, a touch annotation is still written to the object (via the patch)
+    to trigger Kubernetes watch events when the object needs to be re-evaluated
+    (e.g. for delayed handler retries).
+    """
+
+    def __init__(
+            self,
+            *,
+            path: str | pathlib.Path,
+            prefix: str = 'kopf.zalando.org',
+            touch_key: str = 'touch-dummy',
+    ) -> None:
+        super().__init__()
+        self._path = pathlib.Path(path)
+        self.prefix = prefix
+        self.touch_key = touch_key
+
+    def _build_filename(self, body: bodies.Body) -> pathlib.Path | None:
+        namespace = body.get('metadata', {}).get('namespace')
+        name = body.get('metadata', {}).get('name')
+        uid = body.get('metadata', {}).get('uid')
+        if not name or not uid:
+            return None
+        prefix = f'{namespace}-' if namespace else ''
+        return self._path / f'{prefix}{name}-{uid}.progress.yaml'
+
+    def fetch(
+            self,
+            *,
+            key: ids.HandlerId,
+            body: bodies.Body,
+    ) -> ProgressRecord | None:
+        filepath = self._build_filename(body)
+        if filepath is None or not filepath.exists():
+            return None
+        data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+        if not isinstance(data, dict):
+            return None
+        record = data.get(key)
+        return cast(ProgressRecord, record) if record is not None else None
+
+    def store(
+            self,
+            *,
+            key: ids.HandlerId,
+            record: ProgressRecord,
+            body: bodies.Body,
+            patch: patches.Patch,
+    ) -> None:
+        filepath = self._build_filename(body)
+        if filepath is None:
+            return
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        data: dict[str, Any] = {}
+        if filepath.exists():
+            loaded = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+            if isinstance(loaded, dict):
+                data = loaded
+        data[key] = {k: v for k, v in record.items() if v is not None}
+        filepath.write_text(yaml.safe_dump(data, default_flow_style=False), encoding='utf-8')
+
+    def purge(
+            self,
+            *,
+            key: ids.HandlerId,
+            body: bodies.Body,
+            patch: patches.Patch,
+    ) -> None:
+        filepath = self._build_filename(body)
+        if filepath is None or not filepath.exists():
+            return
+        loaded = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+        data: dict[str, Any] = loaded if isinstance(loaded, dict) else {}
+        data.pop(key, None)
+        if data:
+            filepath.write_text(yaml.safe_dump(data, default_flow_style=False), encoding='utf-8')
+        else:
+            filepath.unlink(missing_ok=True)
+
+    def touch(
+            self,
+            *,
+            body: bodies.Body,
+            patch: patches.Patch,
+            value: str | None,
+    ) -> None:
+        full_key = f'{self.prefix}/{self.touch_key}' if self.prefix else self.touch_key
+        key_field = ['metadata', 'annotations', full_key]
+        body_value = dicts.resolve(body, key_field, None)
+        if body_value != value:  # also covers absent-vs-None cases.
+            dicts.ensure(patch, key_field, value)
+
+    def clear(self, *, essence: bodies.BodyEssence) -> bodies.BodyEssence:
+        essence = super().clear(essence=essence)
+        annotations = essence.get('metadata', {}).get('annotations', {})
+        keys = {key for key in annotations if self.prefix and key.startswith(f'{self.prefix}/')}
+        self.remove_annotations(essence, keys)
         self.remove_empty_stanzas(essence)
         return essence
 

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -402,8 +402,8 @@ class FileProgressStorage(conventions.FileNamingConvention, ProgressStorage):
 
     def __init__(
             self,
-            *,
             path: str | pathlib.Path,
+            *,
             prefix: str = 'kopf.dev',
             touch_key: str = 'touch-dummy',
     ) -> None:

--- a/tests/persistence/test_storing_of_file_diffbase.py
+++ b/tests/persistence/test_storing_of_file_diffbase.py
@@ -97,6 +97,23 @@ def test_filename_escapes_double_dots(tmp_path):
     assert filepath.parent == tmp_path
 
 
+def test_filename_escapes_double_dots_with_slashes(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': '../path', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '..' not in filepath.name
+    assert '%2E%2E%2Fpath' in filepath.name
+    assert filepath.parent == tmp_path
+
+
+def test_filename_escapes_double_dots_in_middle(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a/../b', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '..' not in filepath.name
+    assert filepath.parent == tmp_path
+
+
 def test_filename_escapes_special_characters(tmp_path):
     storage = FileDiffBaseStorage(path=tmp_path)
     body = Body({'metadata': {'namespace': 'ns', 'name': 'a:b@c', 'uid': 'uid1'}})

--- a/tests/persistence/test_storing_of_file_diffbase.py
+++ b/tests/persistence/test_storing_of_file_diffbase.py
@@ -1,0 +1,214 @@
+import pytest
+import yaml
+
+from kopf._cogs.configs.diffbase import FileDiffBaseStorage
+from kopf._cogs.structs.bodies import Body, BodyEssence
+from kopf._cogs.structs.patches import Patch
+
+NAMESPACED_BODY = Body({'metadata': {'namespace': 'ns1', 'name': 'name1', 'uid': 'uid1'}})
+CLUSTER_BODY = Body({'metadata': {'name': 'name1', 'uid': 'uid1'}})
+
+ESSENCE_DATA_1 = BodyEssence(
+    spec={
+        'string-field': 'value1',
+        'integer-field': 123,
+        'float-field': 123.456,
+        'false-field': False,
+        'true-field': True,
+    },
+)
+
+ESSENCE_DATA_2 = BodyEssence(
+    spec={
+        'hello': 'world',
+        'the-cake': False,
+    },
+)
+
+
+#
+# Storage creation.
+#
+
+
+def test_file_storage_with_path(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    assert storage._path == tmp_path
+
+
+def test_file_storage_with_string_path(tmp_path):
+    storage = FileDiffBaseStorage(path=str(tmp_path))
+    assert storage._path == tmp_path
+
+
+#
+# Filename building.
+#
+
+
+def test_filename_for_namespaced_resource(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'default', 'name': 'my-app', 'uid': 'abc-123'}})
+    filepath = storage._build_filename(body)
+    assert filepath == tmp_path / 'default-my-app-abc-123.diffbase.yaml'
+
+
+def test_filename_for_cluster_resource(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'name': 'my-node', 'uid': 'abc-123'}})
+    filepath = storage._build_filename(body)
+    assert filepath == tmp_path / 'my-node-abc-123.diffbase.yaml'
+
+
+def test_filename_for_empty_body(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+def test_filename_for_body_without_name(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+def test_filename_for_body_without_uid(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'name': 'name1'}})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+#
+# Fetching.
+#
+
+
+def test_fetching_from_empty_body_returns_none(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({})
+    data = storage.fetch(body=body)
+    assert data is None
+
+
+def test_fetching_when_no_file_exists(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    data = storage.fetch(body=NAMESPACED_BODY)
+    assert data is None
+
+
+def test_fetching_existing_essence(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    filepath.write_text(yaml.safe_dump(dict(ESSENCE_DATA_1)), encoding='utf-8')
+
+    data = storage.fetch(body=NAMESPACED_BODY)
+    assert data == ESSENCE_DATA_1
+
+
+#
+# Storing.
+#
+
+
+def test_storing_creates_file(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    body = Body({'metadata': {'namespace': 'ns1', 'name': 'name1', 'uid': 'uid1'}})
+    storage.store(body=body, patch=patch, essence=ESSENCE_DATA_1)
+
+    filepath = storage._build_filename(body)
+    assert filepath.exists()
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    assert data == ESSENCE_DATA_1
+
+
+def test_storing_does_not_modify_patch(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    assert not patch
+
+
+def test_storing_creates_parent_directories(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path / 'sub' / 'dir')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    assert filepath.exists()
+
+
+def test_storing_overwrites_old_content(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_2)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    assert data == ESSENCE_DATA_2
+
+
+def test_storing_with_empty_body_is_noop(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    body = Body({})
+    storage.store(body=body, patch=patch, essence=ESSENCE_DATA_1)
+    assert not list(tmp_path.iterdir())
+
+
+def test_storing_for_cluster_resource(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=CLUSTER_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    filepath = storage._build_filename(CLUSTER_BODY)
+    assert filepath.exists()
+    assert filepath.name == 'name1-uid1.diffbase.yaml'
+
+
+#
+# YAML round-trip integrity.
+#
+
+
+def test_yaml_roundtrip_preserves_types(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    essence = BodyEssence(
+        spec={
+            'string-field': 'value1',
+            'integer-field': 123,
+            'float-field': 123.456,
+            'false-field': False,
+            'true-field': True,
+            'list-field': ['a', 'b', 'c'],
+            'nested-field': {'key': 'value'},
+        },
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=essence)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+
+    assert fetched['spec']['string-field'] == 'value1'
+    assert fetched['spec']['integer-field'] == 123
+    assert fetched['spec']['float-field'] == 123.456
+    assert fetched['spec']['false-field'] is False
+    assert fetched['spec']['true-field'] is True
+    assert fetched['spec']['list-field'] == ['a', 'b', 'c']
+    assert fetched['spec']['nested-field'] == {'key': 'value'}
+
+
+def test_fetch_and_store_roundtrip(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+    assert fetched == ESSENCE_DATA_1
+
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_2)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+    assert fetched == ESSENCE_DATA_2

--- a/tests/persistence/test_storing_of_file_diffbase.py
+++ b/tests/persistence/test_storing_of_file_diffbase.py
@@ -81,6 +81,31 @@ def test_filename_for_body_without_uid(tmp_path):
     assert filepath is None
 
 
+def test_filename_escapes_slashes(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a/b', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '/' not in filepath.name
+    assert 'a%2Fb' in filepath.name
+
+
+def test_filename_escapes_double_dots(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': '..', 'name': '..', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert filepath.name == '%2E%2E-%2E%2E-uid1.diffbase.yaml'
+    assert filepath.parent == tmp_path
+
+
+def test_filename_escapes_special_characters(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a:b@c', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '/' not in filepath.name
+    assert ':' not in filepath.name
+    assert '@' not in filepath.name
+
+
 #
 # Fetching.
 #

--- a/tests/persistence/test_storing_of_file_progress.py
+++ b/tests/persistence/test_storing_of_file_progress.py
@@ -69,6 +69,13 @@ def test_filename_for_namespaced_resource(tmp_path):
     assert filepath == tmp_path / 'default-my-app-abc-123.progress.yaml'
 
 
+def test_filename_for_dotted_name(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'default', 'name': 'my.app.v1', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert filepath == tmp_path / 'default-my%2Eapp%2Ev1-uid1.progress.yaml'
+
+
 def test_filename_for_cluster_resource(tmp_path):
     storage = FileProgressStorage(path=tmp_path)
     body = Body({'metadata': {'name': 'my-node', 'uid': 'abc-123'}})
@@ -95,6 +102,32 @@ def test_filename_for_body_without_uid(tmp_path):
     body = Body({'metadata': {'name': 'name1'}})
     filepath = storage._build_filename(body)
     assert filepath is None
+
+
+def test_filename_escapes_slashes(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a/b', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '/' not in filepath.name
+    assert 'a%2Fb' in filepath.name
+
+
+def test_filename_escapes_double_dots(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': '..', 'name': '..', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert filepath.name == '%2E%2E-%2E%2E-uid1.progress.yaml'
+    # Must stay flat in the configured directory (no path traversal).
+    assert filepath.parent == tmp_path
+
+
+def test_filename_escapes_special_characters(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a:b@c', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '/' not in filepath.name
+    assert ':' not in filepath.name
+    assert '@' not in filepath.name
 
 
 #

--- a/tests/persistence/test_storing_of_file_progress.py
+++ b/tests/persistence/test_storing_of_file_progress.py
@@ -1,0 +1,387 @@
+import pytest
+import yaml
+
+from kopf._cogs.configs.progress import FileProgressStorage, ProgressRecord
+from kopf._cogs.structs.bodies import Body, BodyEssence
+from kopf._cogs.structs.ids import HandlerId
+from kopf._cogs.structs.patches import Patch
+
+CONTENT_DATA_1 = ProgressRecord(
+    started='2020-01-01T00:00:00',
+    stopped='2020-12-31T23:59:59',
+    delayed='3000-01-01T00:00:00',
+    retries=123,
+    success=False,
+    failure=False,
+    message=None,
+    subrefs=None,
+)
+
+CONTENT_DATA_2 = ProgressRecord(
+    started='2021-01-01T00:00:00',
+    stopped='2021-12-31T23:59:59',
+    delayed='3001-01-01T00:00:00',
+    retries=456,
+    success=False,
+    failure=False,
+    message="Some error.",
+    subrefs=['sub1', 'sub2'],
+)
+
+NAMESPACED_BODY = Body({'metadata': {'namespace': 'ns1', 'name': 'name1', 'uid': 'uid1'}})
+CLUSTER_BODY = Body({'metadata': {'name': 'name1', 'uid': 'uid1'}})
+
+
+#
+# Storage creation.
+#
+
+
+def test_file_storage_with_path(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    assert storage._path == tmp_path
+
+
+def test_file_storage_with_string_path(tmp_path):
+    storage = FileProgressStorage(path=str(tmp_path))
+    assert storage._path == tmp_path
+
+
+def test_file_storage_with_prefix(tmp_path):
+    storage = FileProgressStorage(path=tmp_path, prefix='my-op.example.com')
+    assert storage.prefix == 'my-op.example.com'
+
+
+def test_file_storage_with_touch_key(tmp_path):
+    storage = FileProgressStorage(path=tmp_path, touch_key='my-dummy')
+    assert storage.touch_key == 'my-dummy'
+
+
+#
+# Filename building.
+#
+
+
+def test_filename_for_namespaced_resource(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'default', 'name': 'my-app', 'uid': 'abc-123'}})
+    filepath = storage._build_filename(body)
+    assert filepath == tmp_path / 'default-my-app-abc-123.progress.yaml'
+
+
+def test_filename_for_cluster_resource(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'name': 'my-node', 'uid': 'abc-123'}})
+    filepath = storage._build_filename(body)
+    assert filepath == tmp_path / 'my-node-abc-123.progress.yaml'
+
+
+def test_filename_for_empty_body(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+def test_filename_for_body_without_name(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+def test_filename_for_body_without_uid(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'name': 'name1'}})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+#
+# Fetching.
+#
+
+
+def test_fetching_from_empty_body_returns_none(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({})
+    data = storage.fetch(body=body, key=HandlerId('id1'))
+    assert data is None
+
+
+def test_fetching_when_no_file_exists(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    assert data is None
+
+
+def test_fetching_existing_record(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    # Write without None values, as store() does.
+    clean_data = {k: v for k, v in CONTENT_DATA_1.items() if v is not None}
+    filepath.write_text(yaml.safe_dump({'id1': clean_data}), encoding='utf-8')
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    assert data == clean_data
+
+
+def test_fetching_nonexistent_key_returns_none(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    filepath.write_text(yaml.safe_dump({'id1': dict(CONTENT_DATA_1)}), encoding='utf-8')
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id2'))
+    assert data is None
+
+
+#
+# Storing.
+#
+
+
+def test_storing_creates_file(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    assert filepath.exists()
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    expected = {k: v for k, v in CONTENT_DATA_1.items() if v is not None}
+    assert data['id1'] == expected
+
+
+def test_storing_does_not_modify_patch(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    assert not patch
+
+
+def test_storing_creates_parent_directories(tmp_path):
+    storage = FileProgressStorage(path=tmp_path / 'sub' / 'dir')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    assert filepath.exists()
+
+
+def test_storing_appends_keys(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id2'), record=CONTENT_DATA_2)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    assert 'id1' in data
+    assert 'id2' in data
+
+
+def test_storing_overwrites_existing_key(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_2)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    expected = {k: v for k, v in CONTENT_DATA_2.items() if v is not None}
+    assert data['id1'] == expected
+
+
+def test_storing_filters_none_values(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    record = ProgressRecord(
+        started=None,
+        stopped=None,
+        delayed=None,
+        retries=None,
+        success=None,
+        failure=None,
+        message=None,
+        subrefs=None,
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=record)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    assert data['id1'] == {}
+
+
+def test_storing_with_empty_body_is_noop(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    body = Body({})
+    storage.store(body=body, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    assert not list(tmp_path.iterdir())
+
+
+def test_storing_for_cluster_resource(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=CLUSTER_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    filepath = storage._build_filename(CLUSTER_BODY)
+    assert filepath.exists()
+    assert filepath.name == 'name1-uid1.progress.yaml'
+
+
+#
+# Purging.
+#
+
+
+def test_purging_already_empty_body_does_nothing(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    body = Body({})
+    storage.purge(body=body, patch=patch, key=HandlerId('id1'))
+    assert not patch
+
+
+def test_purging_when_no_file_exists(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.purge(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'))
+    assert not patch
+
+
+def test_purging_removes_key(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id2'), record=CONTENT_DATA_2)
+
+    storage.purge(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'))
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    assert 'id1' not in data
+    assert 'id2' in data
+
+
+def test_purging_last_key_removes_file(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    storage.purge(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'))
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    assert not filepath.exists()
+
+
+def test_purging_does_not_modify_patch(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    patch2 = Patch()
+    storage.purge(body=NAMESPACED_BODY, patch=patch2, key=HandlerId('id1'))
+    assert not patch2
+
+
+#
+# Touching.
+#
+
+
+@pytest.mark.parametrize('body_data', [
+    pytest.param({}, id='without-data'),
+    pytest.param({'metadata': {'annotations': {'my-op.example.com/my-dummy': 'something'}}}, id='with-data'),
+])
+def test_touching_with_payload(tmp_path, body_data):
+    storage = FileProgressStorage(path=tmp_path, prefix='my-op.example.com', touch_key='my-dummy')
+    patch = Patch()
+    body = Body(body_data)
+    storage.touch(body=body, patch=patch, value='hello')
+
+    assert patch
+    assert patch['metadata']['annotations']['my-op.example.com/my-dummy'] == 'hello'
+
+
+def test_touching_with_none_when_absent(tmp_path):
+    storage = FileProgressStorage(path=tmp_path, prefix='my-op.example.com', touch_key='my-dummy')
+    patch = Patch()
+    body = Body({})
+    storage.touch(body=body, patch=patch, value=None)
+
+    assert not patch
+
+
+def test_touching_with_none_when_present(tmp_path):
+    storage = FileProgressStorage(path=tmp_path, prefix='my-op.example.com', touch_key='my-dummy')
+    patch = Patch()
+    body = Body({'metadata': {'annotations': {'my-op.example.com/my-dummy': 'something'}}})
+    storage.touch(body=body, patch=patch, value=None)
+
+    assert patch
+    assert patch['metadata']['annotations']['my-op.example.com/my-dummy'] is None
+
+
+#
+# Clearing.
+#
+
+
+def test_clearing_returns_essence_unchanged_without_annotations(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    essence = BodyEssence(
+        spec={'field': 'value'},
+        metadata={'labels': {'app': 'test'}},
+    )
+    result = storage.clear(essence=essence)
+    assert result == essence
+    # Must be a deep copy, not the same object.
+    assert result is not essence
+
+
+def test_clearing_removes_touch_annotation(tmp_path):
+    storage = FileProgressStorage(path=tmp_path, prefix='my-op.example.com')
+    essence = BodyEssence(
+        spec={'field': 'value'},
+        metadata={'annotations': {
+            'my-op.example.com/touch-dummy': 'some-value',
+            'unrelated-annotation': 'keep-this',
+        }},
+    )
+    result = storage.clear(essence=essence)
+    assert 'my-op.example.com/touch-dummy' not in result.get('metadata', {}).get('annotations', {})
+    assert result['metadata']['annotations']['unrelated-annotation'] == 'keep-this'
+
+
+#
+# YAML round-trip integrity.
+#
+
+
+def test_yaml_roundtrip_preserves_types(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    record = ProgressRecord(
+        started='2020-01-01T00:00:00',
+        stopped='2020-12-31T23:59:59',
+        delayed='3000-01-01T00:00:00',
+        retries=123,
+        success=True,
+        failure=False,
+        message="Some error.",
+        subrefs=['sub1', 'sub2'],
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=record)
+    fetched = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+
+    assert isinstance(fetched['started'], str)
+    assert isinstance(fetched['retries'], int)
+    assert isinstance(fetched['success'], bool)
+    assert isinstance(fetched['failure'], bool)
+    assert isinstance(fetched['message'], str)
+    assert isinstance(fetched['subrefs'], list)
+    assert fetched['started'] == '2020-01-01T00:00:00'
+    assert fetched['retries'] == 123
+    assert fetched['success'] is True
+    assert fetched['failure'] is False

--- a/tests/persistence/test_storing_of_file_progress.py
+++ b/tests/persistence/test_storing_of_file_progress.py
@@ -121,6 +121,23 @@ def test_filename_escapes_double_dots(tmp_path):
     assert filepath.parent == tmp_path
 
 
+def test_filename_escapes_double_dots_with_slashes(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': '../path', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '..' not in filepath.name
+    assert '%2E%2E%2Fpath' in filepath.name
+    assert filepath.parent == tmp_path
+
+
+def test_filename_escapes_double_dots_in_middle(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a/../b', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '..' not in filepath.name
+    assert filepath.parent == tmp_path
+
+
 def test_filename_escapes_special_characters(tmp_path):
     storage = FileProgressStorage(path=tmp_path)
     body = Body({'metadata': {'namespace': 'ns', 'name': 'a:b@c', 'uid': 'uid1'}})

--- a/tests/persistence/test_storing_of_file_progress.py
+++ b/tests/persistence/test_storing_of_file_progress.py
@@ -73,7 +73,7 @@ def test_filename_for_dotted_name(tmp_path):
     storage = FileProgressStorage(path=tmp_path)
     body = Body({'metadata': {'namespace': 'default', 'name': 'my.app.v1', 'uid': 'uid1'}})
     filepath = storage._build_filename(body)
-    assert filepath == tmp_path / 'default-my%2Eapp%2Ev1-uid1.progress.yaml'
+    assert filepath == tmp_path / 'default-my.app.v1-uid1.progress.yaml'
 
 
 def test_filename_for_cluster_resource(tmp_path):

--- a/tests/persistence/test_storing_of_sqlite_diffbase.py
+++ b/tests/persistence/test_storing_of_sqlite_diffbase.py
@@ -1,0 +1,211 @@
+import json
+import sqlite3
+
+import pytest
+
+from kopf._cogs.configs.diffbase import SQLiteDiffBaseStorage
+from kopf._cogs.structs.bodies import Body, BodyEssence
+from kopf._cogs.structs.patches import Patch
+
+NAMESPACED_BODY = Body({'metadata': {'namespace': 'ns1', 'name': 'name1', 'uid': 'uid1'}})
+CLUSTER_BODY = Body({'metadata': {'name': 'name1', 'uid': 'uid1'}})
+
+ESSENCE_DATA_1 = BodyEssence(
+    spec={
+        'string-field': 'value1',
+        'integer-field': 123,
+        'float-field': 123.456,
+        'false-field': False,
+        'true-field': True,
+    },
+)
+
+ESSENCE_DATA_2 = BodyEssence(
+    spec={
+        'hello': 'world',
+        'the-cake': False,
+    },
+)
+
+
+#
+# Storage creation.
+#
+
+
+def test_sqlite_storage_with_path(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    assert storage._path == tmp_path / 'db.sqlite'
+
+
+def test_sqlite_storage_with_string_path(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=str(tmp_path / 'db.sqlite'))
+    assert storage._path == tmp_path / 'db.sqlite'
+
+
+#
+# Fetching.
+#
+
+
+def test_fetching_from_empty_body_returns_none(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    body = Body({})
+    data = storage.fetch(body=body)
+    assert data is None
+
+
+def test_fetching_when_no_table_exists(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    data = storage.fetch(body=NAMESPACED_BODY)
+    assert data is None
+
+
+def test_fetching_existing_essence(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    data = storage.fetch(body=NAMESPACED_BODY)
+    assert data == ESSENCE_DATA_1
+
+
+#
+# Storing.
+#
+
+
+def test_storing_creates_table(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    conn = sqlite3.connect(str(tmp_path / 'db.sqlite'))
+    tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    conn.close()
+    assert ('diffbase',) in tables
+
+
+def test_storing_does_not_modify_patch(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    assert not patch
+
+
+def test_storing_creates_parent_directories(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'sub' / 'dir' / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    assert (tmp_path / 'sub' / 'dir' / 'db.sqlite').exists()
+
+
+def test_storing_overwrites_old_content(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_2)
+
+    data = storage.fetch(body=NAMESPACED_BODY)
+    assert data == ESSENCE_DATA_2
+
+
+def test_storing_with_empty_body_is_noop(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    body = Body({})
+    storage.store(body=body, patch=patch, essence=ESSENCE_DATA_1)
+    assert not (tmp_path / 'db.sqlite').exists()
+
+
+def test_storing_for_cluster_resource(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=CLUSTER_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    data = storage.fetch(body=CLUSTER_BODY)
+    assert data == ESSENCE_DATA_1
+
+
+def test_storing_isolates_namespaced_and_cluster_resources(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    storage.store(body=CLUSTER_BODY, patch=patch, essence=ESSENCE_DATA_2)
+
+    data_ns = storage.fetch(body=NAMESPACED_BODY)
+    data_cl = storage.fetch(body=CLUSTER_BODY)
+    assert data_ns == ESSENCE_DATA_1
+    assert data_cl == ESSENCE_DATA_2
+
+
+#
+# Shared database file.
+#
+
+
+def test_shared_database_between_storages(tmp_path):
+    db_path = tmp_path / 'shared.sqlite'
+    progress_storage = __import__('kopf._cogs.configs.progress', fromlist=['SQLiteProgressStorage']).SQLiteProgressStorage(path=db_path)
+    diffbase_storage = SQLiteDiffBaseStorage(path=db_path)
+    patch = Patch()
+
+    from kopf._cogs.configs.progress import ProgressRecord
+    from kopf._cogs.structs.ids import HandlerId
+
+    record = ProgressRecord(started='2020-01-01T00:00:00', retries=1, success=True)
+    progress_storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('h1'), record=record)
+    diffbase_storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    conn = sqlite3.connect(str(db_path))
+    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    conn.close()
+    assert 'progress' in tables
+    assert 'diffbase' in tables
+
+    assert progress_storage.fetch(body=NAMESPACED_BODY, key=HandlerId('h1')) is not None
+    assert diffbase_storage.fetch(body=NAMESPACED_BODY) == ESSENCE_DATA_1
+
+
+#
+# JSON round-trip integrity.
+#
+
+
+def test_json_roundtrip_preserves_types(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    essence = BodyEssence(
+        spec={
+            'string-field': 'value1',
+            'integer-field': 123,
+            'float-field': 123.456,
+            'false-field': False,
+            'true-field': True,
+            'list-field': ['a', 'b', 'c'],
+            'nested-field': {'key': 'value'},
+        },
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=essence)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+
+    assert fetched['spec']['string-field'] == 'value1'
+    assert fetched['spec']['integer-field'] == 123
+    assert fetched['spec']['float-field'] == 123.456
+    assert fetched['spec']['false-field'] is False
+    assert fetched['spec']['true-field'] is True
+    assert fetched['spec']['list-field'] == ['a', 'b', 'c']
+    assert fetched['spec']['nested-field'] == {'key': 'value'}
+
+
+def test_fetch_and_store_roundtrip(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+    assert fetched == ESSENCE_DATA_1
+
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_2)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+    assert fetched == ESSENCE_DATA_2

--- a/tests/persistence/test_storing_of_sqlite_progress.py
+++ b/tests/persistence/test_storing_of_sqlite_progress.py
@@ -1,0 +1,342 @@
+import json
+import sqlite3
+
+import pytest
+
+from kopf._cogs.configs.progress import ProgressRecord, SQLiteProgressStorage
+from kopf._cogs.structs.bodies import Body, BodyEssence
+from kopf._cogs.structs.ids import HandlerId
+from kopf._cogs.structs.patches import Patch
+
+CONTENT_DATA_1 = ProgressRecord(
+    started='2020-01-01T00:00:00',
+    stopped='2020-12-31T23:59:59',
+    delayed='3000-01-01T00:00:00',
+    retries=123,
+    success=False,
+    failure=False,
+    message=None,
+    subrefs=None,
+)
+
+CONTENT_DATA_2 = ProgressRecord(
+    started='2021-01-01T00:00:00',
+    stopped='2021-12-31T23:59:59',
+    delayed='3001-01-01T00:00:00',
+    retries=456,
+    success=False,
+    failure=False,
+    message="Some error.",
+    subrefs=['sub1', 'sub2'],
+)
+
+NAMESPACED_BODY = Body({'metadata': {'namespace': 'ns1', 'name': 'name1', 'uid': 'uid1'}})
+CLUSTER_BODY = Body({'metadata': {'name': 'name1', 'uid': 'uid1'}})
+
+
+#
+# Storage creation.
+#
+
+
+def test_sqlite_storage_with_path(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    assert storage._path == tmp_path / 'db.sqlite'
+
+
+def test_sqlite_storage_with_string_path(tmp_path):
+    storage = SQLiteProgressStorage(path=str(tmp_path / 'db.sqlite'))
+    assert storage._path == tmp_path / 'db.sqlite'
+
+
+def test_sqlite_storage_with_prefix(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite', prefix='my-op.example.com')
+    assert storage.prefix == 'my-op.example.com'
+
+
+def test_sqlite_storage_with_touch_key(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite', touch_key='my-dummy')
+    assert storage.touch_key == 'my-dummy'
+
+
+#
+# Fetching.
+#
+
+
+def test_fetching_from_empty_body_returns_none(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    body = Body({})
+    data = storage.fetch(body=body, key=HandlerId('id1'))
+    assert data is None
+
+
+def test_fetching_when_no_table_exists(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    assert data is None
+
+
+def test_fetching_existing_record(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    expected = {k: v for k, v in CONTENT_DATA_1.items() if v is not None}
+    assert data == expected
+
+
+def test_fetching_nonexistent_key_returns_none(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id2'))
+    assert data is None
+
+
+#
+# Storing.
+#
+
+
+def test_storing_creates_table(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    conn = sqlite3.connect(str(tmp_path / 'db.sqlite'))
+    tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    conn.close()
+    assert ('progress',) in tables
+
+
+def test_storing_does_not_modify_patch(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    assert not patch
+
+
+def test_storing_creates_parent_directories(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'sub' / 'dir' / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    assert (tmp_path / 'sub' / 'dir' / 'db.sqlite').exists()
+
+
+def test_storing_appends_keys(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id2'), record=CONTENT_DATA_2)
+
+    data1 = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    data2 = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id2'))
+    assert data1 is not None
+    assert data2 is not None
+
+
+def test_storing_overwrites_existing_key(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_2)
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    expected = {k: v for k, v in CONTENT_DATA_2.items() if v is not None}
+    assert data == expected
+
+
+def test_storing_filters_none_values(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    record = ProgressRecord(
+        started=None,
+        stopped=None,
+        delayed=None,
+        retries=None,
+        success=None,
+        failure=None,
+        message=None,
+        subrefs=None,
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=record)
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    assert data == {}
+
+
+def test_storing_with_empty_body_is_noop(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    body = Body({})
+    storage.store(body=body, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    assert not (tmp_path / 'db.sqlite').exists()
+
+
+def test_storing_for_cluster_resource(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=CLUSTER_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    data = storage.fetch(body=CLUSTER_BODY, key=HandlerId('id1'))
+    assert data is not None
+
+
+def test_storing_isolates_namespaced_and_cluster_resources(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=CLUSTER_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_2)
+
+    data_ns = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    data_cl = storage.fetch(body=CLUSTER_BODY, key=HandlerId('id1'))
+    expected_ns = {k: v for k, v in CONTENT_DATA_1.items() if v is not None}
+    expected_cl = {k: v for k, v in CONTENT_DATA_2.items() if v is not None}
+    assert data_ns == expected_ns
+    assert data_cl == expected_cl
+
+
+#
+# Purging.
+#
+
+
+def test_purging_already_empty_body_does_nothing(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    body = Body({})
+    storage.purge(body=body, patch=patch, key=HandlerId('id1'))
+    assert not patch
+
+
+def test_purging_when_no_table_exists(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.purge(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'))
+    assert not patch
+
+
+def test_purging_removes_key(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id2'), record=CONTENT_DATA_2)
+
+    storage.purge(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'))
+
+    assert storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1')) is None
+    assert storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id2')) is not None
+
+
+def test_purging_does_not_modify_patch(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    patch2 = Patch()
+    storage.purge(body=NAMESPACED_BODY, patch=patch2, key=HandlerId('id1'))
+    assert not patch2
+
+
+#
+# Touching.
+#
+
+
+@pytest.mark.parametrize('body_data', [
+    pytest.param({}, id='without-data'),
+    pytest.param({'metadata': {'annotations': {'my-op.example.com/my-dummy': 'something'}}}, id='with-data'),
+])
+def test_touching_with_payload(tmp_path, body_data):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite', prefix='my-op.example.com', touch_key='my-dummy')
+    patch = Patch()
+    body = Body(body_data)
+    storage.touch(body=body, patch=patch, value='hello')
+
+    assert patch
+    assert patch['metadata']['annotations']['my-op.example.com/my-dummy'] == 'hello'
+
+
+def test_touching_with_none_when_absent(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite', prefix='my-op.example.com', touch_key='my-dummy')
+    patch = Patch()
+    body = Body({})
+    storage.touch(body=body, patch=patch, value=None)
+
+    assert not patch
+
+
+def test_touching_with_none_when_present(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite', prefix='my-op.example.com', touch_key='my-dummy')
+    patch = Patch()
+    body = Body({'metadata': {'annotations': {'my-op.example.com/my-dummy': 'something'}}})
+    storage.touch(body=body, patch=patch, value=None)
+
+    assert patch
+    assert patch['metadata']['annotations']['my-op.example.com/my-dummy'] is None
+
+
+#
+# Clearing.
+#
+
+
+def test_clearing_returns_essence_unchanged_without_annotations(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    essence = BodyEssence(
+        spec={'field': 'value'},
+        metadata={'labels': {'app': 'test'}},
+    )
+    result = storage.clear(essence=essence)
+    assert result == essence
+    assert result is not essence
+
+
+def test_clearing_removes_touch_annotation(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite', prefix='my-op.example.com')
+    essence = BodyEssence(
+        spec={'field': 'value'},
+        metadata={'annotations': {
+            'my-op.example.com/touch-dummy': 'some-value',
+            'unrelated-annotation': 'keep-this',
+        }},
+    )
+    result = storage.clear(essence=essence)
+    assert 'my-op.example.com/touch-dummy' not in result.get('metadata', {}).get('annotations', {})
+    assert result['metadata']['annotations']['unrelated-annotation'] == 'keep-this'
+
+
+#
+# JSON round-trip integrity.
+#
+
+
+def test_json_roundtrip_preserves_types(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    record = ProgressRecord(
+        started='2020-01-01T00:00:00',
+        stopped='2020-12-31T23:59:59',
+        delayed='3000-01-01T00:00:00',
+        retries=123,
+        success=True,
+        failure=False,
+        message="Some error.",
+        subrefs=['sub1', 'sub2'],
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=record)
+    fetched = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+
+    assert isinstance(fetched['started'], str)
+    assert isinstance(fetched['retries'], int)
+    assert isinstance(fetched['success'], bool)
+    assert isinstance(fetched['failure'], bool)
+    assert isinstance(fetched['message'], str)
+    assert isinstance(fetched['subrefs'], list)
+    assert fetched['started'] == '2020-01-01T00:00:00'
+    assert fetched['retries'] == 123
+    assert fetched['success'] is True
+    assert fetched['failure'] is False


### PR DESCRIPTION
## Summary

Add file-based and SQLite-based storage backends for progress and diffbase data, as alternatives to storing state on the Kubernetes object itself (annotations/status).

This should benefit users who do not want to store the state of the state-tracking handlers on the objects, e.g. to reduce the number of API PATCH requests to the cluster, but at the same time want something out of the box (instead of implementing it themselves).

These storages depend on StdLib alone and do not bring new dependencies. However, they cannot be made a new default (also out of the box), since each of them requires some external configuration — the persistent volume or a shared flilesystem in the container for all operator instances running (including the dev instances, if any). The storage in the object itself remains the default. 

See also a PR to reduce those patches: 

* #1259 



**File-based storages** (`FileProgressStorage`, `FileDiffBaseStorage`):
- Each K8s resource gets its own YAML file on a shared filesystem or pod volume
- Filenames use encoded/escaped namespace/name/uid for path safety
- Common logic extracted into a `FileNamingConvention` mixin

**SQLite-based storages** (`SQLiteProgressStorage`, `SQLiteDiffBaseStorage`):
- Progress stored as one row per handler with composite key `(namespace, name, uid, handler_id)`
- Diffbase stored as one row per resource with composite key `(namespace, name, uid)`
- Tables created optimistically on first write via try-except; reads return None if the table doesn't exist yet
- Both storage types can share the same `.db` file (separate tables)
- Uses only stdlib `sqlite3` — no new dependencies

Both storage types still write a touch annotation to the K8s object to trigger watch events for delayed handler retries.

All new classes are exported from the top-level `kopf` namespace and documented in `docs/configuration.rst`.

https://claude.ai/code/session_01TMbVk9bPSsTFQmFWhrEk19
