### PR TITLE
Detect silent connection loss behind the cloud load balancers

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -273,6 +273,13 @@ The server-side timeouts are unpredictable, they can be 10 seconds or
 watching requests -- to prevent API flooding in case of errors or disconnects.
 The default is 0.1 seconds (nearly instant, but not flooding).
 
+``settings.watching.inactivity_timeout`` (seconds) is how long the watch stream
+is allowed to stay completely silent — delivering no events, not even bookmarks —
+before it is considered dead and closed for reconnection.
+Kubernetes sends bookmark events roughly every 60 seconds as a heartbeat,
+so the default of 90 seconds allows for reasonable jitter while still detecting
+streams that are silently stalled at the TCP level.
+
 .. code-block:: python
 
     import kopf

--- a/kopf/_cogs/clients/watching.py
+++ b/kopf/_cogs/clients/watching.py
@@ -21,6 +21,7 @@ import asyncio
 import contextlib
 import enum
 import logging
+import sys
 from collections.abc import AsyncIterator
 from typing import cast
 
@@ -257,30 +258,32 @@ async def watch_objs(
 
     # Stream the parsed events from the response until it is closed server-side,
     # or until it is closed client-side by the pause-waiting future's callbacks.
+    # The inactivity timeout is reset after each received event; if no event arrives
+    # within the window, asyncio.timeout() cancels the outer task and we log & return.
     try:
-        stream = api.stream(
-            url=resource.get_url(namespace=namespace, params=params),
-            logger=logger,
-            settings=settings,
-            stopper=operator_pause_waiter,
-            timeout=aiohttp.ClientTimeout(
-                total=settings.watching.client_timeout,
-                sock_connect=connect_timeout,
-            ),
-        ).__aiter__()
-        while True:
-            try:
-                raw_input = await asyncio.wait_for(
-                    anext(stream),
-                    timeout=settings.watching.inactivity_timeout,
-                )
-            except StopAsyncIteration:
-                break
-            except asyncio.TimeoutError:
-                where = f'in {namespace!r}' if namespace is not None else 'cluster-wide'
-                logger.debug(f"Watch-stream for {resource} {where} is inactive, reconnecting.")
-                return
-            yield raw_input
-
+        # Python 3.10 does not have asyncio.timeout(); fall back to the unprotected version.
+        # TODO: Remove when Python 3.10 is deprecated in Oct'26 (and the "if timeout_cm…" below).
+        if sys.version_info < (3, 11):  # 3.10 only
+            timeout = contextlib.nullcontext(None)
+        else:
+            timeout = asyncio.timeout(settings.watching.inactivity_timeout)
+        async with timeout as timeout_cm:
+            async for raw_input in api.stream(
+                url=resource.get_url(namespace=namespace, params=params),
+                logger=logger,
+                settings=settings,
+                stopper=operator_pause_waiter,
+                timeout=aiohttp.ClientTimeout(
+                    total=settings.watching.client_timeout,
+                    sock_connect=connect_timeout,
+                ),
+            ):
+                yield raw_input
+                if timeout_cm is not None:
+                    now = asyncio.get_running_loop().time()
+                    timeout_cm.reschedule(now + settings.watching.inactivity_timeout)
+    except TimeoutError:
+        where = f'in {namespace!r}' if namespace is not None else 'cluster-wide'
+        logger.debug(f"Watch-stream for {resource} {where} is inactive, reconnecting.")
     except (aiohttp.ClientConnectionError, aiohttp.ClientPayloadError, asyncio.TimeoutError):
         pass

--- a/kopf/_cogs/clients/watching.py
+++ b/kopf/_cogs/clients/watching.py
@@ -209,7 +209,7 @@ async def continuous_watch(
                 raise WatchingError(f"Error in the watch-stream: {raw_object}")
 
             # Ensure that the event is something we understand and can handle.
-            if raw_type not in ['ADDED', 'MODIFIED', 'DELETED']:
+            if raw_type not in ['ADDED', 'MODIFIED', 'DELETED', 'BOOKMARK']:
                 logger.warning(f"Ignoring an unsupported event type: {raw_input!r}")
                 continue
 
@@ -243,6 +243,7 @@ async def watch_objs(
     """
     params: dict[str, str] = {}
     params['watch'] = 'true'
+    params['allowWatchBookmarks'] = 'true'
     if since is not None:
         params['resourceVersion'] = since
     if settings.watching.server_timeout is not None:

--- a/kopf/_cogs/clients/watching.py
+++ b/kopf/_cogs/clients/watching.py
@@ -258,7 +258,7 @@ async def watch_objs(
     # Stream the parsed events from the response until it is closed server-side,
     # or until it is closed client-side by the pause-waiting future's callbacks.
     try:
-        async for raw_input in api.stream(
+        stream = api.stream(
             url=resource.get_url(namespace=namespace, params=params),
             logger=logger,
             settings=settings,
@@ -267,7 +267,19 @@ async def watch_objs(
                 total=settings.watching.client_timeout,
                 sock_connect=connect_timeout,
             ),
-        ):
+        ).__aiter__()
+        while True:
+            try:
+                raw_input = await asyncio.wait_for(
+                    anext(stream),
+                    timeout=settings.watching.inactivity_timeout,
+                )
+            except StopAsyncIteration:
+                break
+            except asyncio.TimeoutError:
+                where = f'in {namespace!r}' if namespace is not None else 'cluster-wide'
+                logger.debug(f"Watch-stream for {resource} {where} is inactive, reconnecting.")
+                return
             yield raw_input
 
     except (aiohttp.ClientConnectionError, aiohttp.ClientPayloadError, asyncio.TimeoutError):

--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -200,6 +200,14 @@ class WatchingSettings:
     How long should a pause be between watch requests (to prevent API flooding).
     """
 
+    inactivity_timeout: float = 90.0
+    """
+    How long to wait for any event (including bookmarks) from the watch stream
+    before considering the stream dead and reconnecting. Kubernetes sends
+    bookmark events every 60 seconds, so the default of 90 seconds allows
+    for reasonable jitter while still detecting dead streams.
+    """
+
 
 @dataclasses.dataclass
 class QueueingSettings:

--- a/kopf/_cogs/structs/bodies.py
+++ b/kopf/_cogs/structs/bodies.py
@@ -60,8 +60,8 @@ Annotations: TypeAlias = Mapping[str, str]
 #
 
 # ``None`` is used for the listing, when the pseudo-watch-stream is simulated.
-RawInputType = Literal[None, 'ADDED', 'MODIFIED', 'DELETED', 'ERROR']
-RawEventType = Literal[None, 'ADDED', 'MODIFIED', 'DELETED']
+RawInputType = Literal[None, 'ADDED', 'MODIFIED', 'DELETED', 'BOOKMARK', 'ERROR']
+RawEventType = Literal[None, 'ADDED', 'MODIFIED', 'DELETED', 'BOOKMARK']
 
 
 class RawMeta(TypedDict, total=False):

--- a/kopf/_core/reactor/queueing.py
+++ b/kopf/_core/reactor/queueing.py
@@ -192,6 +192,11 @@ async def watcher(
             if isinstance(raw_event, watching.Bookmark):
                 continue
 
+            # Skip BOOKMARK events from K8s: they carry no object identity (no uid/name/namespace),
+            # and are only useful for resource version tracking (already done in the watch stream).
+            if raw_event.get('type') == 'BOOKMARK':
+                continue
+
             # Multiplex the raw events to per-resource workers/queues. Start the new ones if needed.
             key: ObjectRef = (resource, get_uid(raw_event))
             try:

--- a/tests/k8s/test_watching_bookmarks.py
+++ b/tests/k8s/test_watching_bookmarks.py
@@ -31,3 +31,61 @@ async def test_listed_is_inbetween(settings, resource, namespace, kmock):
     assert events[2] == Bookmark.LISTED
     assert events[3]['object']['spec'] == 'c'
     assert events[4]['object']['spec'] == 'd'
+
+
+async def test_bookmark_event_is_yielded(settings, resource, namespace, kmock):
+
+    kmock['list', resource, kmock.namespace(namespace)] << {
+        'metadata': {'resourceVersion': '100'},
+        'items': [],
+    }
+    kmock['watch', resource, kmock.namespace(namespace), kmock.params(resourceVersion='100')] << (
+        {'type': 'ADDED', 'object': {'metadata': {'resourceVersion': '101'}}},
+        {'type': 'BOOKMARK', 'object': {'metadata': {'resourceVersion': '102'}}},
+        {'type': 'ADDED', 'object': {'metadata': {'resourceVersion': '103'}}},
+        {'type': 'ERROR', 'object': {'code': 410}},
+    )
+
+    events = []
+    async for event in continuous_watch(settings=settings,
+                                        resource=resource,
+                                        namespace=namespace,
+                                        operator_pause_waiter=asyncio.Future()):
+        events.append(event)
+
+    assert len(events) == 4
+    assert events[0] == Bookmark.LISTED
+    assert events[1]['type'] == 'ADDED'
+    assert events[2]['type'] == 'BOOKMARK'
+    assert events[3]['type'] == 'ADDED'
+
+
+async def test_bookmark_updates_resource_version(settings, resource, namespace, kmock):
+
+    kmock['list', resource, kmock.namespace(namespace)] << {
+        'metadata': {'resourceVersion': '100'},
+        'items': [],
+    }
+
+    # First watch: a bookmark advances the resource version, then the stream ends naturally.
+    kmock['watch', resource, kmock.namespace(namespace), kmock.params(resourceVersion='100')] << (
+        {'type': 'BOOKMARK', 'object': {'metadata': {'resourceVersion': '200'}}},
+    )
+
+    # Second watch: must resume from the bookmark's resource version, not the list's.
+    kmock['watch', resource, kmock.namespace(namespace), kmock.params(resourceVersion='200')] << (
+        {'type': 'ADDED', 'object': {'metadata': {'resourceVersion': '201'}}},
+        {'type': 'ERROR', 'object': {'code': 410}},
+    )
+
+    events = []
+    async for event in continuous_watch(settings=settings,
+                                        resource=resource,
+                                        namespace=namespace,
+                                        operator_pause_waiter=asyncio.Future()):
+        events.append(event)
+
+    assert len(events) == 3
+    assert events[0] == Bookmark.LISTED
+    assert events[1]['type'] == 'BOOKMARK'
+    assert events[2]['type'] == 'ADDED'

--- a/tests/k8s/test_watching_inactivity.py
+++ b/tests/k8s/test_watching_inactivity.py
@@ -1,0 +1,134 @@
+"""
+Tests for the inactivity timeout in watch_objs().
+
+When no events (including bookmarks) arrive within settings.watching.inactivity_timeout,
+watch_objs() closes the stream and returns, causing continuous_watch() to reconnect.
+"""
+import asyncio
+
+from kopf._cogs.clients.watching import Bookmark, continuous_watch, watch_objs
+
+
+async def test_empty_stream_times_out(settings, resource, namespace, kmock, looptime, assert_logs):
+    """A watch stream that sends no events at all is closed after the inactivity timeout."""
+    settings.watching.inactivity_timeout = 15.0
+    kmock['watch', resource, kmock.namespace(namespace)] << (lambda: asyncio.sleep(99))
+
+    events = []
+    async for event in watch_objs(
+            settings=settings,
+            resource=resource,
+            namespace=namespace,
+            since='100',
+            operator_pause_waiter=asyncio.Future()):
+        events.append(event)
+
+    assert events == []
+    assert looptime == 15
+    assert_logs([r"Watch-stream.*inactive.*reconnecting"])
+
+
+async def test_stalled_stream_times_out(settings, resource, namespace, kmock, looptime, assert_logs):
+    """A watch stream that stalls after some events is closed after the inactivity timeout."""
+    settings.watching.inactivity_timeout = 15.0
+    kmock['watch', resource, kmock.namespace(namespace)] << (
+        {'type': 'ADDED', 'object': {'metadata': {'resourceVersion': '101'}}},
+        lambda: asyncio.sleep(99),
+    )
+
+    events = []
+    async for event in watch_objs(
+            settings=settings,
+            resource=resource,
+            namespace=namespace,
+            since='100',
+            operator_pause_waiter=asyncio.Future()):
+        events.append(event)
+
+    assert len(events) == 1
+    assert events[0]['type'] == 'ADDED'
+    assert looptime == 15
+    assert_logs([r"Watch-stream.*inactive.*reconnecting"])
+
+
+async def test_bookmark_event_resets_inactivity_timer(settings, resource, namespace, kmock, looptime, assert_logs):
+    """A BOOKMARK event resets the inactivity timer, just like any other event."""
+    settings.watching.inactivity_timeout = 30.0
+    kmock['watch', resource, kmock.namespace(namespace)] << (
+        lambda: asyncio.sleep(15),
+        {'type': 'BOOKMARK', 'object': {'metadata': {'resourceVersion': '101'}}},
+        lambda: asyncio.sleep(99)
+    )
+
+    events = []
+    async for event in watch_objs(
+            settings=settings,
+            resource=resource,
+            namespace=namespace,
+            since='100',
+            operator_pause_waiter=asyncio.Future()):
+        events.append(event)
+
+    assert len(events) == 1
+    assert events[0]['type'] == 'BOOKMARK'
+    assert looptime == 15 + 30  # 15s before the bookmark + 30s of inactivity after it
+    assert_logs([r"Watch-stream.*inactive.*reconnecting"])
+
+
+async def test_active_stream_does_not_time_out(settings, resource, namespace, kmock, looptime):
+    """A stream delivering events within the timeout window is not closed prematurely."""
+    settings.watching.inactivity_timeout = 15.0
+    kmock['watch', resource, kmock.namespace(namespace)] << (
+        {'type': 'ADDED', 'object': {'metadata': {'resourceVersion': '101'}}},
+        lambda: asyncio.sleep(10),  # 10s < 15s timeout: well within the window
+        {'type': 'ADDED', 'object': {'metadata': {'resourceVersion': '102'}}},
+
+    )
+
+    events = []
+    async for event in watch_objs(
+            settings=settings,
+            resource=resource,
+            namespace=namespace,
+            since='100',
+            operator_pause_waiter=asyncio.Future()):
+        events.append(event)
+
+    assert len(events) == 2
+    assert looptime == 10  # only the inter-event sleep, no inactivity timeout
+
+
+async def test_inactivity_reconnects_with_last_resource_version(
+        settings, resource, namespace, kmock, looptime):
+    """After an inactivity timeout, continuous_watch() reconnects from the last seen resource version."""
+    settings.watching.inactivity_timeout = 15.0
+    kmock['list', resource, kmock.namespace(namespace)] << {
+        'metadata': {'resourceVersion': '100'},
+        'items': [],
+    }
+
+    # First watch: advances resource version via a bookmark, then hangs.
+    kmock['watch', resource, kmock.namespace(namespace), kmock.params(resourceVersion='100')] << (
+        {'type': 'BOOKMARK', 'object': {'metadata': {'resourceVersion': '200'}}},
+        lambda: asyncio.sleep(99),
+    )
+
+    # Second watch: must be called with the bookmark's resource version, not the list's.
+    kmock['watch', resource, kmock.namespace(namespace), kmock.params(resourceVersion='200')] << (
+        {'type': 'ERROR', 'object': {'code': 410}},
+    )
+
+    events = []
+    async for event in continuous_watch(settings=settings,
+                                        resource=resource,
+                                        namespace=namespace,
+                                        operator_pause_waiter=asyncio.Future()):
+        events.append(event)
+
+    assert looptime == 15
+    assert Bookmark.LISTED in events
+    assert any(
+        isinstance(e, dict) and e.get('type') == 'BOOKMARK'
+        and e.get('object', {}).get('metadata', {}).get('resourceVersion') == '200'
+        for e in events
+    )

--- a/tests/k8s/test_watching_inactivity.py
+++ b/tests/k8s/test_watching_inactivity.py
@@ -3,12 +3,21 @@ Tests for the inactivity timeout in watch_objs().
 
 When no events (including bookmarks) arrive within settings.watching.inactivity_timeout,
 watch_objs() closes the stream and returns, causing continuous_watch() to reconnect.
+This feature uses asyncio.timeout() which is only available in Python 3.11+.
+On Python 3.10, the inactivity timeout is not enforced; streams run to their natural end.
 """
 import asyncio
+import sys
+
+import pytest
 
 from kopf._cogs.clients.watching import Bookmark, continuous_watch, watch_objs
 
+only_on_py311 = pytest.mark.skipif(sys.version_info < (3, 11), reason="asyncio.timeout() requires Python 3.11+")
+only_on_py310 = pytest.mark.skipif(sys.version_info >= (3, 11), reason="Python 3.10 fallback only")
 
+
+@only_on_py311
 async def test_empty_stream_times_out(settings, resource, namespace, kmock, looptime, assert_logs):
     """A watch stream that sends no events at all is closed after the inactivity timeout."""
     settings.watching.inactivity_timeout = 15.0
@@ -28,6 +37,7 @@ async def test_empty_stream_times_out(settings, resource, namespace, kmock, loop
     assert_logs([r"Watch-stream.*inactive.*reconnecting"])
 
 
+@only_on_py311
 async def test_stalled_stream_times_out(settings, resource, namespace, kmock, looptime, assert_logs):
     """A watch stream that stalls after some events is closed after the inactivity timeout."""
     settings.watching.inactivity_timeout = 15.0
@@ -51,6 +61,7 @@ async def test_stalled_stream_times_out(settings, resource, namespace, kmock, lo
     assert_logs([r"Watch-stream.*inactive.*reconnecting"])
 
 
+@only_on_py311
 async def test_bookmark_event_resets_inactivity_timer(settings, resource, namespace, kmock, looptime, assert_logs):
     """A BOOKMARK event resets the inactivity timer, just like any other event."""
     settings.watching.inactivity_timeout = 30.0
@@ -75,6 +86,7 @@ async def test_bookmark_event_resets_inactivity_timer(settings, resource, namesp
     assert_logs([r"Watch-stream.*inactive.*reconnecting"])
 
 
+@only_on_py311
 async def test_active_stream_does_not_time_out(settings, resource, namespace, kmock, looptime):
     """A stream delivering events within the timeout window is not closed prematurely."""
     settings.watching.inactivity_timeout = 15.0
@@ -98,6 +110,7 @@ async def test_active_stream_does_not_time_out(settings, resource, namespace, km
     assert looptime == 10  # only the inter-event sleep, no inactivity timeout
 
 
+@only_on_py311
 async def test_inactivity_reconnects_with_last_resource_version(
         settings, resource, namespace, kmock, looptime):
     """After an inactivity timeout, continuous_watch() reconnects from the last seen resource version."""
@@ -132,3 +145,53 @@ async def test_inactivity_reconnects_with_last_resource_version(
         and e.get('object', {}).get('metadata', {}).get('resourceVersion') == '200'
         for e in events
     )
+
+
+@only_on_py310
+async def test_empty_stream_not_timed_out_on_python_310(
+        settings, resource, namespace, kmock, looptime, assert_logs):
+    """On Python 3.10, an empty stream runs to natural end; the inactivity timeout does not fire."""
+    settings.watching.inactivity_timeout = 15.0
+    kmock['watch', resource, kmock.namespace(namespace)] << (
+        lambda: asyncio.sleep(99),  # would trigger the timeout on 3.11+, but not on 3.10
+        {'type': 'ADDED', 'object': {'metadata': {'resourceVersion': '101'}}},
+    )
+
+    events = []
+    async for event in watch_objs(
+            settings=settings,
+            resource=resource,
+            namespace=namespace,
+            since='100',
+            operator_pause_waiter=asyncio.Future()):
+        events.append(event)
+
+    assert len(events) == 1
+    assert events[0]['type'] == 'ADDED'
+    assert looptime == 99  # full sleep elapsed; not cut short at 15s
+    assert_logs(prohibited=[r"Watch-stream.*inactive.*reconnecting"])
+
+
+@only_on_py310
+async def test_stalled_stream_not_timed_out_on_python_310(
+        settings, resource, namespace, kmock, looptime, assert_logs):
+    """On Python 3.10, a stalled stream after an event also runs to natural end."""
+    settings.watching.inactivity_timeout = 15.0
+    kmock['watch', resource, kmock.namespace(namespace)] << (
+        {'type': 'ADDED', 'object': {'metadata': {'resourceVersion': '101'}}},
+        lambda: asyncio.sleep(99),  # would trigger the timeout on 3.11+, but not on 3.10
+    )
+
+    events = []
+    async for event in watch_objs(
+            settings=settings,
+            resource=resource,
+            namespace=namespace,
+            since='100',
+            operator_pause_waiter=asyncio.Future()):
+        events.append(event)
+
+    assert len(events) == 1
+    assert events[0]['type'] == 'ADDED'
+    assert looptime == 99  # full sleep elapsed; not cut short at 15s after the event
+    assert_logs(prohibited=[r"Watch-stream.*inactive.*reconnecting"])

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -95,6 +95,39 @@ async def test_watchevent_demultiplexing(worker_mock, looptime, resource, proces
                    for queue_event in queue_events[:-1])
 
 
+@pytest.mark.usefixtures('watcher_limited')
+async def test_bookmarks_are_ignored(worker_mock, looptime, resource, processor,
+                                     settings, kmock):
+    """ Verify that BOOKMARK events are silently skipped and never reach the workers. """
+    kmock.resources[resource] = {}
+    kmock['watch', resource] << (
+        {'type': 'BOOKMARK', 'object': {'metadata': {'resourceVersion': '999'}}},
+        {'type': 'ADDED', 'object': {'metadata': {'uid': 'uid1'}}},
+        {'type': 'BOOKMARK', 'object': {'metadata': {'resourceVersion': '9999'}}},
+        {'type': 'ERROR', 'object': {'code': 410}},
+    )
+
+    settings.queueing.idle_timeout = 100
+    settings.queueing.exit_timeout = 110
+
+    await watcher(
+        namespace=None,
+        resource=resource,
+        settings=settings,
+        processor=processor,
+    )
+
+    assert looptime == 0
+    assert worker_mock.call_count == 1
+
+    streams = worker_mock.call_args_list[0].kwargs['streams']
+    key = worker_mock.call_args_list[0].kwargs['key']
+    queue_events = []
+    while not streams[key].backlog.empty():
+        queue_events.append(streams[key].backlog.get_nowait())
+    assert all(e is EOS.token or e['type'] != 'BOOKMARK' for e in queue_events)
+
+
 @pytest.mark.parametrize('unique, events', [
 
     pytest.param(1, (


### PR DESCRIPTION
**Problem:** There is a well-known and frequent issue: the watch-stream sometimes becomes silent after 5-10 mins of inactivity, especially on the low-load clusters. This usually happens when any kind of cloud-hosted k8s is used like this: K8s<>LB<>Kopf.

The primary hypothesis (unproven) is that it is caused by the load balancer losing the connection K8s<>LB, but keeping the connection LB<>Kopf alive. As a result, Kopf (aiohttp, even the OS) does not know that the watch-stream is not alive anymore, and therefore does not reconnect.

**UPD:** _The users of Kopf reported a different analysis, where the connection is lost not because of a LB, which they do not have, but because of changing the internal IP addresses out of a pool of several of them. This does not change anything for Kopf: the effects are the same (silently dead connections), the fix is the same (inactivity tracking)._

* #957
* #585
* #614 
* #847 
* #698 
* #232 
* #204
* #860 (a failed attempt to fix it)
* maybe more, but I stopped searching

A helpful external issue:

* https://github.com/Azure/AKS/issues/1755
* https://github.com/nolar/kopf/issues/847#issuecomment-958963392

**Workaround:** A typical workaround is to set the client-side timeout to anything 1-10-20 minutes, but there is no good default that suits everyone — it depends on the cluster size and load. The downside is that we reconnect regardless of whether the connection is semi-dead or actually alive.

**Solution:** Now, it will activate k8s BOOKMARK events in the watch-stream, available since K8s 1.15 (the latest now is 1.35).

* https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks
* https://www.kubernetes.dev/resources/keps/956/

The bookmarks are hard-coded to happen every 60 seconds (currently non-configurable):

* https://github.com/kubernetes/kubernetes/blob/c20e0bc54189aef73a6a1498b4eab28b2457914f/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go#L62-L77

So, if there are no BOOKMARK events for longer than 60+ (e.g. 70) seconds, we can reliably conclude that the watch-stream is silently closed, so we can explicitly close it on our side and reconnect.

In the normal flow of operations, while the connection is alive, the BOOKMARK events will arrive, keeping the same original connection as long as possible.

**Scope:** Fixed only in Python 3.11+. It requires `asyncio.timeout()` and fails terribly with `asyncio.wait_for()` in tests. It is easier to wait ≈7 months till the Python 3.10 end-of-life (Oct 2026) than to build a complicated solution for it, which is already available in Python 3.11+.

Python 3.10 will work the old way — with potential freezes, ignoring the inactivity timeout. Nevertheless, Python 3.10 users can benefit from the BOOKMARK events flowing every 60 seconds and thus keeping the TCP connection alive — even without timeouts and reconnections.

**Difference:** This differs from the workaround with the same 60-second timeout (or any other default timeout) on the client connection, since we do not reconnect if the connection remains alive and the events are streaming. Frequent unnecessary reconnections were the main flaw in the workaround with timeouts.

**Side benefit 1:** Moreover, the mere existence of the BOOKMARK events might work as a keep-alive for the TCP connection (some traffic going), so it will not disconnect on the K8s<>LB part due to TCP inactivity — but this is a blind guess, no proof that it works or breaks that particular way, the safeguard for the reconnection is still needed.

**Side benefit 2:** Among other things, though not the goal, it helps keeping the latest resource version closer in time rather than the current resource version from the actual latest event — so the reconnections will use the time window of approximately 1 minute on the server side.