### PR TITLE
Disable the metrics.k8s.io extension in CI K8s clusters

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,6 +120,7 @@ jobs:
         with:
           version: ${{ matrix.k3s }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          k3s-args: --disable=metrics-server@server:*
       - run: uv sync --group test
       - run: uv pip install -r examples/requirements.txt
       - run: uv run pytest --color=yes --timeout=30 --only-e2e


### PR DESCRIPTION
The k3s cluster takes some time to start up because of its "metrics.k8s.io" extension, which takes longer than 5 or even 10 seconds (approximately 18-20 seconds).

Because of the absent readiness criterion in this test, we create an object too early — before the operator handles it. This is not a problem per se, but we also expect the reaction too early — within 5 seconds. And so, the e2e test fails — because nothing happens, because the operator is not running, it is still scanning the cluster resources in the initial cluster discovery.

We do not need those "metrics.k8s.io" resources for e2e tests. This fix disables them in CI, so the e2e tests can now pass. This is better than playing with tests timing or complicating their logic to wait for proper readiness log lines.
