### PR TITLE
Disable the metrics.k8s.io extension in CI K8s clusters (in thorough tests)

### DIFF
--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -124,6 +124,7 @@ jobs:
         with:
           version: ${{ matrix.k3s }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          k3s-args: --disable=metrics-server@server:*
       - run: uv sync --group test
       - run: uv pip install -r examples/requirements.txt
       - run: uv run pytest --color=yes --timeout=30 --only-e2e


### PR DESCRIPTION
Forgotten in 0e5f93f743d9e41b54d4f33c797b5f36c1203bf5 — there, it was added only for the CI tests (and it did help).

* #1265 
