### PR TITLE
Store the progress & diff base in file and sqlite storages [v2]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,12 @@ repos:
       # Intentionally disabled:
       # - id: python-no-log-warn  # overreacts to `kopf.warn()`.
 
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.2
+    hooks:
+    -   id: pyupgrade
+        args: [--py310-plus, --keep-mock]
+
   - repo: https://github.com/seddonym/import-linter
     rev: v2.5.2
     hooks:
@@ -81,9 +87,3 @@ repos:
         name: isort-examples
         args: [--settings=examples]
         files: '^examples/'
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-    -   id: pyupgrade
-        args: [--py310-plus, --keep-mock]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -464,6 +464,32 @@ To store the state only in the status or any other field:
     def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.progress_storage = kopf.StatusProgressStorage(field='status.my-operator')
 
+Storing progress in files
+-------------------------
+
+To store the progress in YAML files on a shared filesystem or pod volume,
+instead of on the Kubernetes object itself:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_):
+        settings.persistence.progress_storage = kopf.FileProgressStorage(path='/var/kopf-storage')
+
+Each Kubernetes resource gets its own file, named
+``{namespace}-{name}-{uid}.progress.yaml`` (or ``{name}-{uid}.progress.yaml``
+for cluster-scoped resources). The file contains a YAML mapping of handler IDs
+to their progress records. A small touch annotation is still written to the
+Kubernetes object to trigger watch events for delayed handler retries.
+
+You must configure the operator's environment to persist the directory content
+between restarts and to share it with multiple operator instances.
+Usually, a mounted volume or a shared filesystem work fine,
+but exercise caution with locally running operators on developer machines
+with no access to the same directory/filesystem.
+
 Storing progress in multiple places
 -----------------------------------
 
@@ -605,6 +631,30 @@ The default is an equivalent of:
 
 The stored content is a JSON-serialised essence of the object (i.e., only
 the important fields, with system fields and status stanza removed).
+
+Storing diff base in files
+--------------------------
+
+To store the last-handled configuration in YAML files on a shared filesystem
+or pod volume, instead of on the Kubernetes object itself:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_):
+        settings.persistence.diffbase_storage = kopf.FileDiffBaseStorage(path='/var/kopf-storage')
+
+Each Kubernetes resource gets its own file, named
+``{namespace}-{name}-{uid}.diffbase.yaml`` (or ``{name}-{uid}.diffbase.yaml``
+for cluster-scoped resources). The file contains the YAML-encoded body essence.
+
+You must configure the operator's environment to persist the directory content
+between restarts and to share it with multiple operator instances.
+Usually, a mounted volume or a shared filesystem work fine,
+but exercise caution with locally running operators on developer machines
+with no access to the same directory/filesystem.
 
 Storing diff base in multiple places
 ------------------------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -436,6 +436,9 @@ To keep the handling state across multiple handling cycles, and to be resilient
 to errors and tolerable to restarts and downtimes, the operator keeps its state
 in a configured state storage. See more in :doc:`continuity`.
 
+Storing progress in annotations
+-------------------------------
+
 To store the state only in the annotations with a preferred prefix:
 
 .. code-block:: python
@@ -447,6 +450,9 @@ To store the state only in the annotations with a preferred prefix:
     def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.progress_storage = kopf.AnnotationsProgressStorage(prefix='my-op.example.com')
 
+Storing progress in status
+--------------------------
+
 To store the state only in the status or any other field:
 
 .. code-block:: python
@@ -457,6 +463,9 @@ To store the state only in the status or any other field:
     @kopf.on.startup()
     def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.progress_storage = kopf.StatusProgressStorage(field='status.my-operator')
+
+Storing progress in multiple places
+-----------------------------------
 
 To store in multiple places (all are written to in sync, but the first found
 state will be used when reading, i.e. the first storage has precedence):
@@ -489,10 +498,26 @@ It is an equivalent of:
     def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.progress_storage = kopf.SmartProgressStorage()
 
-It is also possible to implement custom state storage instead of storing
-the state directly in the resource's fields --- e.g., in external databases.
-For this, inherit from :class:`kopf.ProgressStorage` and implement its abstract
-methods (``fetch()``, ``store()``, ``purge()``, optionally ``flush()``).
+Storing progress in custom storages
+-----------------------------------
+
+It is also possible to implement custom progress storages instead of storing
+the progress directly in the resource's fields -- e.g., in external databases.
+For this, inherit from :class:`kopf.ProgressStorage` and implement its methods
+(see the full signatures in the class definition):
+
+- ``fetch()`` to retrieve the handler progress by resource body and handler id;
+- ``store()`` to persist the handler progress by resource body and handler id;
+- ``purge()`` to remove the handler progress by resource body and handler id;
+- optionally ``flush()`` to save all accumulated records for several handlers;
+- optionally ``erase()`` to erase all records related to a specific resource.
+
+Use the resource body to get the required identifiers, usually the namespace,
+name, and/or uid. Use the provided :kwarg:`patch` object to store records
+in the resource in the cluster together with Kopf's own records (if applicable).
+
+Legacy progress storage
+-----------------------
 
 .. note::
 
@@ -552,6 +577,16 @@ against the last handled configuration, and a diff list is formed.
 The last-handled configuration is also used to detect if there were any
 essential changes at all --- i.e. not just the system or status fields.
 
+Kopf tracks only the essential fields, internally known as "the body essence",
+which by default include the full ``spec`` stanza and certain metadata:
+labels and annotations. Note that ``status`` is not considered the essence,
+unless there are handlers directly pointing to status fields, in which case
+those fields (and only those fields) are included into the essence, too.
+Custom storages can define which fields to exclude or include into the essence.
+
+Storing diff base in annotations
+--------------------------------
+
 The last-handled configuration storage can be configured
 with ``settings.persistence.diffbase_storage``.
 The default is an equivalent of:
@@ -571,9 +606,60 @@ The default is an equivalent of:
 The stored content is a JSON-serialised essence of the object (i.e., only
 the important fields, with system fields and status stanza removed).
 
-It is generally not a good idea to override this storage unless multiple
-Kopf-based operators must handle the same resources and must not
-collide with each other. In that case, they must use different names.
+Storing diff base in multiple places
+------------------------------------
+
+To store in multiple places (stored in sync, but the first found essence will be
+used when fetching, i.e. the first storage has precedence):
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_):
+        settings.persistence.diffbase_storage = kopf.MultiDiffBaseStorage([
+            kopf.AnnotationsDiffBaseStorage(prefix='my-op.example.com'),
+            kopf.StatusDiffBaseStorage(field='status.my-operator'),
+        ])
+
+The default storage is in the annotation
+``kopf.zalando.org/last-handled-configuration`` only.
+
+Storing diff base in custom storages
+------------------------------------
+
+It is also possible to implement custom diff base storages instead of storing
+the diff base directly in the resource's fields -- e.g., in external databases.
+For this, inherit from :class:`kopf.DiffBaseStorage` and implement its methods
+(see the full signatures in the class definition):
+
+- ``fetch()`` to retrieve the essence of the resource by the current body;
+- ``store()`` to persist the essence of the resource by the current body;
+- optionally ``build()`` to extract the essence from the full resource body;
+- optionally ``erase()`` to erase all records related to a specific resource.
+
+Use the resource body to get the required identifiers, usually the namespace,
+name, and/or uid. Use the provided :kwarg:`patch` object to store records
+in the resource in the cluster together with Kopf's own records (if applicable).
+
+
+Garbage collection
+==================
+
+The ``erase()`` methods work on the at-MOST-once-delivery basis ---
+they are called on the final ``DELETED`` event from the watch-stream.
+
+Make them fast and reliable, e.g. by using append-only tables or event queues
+with background processing. In case of errors, there will be no retries.
+
+There is no guarantee they are called at all. For example, if the operator
+was down when the resource was deleted, there will be no call after restart,
+so the storage records can become orphaned.
+
+Your storage should have some other machinery for eventual garbage collection
+of deleted resources. The erasure methods can only speed it up in "happy" cases.
+For example, consider using :doc:`indexing` to list all existing resources.
 
 
 Storage transition

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -490,6 +490,25 @@ Usually, a mounted volume or a shared filesystem work fine,
 but exercise caution with locally running operators on developer machines
 with no access to the same directory/filesystem.
 
+Storing progress in sqlite
+--------------------------
+
+To store the state in a SQLite database:
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_):
+        settings.persistence.progress_storage = kopf.SQLiteProgressStorage(path='/var/kopf/state.db')
+
+Each handler's progress record is stored as a separate row in a ``progress``
+table, keyed by the resource's namespace, name, uid, and handler id. The table
+is created automatically on first use. A small touch annotation is still written
+to the Kubernetes object to trigger watch events for delayed handler retries.
+Multiple storage types can share the same database file.
+
 Storing progress in multiple places
 -----------------------------------
 
@@ -655,6 +674,25 @@ between restarts and to share it with multiple operator instances.
 Usually, a mounted volume or a shared filesystem work fine,
 but exercise caution with locally running operators on developer machines
 with no access to the same directory/filesystem.
+
+Storing diff base in sqlite
+---------------------------
+
+To store the last-handled configuration in a SQLite database:
+
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_):
+        settings.persistence.diffbase_storage = kopf.SQLiteDiffBaseStorage(path='/var/kopf/state.db')
+
+Each resource's body essence is stored as a single row in a ``diffbase`` table,
+keyed by the resource's namespace, name, and uid. The table is created
+automatically on first use. Multiple storage types can share the same
+database file.
 
 Storing diff base in multiple places
 ------------------------------------

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -25,6 +25,7 @@ from kopf._cogs.configs.diffbase import (
     AnnotationsDiffBaseStorage,
     StatusDiffBaseStorage,
     FileDiffBaseStorage,
+    SQLiteDiffBaseStorage,
     MultiDiffBaseStorage,
 )
 from kopf._cogs.configs.progress import (
@@ -33,6 +34,7 @@ from kopf._cogs.configs.progress import (
     AnnotationsProgressStorage,
     StatusProgressStorage,
     FileProgressStorage,
+    SQLiteProgressStorage,
     MultiProgressStorage,
     SmartProgressStorage,
 )
@@ -238,12 +240,14 @@ __all__ = [
     'AnnotationsDiffBaseStorage',
     'StatusDiffBaseStorage',
     'FileDiffBaseStorage',
+    'SQLiteDiffBaseStorage',
     'MultiDiffBaseStorage',
     'ProgressRecord',
     'ProgressStorage',
     'AnnotationsProgressStorage',
     'StatusProgressStorage',
     'FileProgressStorage',
+    'SQLiteProgressStorage',
     'MultiProgressStorage',
     'SmartProgressStorage',
     'RawEventType',

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -24,6 +24,7 @@ from kopf._cogs.configs.diffbase import (
     DiffBaseStorage,
     AnnotationsDiffBaseStorage,
     StatusDiffBaseStorage,
+    FileDiffBaseStorage,
     MultiDiffBaseStorage,
 )
 from kopf._cogs.configs.progress import (
@@ -31,6 +32,7 @@ from kopf._cogs.configs.progress import (
     ProgressStorage,
     AnnotationsProgressStorage,
     StatusProgressStorage,
+    FileProgressStorage,
     MultiProgressStorage,
     SmartProgressStorage,
 )
@@ -235,11 +237,13 @@ __all__ = [
     'DiffBaseStorage',
     'AnnotationsDiffBaseStorage',
     'StatusDiffBaseStorage',
+    'FileDiffBaseStorage',
     'MultiDiffBaseStorage',
     'ProgressRecord',
     'ProgressStorage',
     'AnnotationsProgressStorage',
     'StatusProgressStorage',
+    'FileProgressStorage',
     'MultiProgressStorage',
     'SmartProgressStorage',
     'RawEventType',

--- a/kopf/_cogs/configs/conventions.py
+++ b/kopf/_cogs/configs/conventions.py
@@ -38,7 +38,7 @@ import urllib.parse
 import uuid
 import warnings
 from collections.abc import Collection, Iterable, Iterator
-from typing import Any
+from typing import Any, Protocol, cast, runtime_checkable
 
 from kopf._cogs.structs import bodies, patches
 
@@ -347,3 +347,104 @@ class FileNamingConvention:
             raise
         else:
             temp.rename(path)  # atomic overwrite
+
+
+# Sqlite3 is sometimes broken, so we import only on demand, so we cannot use it in annotations.
+# Add more methods as needed. Only actually used methods are listed here. There can be more.
+class sqlite3_Cursor(Protocol):
+    def fetchone(self) -> list[Any]: ...
+
+
+@runtime_checkable
+class sqlite3_Connection(Protocol):
+    def execute(self, sql: str, parameters: tuple[Any, ...] = ()) -> sqlite3_Cursor: ...
+    def close(self) -> None: ...
+    def __enter__(self) -> Any: ...
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None: ...
+
+
+class SQLiteConvention:
+    """
+    A mixin for SQLite-based storages with optimistic table creation.
+
+    Operations are tried first; if the table does not exist, it is created
+    and the operation is retried. This avoids upfront schema management
+    and lets both storage types share the same database file when pointed
+    to the same path.
+    """
+
+    _create_sql: str  # to be defined by subclasses
+
+    # If path is None, we do not own the connection, someone else does, we just use it.
+    # If path is set, we own the connection, create and close it as needed.
+    _path: pathlib.Path | None
+    _conn: sqlite3_Connection | None
+
+    def __init__(
+            self,
+            path_or_conn: sqlite3_Connection | str | pathlib.Path,
+            /,
+            **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        import sqlite3  # sometimes broken, so import only on demand
+        if isinstance(path_or_conn, (sqlite3_Connection, sqlite3.Connection)):
+            self._conn = path_or_conn
+            self._path = None
+        else:
+            self._conn = None
+            self._path = pathlib.Path(path_or_conn)
+
+    async def __aenter__(self) -> None:
+        if self._path is None:
+            return
+        import sqlite3  # sometimes broken, so import only on demand
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = cast(sqlite3_Connection, sqlite3.connect(str(self._path)))
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        if self._path is not None and self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    @staticmethod
+    def _extract_keys(body: bodies.Body) -> tuple[str, str, str]:
+        # Primary keys cannot store nulls, so we use empty strings as markers.
+        # K8s does not allow empty names/uids, so we are safe from collisions.
+        namespace = body.get('metadata', {}).get('namespace', '')
+        name = body.get('metadata', {}).get('name', '')
+        uid = body.get('metadata', {}).get('uid', '')
+        return namespace, name, uid
+
+    def _execute(
+            self,
+            sql: str,
+            params: tuple[Any, ...] = (),
+    ) -> sqlite3_Cursor:
+        """Execute SQL, creating the table optimistically if absent."""
+        import sqlite3  # sometimes broken, so import only on demand
+
+        assert self._conn is not None
+        try:
+            return self._conn.execute(sql, params)
+        except sqlite3.OperationalError as e:
+            if 'no such table' not in str(e):
+                raise
+            self._conn.execute(self._create_sql)
+            return self._conn.execute(sql, params)
+
+    def _try_execute(
+            self,
+            sql: str,
+            params: tuple[Any, ...] = (),
+    ) -> sqlite3_Cursor | None:
+        """Execute SQL, returning None if the table does not exist."""
+        import sqlite3  # sometimes broken, so import only on demand
+
+        assert self._conn is not None
+        try:
+            return self._conn.execute(sql, params)
+        except sqlite3.OperationalError as e:
+            if 'no such table' not in str(e):
+                raise
+            return None

--- a/kopf/_cogs/configs/conventions.py
+++ b/kopf/_cogs/configs/conventions.py
@@ -31,9 +31,13 @@ in most cases, they will be used as the annotation names with special symbols
 replaced; in some cases, they will be cut and hash-suffixed.
 """
 import base64
+import contextlib
 import hashlib
+import pathlib
+import urllib.parse
+import uuid
 import warnings
-from collections.abc import Collection, Iterable
+from collections.abc import Collection, Iterable, Iterator
 from typing import Any
 
 from kopf._cogs.structs import bodies, patches
@@ -285,3 +289,61 @@ class StorageStanzaCleaner:
             del essence['metadata']
         if 'status' in essence and not essence['status']:
             del essence['status']
+
+
+class FileNamingConvention:
+    """
+    A mixin for file-based storages to build filenames from K8s resource metadata.
+
+    Each resource gets a file named after its namespace, name, and uid,
+    with special characters percent-encoded for safe use in file paths.
+    """
+
+    def __init__(
+            self,
+            *args: Any,
+            path: str | pathlib.Path,
+            file_suffix: str,
+            **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._path = pathlib.Path(path)
+        self._file_suffix = file_suffix
+
+    @staticmethod
+    def _escape(value: str) -> str:
+        """Percent-encode a value for safe use in filenames."""
+        # Encode special characters that are unsafe in filenames (slashes, etc.).
+        # Dots are kept as-is since they are common in K8s resource names.
+        safe = urllib.parse.quote(value, safe='-._~')
+        # Protect against '..' path traversal: replace '..' when it appears
+        # as a path component (alone or between encoded slashes %2F).
+        # After quoting, real slashes become %2F, so splitting on %2F
+        # recovers the original path components.
+        parts = safe.split('%2F')
+        parts = ['%2E%2E' if part == '..' else part for part in parts]
+        return '%2F'.join(parts)
+
+    def _build_filename(self, body: bodies.Body) -> pathlib.Path | None:
+        namespace = body.get('metadata', {}).get('namespace')
+        name = body.get('metadata', {}).get('name')
+        uid = body.get('metadata', {}).get('uid')
+        if not name or not uid:
+            return None
+        safe_name = self._escape(name)
+        safe_uid = self._escape(uid)
+        prefix = f'{self._escape(namespace)}-' if namespace is not None else ''
+        return self._path / f'{prefix}{safe_name}-{safe_uid}.{self._file_suffix}.yaml'
+
+    @contextlib.contextmanager
+    def _temp_filename(self, path: pathlib.Path) -> Iterator[pathlib.Path]:
+        # Ensure that different processes in different containers do not overlap their temp files.
+        unique: str = uuid.uuid4().hex
+        temp = path.with_suffix(f".{unique}.tmp")
+        try:
+            yield temp
+        except Exception:
+            temp.unlink(missing_ok=True)
+            raise
+        else:
+            temp.rename(path)  # atomic overwrite

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -2,6 +2,7 @@ import abc
 import copy
 import json
 from collections.abc import Collection, Iterable
+from contextlib import AbstractAsyncContextManager
 from typing import Any, cast
 
 from kopf._cogs.configs import conventions
@@ -10,6 +11,7 @@ from kopf._cogs.structs import bodies, dicts, patches
 
 class DiffBaseStorage(conventions.StorageKeyMarkingConvention,
                       conventions.StorageStanzaCleaner,
+                      AbstractAsyncContextManager[None],
                       metaclass=abc.ABCMeta):
     """
     Store the base essence for diff calculations, i.e. last handled state.
@@ -29,6 +31,12 @@ class DiffBaseStorage(conventions.StorageKeyMarkingConvention,
     def __init__(self, ignored_fields: Iterable[dicts.FieldSpec] | None = None) -> None:
         super().__init__()
         self.ignored_fields = list(ignored_fields or [])  # materialize the iterable
+
+    async def __aenter__(self) -> None:
+        pass
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        pass
 
     def build(
             self,

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -2,10 +2,13 @@ import abc
 import copy
 import inspect
 import json
+import pathlib
 import warnings
 from collections.abc import Awaitable, Collection, Iterable
 from contextlib import AbstractAsyncContextManager
 from typing import Any, cast
+
+import yaml
 
 from kopf._cogs.configs import conventions
 from kopf._cogs.structs import bodies, dicts, patches
@@ -261,6 +264,69 @@ class StatusDiffBaseStorage(DiffBaseStorage):
         # Store as a single string instead of full dict -- to avoid merges and unexpected data.
         encoded: str = json.dumps(essence, separators=(',', ':'))  # NB: no spaces
         dicts.ensure(patch, self.field, encoded)
+
+
+class FileDiffBaseStorage(conventions.FileNamingConvention, DiffBaseStorage):
+    """
+    Diff-base storage in YAML files on a shared filesystem or pod volume.
+
+    Each Kubernetes resource gets its own file, named after its namespace,
+    name, and uid. The file contains the YAML-encoded body essence used for
+    change detection.
+
+    An example file at ``/var/kopf/default-my-app-12345678-abcd.diffbase.yaml``:
+
+    .. code-block:: yaml
+
+        spec:
+          replicas: 3
+          template:
+            spec:
+              containers:
+              - name: my-app
+                image: my-app:latest
+
+    This storage does not write anything to the Kubernetes object itself.
+    """
+
+    def __init__(
+            self,
+            path: str | pathlib.Path,
+            *,
+            ignored_fields: Iterable[dicts.FieldSpec] | None = None,
+    ) -> None:
+        super().__init__(path=path, file_suffix='diffbase', ignored_fields=ignored_fields)
+
+    async def fetch(
+            self,
+            *,
+            body: bodies.Body,
+    ) -> bodies.BodyEssence | None:
+        filepath = self._build_filename(body)
+        if filepath is None or not filepath.exists():
+            return None
+        data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+        return cast(bodies.BodyEssence, data) if isinstance(data, dict) else None
+
+    async def store(
+            self,
+            *,
+            body: bodies.Body,
+            patch: patches.Patch,
+            essence: bodies.BodyEssence,
+    ) -> None:
+        filepath = self._build_filename(body)
+        if filepath is None:
+            return
+        content = yaml.safe_dump(dict(essence), default_flow_style=False)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        with self._temp_filename(filepath) as temppath:
+            temppath.write_text(content, encoding='utf-8')
+
+    async def erase(self, *, body: bodies.Body) -> None:
+        filepath = self._build_filename(body)
+        if filepath is not None:
+            filepath.unlink(missing_ok=True)
 
 
 class MultiDiffBaseStorage(DiffBaseStorage):

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -2,6 +2,7 @@ import abc
 import copy
 import inspect
 import json
+import warnings
 from collections.abc import Awaitable, Collection, Iterable
 from contextlib import AbstractAsyncContextManager
 from typing import Any, cast
@@ -28,6 +29,28 @@ class DiffBaseStorage(conventions.StorageKeyMarkingConvention,
     on any object, and then uses that for the patch calculation:
     https://kubernetes.io/docs/concepts/overview/object-management-kubectl/declarative-config/
     """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # Kopf's own storages remain sync for backwards compatibility, in case
+        # developers inherit these classes and call `super().method(…)` without `await`.
+        # But their protocol now allows returning awaitable coroutines.
+        for method_name in ('fetch', 'store'):
+            method = cls.__dict__.get(method_name)
+            deprecated = (
+                method is not None and
+                not cls.__module__.startswith('kopf.') and
+                not inspect.iscoroutinefunction(method)
+            )
+            if deprecated:
+                warnings.warn(
+                    f"{cls.__qualname__}.{method_name}() is not async; "
+                    f"sync storage methods are deprecated and will stop working "
+                    f"in the future v2 release; they will continue working in v1. "
+                    "Declare it as 'async def' instead (supported since Kopf 1.45).",
+                    FutureWarning,
+                    stacklevel=3,
+                )
 
     def __init__(self, ignored_fields: Iterable[dicts.FieldSpec] | None = None) -> None:
         super().__init__()

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -1,7 +1,8 @@
 import abc
 import copy
+import inspect
 import json
-from collections.abc import Collection, Iterable
+from collections.abc import Awaitable, Collection, Iterable
 from contextlib import AbstractAsyncContextManager
 from typing import Any, cast
 
@@ -106,14 +107,16 @@ class DiffBaseStorage(conventions.StorageKeyMarkingConvention,
 
         return cast(bodies.BodyEssence, essence)
 
+    # Return types makes it mixed sync or async, both are supported.
     @abc.abstractmethod
     def fetch(
             self,
             *,
             body: bodies.Body,
-    ) -> bodies.BodyEssence | None:
+    ) -> bodies.BodyEssence | None | Awaitable[bodies.BodyEssence | None]:
         raise NotImplementedError
 
+    # Return types makes it mixed sync or async, both are supported.
     @abc.abstractmethod
     def store(
             self,
@@ -121,7 +124,7 @@ class DiffBaseStorage(conventions.StorageKeyMarkingConvention,
             body: bodies.Body,
             patch: patches.Patch,
             essence: bodies.BodyEssence,
-    ) -> None:
+    ) -> None | Awaitable[None]:
         raise NotImplementedError
 
 
@@ -255,23 +258,30 @@ class MultiDiffBaseStorage(DiffBaseStorage):
             essence = storage.build(body=bodies.Body(essence), extra_fields=extra_fields)
         return essence
 
-    def fetch(
+    async def fetch(
             self,
             *,
             body: bodies.Body,
     ) -> bodies.BodyEssence | None:
+        # Storage methods were sync originally. Support both sync overrides and newer async methods
+        # without breaking the backwards compatibility and requiring a major semver release.
         for storage in self.storages:
-            content = storage.fetch(body=body)
+            maybe_coro = storage.fetch(body=body)
+            content = await maybe_coro if inspect.isawaitable(maybe_coro) else maybe_coro
             if content is not None:
                 return content
         return None
 
-    def store(
+    async def store(
             self,
             *,
             body: bodies.Body,
             patch: patches.Patch,
             essence: bodies.BodyEssence,
     ) -> None:
+        # Storage methods were sync originally. Support both sync overrides and newer async methods
+        # without breaking the backwards compatibility and requiring a major semver release.
         for storage in self.storages:
-            storage.store(body=body, patch=patch, essence=essence)
+            maybe_coro = storage.store(body=body, patch=patch, essence=essence)
+            if inspect.isawaitable(maybe_coro):
+                await maybe_coro

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -150,6 +150,10 @@ class DiffBaseStorage(conventions.StorageKeyMarkingConvention,
     ) -> None | Awaitable[None]:
         raise NotImplementedError
 
+    # It was always async from addition, sync was never declared and supported.
+    async def erase(self, *, body: bodies.Body) -> None:
+        pass
+
 
 class AnnotationsDiffBaseStorage(conventions.StorageKeyFormingConvention, DiffBaseStorage):
 
@@ -308,3 +312,7 @@ class MultiDiffBaseStorage(DiffBaseStorage):
             maybe_coro = storage.store(body=body, patch=patch, essence=essence)
             if inspect.isawaitable(maybe_coro):
                 await maybe_coro
+
+    async def erase(self, *, body: bodies.Body) -> None:
+        for storage in self.storages:
+            await storage.erase(body=body)

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -329,6 +329,91 @@ class FileDiffBaseStorage(conventions.FileNamingConvention, DiffBaseStorage):
             filepath.unlink(missing_ok=True)
 
 
+class SQLiteDiffBaseStorage(conventions.SQLiteConvention, DiffBaseStorage):
+    """
+    Diff-base storage in a SQLite database file.
+
+    Each resource's body essence is stored as a single row, keyed by the
+    resource's namespace, name, and uid. The essence is stored as a JSON
+    string.
+
+    An example of the ``diffbase`` table contents:
+
+    .. code-block:: text
+
+        namespace | name   | uid   | essence
+        ----------+--------+-------+---------------------------------------
+        default   | my-app | uid1  | {"spec":{"replicas":3,"image":"..."}}
+
+    This storage does not write anything to the Kubernetes object itself.
+    Both the file and SQLite diff-base storages can share the same database
+    file when pointed to the same path.
+    """
+
+    # We do not plan any migrations yet. We pray that this simple schema is sufficient forever.
+    _create_sql = (
+        'CREATE TABLE IF NOT EXISTS diffbase ('
+        'namespace TEXT NOT NULL, '
+        'name TEXT NOT NULL, '
+        'uid TEXT NOT NULL, '
+        'essence TEXT NOT NULL, '
+        'PRIMARY KEY (namespace, name, uid))'
+    )
+
+    def __init__(
+            self,
+            path_or_conn: conventions.sqlite3_Connection | str | pathlib.Path,
+            /,
+            *,
+            ignored_fields: Iterable[dicts.FieldSpec] | None = None,
+    ) -> None:
+        super().__init__(path_or_conn, ignored_fields=ignored_fields)
+
+    async def fetch(
+            self,
+            *,
+            body: bodies.Body,
+    ) -> bodies.BodyEssence | None:
+        namespace, name, uid = self._extract_keys(body)
+        assert self._conn is not None
+        with self._conn:
+            cursor = self._try_execute(
+                'SELECT essence FROM diffbase'
+                ' WHERE namespace=? AND name=? AND uid=?',
+                (namespace, name, uid))
+            if cursor is None:
+                return None
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return cast(bodies.BodyEssence, json.loads(row[0]))
+
+    async def store(
+            self,
+            *,
+            body: bodies.Body,
+            patch: patches.Patch,
+            essence: bodies.BodyEssence,
+    ) -> None:
+        namespace, name, uid = self._extract_keys(body)
+        encoded = json.dumps(dict(essence), separators=(',', ':'))
+        assert self._conn is not None
+        with self._conn:
+            self._execute(
+                'INSERT OR REPLACE INTO diffbase'
+                ' (namespace, name, uid, essence) VALUES (?, ?, ?, ?)',
+                (namespace, name, uid, encoded))
+
+    async def erase(self, *, body: bodies.Body) -> None:
+        namespace, name, uid = self._extract_keys(body)
+        assert self._conn is not None
+        with self._conn:
+            self._try_execute(
+                'DELETE FROM diffbase'
+                ' WHERE namespace=? AND name=? AND uid=?',
+                (namespace, name, uid))
+
+
 class MultiDiffBaseStorage(DiffBaseStorage):
 
     def __init__(

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -42,10 +42,13 @@ import abc
 import copy
 import inspect
 import json
+import pathlib
 import warnings
 from collections.abc import Awaitable, Collection
 from contextlib import AbstractAsyncContextManager
 from typing import Any, TypedDict, cast
+
+import yaml
 
 from kopf._cogs.configs import conventions
 from kopf._cogs.structs import bodies, dicts, ids, patches
@@ -419,6 +422,116 @@ class NoWriteStatusProgressStorage(StatusProgressStorage):
 
     def touch(self, **_: Any) -> None:
         pass
+
+
+class FileProgressStorage(conventions.FileNamingConvention, ProgressStorage):
+    """
+    State storage in YAML files on a shared filesystem or pod volume.
+
+    Each Kubernetes resource gets its own file, named after its namespace,
+    name, and uid. The file contains a YAML mapping of handler IDs to their
+    progress records.
+
+    An example file at ``/var/kopf/default-my-app-12345678-abcd.progress.yaml``:
+
+    .. code-block:: yaml
+
+        my_handler:
+          started: '2020-02-14T16:58:25.396364'
+          stopped: '2020-02-14T16:58:25.401844'
+          retries: 1
+          success: true
+        my_other_handler:
+          started: '2020-02-14T16:58:25.396421'
+          retries: 0
+
+    The progress data itself is stored in files, not on the Kubernetes object.
+    However, a touch annotation is still written to the object (via the patch)
+    to trigger Kubernetes watch events when the object needs to be re-evaluated
+    (e.g. for delayed handler retries).
+    """
+
+    def __init__(
+            self,
+            path: str | pathlib.Path,
+            *,
+            touch_field: dicts.FieldSpec = ('metadata', 'annotations', 'kopf.dev/touch-dummy'),
+    ) -> None:
+        super().__init__(path=path, file_suffix='progress')
+        self.touch_field = touch_field
+
+    async def fetch(
+            self,
+            *,
+            key: ids.HandlerId,
+            body: bodies.Body,
+    ) -> ProgressRecord | None:
+        filepath = self._build_filename(body)
+        if filepath is None or not filepath.exists():
+            return None
+        data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+        if not isinstance(data, dict):
+            return None
+        record = data.get(key)
+        return cast(ProgressRecord, record) if record is not None else None
+
+    async def store(
+            self,
+            *,
+            key: ids.HandlerId,
+            record: ProgressRecord,
+            body: bodies.Body,
+            patch: patches.Patch,
+    ) -> None:
+        filepath = self._build_filename(body)
+        if filepath is None:
+            return
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        data: dict[str, Any] = {}
+        if filepath.exists():
+            loaded = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+            if isinstance(loaded, dict):
+                data = loaded
+        data[key] = {k: v for k, v in record.items() if v is not None}
+        content = yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+        with self._temp_filename(filepath) as temppath:
+            temppath.write_text(content, encoding='utf-8')
+
+    async def purge(
+            self,
+            *,
+            key: ids.HandlerId,
+            body: bodies.Body,
+            patch: patches.Patch,
+    ) -> None:
+        filepath = self._build_filename(body)
+        if filepath is None or not filepath.exists():
+            return
+        loaded = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+        data: dict[str, Any] = loaded if isinstance(loaded, dict) else {}
+        data.pop(key, None)
+        if data:
+            content = yaml.safe_dump(data, default_flow_style=False)
+            with self._temp_filename(filepath) as temppath:
+                temppath.write_text(content, encoding='utf-8')
+        else:
+            filepath.unlink(missing_ok=True)
+
+    def touch(
+            self,
+            *,
+            body: bodies.Body,
+            patch: patches.Patch,
+            value: str | None,
+    ) -> None:
+        body_value = dicts.resolve(body, self.touch_field, None)
+        if body_value != value:  # also covers absent-vs-None cases.
+            dicts.ensure(patch, self.touch_field, value)
+
+    async def erase(self, *, body: bodies.Body) -> None:
+        filepath = self._build_filename(body)
+        if filepath is not None:
+            filepath.unlink(missing_ok=True)
 
 
 class MultiProgressStorage(ProgressStorage):

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -40,8 +40,9 @@ All timestamps are strings in ISO8601 format in UTC (no explicit ``Z`` suffix).
 """
 import abc
 import copy
+import inspect
 import json
-from collections.abc import Collection
+from collections.abc import Awaitable, Collection
 from contextlib import AbstractAsyncContextManager
 from typing import Any, TypedDict, cast
 
@@ -88,15 +89,17 @@ class ProgressStorage(conventions.StorageStanzaCleaner,
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         pass
 
+    # Return types makes it mixed sync or async, both are supported.
     @abc.abstractmethod
     def fetch(
             self,
             *,
             key: ids.HandlerId,
             body: bodies.Body,
-    ) -> ProgressRecord | None:
+    ) -> ProgressRecord | None | Awaitable[ProgressRecord | None]:
         raise NotImplementedError
 
+    # Return types makes it mixed sync or async, both are supported.
     @abc.abstractmethod
     def store(
             self,
@@ -105,9 +108,10 @@ class ProgressStorage(conventions.StorageStanzaCleaner,
             record: ProgressRecord,
             body: bodies.Body,
             patch: patches.Patch,
-    ) -> None:
+    ) -> None | Awaitable[None]:
         raise NotImplementedError
 
+    # Return types makes it mixed sync or async, both are supported.
     @abc.abstractmethod
     def purge(
             self,
@@ -115,7 +119,7 @@ class ProgressStorage(conventions.StorageStanzaCleaner,
             key: ids.HandlerId,
             body: bodies.Body,
             patch: patches.Patch,
-    ) -> None:
+    ) -> None | Awaitable[None]:
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -132,7 +136,8 @@ class ProgressStorage(conventions.StorageStanzaCleaner,
     def clear(self, *, essence: bodies.BodyEssence) -> bodies.BodyEssence:
         return copy.deepcopy(essence)
 
-    def flush(self) -> None:
+    # Return types makes it mixed sync or async, both are supported.
+    def flush(self) -> None | Awaitable[None]:
         pass
 
 
@@ -399,19 +404,24 @@ class MultiProgressStorage(ProgressStorage):
         super().__init__()
         self.storages = storages
 
-    def fetch(
+    # Cannot be sync for backwards compatibility, since it has to use `await` inside.
+    async def fetch(
             self,
             *,
             key: ids.HandlerId,
             body: bodies.Body,
     ) -> ProgressRecord | None:
+        # Storage methods were sync originally. Support both sync overrides and newer async methods
+        # without breaking the backwards compatibility and requiring a major semver release.
         for storage in self.storages:
-            content = storage.fetch(key=key, body=body)
+            maybe_coro = storage.fetch(key=key, body=body)
+            content = await maybe_coro if inspect.isawaitable(maybe_coro) else maybe_coro
             if content is not None:
                 return content
         return None
 
-    def store(
+    # Cannot be sync for backwards compatibility, since it has to use `await` inside.
+    async def store(
             self,
             *,
             key: ids.HandlerId,
@@ -420,9 +430,12 @@ class MultiProgressStorage(ProgressStorage):
             patch: patches.Patch,
     ) -> None:
         for storage in self.storages:
-            storage.store(key=key, record=record, body=body, patch=patch)
+            maybe_coro = storage.store(key=key, record=record, body=body, patch=patch)
+            if inspect.isawaitable(maybe_coro):
+                await maybe_coro
 
-    def purge(
+    # Cannot be sync for backwards compatibility, since it has to use `await` inside.
+    async def purge(
             self,
             *,
             key: ids.HandlerId,
@@ -430,7 +443,9 @@ class MultiProgressStorage(ProgressStorage):
             patch: patches.Patch,
     ) -> None:
         for storage in self.storages:
-            storage.purge(key=key, body=body, patch=patch)
+            maybe_coro = storage.purge(key=key, body=body, patch=patch)
+            if inspect.isawaitable(maybe_coro):
+                await maybe_coro
 
     def touch(
             self,

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -42,6 +42,7 @@ import abc
 import copy
 import inspect
 import json
+import warnings
 from collections.abc import Awaitable, Collection
 from contextlib import AbstractAsyncContextManager
 from typing import Any, TypedDict, cast
@@ -82,6 +83,28 @@ class ProgressStorage(conventions.StorageStanzaCleaner,
     for relational/transactional databases), the keys can be cached in memory
     for short time, and ``flush()`` can be overridden to actually store them.
     """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # Kopf's own storages remain sync for backwards compatibility, in case
+        # developers inherit these classes and call `super().method(…)` without `await`.
+        # But their protocol now allows returning awaitable coroutines.
+        for method_name in ('fetch', 'store', 'purge', 'flush'):
+            method = cls.__dict__.get(method_name)
+            deprecated = (
+                method is not None and
+                not cls.__module__.startswith('kopf.') and
+                not inspect.iscoroutinefunction(method)
+            )
+            if deprecated:
+                warnings.warn(
+                    f"{cls.__qualname__}.{method_name}() is not async; "
+                    f"sync storage methods are deprecated and will stop working "
+                    f"in the future v2 release; they will continue working in v1. "
+                    "Declare it as 'async def' instead (supported since Kopf 1.45).",
+                    FutureWarning,
+                    stacklevel=3,
+                )
 
     async def __aenter__(self) -> None:
         pass

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -534,6 +534,123 @@ class FileProgressStorage(conventions.FileNamingConvention, ProgressStorage):
             filepath.unlink(missing_ok=True)
 
 
+class SQLiteProgressStorage(conventions.SQLiteConvention, ProgressStorage):
+    """
+    State storage in a SQLite database file.
+
+    Each handler's progress record is stored as a separate row, keyed by
+    the resource's namespace, name, uid, and the handler id. The record
+    itself is stored as a JSON string.
+
+    An example of the ``progress`` table contents:
+
+    .. code-block:: text
+
+        namespace | name   | uid   | handler    | record
+        ----------+--------+-------+------------+----------------------------------
+        default   | my-app | uid1  | my_handler | {"started":"...","retries":1,...}
+
+    The progress data itself is stored in SQLite, not on the Kubernetes object.
+    However, a touch annotation is still written to the object (via the patch)
+    to trigger Kubernetes watch events when the object needs to be re-evaluated
+    (e.g. for delayed handler retries).
+    """
+
+    # We do not plan any migrations yet. We pray that this simple schema is sufficient forever.
+    # For this purpose, the record is stored as JSON, not as separate fields.
+    _create_sql = (
+        'CREATE TABLE IF NOT EXISTS progress ('
+        'namespace TEXT NOT NULL, '
+        'name TEXT NOT NULL, '
+        'uid TEXT NOT NULL, '
+        'handler TEXT NOT NULL, '
+        'record TEXT NOT NULL, '
+        'PRIMARY KEY (namespace, name, uid, handler))'
+    )
+
+    def __init__(
+            self,
+            path_or_conn: conventions.sqlite3_Connection | str | pathlib.Path,
+            /,
+            *,
+            touch_field: dicts.FieldSpec = ('metadata', 'annotations', 'kopf.dev/touch-dummy'),
+    ) -> None:
+        super().__init__(path_or_conn)
+        self.touch_field = touch_field
+
+    async def fetch(
+            self,
+            *,
+            key: ids.HandlerId,
+            body: bodies.Body,
+    ) -> ProgressRecord | None:
+        namespace, name, uid = self._extract_keys(body)
+        assert self._conn is not None
+        with self._conn:
+            cursor = self._try_execute(
+                'SELECT record FROM progress'
+                ' WHERE namespace=? AND name=? AND uid=? AND handler=?',
+                (namespace, name, uid, key))
+            if cursor is None:
+                return None
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return cast(ProgressRecord, json.loads(row[0]))
+
+    async def store(
+            self,
+            *,
+            key: ids.HandlerId,
+            record: ProgressRecord,
+            body: bodies.Body,
+            patch: patches.Patch,
+    ) -> None:
+        namespace, name, uid = self._extract_keys(body)
+        encoded = json.dumps({k: v for k, v in record.items() if v is not None})
+        assert self._conn is not None
+        with self._conn:
+            self._execute(
+                'INSERT OR REPLACE INTO progress'
+                ' (namespace, name, uid, handler, record) VALUES (?, ?, ?, ?, ?)',
+                (namespace, name, uid, key, encoded))
+
+    async def purge(
+            self,
+            *,
+            key: ids.HandlerId,
+            body: bodies.Body,
+            patch: patches.Patch,
+    ) -> None:
+        namespace, name, uid = self._extract_keys(body)
+        assert self._conn is not None
+        with self._conn:
+            self._try_execute(
+                'DELETE FROM progress'
+                ' WHERE namespace=? AND name=? AND uid=? AND handler=?',
+                (namespace, name, uid, key))
+
+    def touch(
+            self,
+            *,
+            body: bodies.Body,
+            patch: patches.Patch,
+            value: str | None,
+    ) -> None:
+        body_value = dicts.resolve(body, self.touch_field, None)
+        if body_value != value:  # also covers absent-vs-None cases.
+            dicts.ensure(patch, self.touch_field, value)
+
+    async def erase(self, *, body: bodies.Body) -> None:
+        namespace, name, uid = self._extract_keys(body)
+        assert self._conn is not None
+        with self._conn:
+            self._try_execute(
+                'DELETE FROM progress'
+                ' WHERE namespace=? AND name=? AND uid=?',
+                (namespace, name, uid))
+
+
 class MultiProgressStorage(ProgressStorage):
 
     def __init__(

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -155,12 +155,15 @@ class ProgressStorage(conventions.StorageStanzaCleaner,
     ) -> None:
         raise NotImplementedError
 
-    @abc.abstractmethod
     def clear(self, *, essence: bodies.BodyEssence) -> bodies.BodyEssence:
         return copy.deepcopy(essence)
 
     # Return types makes it mixed sync or async, both are supported.
     def flush(self) -> None | Awaitable[None]:
+        pass
+
+    # It was always async from addition, sync was never declared and supported.
+    async def erase(self, *, body: bodies.Body) -> None:
         pass
 
 
@@ -484,6 +487,10 @@ class MultiProgressStorage(ProgressStorage):
         for storage in self.storages:
             essence = storage.clear(essence=essence)
         return essence
+
+    async def erase(self, *, body: bodies.Body) -> None:
+        for storage in self.storages:
+            await storage.erase(body=body)
 
 
 class SmartProgressStorage(MultiProgressStorage):

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -42,6 +42,7 @@ import abc
 import copy
 import json
 from collections.abc import Collection
+from contextlib import AbstractAsyncContextManager
 from typing import Any, TypedDict, cast
 
 from kopf._cogs.configs import conventions
@@ -61,7 +62,9 @@ class ProgressRecord(TypedDict, total=False):
     subrefs: Collection[ids.HandlerId] | None
 
 
-class ProgressStorage(conventions.StorageStanzaCleaner, metaclass=abc.ABCMeta):
+class ProgressStorage(conventions.StorageStanzaCleaner,
+                      AbstractAsyncContextManager[None],
+                      metaclass=abc.ABCMeta):
     """
     Base class and an interface for all persistent states.
 
@@ -78,6 +81,12 @@ class ProgressStorage(conventions.StorageStanzaCleaner, metaclass=abc.ABCMeta):
     for relational/transactional databases), the keys can be cached in memory
     for short time, and ``flush()`` can be overridden to actually store them.
     """
+
+    async def __aenter__(self) -> None:
+        pass
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        pass
 
     @abc.abstractmethod
     def fetch(

--- a/kopf/_core/actions/progression.py
+++ b/kopf/_core/actions/progression.py
@@ -77,6 +77,7 @@ import collections.abc
 import copy
 import dataclasses
 import datetime
+import inspect
 from collections.abc import Collection, Iterable, Iterator, Mapping
 from typing import Any, NamedTuple, overload
 
@@ -253,18 +254,21 @@ class State(execution.State):
         return cls({}, basetime=_get_basetime())
 
     @classmethod
-    def from_storage(
+    async def from_storage(
             cls,
             *,
             body: bodies.Body,
             storage: progress.ProgressStorage,
             handlers: Iterable[execution.Handler],
     ) -> "State":
+        # Storage methods were sync originally. Support both sync overrides and newer async methods
+        # without breaking the backwards compatibility and requiring a major semver release.
         basetime = _get_basetime()
         handler_ids = {handler.id for handler in handlers}
         handler_states: dict[ids.HandlerId, HandlerState] = {}
         for handler_id in handler_ids:
-            content = storage.fetch(key=handler_id, body=body)
+            maybe_coro = storage.fetch(key=handler_id, body=body)
+            content = await maybe_coro if inspect.isawaitable(maybe_coro) else maybe_coro
             if content is not None:
                 handler_states[handler_id] = HandlerState.from_storage(content, basetime=basetime)
         return cls(handler_states, basetime=basetime)
@@ -317,20 +321,26 @@ class State(execution.State):
             if not handler_state.success # i.e. failures & in-progress/retrying
         }, basetime=self.basetime)
 
-    def store(
+    async def store(
             self,
             body: bodies.Body,
             patch: patches.Patch,
             storage: progress.ProgressStorage,
     ) -> None:
+        # Storage methods were sync originally. Support both sync overrides and newer async methods
+        # without breaking the backwards compatibility and requiring a major semver release.
         for handler_id, handler_state in self._states.items():
             full_record = handler_state.for_storage()
             pure_record = handler_state.as_in_storage()
             if pure_record != handler_state._origin:
-                storage.store(key=handler_id, record=full_record, body=body, patch=patch)
-        storage.flush()
+                maybe_coro = storage.store(key=handler_id, record=full_record, body=body, patch=patch)
+                if inspect.isawaitable(maybe_coro):
+                    await maybe_coro
+        maybe_coro = storage.flush()
+        if inspect.isawaitable(maybe_coro):
+            await maybe_coro
 
-    def purge(
+    async def purge(
             self,
             *,
             body: bodies.Body,
@@ -338,17 +348,27 @@ class State(execution.State):
             storage: progress.ProgressStorage,
             handlers: Iterable[execution.Handler],
     ) -> None:
+        # Storage methods were sync originally. Support both sync overrides and newer async methods
+        # without breaking the backwards compatibility and requiring a major semver release.
         # Purge only our own handlers and their direct & indirect sub-handlers of all levels deep.
         # Ignore other handlers (e.g. handlers of other operators).
         handler_ids = {handler.id for handler in handlers}
         for handler_id in handler_ids:
-            storage.purge(key=handler_id, body=body, patch=patch)
+            maybe_coro = storage.purge(key=handler_id, body=body, patch=patch)
+            if inspect.isawaitable(maybe_coro):
+                await maybe_coro
         for handler_id, handler_state in self._states.items():
             if handler_id not in handler_ids:
-                storage.purge(key=handler_id, body=body, patch=patch)
+                maybe_coro = storage.purge(key=handler_id, body=body, patch=patch)
+                if inspect.isawaitable(maybe_coro):
+                    await maybe_coro
             for subref in handler_state.subrefs:
-                storage.purge(key=subref, body=body, patch=patch)
-        storage.flush()
+                maybe_coro = storage.purge(key=subref, body=body, patch=patch)
+                if inspect.isawaitable(maybe_coro):
+                    await maybe_coro
+        maybe_coro = storage.flush()
+        if inspect.isawaitable(maybe_coro):
+            await maybe_coro
 
     def __len__(self) -> int:
         return len(self._states)

--- a/kopf/_core/reactor/processing.py
+++ b/kopf/_core/reactor/processing.py
@@ -533,6 +533,12 @@ async def process_changing_cause(
         # prevent further resume-handlers (which otherwise happens on each watch-stream re-listing).
         memory.fully_handled_once = True
 
+    # The last and the only chance to do garbage collection of the stored data.
+    # DiffBase first - it is more likely to have data, so the progress storage must not block it.
+    if cause.reason == causes.Reason.GONE:
+        await settings.persistence.diffbase_storage.erase(body=body)
+        await settings.persistence.progress_storage.erase(body=body)
+
     # Informational causes just print the log lines.
     if cause.reason == causes.Reason.GONE:
         logger.debug("Deleted, really deleted, and we are notified.")

--- a/kopf/_core/reactor/processing.py
+++ b/kopf/_core/reactor/processing.py
@@ -16,6 +16,7 @@ and therefore do not trigger the user-defined handlers.
 import asyncio
 import contextlib
 import functools
+import inspect
 from collections.abc import Collection
 from typing import NamedTuple
 
@@ -155,7 +156,7 @@ class _Causes(NamedTuple):
     changing_cause: causes.ChangingCause | None
 
 
-def _detect_causes(
+async def _detect_causes(
         indexers: indexing.OperatorIndexers,
         registry: registries.OperatorRegistry,
         settings: configuration.OperatorSettings,
@@ -175,7 +176,11 @@ def _detect_causes(
         registry._watching.get_extra_fields(resource=resource) |
         registry._changing.get_extra_fields(resource=resource) |
         registry._spawning.get_extra_fields(resource=resource))
-    old = settings.persistence.diffbase_storage.fetch(body=body)
+
+    # These methods were sync originally. Support both sync overrides and newer async methods
+    # without breaking the backwards compatibility and requiring a major semver release.
+    maybe_coro = settings.persistence.diffbase_storage.fetch(body=body)
+    old = await maybe_coro if inspect.isawaitable(maybe_coro) else maybe_coro
     new = settings.persistence.diffbase_storage.build(body=body, extra_fields=extra_fields)
     old = settings.persistence.progress_storage.clear(essence=old) if old is not None else None
     new = settings.persistence.progress_storage.clear(essence=new) if new is not None else None
@@ -238,7 +243,7 @@ async def process_resource_causes(
     patch_initially_empty = not patch  # before we add new things in low-level handlers
 
     finalizer = settings.persistence.finalizer
-    watching_cause, spawning_cause, changing_cause = _detect_causes(
+    watching_cause, spawning_cause, changing_cause = await _detect_causes(
         indexers=indexers,
         registry=registry,
         settings=settings,
@@ -462,7 +467,7 @@ async def process_changing_cause(
         owned_handlers = resource_registry.get_resource_handlers(resource=cause.resource)
         cause_handlers = resource_registry.get_handlers(cause=cause)
         storage = settings.persistence.progress_storage
-        state = progression.State.from_storage(body=cause.body, storage=storage, handlers=owned_handlers)
+        state = await progression.State.from_storage(body=cause.body, storage=storage, handlers=owned_handlers)
         state = state.with_purpose(cause.reason).with_handlers(cause_handlers)
 
         # Report the causes that have been superseded (intercepted, overridden) by the current one.
@@ -480,8 +485,8 @@ async def process_changing_cause(
         # The current cause continues afterwards, and overrides its own pre-purged handler states.
         # TODO: purge only the handlers that fell out of current purpose; but it is not critical
         if state.extras:
-            state.purge(body=cause.body, patch=cause.patch,
-                        storage=storage, handlers=owned_handlers)
+            await state.purge(body=cause.body, patch=cause.patch,
+                              storage=storage, handlers=owned_handlers)
 
         # Inform on the current cause/event on every processing cycle. Even if there are
         # no handlers -- to show what has happened and why the diff-base is patched.
@@ -499,7 +504,7 @@ async def process_changing_cause(
                 extra_context=subhandling.subhandling_context,
             )
             state = state.with_outcomes(outcomes)
-            state.store(body=cause.body, patch=cause.patch, storage=storage)
+            await state.store(body=cause.body, patch=cause.patch, storage=storage)
             progression.deliver_results(outcomes=outcomes, patch=cause.patch)
 
             if state.done:
@@ -507,8 +512,8 @@ async def process_changing_cause(
                 logger.info(f"{title.capitalize()} is processed: "
                             f"{counters.success} succeeded; "
                             f"{counters.failure} failed.")
-                state.purge(body=cause.body, patch=cause.patch,
-                            storage=storage, handlers=owned_handlers)
+                await state.purge(body=cause.body, patch=cause.patch,
+                                  storage=storage, handlers=owned_handlers)
 
             done = state.done
             delays = state.delays
@@ -518,7 +523,11 @@ async def process_changing_cause(
     # Regular causes also do some implicit post-handling when all handlers are done.
     if done or skip:
         if cause.new is not None and cause.old != cause.new:
-            settings.persistence.diffbase_storage.store(body=body, patch=patch, essence=cause.new)
+            # This method was sync originally. Support both sync overrides and newer async methods
+            # without breaking the backwards compatibility and requiring a major semver release.
+            maybe_coro = settings.persistence.diffbase_storage.store(body=body, patch=patch, essence=cause.new)
+            if inspect.isawaitable(maybe_coro):
+                await maybe_coro
 
         # Once all handlers have succeeded at least once for any reason, or if there were none,
         # prevent further resume-handlers (which otherwise happens on each watch-stream re-listing).

--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -519,25 +519,29 @@ async def startup_cleanup_activities(
             logger.warning("Startup activity is only partially executed due to cancellation.")
             raise
 
-        # Notify the caller that we are ready to be executed. This unfreezes all the root tasks.
-        started_flag.set()
-        await aioadapters.raise_flag(ready_flag)
+        # NB: after the configuration, where storages are set, but before the task unblocking via flags.
+        # Keep them active even while the root tasks are exiting: the watchers can still be triggering.
+        async with settings.persistence.progress_storage, settings.persistence.diffbase_storage:
 
-        # Sleep forever, or until cancelled, which happens when the operator begins its shutdown.
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            pass
+            # Notify the caller that we are ready to be executed. This unfreezes all the root tasks.
+            started_flag.set()
+            await aioadapters.raise_flag(ready_flag)
 
-        # Wait for all other root tasks to exit before cleaning up.
-        # Beware: on explicit operator cancellation, there is no graceful period at all.
-        try:
-            current_task = asyncio.current_task()
-            awaited_tasks = {task for task in root_tasks if task is not current_task}
-            await aiotasks.wait(awaited_tasks)
-        except asyncio.CancelledError:
-            logger.warning("Cleanup activity is not executed at all due to cancellation.")
-            raise
+            # Sleep forever, or until cancelled, which happens when the operator begins its shutdown.
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                pass
+
+            # Wait for all other root tasks to exit before cleaning up.
+            # Beware: on explicit operator cancellation, there is no graceful period at all.
+            try:
+                current_task = asyncio.current_task()
+                awaited_tasks = {task for task in root_tasks if task is not current_task}
+                await aiotasks.wait(awaited_tasks)
+            except asyncio.CancelledError:
+                logger.warning("Cleanup activity is not executed at all due to cancellation.")
+                raise
 
         # Execute the cleanup activity after all other root tasks are presumably done.
         try:

--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -538,29 +538,26 @@ async def startup_cleanup_activities(
         except asyncio.CancelledError:
             logger.warning("Cleanup activity is not executed at all due to cancellation.")
             raise
+
+        # Execute the cleanup activity after all other root tasks are presumably done.
+        try:
+            await activities.run_activity(
+                lifecycle=lifecycles.all_at_once,
+                registry=registry,
+                settings=settings,
+                activity=causes.Activity.CLEANUP,
+                indices=indices,
+                memo=memo,
+            )
+            await vault.close()
+        except asyncio.CancelledError:
+            logger.warning("Cleanup activity is only partially executed due to cancellation.")
+            raise
+
     finally:
         # Cancel the special "core" tasks after all "root" tasks are gone (happy path)
         # or when the startup/cleanup activities are cancelled (operator termination case).
         # The "core" tasks are excluded from "root" tasks, so not canceled with them.
         # We own and manage "core" tasks, we cannot let them remain unattended or orphaned.
-        try:
-            core_done, _ = await aiotasks.stop(core_tasks, title="Core", logger=logger, interval=10)
-            await aiotasks.reraise(core_done)
-        except asyncio.CancelledError:
-            logger.warning("Cleanup activity is not executed at all due to cancellation.")
-            raise
-
-    # Execute the cleanup activity after all other root tasks are presumably done.
-    try:
-        await activities.run_activity(
-            lifecycle=lifecycles.all_at_once,
-            registry=registry,
-            settings=settings,
-            activity=causes.Activity.CLEANUP,
-            indices=indices,
-            memo=memo,
-        )
-        await vault.close()
-    except asyncio.CancelledError:
-        logger.warning("Cleanup activity is only partially executed due to cancellation.")
-        raise
+        core_done, _ = await aiotasks.stop(core_tasks, title="Core", logger=logger, interval=10)
+        await aiotasks.reraise(core_done)

--- a/kopf/_core/reactor/subhandling.py
+++ b/kopf/_core/reactor/subhandling.py
@@ -123,7 +123,7 @@ async def execute(
     owned_handlers = subregistry.get_resource_handlers(resource=cause.resource)
     cause_handlers = subregistry.get_handlers(cause=cause)
     storage = settings.persistence.progress_storage
-    state = progression.State.from_storage(body=cause.body, storage=storage, handlers=owned_handlers)
+    state = await progression.State.from_storage(body=cause.body, storage=storage, handlers=owned_handlers)
     state = state.with_purpose(cause.reason).with_handlers(cause_handlers)
     outcomes = await execution.execute_handlers_once(
         lifecycle=lifecycle,
@@ -134,7 +134,7 @@ async def execute(
         extra_context=subhandling_context,
     )
     state = state.with_outcomes(outcomes)
-    state.store(body=cause.body, patch=cause.patch, storage=storage)
+    await state.store(body=cause.body, patch=cause.patch, storage=storage)
     progression.deliver_results(outcomes=outcomes, patch=cause.patch)
 
     # Enrich all parents with references to sub-handlers of any level deep (sub-sub-handlers, etc).

--- a/tests/handling/test_cause_handling.py
+++ b/tests/handling/test_cause_handling.py
@@ -3,6 +3,8 @@ import asyncio
 import pytest
 
 import kopf
+from kopf._cogs.configs.diffbase import DiffBaseStorage
+from kopf._cogs.configs.progress import ProgressStorage
 from kopf._cogs.structs.ephemera import Memo
 from kopf._core.engines.indexing import OperatorIndexers
 from kopf._core.intents.causes import Reason
@@ -140,8 +142,10 @@ async def test_delete(registry, settings, handlers, resource, cause_mock, event_
 @pytest.mark.parametrize('consistency_time', [0, 100], ids=['now', 'future'])
 @pytest.mark.parametrize('event_type', EVENT_TYPES)
 async def test_gone(registry, settings, handlers, resource, cause_mock, event_type,
-                    assert_logs, k8s_mocked, consistency_time, looptime):
+                    assert_logs, k8s_mocked, mocker, consistency_time, looptime):
     cause_mock.reason = Reason.GONE
+    settings.persistence.diffbase_storage = mocker.Mock(spec=DiffBaseStorage)
+    settings.persistence.progress_storage = mocker.Mock(spec=ProgressStorage)
 
     settings.posting.loggers = True
     event_queue = asyncio.Queue()
@@ -198,6 +202,9 @@ async def test_gone_with_finalizer_not_removed_on_deleted_event(
 
     assert not k8s_mocked.patch.called
     assert event_queue.empty()
+
+    assert settings.persistence.diffbase_storage.erase.called
+    assert settings.persistence.progress_storage.erase.called
 
     assert_logs([
         "Deleted, really deleted",

--- a/tests/persistence/test_storing_of_diffbase_in_files.py
+++ b/tests/persistence/test_storing_of_diffbase_in_files.py
@@ -1,0 +1,282 @@
+import yaml
+
+from kopf._cogs.configs.diffbase import FileDiffBaseStorage
+from kopf._cogs.structs.bodies import Body, BodyEssence
+from kopf._cogs.structs.patches import Patch
+
+NAMESPACED_BODY = Body({'metadata': {'namespace': 'ns1', 'name': 'name1', 'uid': 'uid1'}})
+CLUSTER_BODY = Body({'metadata': {'name': 'name1', 'uid': 'uid1'}})
+
+ESSENCE_DATA_1 = BodyEssence(
+    spec={
+        'string-field': 'value1',
+        'integer-field': 123,
+        'float-field': 123.456,
+        'false-field': False,
+        'true-field': True,
+    },
+)
+
+ESSENCE_DATA_2 = BodyEssence(
+    spec={
+        'hello': 'world',
+        'the-cake': False,
+    },
+)
+
+
+#
+# Storage creation.
+#
+
+
+def test_file_storage_with_path(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    assert storage._path == tmp_path
+
+
+def test_file_storage_with_string_path(tmp_path):
+    storage = FileDiffBaseStorage(path=str(tmp_path))
+    assert storage._path == tmp_path
+
+
+#
+# Filename building.
+#
+
+
+def test_filename_for_namespaced_resource(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'default', 'name': 'my-app', 'uid': 'abc-123'}})
+    filepath = storage._build_filename(body)
+    assert filepath == tmp_path / 'default-my-app-abc-123.diffbase.yaml'
+
+
+def test_filename_for_cluster_resource(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'name': 'my-node', 'uid': 'abc-123'}})
+    filepath = storage._build_filename(body)
+    assert filepath == tmp_path / 'my-node-abc-123.diffbase.yaml'
+
+
+def test_filename_for_empty_body(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+def test_filename_for_body_without_name(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+def test_filename_for_body_without_uid(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'name': 'name1'}})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+def test_filename_escapes_slashes(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a/b', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '/' not in filepath.name
+    assert 'a%2Fb' in filepath.name
+
+
+def test_filename_escapes_double_dots(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': '..', 'name': '..', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert filepath.name == '%2E%2E-%2E%2E-uid1.diffbase.yaml'
+    assert filepath.parent == tmp_path
+
+
+def test_filename_escapes_double_dots_with_slashes(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': '../path', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '..' not in filepath.name
+    assert '%2E%2E%2Fpath' in filepath.name
+    assert filepath.parent == tmp_path
+
+
+def test_filename_escapes_double_dots_in_middle(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a/../b', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '..' not in filepath.name
+    assert filepath.parent == tmp_path
+
+
+def test_filename_escapes_special_characters(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a:b@c', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '/' not in filepath.name
+    assert ':' not in filepath.name
+    assert '@' not in filepath.name
+
+
+#
+# Fetching.
+#
+
+
+def test_fetching_from_empty_body_returns_none(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    body = Body({})
+    data = storage.fetch(body=body)
+    assert data is None
+
+
+def test_fetching_when_no_file_exists(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    data = storage.fetch(body=NAMESPACED_BODY)
+    assert data is None
+
+
+def test_fetching_existing_essence(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    filepath.write_text(yaml.safe_dump(dict(ESSENCE_DATA_1)), encoding='utf-8')
+
+    data = storage.fetch(body=NAMESPACED_BODY)
+    assert data == ESSENCE_DATA_1
+
+
+#
+# Storing.
+#
+
+
+def test_storing_creates_file(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    body = Body({'metadata': {'namespace': 'ns1', 'name': 'name1', 'uid': 'uid1'}})
+    storage.store(body=body, patch=patch, essence=ESSENCE_DATA_1)
+
+    filepath = storage._build_filename(body)
+    assert filepath.exists()
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    assert data == ESSENCE_DATA_1
+
+
+def test_storing_does_not_modify_patch(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    assert not patch
+
+
+def test_storing_creates_parent_directories(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path / 'sub' / 'dir')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    assert filepath.exists()
+
+
+def test_storing_overwrites_old_content(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_2)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    assert data == ESSENCE_DATA_2
+
+
+def test_storing_for_cluster_resource(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=CLUSTER_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    filepath = storage._build_filename(CLUSTER_BODY)
+    assert filepath.exists()
+    assert filepath.name == 'name1-uid1.diffbase.yaml'
+
+
+#
+# Erasing.
+#
+
+
+def test_erasing_removes_file(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    storage.erase(body=NAMESPACED_BODY)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    assert not filepath.exists()
+
+
+def test_erasing_when_no_file_exists(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    storage.erase(body=NAMESPACED_BODY)  # must not raise
+
+
+def test_erasing_does_not_affect_other_resources(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    storage.store(body=CLUSTER_BODY, patch=patch, essence=ESSENCE_DATA_2)
+
+    storage.erase(body=NAMESPACED_BODY)
+
+    namespaced_file = storage._build_filename(NAMESPACED_BODY)
+    cluster_file = storage._build_filename(CLUSTER_BODY)
+    assert not namespaced_file.exists()
+    assert cluster_file.exists()
+
+
+#
+# YAML round-trip integrity.
+#
+
+
+def test_yaml_roundtrip_preserves_types(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+    essence = BodyEssence(
+        spec={
+            'string-field': 'value1',
+            'integer-field': 123,
+            'float-field': 123.456,
+            'false-field': False,
+            'true-field': True,
+            'list-field': ['a', 'b', 'c'],
+            'nested-field': {'key': 'value'},
+        },
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=essence)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+
+    assert fetched['spec']['string-field'] == 'value1'
+    assert fetched['spec']['integer-field'] == 123
+    assert fetched['spec']['float-field'] == 123.456
+    assert fetched['spec']['false-field'] is False
+    assert fetched['spec']['true-field'] is True
+    assert fetched['spec']['list-field'] == ['a', 'b', 'c']
+    assert fetched['spec']['nested-field'] == {'key': 'value'}
+
+
+def test_fetch_and_store_roundtrip(tmp_path):
+    storage = FileDiffBaseStorage(path=tmp_path)
+    patch = Patch()
+
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+    assert fetched == ESSENCE_DATA_1
+
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_2)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+    assert fetched == ESSENCE_DATA_2

--- a/tests/persistence/test_storing_of_diffbase_in_sqlite.py
+++ b/tests/persistence/test_storing_of_diffbase_in_sqlite.py
@@ -1,0 +1,238 @@
+import sqlite3
+
+from kopf._cogs.configs.diffbase import SQLiteDiffBaseStorage
+from kopf._cogs.structs.bodies import Body, BodyEssence
+from kopf._cogs.structs.patches import Patch
+
+NAMESPACED_BODY = Body({'metadata': {'namespace': 'ns1', 'name': 'name1', 'uid': 'uid1'}})
+CLUSTER_BODY = Body({'metadata': {'name': 'name1', 'uid': 'uid1'}})
+
+ESSENCE_DATA_1 = BodyEssence(
+    spec={
+        'string-field': 'value1',
+        'integer-field': 123,
+        'float-field': 123.456,
+        'false-field': False,
+        'true-field': True,
+    },
+)
+
+ESSENCE_DATA_2 = BodyEssence(
+    spec={
+        'hello': 'world',
+        'the-cake': False,
+    },
+)
+
+
+#
+# Storage creation.
+#
+
+
+def test_sqlite_storage_with_path(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    assert storage._path == tmp_path / 'db.sqlite'
+
+
+def test_sqlite_storage_with_string_path(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=str(tmp_path / 'db.sqlite'))
+    assert storage._path == tmp_path / 'db.sqlite'
+
+
+#
+# Fetching.
+#
+
+
+def test_fetching_from_empty_body_returns_none(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    body = Body({})
+    data = storage.fetch(body=body)
+    assert data is None
+
+
+def test_fetching_when_no_table_exists(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    data = storage.fetch(body=NAMESPACED_BODY)
+    assert data is None
+
+
+def test_fetching_existing_essence(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    data = storage.fetch(body=NAMESPACED_BODY)
+    assert data == ESSENCE_DATA_1
+
+
+#
+# Storing.
+#
+
+
+def test_storing_creates_table(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    conn = sqlite3.connect(str(tmp_path / 'db.sqlite'))
+    tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    conn.close()
+    assert ('diffbase',) in tables
+
+
+def test_storing_does_not_modify_patch(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    assert not patch
+
+
+def test_storing_creates_parent_directories(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'sub' / 'dir' / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    assert (tmp_path / 'sub' / 'dir' / 'db.sqlite').exists()
+
+
+def test_storing_overwrites_old_content(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_2)
+
+    data = storage.fetch(body=NAMESPACED_BODY)
+    assert data == ESSENCE_DATA_2
+
+
+def test_storing_for_cluster_resource(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=CLUSTER_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    data = storage.fetch(body=CLUSTER_BODY)
+    assert data == ESSENCE_DATA_1
+
+
+def test_storing_isolates_namespaced_and_cluster_resources(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    storage.store(body=CLUSTER_BODY, patch=patch, essence=ESSENCE_DATA_2)
+
+    data_ns = storage.fetch(body=NAMESPACED_BODY)
+    data_cl = storage.fetch(body=CLUSTER_BODY)
+    assert data_ns == ESSENCE_DATA_1
+    assert data_cl == ESSENCE_DATA_2
+
+
+#
+# Erasing.
+#
+
+
+def test_erasing_removes_record(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    storage.erase(body=NAMESPACED_BODY)
+
+    assert storage.fetch(body=NAMESPACED_BODY) is None
+
+
+def test_erasing_when_no_table_exists(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    storage.erase(body=NAMESPACED_BODY)  # must not raise
+
+
+def test_erasing_with_empty_body_is_noop(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    body = Body({})
+    storage.erase(body=body)  # must not raise
+
+
+def test_erasing_does_not_affect_other_resources(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    storage.store(body=CLUSTER_BODY, patch=patch, essence=ESSENCE_DATA_2)
+
+    storage.erase(body=NAMESPACED_BODY)
+
+    assert storage.fetch(body=NAMESPACED_BODY) is None
+    assert storage.fetch(body=CLUSTER_BODY) == ESSENCE_DATA_2
+
+
+#
+# Shared database file.
+#
+
+
+def test_shared_database_between_storages(tmp_path):
+    db_path = tmp_path / 'shared.sqlite'
+    progress_storage = __import__('kopf._cogs.configs.progress', fromlist=['SQLiteProgressStorage']).SQLiteProgressStorage(path=db_path)
+    diffbase_storage = SQLiteDiffBaseStorage(path=db_path)
+    patch = Patch()
+
+    from kopf._cogs.configs.progress import ProgressRecord
+    from kopf._cogs.structs.ids import HandlerId
+
+    record = ProgressRecord(started='2020-01-01T00:00:00', retries=1, success=True)
+    progress_storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('h1'), record=record)
+    diffbase_storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+
+    conn = sqlite3.connect(str(db_path))
+    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    conn.close()
+    assert 'progress' in tables
+    assert 'diffbase' in tables
+
+    assert progress_storage.fetch(body=NAMESPACED_BODY, key=HandlerId('h1')) is not None
+    assert diffbase_storage.fetch(body=NAMESPACED_BODY) == ESSENCE_DATA_1
+
+
+#
+# JSON round-trip integrity.
+#
+
+
+def test_json_roundtrip_preserves_types(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    essence = BodyEssence(
+        spec={
+            'string-field': 'value1',
+            'integer-field': 123,
+            'float-field': 123.456,
+            'false-field': False,
+            'true-field': True,
+            'list-field': ['a', 'b', 'c'],
+            'nested-field': {'key': 'value'},
+        },
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=essence)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+
+    assert fetched['spec']['string-field'] == 'value1'
+    assert fetched['spec']['integer-field'] == 123
+    assert fetched['spec']['float-field'] == 123.456
+    assert fetched['spec']['false-field'] is False
+    assert fetched['spec']['true-field'] is True
+    assert fetched['spec']['list-field'] == ['a', 'b', 'c']
+    assert fetched['spec']['nested-field'] == {'key': 'value'}
+
+
+def test_fetch_and_store_roundtrip(tmp_path):
+    storage = SQLiteDiffBaseStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_1)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+    assert fetched == ESSENCE_DATA_1
+
+    storage.store(body=NAMESPACED_BODY, patch=patch, essence=ESSENCE_DATA_2)
+    fetched = storage.fetch(body=NAMESPACED_BODY)
+    assert fetched == ESSENCE_DATA_2

--- a/tests/persistence/test_storing_of_progress_in_files.py
+++ b/tests/persistence/test_storing_of_progress_in_files.py
@@ -1,0 +1,429 @@
+import pytest
+import yaml
+
+from kopf._cogs.configs.progress import FileProgressStorage, ProgressRecord
+from kopf._cogs.structs.bodies import Body
+from kopf._cogs.structs.ids import HandlerId
+from kopf._cogs.structs.patches import Patch
+
+CONTENT_DATA_1 = ProgressRecord(
+    started='2020-01-01T00:00:00',
+    stopped='2020-12-31T23:59:59',
+    delayed='3000-01-01T00:00:00',
+    retries=123,
+    success=False,
+    failure=False,
+    message=None,
+    subrefs=None,
+)
+
+CONTENT_DATA_2 = ProgressRecord(
+    started='2021-01-01T00:00:00',
+    stopped='2021-12-31T23:59:59',
+    delayed='3001-01-01T00:00:00',
+    retries=456,
+    success=False,
+    failure=False,
+    message="Some error.",
+    subrefs=['sub1', 'sub2'],
+)
+
+NAMESPACED_BODY = Body({'metadata': {'namespace': 'ns1', 'name': 'name1', 'uid': 'uid1'}})
+CLUSTER_BODY = Body({'metadata': {'name': 'name1', 'uid': 'uid1'}})
+
+
+#
+# Storage creation.
+#
+
+
+def test_file_storage_with_path(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    assert storage._path == tmp_path
+
+
+def test_file_storage_with_string_path(tmp_path):
+    storage = FileProgressStorage(path=str(tmp_path))
+    assert storage._path == tmp_path
+
+
+def test_file_storage_with_touch_field(tmp_path):
+    storage = FileProgressStorage(path=tmp_path, touch_field='status.my-dummy')
+    assert storage.touch_field == 'status.my-dummy'
+
+
+#
+# Filename building.
+#
+
+
+def test_filename_for_namespaced_resource(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'default', 'name': 'my-app', 'uid': 'abc-123'}})
+    filepath = storage._build_filename(body)
+    assert filepath == tmp_path / 'default-my-app-abc-123.progress.yaml'
+
+
+def test_filename_for_dotted_name(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'default', 'name': 'my.app.v1', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert filepath == tmp_path / 'default-my.app.v1-uid1.progress.yaml'
+
+
+def test_filename_for_cluster_resource(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'name': 'my-node', 'uid': 'abc-123'}})
+    filepath = storage._build_filename(body)
+    assert filepath == tmp_path / 'my-node-abc-123.progress.yaml'
+
+
+def test_filename_for_empty_body(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+def test_filename_for_body_without_name(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+def test_filename_for_body_without_uid(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'name': 'name1'}})
+    filepath = storage._build_filename(body)
+    assert filepath is None
+
+
+def test_filename_escapes_slashes(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a/b', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '/' not in filepath.name
+    assert 'a%2Fb' in filepath.name
+
+
+def test_filename_escapes_double_dots(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': '..', 'name': '..', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert filepath.name == '%2E%2E-%2E%2E-uid1.progress.yaml'
+    # Must stay flat in the configured directory (no path traversal).
+    assert filepath.parent == tmp_path
+
+
+def test_filename_escapes_double_dots_with_slashes(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': '../path', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '..' not in filepath.name
+    assert '%2E%2E%2Fpath' in filepath.name
+    assert filepath.parent == tmp_path
+
+
+def test_filename_escapes_double_dots_in_middle(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a/../b', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '..' not in filepath.name
+    assert filepath.parent == tmp_path
+
+
+def test_filename_escapes_special_characters(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({'metadata': {'namespace': 'ns', 'name': 'a:b@c', 'uid': 'uid1'}})
+    filepath = storage._build_filename(body)
+    assert '/' not in filepath.name
+    assert ':' not in filepath.name
+    assert '@' not in filepath.name
+
+
+#
+# Fetching.
+#
+
+
+def test_fetching_from_empty_body_returns_none(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    body = Body({})
+    data = storage.fetch(body=body, key=HandlerId('id1'))
+    assert data is None
+
+
+def test_fetching_when_no_file_exists(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    assert data is None
+
+
+def test_fetching_existing_record(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    # Write without None values, as store() does.
+    clean_data = {k: v for k, v in CONTENT_DATA_1.items() if v is not None}
+    filepath.write_text(yaml.safe_dump({'id1': clean_data}), encoding='utf-8')
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    assert data == clean_data
+
+
+def test_fetching_nonexistent_key_returns_none(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    filepath.write_text(yaml.safe_dump({'id1': dict(CONTENT_DATA_1)}), encoding='utf-8')
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id2'))
+    assert data is None
+
+
+#
+# Storing.
+#
+
+
+def test_storing_creates_file(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    assert filepath.exists()
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    expected = {k: v for k, v in CONTENT_DATA_1.items() if v is not None}
+    assert data['id1'] == expected
+
+
+def test_storing_does_not_modify_patch(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    assert not patch
+
+
+def test_storing_creates_parent_directories(tmp_path):
+    storage = FileProgressStorage(path=tmp_path / 'sub' / 'dir')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    assert filepath.exists()
+
+
+def test_storing_appends_keys(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id2'), record=CONTENT_DATA_2)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    assert 'id1' in data
+    assert 'id2' in data
+
+
+def test_storing_overwrites_existing_key(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_2)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    expected = {k: v for k, v in CONTENT_DATA_2.items() if v is not None}
+    assert data['id1'] == expected
+
+
+def test_storing_filters_none_values(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    record = ProgressRecord(
+        started=None,
+        stopped=None,
+        delayed=None,
+        retries=None,
+        success=None,
+        failure=None,
+        message=None,
+        subrefs=None,
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=record)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    assert data['id1'] == {}
+
+
+def test_storing_for_cluster_resource(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=CLUSTER_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    filepath = storage._build_filename(CLUSTER_BODY)
+    assert filepath.exists()
+    assert filepath.name == 'name1-uid1.progress.yaml'
+
+
+#
+# Purging.
+#
+
+
+def test_purging_already_empty_body_does_nothing(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    body = Body({})
+    storage.purge(body=body, patch=patch, key=HandlerId('id1'))
+    assert not patch
+
+
+def test_purging_when_no_file_exists(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.purge(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'))
+    assert not patch
+
+
+def test_purging_removes_key(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id2'), record=CONTENT_DATA_2)
+
+    storage.purge(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'))
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    data = yaml.safe_load(filepath.read_text(encoding='utf-8'))
+    assert 'id1' not in data
+    assert 'id2' in data
+
+
+def test_purging_last_key_removes_file(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    storage.purge(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'))
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    assert not filepath.exists()
+
+
+def test_purging_does_not_modify_patch(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    patch2 = Patch()
+    storage.purge(body=NAMESPACED_BODY, patch=patch2, key=HandlerId('id1'))
+    assert not patch2
+
+
+#
+# Erasing.
+#
+
+
+def test_erasing_removes_file(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id2'), record=CONTENT_DATA_2)
+
+    storage.erase(body=NAMESPACED_BODY)
+
+    filepath = storage._build_filename(NAMESPACED_BODY)
+    assert not filepath.exists()
+
+
+def test_erasing_when_no_file_exists(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    storage.erase(body=NAMESPACED_BODY)  # must not raise
+
+
+def test_erasing_does_not_affect_other_resources(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=CLUSTER_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_2)
+
+    storage.erase(body=NAMESPACED_BODY)
+
+    namespaced_file = storage._build_filename(NAMESPACED_BODY)
+    cluster_file = storage._build_filename(CLUSTER_BODY)
+    assert not namespaced_file.exists()
+    assert cluster_file.exists()
+
+
+#
+# Touching.
+#
+
+
+@pytest.mark.parametrize('body_data', [
+    pytest.param({}, id='without-data'),
+    pytest.param({'metadata': {'annotations': {'kopf.dev/my-dummy': 'something'}}}, id='with-data'),
+])
+def test_touching_with_payload(tmp_path, body_data):
+    storage = FileProgressStorage(path=tmp_path, touch_field=['metadata', 'annotations', 'kopf.dev/my-dummy'])
+    patch = Patch()
+    body = Body(body_data)
+    storage.touch(body=body, patch=patch, value='hello')
+
+    assert patch
+    assert patch['metadata']['annotations']['kopf.dev/my-dummy'] == 'hello'
+
+
+def test_touching_with_none_when_absent(tmp_path):
+    storage = FileProgressStorage(path=tmp_path, touch_field=['metadata', 'annotations', 'kopf.dev/my-dummy'])
+    patch = Patch()
+    body = Body({})
+    storage.touch(body=body, patch=patch, value=None)
+
+    assert not patch
+
+
+def test_touching_with_none_when_present(tmp_path):
+    storage = FileProgressStorage(path=tmp_path, touch_field=['metadata', 'annotations', 'kopf.dev/my-dummy'])
+    patch = Patch()
+    body = Body({'metadata': {'annotations': {'kopf.dev/my-dummy': 'something'}}})
+    storage.touch(body=body, patch=patch, value=None)
+
+    assert patch
+    assert patch['metadata']['annotations']['kopf.dev/my-dummy'] is None
+
+
+#
+# YAML round-trip integrity.
+#
+
+
+def test_yaml_roundtrip_preserves_types(tmp_path):
+    storage = FileProgressStorage(path=tmp_path)
+    patch = Patch()
+    record = ProgressRecord(
+        started='2020-01-01T00:00:00',
+        stopped='2020-12-31T23:59:59',
+        delayed='3000-01-01T00:00:00',
+        retries=123,
+        success=True,
+        failure=False,
+        message="Some error.",
+        subrefs=['sub1', 'sub2'],
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=record)
+    fetched = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+
+    assert isinstance(fetched['started'], str)
+    assert isinstance(fetched['retries'], int)
+    assert isinstance(fetched['success'], bool)
+    assert isinstance(fetched['failure'], bool)
+    assert isinstance(fetched['message'], str)
+    assert isinstance(fetched['subrefs'], list)
+    assert fetched['started'] == '2020-01-01T00:00:00'
+    assert fetched['retries'] == 123
+    assert fetched['success'] is True
+    assert fetched['failure'] is False

--- a/tests/persistence/test_storing_of_progress_in_sqlite.py
+++ b/tests/persistence/test_storing_of_progress_in_sqlite.py
@@ -1,0 +1,338 @@
+import sqlite3
+
+import pytest
+
+from kopf._cogs.configs.progress import ProgressRecord, SQLiteProgressStorage
+from kopf._cogs.structs.bodies import Body
+from kopf._cogs.structs.ids import HandlerId
+from kopf._cogs.structs.patches import Patch
+
+CONTENT_DATA_1 = ProgressRecord(
+    started='2020-01-01T00:00:00',
+    stopped='2020-12-31T23:59:59',
+    delayed='3000-01-01T00:00:00',
+    retries=123,
+    success=False,
+    failure=False,
+    message=None,
+    subrefs=None,
+)
+
+CONTENT_DATA_2 = ProgressRecord(
+    started='2021-01-01T00:00:00',
+    stopped='2021-12-31T23:59:59',
+    delayed='3001-01-01T00:00:00',
+    retries=456,
+    success=False,
+    failure=False,
+    message="Some error.",
+    subrefs=['sub1', 'sub2'],
+)
+
+NAMESPACED_BODY = Body({'metadata': {'namespace': 'ns1', 'name': 'name1', 'uid': 'uid1'}})
+CLUSTER_BODY = Body({'metadata': {'name': 'name1', 'uid': 'uid1'}})
+
+
+#
+# Storage creation.
+#
+
+
+def test_sqlite_storage_with_path(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    assert storage._path == tmp_path / 'db.sqlite'
+
+
+def test_sqlite_storage_with_string_path(tmp_path):
+    storage = SQLiteProgressStorage(path=str(tmp_path / 'db.sqlite'))
+    assert storage._path == tmp_path / 'db.sqlite'
+
+
+def test_sqlite_storage_with_touch_field(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite', touch_field='status.my-dummy')
+    assert storage.touch_field == 'status.my-dummy'
+
+
+#
+# Fetching.
+#
+
+
+def test_fetching_from_empty_body_returns_none(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    body = Body({})
+    data = storage.fetch(body=body, key=HandlerId('id1'))
+    assert data is None
+
+
+def test_fetching_when_no_table_exists(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    assert data is None
+
+
+def test_fetching_existing_record(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    expected = {k: v for k, v in CONTENT_DATA_1.items() if v is not None}
+    assert data == expected
+
+
+def test_fetching_nonexistent_key_returns_none(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id2'))
+    assert data is None
+
+
+#
+# Storing.
+#
+
+
+def test_storing_creates_table(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    conn = sqlite3.connect(str(tmp_path / 'db.sqlite'))
+    tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    conn.close()
+    assert ('progress',) in tables
+
+
+def test_storing_does_not_modify_patch(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    assert not patch
+
+
+def test_storing_creates_parent_directories(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'sub' / 'dir' / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    assert (tmp_path / 'sub' / 'dir' / 'db.sqlite').exists()
+
+
+def test_storing_appends_keys(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id2'), record=CONTENT_DATA_2)
+
+    data1 = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    data2 = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id2'))
+    assert data1 is not None
+    assert data2 is not None
+
+
+def test_storing_overwrites_existing_key(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_2)
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    expected = {k: v for k, v in CONTENT_DATA_2.items() if v is not None}
+    assert data == expected
+
+
+def test_storing_filters_none_values(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    record = ProgressRecord(
+        started=None,
+        stopped=None,
+        delayed=None,
+        retries=None,
+        success=None,
+        failure=None,
+        message=None,
+        subrefs=None,
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=record)
+
+    data = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    assert data == {}
+
+
+def test_storing_for_cluster_resource(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=CLUSTER_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    data = storage.fetch(body=CLUSTER_BODY, key=HandlerId('id1'))
+    assert data is not None
+
+
+def test_storing_isolates_namespaced_and_cluster_resources(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=CLUSTER_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_2)
+
+    data_ns = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+    data_cl = storage.fetch(body=CLUSTER_BODY, key=HandlerId('id1'))
+    expected_ns = {k: v for k, v in CONTENT_DATA_1.items() if v is not None}
+    expected_cl = {k: v for k, v in CONTENT_DATA_2.items() if v is not None}
+    assert data_ns == expected_ns
+    assert data_cl == expected_cl
+
+
+#
+# Purging.
+#
+
+
+def test_purging_already_empty_body_does_nothing(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    body = Body({})
+    storage.purge(body=body, patch=patch, key=HandlerId('id1'))
+    assert not patch
+
+
+def test_purging_when_no_table_exists(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.purge(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'))
+    assert not patch
+
+
+def test_purging_removes_key(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id2'), record=CONTENT_DATA_2)
+
+    storage.purge(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'))
+
+    assert storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1')) is None
+    assert storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id2')) is not None
+
+
+def test_purging_does_not_modify_patch(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+
+    patch2 = Patch()
+    storage.purge(body=NAMESPACED_BODY, patch=patch2, key=HandlerId('id1'))
+    assert not patch2
+
+
+#
+# Erasing.
+#
+
+
+def test_erasing_removes_all_records_for_resource(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id2'), record=CONTENT_DATA_2)
+
+    storage.erase(body=NAMESPACED_BODY)
+
+    assert storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1')) is None
+    assert storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id2')) is None
+
+
+def test_erasing_when_no_table_exists(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    storage.erase(body=NAMESPACED_BODY)  # must not raise
+
+
+def test_erasing_with_empty_body_is_noop(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    body = Body({})
+    storage.erase(body=body)  # must not raise
+
+
+def test_erasing_does_not_affect_other_resources(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_1)
+    storage.store(body=CLUSTER_BODY, patch=patch, key=HandlerId('id1'), record=CONTENT_DATA_2)
+
+    storage.erase(body=NAMESPACED_BODY)
+
+    assert storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1')) is None
+    assert storage.fetch(body=CLUSTER_BODY, key=HandlerId('id1')) is not None
+
+
+#
+# Touching.
+#
+
+
+@pytest.mark.parametrize('body_data', [
+    pytest.param({}, id='without-data'),
+    pytest.param({'metadata': {'annotations': {'kopf.dev/my-dummy': 'something'}}}, id='with-data'),
+])
+def test_touching_with_payload(tmp_path, body_data):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite', touch_field=['metadata', 'annotations', 'kopf.dev/my-dummy'])
+    patch = Patch()
+    body = Body(body_data)
+    storage.touch(body=body, patch=patch, value='hello')
+
+    assert patch
+    assert patch['metadata']['annotations']['kopf.dev/my-dummy'] == 'hello'
+
+
+def test_touching_with_none_when_absent(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite', touch_field=['metadata', 'annotations', 'kopf.dev/my-dummy'])
+    patch = Patch()
+    body = Body({})
+    storage.touch(body=body, patch=patch, value=None)
+
+    assert not patch
+
+
+def test_touching_with_none_when_present(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite', touch_field=['metadata', 'annotations', 'kopf.dev/my-dummy'])
+    patch = Patch()
+    body = Body({'metadata': {'annotations': {'kopf.dev/my-dummy': 'something'}}})
+    storage.touch(body=body, patch=patch, value=None)
+
+    assert patch
+    assert patch['metadata']['annotations']['kopf.dev/my-dummy'] is None
+
+
+#
+# JSON round-trip integrity.
+#
+
+
+def test_json_roundtrip_preserves_types(tmp_path):
+    storage = SQLiteProgressStorage(path=tmp_path / 'db.sqlite')
+    patch = Patch()
+    record = ProgressRecord(
+        started='2020-01-01T00:00:00',
+        stopped='2020-12-31T23:59:59',
+        delayed='3000-01-01T00:00:00',
+        retries=123,
+        success=True,
+        failure=False,
+        message="Some error.",
+        subrefs=['sub1', 'sub2'],
+    )
+    storage.store(body=NAMESPACED_BODY, patch=patch, key=HandlerId('id1'), record=record)
+    fetched = storage.fetch(body=NAMESPACED_BODY, key=HandlerId('id1'))
+
+    assert isinstance(fetched['started'], str)
+    assert isinstance(fetched['retries'], int)
+    assert isinstance(fetched['success'], bool)
+    assert isinstance(fetched['failure'], bool)
+    assert isinstance(fetched['message'], str)
+    assert isinstance(fetched['subrefs'], list)
+    assert fetched['started'] == '2020-01-01T00:00:00'
+    assert fetched['retries'] == 123
+    assert fetched['success'] is True
+    assert fetched['failure'] is False

--- a/tests/persistence/test_sync_deprecation.py
+++ b/tests/persistence/test_sync_deprecation.py
@@ -1,0 +1,88 @@
+import warnings
+
+import pytest
+
+from kopf._cogs.configs.diffbase import DiffBaseStorage
+from kopf._cogs.configs.progress import ProgressStorage
+
+
+def test_sync_progress_methods_are_deprecated():
+    with pytest.warns(FutureWarning) as record:
+        class SyncProgressStorage(ProgressStorage):
+            def fetch(self, **_): ...
+            def store(self, **_): ...
+            def purge(self, **_): ...
+            def flush(self): ...
+
+    messages = [str(w.message) for w in record]
+    assert len(messages) == 4
+    assert any("SyncProgressStorage.fetch() is not async;" in m for m in messages)
+    assert any("SyncProgressStorage.store() is not async;" in m for m in messages)
+    assert any("SyncProgressStorage.purge() is not async;" in m for m in messages)
+    assert any("SyncProgressStorage.flush() is not async;" in m for m in messages)
+
+
+def test_sync_diffbase_methods_are_deprecated():
+    with pytest.warns(FutureWarning) as record:
+        class SyncDiffBaseStorage(DiffBaseStorage):
+            def fetch(self, **_): ...
+            def store(self, **_): ...
+
+    messages = [str(w.message) for w in record]
+    assert len(messages) == 2
+    assert any("SyncDiffBaseStorage.fetch() is not async;" in m for m in messages)
+    assert any("SyncDiffBaseStorage.store() is not async;" in m for m in messages)
+
+
+def test_async_progress_methods_are_not_deprecated():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        class AsyncProgressStorage(ProgressStorage):
+            async def fetch(self, **_): ...
+            async def store(self, **_): ...
+            async def purge(self, **_): ...
+            async def flush(self): ...
+
+
+def test_async_diffbase_methods_are_not_deprecated():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        class AsyncDiffBaseStorage(DiffBaseStorage):
+            async def fetch(self, **_): ...
+            async def store(self, **_): ...
+
+
+def test_inherited_progress_methods_are_not_deprecated():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        class DerivedProgressStorage(ProgressStorage):
+            pass
+
+
+def test_inherited_diffbase_methods_are_not_deprecated():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        class DerivedDiffBaseStorage(DiffBaseStorage):
+            pass
+
+
+def test_kopf_module_progress_storages_are_not_deprecated():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        type('KopfProgressStorage', (ProgressStorage,), {
+            '__module__': 'kopf._cogs.configs.custom',
+            'fetch': lambda self, **_: None,
+            'store': lambda self, **_: None,
+            'purge': lambda self, **_: None,
+            'flush': lambda self: None,
+        })
+
+
+def test_kopf_module_diffbase_storages_are_not_deprecated():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        type('KopfDiffBaseStorage', (DiffBaseStorage,), {
+            '__module__': 'kopf._cogs.configs.custom',
+            'fetch': lambda self, **_: None,
+            'store': lambda self, **_: None,
+        })

--- a/tests/running/test_startup_cleanup_activities.py
+++ b/tests/running/test_startup_cleanup_activities.py
@@ -257,7 +257,6 @@ async def test_cancellation_during_core_task_stop(registry, settings, assert_log
         await task
 
     assert looptime == 5
-    assert_logs(["Cleanup activity is not executed at all due to cancellation."])
 
     # Clean up the stubborn core task.
     core_tasks[0].cancel()


### PR DESCRIPTION
While storing Kopf's state in the resource's annotations is the best & easiest way, some people might be unhappy about many API calls and heavy payloads. There was always a possibility to implement custom strages, though not documented well — now documented. 

As an example of custom storages, Kopf now bundles with a couple of "out of the box" storages, specifically the filesystem & sqlite storages. However, they require configuring a shared volume, so they cannot work "out of the box" as a default storage — but they can be a good starting point for custom storages for users.

No external dependencies are needed, StdLib is enough (however, sqlite3 can be broken or not compiled, so imported only on demand).

**Supersedes** the AI-generated PR (too many micro-issues there, which I had to rewrite by hand, massively):

* #1261 

TODOs:

- [x] File storage: atomic file writes (with renames, or with file locks).
- [x] Sqlite storage: shared connection management via context manager
- [x] Sqlite storage: `import sqlite3`  only on demand, broken sometimes
- [x] All storages must be context managers, too (globally entered/exited)
- [x] All storages must be async (fetch/store/purge/erase methods at least).
  - [x] 🔥 But backwards compatible with sync overrides.
    - BEWARE the `super().fetch(…)` trap - not awaited in descendants.
  - [x] With a DeprecationWarning on the legacy sync override (via `__new__`? or in the post-startup checks?)
- [ ] There should be only one storage for all data types, progress and diffbase, with a shared connection (pool).
  - [ ] But backwards compatible with separate storages if used so.
  - [ ] With a DeprecationWarning on the legacy separate mode usage.
  - [ ] Alternatively: accept a pre-created shared connection/pool to the constructor. This seems easier for transition.
- [ ] Tests for all this.