### PR TITLE
Add Python and Kubernetes health badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/kopf.svg)](https://pypi.org/project/kopf/)
 [![codecov](https://codecov.io/gh/nolar/kopf/branch/main/graph/badge.svg)](https://codecov.io/gh/nolar/kopf)
 [![coverage](https://coveralls.io/repos/github/nolar/kopf/badge.svg?branch=main)](https://coveralls.io/github/nolar/kopf?branch=main)
+[![Python Health](https://img.releaserun.com/badge/health/python.svg)](https://releaserun.com/badges/python/)
+[![Kubernetes Health](https://img.releaserun.com/badge/health/kubernetes.svg)](https://releaserun.com/badges/kubernetes/)
 
 **Kopf** —Kubernetes Operator Pythonic Framework— is a framework and a library
 to make Kubernetes operators development easier, just in a few lines of Python code.


### PR DESCRIPTION
Adds Python and Kubernetes health badges from [ReleaseRun](https://releaserun.com) to the README. Since Kopf is a Python framework for Kubernetes operators, both badges are relevant. They show the current health grade of each platform, updated automatically based on version freshness, CVE status, and end-of-life timeline.

**Badge previews**:
![Python Health](https://img.releaserun.com/badge/health/python.svg) ![Kubernetes Health](https://img.releaserun.com/badge/health/kubernetes.svg)

Free, no API key needed. Fits alongside the existing PyPI and CI badges.

Happy to adjust if you'd prefer different placement or only one of the two.