### PR TITLE
Ignore the proxy configuration from the env vars leaked through the official client

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -106,6 +106,10 @@ Multiple handlers can be declared to retrieve different credentials
 or the same credentials via different libraries. All of the retrieved
 credentials will be used in random order with no specific priority.
 
+The connection info does **not** respect environment variables by default,
+such as ``HTTP_PROXY``, ``HTTPS_PROXY``, or ``NO_PROXY``. For this,
+use ``trust_env=True`` with the custom aiohttp session (see examples below).
+
 
 .. _custom-http-sessions:
 
@@ -164,7 +168,7 @@ Kopf will own and manage the provided session and will close it when needed.
             ),
             headers=credentials.as_http_headers() | headers,
             auth=credentials.as_aiohttp_basic_auth(),
-            trust_env=True,  # to use HTTP_PROXY and ~/.netrc
+            trust_env=True,  # respect HTTP_PROXY, HTTPS_PROXY, NO_PROXY, and ~/.netrc
         )
         return kopf.AiohttpSession(
             aiohttp_session=session,
@@ -177,7 +181,7 @@ Kopf will own and manage the provided session and will close it when needed.
     and is normally not exposed to users except for very advanced use-cases.
     Kopf reserves the right to change its internal HTTP library
     without warning or backwards compatibility. In that case, Kopf will
-    fail running if this field is set (will raise an exception) --- to prevent
+    fail if this class is returned (will raise an exception) --- to prevent
     the unnoticed accidental damage during such upgrades. Use at your own risk.
 
 

--- a/kopf/_core/intents/piggybacking.py
+++ b/kopf/_core/intents/piggybacking.py
@@ -114,8 +114,9 @@ def login_via_client(
         token=token,
         certificate_path=config.cert_file,  # can be a temporary file
         private_key_path=config.key_file,  # can be a temporary file
-        proxy_url=config.proxy,
         priority=PRIORITY_OF_CLIENT,
+        # NB: no proxy_url: not parsed by the client, it only uses the env vars,
+        # and we cannot respect the $NO_PROXY properly without trust_env=True.
     )
 
 


### PR DESCRIPTION
The official client (`kubernetes`) does NOT parse the `proxy-url` field of the config file (I could not find it in the source code). Instead, it uses the environment variables `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`. Implementing it ourselves is complicated (especially `NO_PROXY` and is out of scope of the framework).

**Problem:** In some pod configurations (#1277), which naturally define these variables for their applications, these env vars go into the official client config, and then leak into Kopf's connection info — which is not intended. The intention was that ONLY the explicit `proxy-url` from the config file is respected. The env vars are not trusted by default, unless the user explicitly makes it trusted (see the docs) — and so they should not leak into the config via the helper libraries.

**Solution:** ignore the proxy from the official client entirely. At least until it starts parsing the `proxy-url` field (which it does not do now). But continue respecting this field from pykube-ng and the direct config parser — which means that it is explicitly requested by the user.

All in all, this means we fall back to the previous behaviour with no proxies, except for cases when the proxy is explicitly set in the config.

**Alternatives considered:**

1) Injecting NO_PROXY into aiohttp's configs. This won't work as aiohttp does not accept this config in any way and even does not store it. It delegates to the undocumented `urllib.request.proxy_bypass(host)` to check if the host is proxied or not, and with which specific proxy. So, we cannot request aiohttp to skip some hosts as configured.

2) Parsing NO_PROXY ourselves and checking `info.server` against it. Doable, but the logic of the env var is complicated — it also contains wildcard domains and CIDRs, case-insensitive domains, optional ports, etc. This will bloat the code with the logic not related to the operator framework, duplicating the responsitibilies of the underlying http client library. Or using an undocumented StdLib function. That is a rare use case for such complication.


Fixes #1277

Related: 

* #1279  