### PR TITLE
Prevent daemons/timers from spawning precisely when the operator is paused

### DIFF
--- a/docs/daemons.rst
+++ b/docs/daemons.rst
@@ -52,9 +52,9 @@ Termination
 ===========
 
 The daemons are terminated when either their resource is marked for deletion,
-or the operator itself is exiting.
+or the operator itself is exiting or pausing (see :doc:`peering`).
 
-In both cases, the daemons are requested to terminate gracefully by setting
+In both cases, Kopf requests all daemons to terminate gracefully by setting
 the :kwarg:`stopped` kwarg. The synchronous daemons MUST_, and asynchronous
 daemons SHOULD_ check for the value of this flag as often as possible:
 
@@ -71,7 +71,7 @@ daemons SHOULD_ check for the value of this flag as often as possible:
 
 The asynchronous daemons can skip these checks if they define the cancellation
 timeout. In that case, they can expect an :class:`asyncio.CancelledError`
-to be raised at any point of their code (specifically, at any ``await`` clause):
+raised at any point of their code (specifically, at any ``await`` clause):
 
 .. code-block:: python
 
@@ -121,15 +121,22 @@ The termination sequence parameters can be controlled when declaring a daemon:
 There are three stages of how the daemon is terminated:
 
 * 1. Graceful termination:
+
   * ``stopped`` is set immediately (unconditionally).
   * ``cancellation_backoff`` is awaited (if set).
+
 * 2. Forced termination --- only if ``cancellation_timeout`` is set:
+
   * :class:`asyncio.CancelledError` is raised (for async daemons only).
   * ``cancellation_timeout`` is awaited (if set).
+
 * 3a. Giving up and abandoning --- only if ``cancellation_timeout`` is set:
+
   * A :class:`ResourceWarning` is issued for potential OS resource leaks.
   * The finalizer is removed, and the object is released for potential deletion.
+
 * 3b. Forever polling --- only if ``cancellation_timeout`` is not set:
+
   * The daemon awaiting continues forever, logging from time to time.
   * The finalizer is not removed and the object remains blocked from deletion.
 

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -23,6 +23,7 @@ since we are aware of the daemons, and they are not actually "hung".
 import abc
 import asyncio
 import dataclasses
+import sys
 import warnings
 from collections.abc import Collection, Iterable, Mapping, MutableMapping, Sequence
 
@@ -325,18 +326,29 @@ async def daemon_killer(
 
             # The stopping tasks are "fire-and-forget" -- we do not get (or care of) the result.
             # The daemons remain resumable, since they exit not on their own accord.
-            for memory in memories.iter_all_daemon_memories():
-                for daemon in memory.running_daemons.values():
-                    await scheduler.spawn(
-                        name=f"pausing stopper of {daemon}",
-                        coro=stop_daemon(
-                            settings=settings,
-                            daemon=daemon,
-                            reason=stoppers.DaemonStoppingReason.OPERATOR_PAUSING))
+            # From time to time, continue killing the daemons that sneak into processing queues.
+            # This is a secondary safeguard against #1266: events sneaked into workers on pausing.
+            # The primary safeguard is in pause_daemons(): stop daemons immediately on spawning.
+            while operator_paused.is_on():
+                for memory in memories.iter_all_daemon_memories():
+                    for daemon in memory.running_daemons.values():
+                        await scheduler.spawn(
+                            name=f"pausing stopper of {daemon}",
+                            coro=stop_daemon(
+                                settings=settings,
+                                daemon=daemon,
+                                reason=stoppers.DaemonStoppingReason.OPERATOR_PAUSING))
 
-            # Stay here while the operator is paused, until it is resumed.
-            # The fresh stream of watch-events will spawn new daemons naturally.
-            await operator_paused.wait_for(False)
+                # Stay here while the operator is paused, until it is resumed.
+                # The fresh stream of watch-events will spawn new daemons naturally.
+                if sys.version_info < (3, 11):  # python 3.10 only, TODO remove in Oct'26
+                    await operator_paused.wait_for(False)
+                else:
+                    try:
+                        async with asyncio.timeout(1.0):
+                            await operator_paused.wait_for(False)
+                    except TimeoutError:
+                        pass
 
     # Terminate all running daemons when the operator exits (and this task is cancelled).
     finally:

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -138,6 +138,46 @@ async def match_daemons(
     return delays
 
 
+async def pause_daemons(
+        *,
+        settings: configuration.OperatorSettings,
+        daemons: MutableMapping[ids.HandlerId, Daemon],
+        operator_paused: aiotoggles.ToggleSet | None,  # None for tests
+) -> Collection[float]:
+    """
+    Re-check the desired state of daemons according to the operator's state.
+
+    There is a glitch in the daemon orchestration (e.g., with 3+ pods in #1266):
+
+    If the operator is paused, the watcher() can still produce some events
+    before being stopped. The watcher() spawns a worker(). The worker() calls
+    the processor(). The process_resource_event() calls the spawn_daemons().
+    The spawn_daemons() creates new daemons with the `stopper` set to "off"
+    and registers them in memories. It all takes time.
+
+    Meanwhile, once the operator is paused, the daemon_killer()
+    kills the daemons it knows to the moment, which excludes the daemons
+    that will be spawned a few moments later in the flow described above.
+
+    There is no good synchronization primitive to protect against this case
+    without syncing all resources, breaking the async nature of the operator.
+
+    The only remedy is to let such daemons spawn, but trigger their stop flags
+    after (strictly after!) they register themselves to the memories
+    in spawn_daemons() and become exposed to the daemon killer.
+
+    This routine does exactly that: stops newly spawned daemons.
+    """
+    delays: Collection[float] = []
+    if operator_paused is not None and operator_paused.is_on():
+        delays = await stop_daemons(
+            settings=settings,
+            daemons=daemons,
+            reason=stoppers.DaemonStoppingReason.OPERATOR_PAUSING,
+        )
+    return delays
+
+
 async def stop_daemons(
         *,
         settings: configuration.OperatorSettings,

--- a/kopf/_core/reactor/processing.py
+++ b/kopf/_core/reactor/processing.py
@@ -39,6 +39,7 @@ async def process_resource_event(
         raw_event: bodies.RawEvent,
         event_queue: posting.K8sEventQueue,
         stream_pressure: asyncio.Event | None = None,  # None for tests
+        operator_paused: aiotoggles.ToggleSet | None = None,  # None for tests & observation
         resource_indexed: aiotoggles.Toggle | None = None,  # None for tests & observation
         operator_indexed: aiotoggles.ToggleSet | None = None,  # None for tests & observation
         consistency_time: float | None = None,  # None for tests
@@ -124,6 +125,7 @@ async def process_resource_event(
                 local_logger=local_logger,
                 event_logger=event_logger,
                 stream_pressure=stream_pressure,
+                operator_paused=operator_paused,
                 consistency_time=consistency_time,
             )
 
@@ -230,6 +232,7 @@ async def process_resource_causes(
         local_logger: loggers.ObjectLogger,
         event_logger: loggers.ObjectLogger,
         stream_pressure: asyncio.Event | None,  # None for tests
+        operator_paused: aiotoggles.ToggleSet | None,  # None for tests
         consistency_time: float | None,
 ) -> tuple[Collection[float], bool]:
     patch_initially_empty = not patch  # before we add new things in low-level handlers
@@ -266,6 +269,7 @@ async def process_resource_causes(
             settings=settings,
             memory=memory,
             cause=spawning_cause,
+            operator_paused=operator_paused,
         )
 
     # If there are any handlers for this resource kind in general, but not for this specific object
@@ -378,6 +382,7 @@ async def process_spawning_cause(
         settings: configuration.OperatorSettings,
         memory: inventory.ResourceMemory,
         cause: causes.SpawningCause,
+        operator_paused: aiotoggles.ToggleSet | None,  # None for tests
 ) -> Collection[float]:
     """
     Spawn/kill all the background tasks of a resource.
@@ -423,7 +428,13 @@ async def process_spawning_cause(
             daemons=memory.daemons_memory.running_daemons,
             handlers=handlers,
         )
-        return list(spawning_delays) + list(matching_delays)
+        # Critical: strictly after spawning; see the docstring why.
+        pausing_delays = await daemons.pause_daemons(
+            settings=settings,
+            daemons=memory.daemons_memory.running_daemons,
+            operator_paused=operator_paused,
+        )
+        return list(spawning_delays) + list(matching_delays) + list(pausing_delays)
 
 
 async def process_changing_cause(

--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -340,6 +340,7 @@ async def spawn_tasks(
                                             indexers=indexers,
                                             memories=memories,
                                             memobase=memo,
+                                            operator_paused=operator_paused,
                                             event_queue=event_queue))))
 
     # Ensure that all guarded tasks got control for a moment to enter the guard.

--- a/tests/handling/daemons/conftest.py
+++ b/tests/handling/daemons/conftest.py
@@ -22,6 +22,8 @@ class DaemonDummy:
         self.mock = MagicMock()
 
     async def wait_for_daemon_done(self) -> None:
+        if not self.mock.called:
+            return
         stopped = self.mock.call_args.kwargs['stopped']
         await stopped.wait()
         while stopped.reason is None or not stopped.reason & stopped.reason.DONE:
@@ -57,6 +59,7 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
             event_object: RawBody,
             *,
             stream_pressure: asyncio.Event | None = None,
+            operator_paused: ToggleSet | None = None,
     ) -> None:
         mocker.resetall()
 
@@ -71,6 +74,7 @@ def simulate_cycle(k8s_mocked, registry, settings, resource, memories, mocker):
             raw_event={'type': 'irrelevant', 'object': event_object},
             event_queue=asyncio.Queue(),
             stream_pressure=stream_pressure,
+            operator_paused=operator_paused,
             no_throttling=True,
         )
 

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import sys
 
 import pytest
 
@@ -79,7 +80,7 @@ async def test_daemon_exits_gracefully_and_instantly_on_operator_exiting(
 
 
 @pytest.mark.usefixtures('background_daemon_killer')
-async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing_via_daemon_killer(
+async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing_via_early_daemon_killer(
         settings, memories, resource, dummy, simulate_cycle, conflicts_found,
         looptime, assert_logs, k8s_mocked, mocker):
     called = asyncio.Condition()
@@ -102,10 +103,50 @@ async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing_via_dae
     # 1st stage: trigger termination due to the operator's pause.
     mocker.resetall()
     await conflicts_found.turn_to(True)
+    await asyncio.sleep(0)  # give control to the daemon killer for the 1st round
 
     # Check that the daemon has exited near-instantly, with no delays.
     await dummy.wait_for_daemon_done()
     assert looptime == 0
+
+    # There is no way to test for re-spawning here: it is done by watch-events,
+    # which are tested by the paused operators elsewhere (test_daemon_spawning.py).
+    # We only test that it is capable for respawning (not forever-stopped):
+    memory = await memories.recall(event_object)
+    assert not memory.daemons_memory.forever_stopped
+    assert not memory.daemons_memory.running_daemons
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="asyncio.timeout() requires Python 3.11+")
+@pytest.mark.usefixtures('background_daemon_killer')
+async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing_via_late_daemon_killer(
+        settings, memories, resource, dummy, simulate_cycle, conflicts_found,
+        looptime, assert_logs, k8s_mocked):
+    called = asyncio.Condition()
+
+    # Send the daemon killer to waiting for False.
+    # It kills the non-existent daemons instantly, then waits.
+    await conflicts_found.turn_to(True)
+    await asyncio.sleep(0)  # give control to the daemon killer for the 1st round
+
+    # A daemon-under-test.
+    @kopf.daemon(*resource, id='fn')
+    async def fn(**kwargs):
+        dummy.mock(**kwargs)
+        async with called:
+            called.notify_all()
+        await kwargs['stopped'].wait()
+
+    # 0th cycle: trigger spawning and wait until ready. Assume the finalizers are already added.
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer]}}
+    await simulate_cycle(event_object)
+    async with called:
+        await called.wait()
+
+    # Check that the daemon has exited on the next daemon killing cycle (hard-coded timing).
+    await dummy.wait_for_daemon_done()
+    assert looptime == 1
 
     # There is no way to test for re-spawning here: it is done by watch-events,
     # which are tested by the paused operators elsewhere (test_daemon_spawning.py).
@@ -134,6 +175,7 @@ async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing_via_pau
     finalizer = settings.persistence.finalizer
     event_object = {'metadata': {'finalizers': [finalizer]}}
     await conflicts_found.turn_to(True)
+    await asyncio.sleep(0)  # give control to the daemon killer for the 1st round
 
     # The event arrives while paused; pause_daemons() signals the daemon to stop.
     await simulate_cycle(event_object, operator_paused=operator_paused)

--- a/tests/handling/daemons/test_daemon_termination.py
+++ b/tests/handling/daemons/test_daemon_termination.py
@@ -79,7 +79,7 @@ async def test_daemon_exits_gracefully_and_instantly_on_operator_exiting(
 
 
 @pytest.mark.usefixtures('background_daemon_killer')
-async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing(
+async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing_via_daemon_killer(
         settings, memories, resource, dummy, simulate_cycle, conflicts_found,
         looptime, assert_logs, k8s_mocked, mocker):
     called = asyncio.Condition()
@@ -112,6 +112,41 @@ async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing(
     # We only test that it is capable for respawning (not forever-stopped):
     memory = await memories.recall(event_object)
     assert not memory.daemons_memory.forever_stopped
+    assert not memory.daemons_memory.running_daemons
+
+
+# NB: no `background_daemon_killer` fixture!
+async def test_daemon_exits_gracefully_and_instantly_on_operator_pausing_via_paused_flag(
+        settings, memories, resource, dummy, simulate_cycle, operator_paused, conflicts_found,
+        looptime, assert_logs, k8s_mocked, mocker):
+    """Test that daemons are stopped inline by pause_daemons() without the daemon killer."""
+    called = asyncio.Condition()
+
+    # A daemon-under-test.
+    @kopf.daemon(*resource, id='fn')
+    async def fn(**kwargs):
+        dummy.mock(**kwargs)
+        async with called:
+            called.notify_all()
+        await kwargs['stopped'].wait()
+
+    # Pause the operator (no daemon killer is running to react to this).
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer]}}
+    await conflicts_found.turn_to(True)
+
+    # The event arrives while paused; pause_daemons() signals the daemon to stop.
+    await simulate_cycle(event_object, operator_paused=operator_paused)
+
+    # Check that the daemon has exited near-instantly, with no delays.
+    assert not dummy.mock.called
+    await dummy.wait_for_daemon_done()
+    assert looptime == 0
+
+    # The daemon should be stoppable but respawnable after unpausing.
+    memory = await memories.recall(event_object)
+    assert not memory.daemons_memory.forever_stopped
+    assert not memory.daemons_memory.running_daemons
 
 
 async def test_daemon_exits_instantly_on_cancellation_with_backoff(


### PR DESCRIPTION
**Problem:** The issue happens after the moment the operator pauses but before the watch-stream stops. Some events may sneak into the queue and workers, and be processed. Processing causes the timers/daemons to spawn. Normally, the running daemons would be killed by the daemon killer. However, the daemon killer kills the daemons immediately at the moment of operator pausing (and it is fast), and does not wait for newer daemons to appear — so it skips the newly spawned daemons after that moment.

**Solution 1 (primary):** The easier way is let the daemons spawn (they would spawn anyway), but signal them to stop immediately after — as we already do with filter mismatches anyway. This causes the double-signalling to the older running daemons — from the daemon-killer AND from the new routine. But this is fine, the signal is only a flag-setter, there is no double-cancellation or other duplicated side effects.

**Solution 2 (secondary):** The straightforward way is to regularly kill the daemons in the daemon killer, including the new ones. But that requires syncing the `operator_paused` toggle set with the daemons memories (after a global condition is added and notified) — i.e. waiting for 2 primitives in parallel and cleaning up the task of the other (non-triggering) primitive. That alone is clumsy but doable. Additionally, it requires a global condition (lock) for all memories of all resources, while we narrow the processor/processing to one resource only. This implies sharing a global lock or global memories with narrow resource-specific routines, which feels dirty (more dirty that sharing a global flag for `operator_paused` state). — Overall, way too complicated.

We go both ways, except that in the secondary measure, we do not introduce a global lock/condition, but do this on a time basis every 1 second. Since this is a secondary safeguard, this is sufficient. The primary safeguard remains the instant stopping.

* fixes #1266 

---
TODOs:

- [x] A concern: what if there is no idle time and the daemon/timer actually started, and is blocking? will there be attempts to stop it over time, taking into account that the watch-stream is stopped, so no new wake-up events ever arrive?
  - => the daemon/timers starts and executes at least one iteration, but eventually exits (if it obeys the stop-flag). This is acceptable and unavoidable, especially with the sync daemons (we cannot cancel them).
  - => the only worry was the async daemon with `cancellation_backoff`, because this is the only place where delays are returned (causing sleep+touch). The daemon was cancelled properly either way, all's good.
- [x] Maybe: nevertheless, add a time-based (every 1 second?) cycle for repeatative killing of daemons/timers in `daemon_killer()` when we `wait_for(False)`, without adding a global condition. This will reduce the probability of this issue persisting — even if it happened.
  - => worth it, implemented.