### PR TITLE
Suppress patching logs in peering keepalives to reduce noise

### DIFF
--- a/kopf/_cogs/clients/patching.py
+++ b/kopf/_cogs/clients/patching.py
@@ -12,6 +12,7 @@ async def patch_obj(
         name: str | None,
         patch: patches.Patch,
         logger: typedefs.Logger,
+        silent: bool = False,
 ) -> tuple[bodies.RawBody | None, patches.Patch | None]:
     """
     Patch a resource of specific kind.
@@ -43,7 +44,8 @@ async def patch_obj(
         patched_body: bodies.RawBody | None = None
 
         if body_patch:
-            logger.debug(f"Merge-patching the resource with: {body_patch!r}")
+            if not silent:
+                logger.debug(f"Merge-patching the resource with: {body_patch!r}")
             patched_body = await api.patch(
                 url=resource.get_url(namespace=namespace, name=name),
                 headers={'Content-Type': 'application/merge-patch+json'},
@@ -54,7 +56,8 @@ async def patch_obj(
 
         if status_patch:
             # NB: we need the new resourceVersion, so we take the whole new patched body.
-            logger.debug(f"Merge-patching the status with: {status_patch!r}")
+            if not silent:
+                logger.debug(f"Merge-patching the status with: {status_patch!r}")
             patched_body = await api.patch(
                 url=resource.get_url(namespace=namespace, name=name, subresource='status'),
                 headers={'Content-Type': 'application/merge-patch+json'},
@@ -93,7 +96,8 @@ async def patch_obj(
             resource_version = (fresh_body or {}).get('metadata', {}).get('resourceVersion')
             test = patches.JSONPatchItem(op='test', path='/metadata/resourceVersion', value=resource_version)
             ops = [test] + body_ops
-            logger.debug(f"JSON-patching the resource with: {ops!r}")
+            if not silent:
+                logger.debug(f"JSON-patching the resource with: {ops!r}")
             try:
                 patched_body = await api.patch(
                     url=resource.get_url(namespace=namespace, name=name),
@@ -104,10 +108,11 @@ async def patch_obj(
                 )
             except errors.APIUnprocessableEntityError:
                 # NB: also detach from the current freshest body, persist only the patch fns.
-                logger.debug(
-                    "Could not apply the patch in full due to conflicts with newer changes. "
-                    f"Will try on the next cycle soon. Remaining: {remaining_patch!r}"
-                )
+                if not silent:
+                    logger.debug(
+                        "Could not apply the patch in full due to conflicts with newer changes. "
+                        f"Will try on the next cycle soon. Remaining: {remaining_patch!r}"
+                    )
                 return patched_body, remaining_patch
             else:
                 fresh_body = patched_body
@@ -120,7 +125,8 @@ async def patch_obj(
             resource_version = (fresh_body or {}).get('metadata', {}).get('resourceVersion')
             test = patches.JSONPatchItem(op='test', path='/metadata/resourceVersion', value=resource_version)
             ops = [test] + status_ops
-            logger.debug(f"JSON-patching the status with: {ops!r}")
+            if not silent:
+                logger.debug(f"JSON-patching the status with: {ops!r}")
             try:
                 patched_body = await api.patch(
                     url=resource.get_url(namespace=namespace, name=name, subresource='status'),
@@ -131,10 +137,11 @@ async def patch_obj(
                 )
             except errors.APIUnprocessableEntityError:
                 # NB: also detach from the current freshest body, persist only the patch fns.
-                logger.debug(
-                    "Could not apply the patch in full due to conflicts with newer changes. "
-                    f"Will try on the next cycle soon. Remaining: {remaining_patch!r}"
-                )
+                if not silent:
+                    logger.debug(
+                        "Could not apply the patch in full due to conflicts with newer changes. "
+                        f"Will try on the next cycle soon. Remaining: {remaining_patch!r}"
+                    )
                 return patched_body, remaining_patch
 
         return patched_body, None

--- a/kopf/_core/engines/peering.py
+++ b/kopf/_core/engines/peering.py
@@ -230,6 +230,7 @@ async def touch(
         name=name,
         patch=patch,
         logger=logger,
+        silent=True,
     )
 
     if not settings.peering.stealth or rsp is None:
@@ -255,6 +256,7 @@ async def clean(
         name=name,
         patch=patch,
         logger=logger,
+        silent=True,
     )
 
 

--- a/tests/peering/test_freeze_mode.py
+++ b/tests/peering/test_freeze_mode.py
@@ -9,7 +9,7 @@ from kopf._core.engines.peering import process_peering_event
 
 
 async def test_other_peering_objects_are_ignored(
-        mocker, k8s_mocked, settings, looptime,
+        mocker, k8s_mocked, assert_logs, settings, looptime,
         peering_resource, peering_namespace):
 
     status = mocker.Mock()
@@ -33,6 +33,7 @@ async def test_other_peering_objects_are_ignored(
     assert not status.items.called
     assert not k8s_mocked.patch.called
     assert looptime == 0
+    assert_logs(prohibited=["patching"])
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
@@ -78,6 +79,7 @@ async def test_toggled_on_for_higher_priority_peer_when_initially_off(
         "Possibly conflicting operators",
         "Pausing all operators, including self",
         "Resuming operations after the pause",
+        "patching",
     ])
 
 
@@ -125,6 +127,7 @@ async def test_ignored_for_higher_priority_peer_when_already_on(
         "Pausing all operators, including self",
         "Pausing operations in favour of",
         "Resuming operations after the pause",
+        "patching",
     ])
 
 
@@ -171,6 +174,7 @@ async def test_toggled_off_for_lower_priority_peer_when_initially_on(
         "Possibly conflicting operators",
         "Pausing all operators, including self",
         "Pausing operations in favour of",
+        "patching",
     ])
 
 
@@ -218,6 +222,7 @@ async def test_ignored_for_lower_priority_peer_when_already_off(
         "Pausing all operators, including self",
         "Pausing operations in favour of",
         "Resuming operations after the pause",
+        "patching",
     ])
 
 
@@ -266,6 +271,7 @@ async def test_toggled_on_for_same_priority_peer_when_initially_off(
     ], prohibited=[
         "Pausing operations in favour of",
         "Resuming operations after the pause",
+        "patching",
     ])
 
 
@@ -314,6 +320,7 @@ async def test_ignored_for_same_priority_peer_when_already_on(
         "Pausing all operators, including self",
         "Pausing operations in favour of",
         "Resuming operations after the pause",
+        "patching",
     ])
 
 
@@ -355,3 +362,4 @@ async def test_resumes_immediately_on_expiration_of_blocking_peers(
     assert conflicts_found.is_on()
     assert looptime == 9.876544
     assert k8s_mocked.patch.called
+    assert_logs(prohibited=["patching"])

--- a/tests/peering/test_keepalive.py
+++ b/tests/peering/test_keepalive.py
@@ -10,7 +10,7 @@ class StopInfiniteCycleException(Exception):
     pass
 
 
-async def test_background_task_runs(mocker, settings, namespaced_peering_resource):
+async def test_background_task_runs(mocker, settings, assert_logs, namespaced_peering_resource):
     touch_mock = mocker.patch('kopf._core.engines.peering.touch')
 
     sleep_mock = mocker.patch('asyncio.sleep')
@@ -33,3 +33,4 @@ async def test_background_task_runs(mocker, settings, namespaced_peering_resourc
     assert sleep_mock.call_args_list[2].args[0] == 33 - 9
 
     assert touch_mock.call_count == 4  # 3 updates + 1 clean-up
+    assert_logs(prohibited=["patching"])

--- a/tests/peering/test_peer_patching.py
+++ b/tests/peering/test_peer_patching.py
@@ -10,7 +10,7 @@ from kopf._core.engines.peering import Peer, clean, touch
 ])
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
 async def test_cleaning_peers_purges_them(
-        kmock, settings, lastseen, peering_resource, peering_namespace):
+        kmock, settings, assert_logs, lastseen, peering_resource, peering_namespace):
     settings.peering.name = 'name0'
     kmock.objects[peering_resource, peering_namespace, 'name0'] = {}
 
@@ -22,10 +22,11 @@ async def test_cleaning_peers_purges_them(
     assert set(kmock[0].data['status']) == {'id1'}
     assert kmock[0].data['status']['id1'] is None
     assert kmock.objects[peering_resource, peering_namespace, 'name0'] == {'status': {}}
+    assert_logs(prohibited=["patching"])
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
-async def test_touching_a_peer_stores_it(kmock, settings, peering_resource, peering_namespace):
+async def test_touching_a_peer_stores_it(kmock, settings, assert_logs, peering_resource, peering_namespace):
     settings.peering.name = 'name0'
     kmock.objects[peering_resource, peering_namespace, 'name0'] = {}
 
@@ -39,10 +40,11 @@ async def test_touching_a_peer_stores_it(kmock, settings, peering_resource, peer
     assert patch['status']['id1']['lastseen'] == '2020-12-31T23:59:59.123456+00:00'
     assert patch['status']['id1']['lifetime'] == 60
     assert kmock.objects[peering_resource, peering_namespace, 'name0'] == {'status': {'id1': {'lastseen': ..., 'lifetime': 60, 'priority': 0}}}
+    assert_logs(prohibited=["patching"])
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
-async def test_expiring_a_peer_purges_it(kmock, settings, peering_resource, peering_namespace):
+async def test_expiring_a_peer_purges_it(kmock, settings, assert_logs, peering_resource, peering_namespace):
     settings.peering.name = 'name0'
     kmock.objects[peering_resource, peering_namespace, 'name0'] = {}
 
@@ -54,6 +56,7 @@ async def test_expiring_a_peer_purges_it(kmock, settings, peering_resource, peer
     assert set(patch['status']) == {'id1'}
     assert patch['status']['id1'] is None
     assert kmock.objects[peering_resource, peering_namespace, 'name0'] == {'status': {}}
+    assert_logs(prohibited=["patching"])
 
 
 @freezegun.freeze_time('2020-12-31T23:59:59.123456')
@@ -69,6 +72,7 @@ async def test_logs_are_skipped_in_stealth_mode(
 
     assert_logs(prohibited=[
         "Keep-alive in",
+        "patching",
     ])
 
 
@@ -84,7 +88,7 @@ async def test_logs_are_logged_in_exposed_mode(
 
     assert_logs([
         r"Keep-alive in 'name0' (in 'ns'|cluster-wide): ok",
-    ])
+    ], prohibited=["patching"])
 
 
 @pytest.mark.parametrize('stealth', [True, False], ids=['stealth', 'exposed'])
@@ -99,4 +103,4 @@ async def test_logs_are_logged_when_absent(
 
     assert_logs([
         r"Keep-alive in 'name0' (in 'ns'|cluster-wide): not found",
-    ])
+    ], prohibited=["patching"])


### PR DESCRIPTION
Peering's touch() and clean() call patch_obj() every ~60 seconds as part of the keepalive cycle. After the patch logging was moved into patch_obj() itself (instead of the higher-level patch_and_check()), these routine operations started emitting debug log lines on every cycle, which is noisy. A new silent=True parameter on patch_obj() suppresses those logs when called from peering context.

The logs were introduced in 

* #1253 