### PR TITLE
Add `trust_env` setting for proxies from environment variables

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -54,6 +54,7 @@ or an instance of :class:`kopf.ConnectionInfo`:
             private_key_path='~/.minikube/client.key',
             certificate_data=b'...',
             private_key_data=b'...',
+            trust_env=True,
             expiration=datetime.datetime(2099, 12, 31, 23, 59, 59),
         )
 
@@ -107,8 +108,16 @@ or the same credentials via different libraries. All of the retrieved
 credentials will be used in random order with no specific priority.
 
 The connection info does **not** respect environment variables by default,
-such as ``HTTP_PROXY``, ``HTTPS_PROXY``, or ``NO_PROXY``. For this,
-use ``trust_env=True`` with the custom aiohttp session (see examples below).
+such as ``HTTP_PROXY``, ``HTTPS_PROXY``, ``NO_PROXY``, or ``~/.netrc``.
+The easiest way to enable this is to set ``settings.networking.trust_env = True``
+in a startup handler (see :doc:`configuration`).
+The built-in login handlers will propagate this setting
+to :class:`kopf.ConnectionInfo` automatically.
+
+Custom login handlers can set ``trust_env=True`` directly
+on the returned :class:`kopf.ConnectionInfo` (see example above).
+As a last resort, advanced users can provide a custom ``aiohttp`` session
+with ``trust_env=True`` (see examples below).
 
 
 .. _custom-http-sessions:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -308,6 +308,33 @@ __ https://github.com/kubernetes/kubernetes/blob/c20e0bc54189aef73a6a1498b4eab28
         settings.watching.server_timeout = 10 * 60
 
 
+Proxy and environment trust
+---------------------------
+
+``settings.networking.trust_env`` (boolean) controls whether the HTTP client
+session respects the proxy-related environment variables (``HTTP_PROXY``,
+``HTTPS_PROXY``, ``NO_PROXY``) and the ``~/.netrc`` file for credentials.
+The default is ``False``.
+
+When set to ``True``, all built-in login handlers propagate this flag
+to :class:`kopf.ConnectionInfo`, which in turn passes it to the HTTP client
+session. The session will then use the environment variables and ``~/.netrc``
+to configure proxies and credentials automatically.
+This is useful in environments where the operator must route traffic
+through a corporate proxy or where the credentials are managed externally.
+
+For more details on authentication and custom login handlers,
+see :doc:`authentication`.
+
+.. code-block:: python
+
+    import kopf
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_):
+        settings.networking.trust_env = True
+
+
 .. _consistency:
 
 Consistency

--- a/kopf/_cogs/clients/auth.py
+++ b/kopf/_cogs/clients/auth.py
@@ -100,6 +100,7 @@ class APIContext:
                     headers=info.as_http_headers(),
                     auth=info.as_aiohttp_basic_auth(),
                     proxy=info.proxy_url,
+                    trust_env=info.trust_env,
                 )
             case credentials.AiohttpSession():
                 self.session = info.aiohttp_session

--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -398,6 +398,17 @@ class NetworkingSettings:
     (the request attempt never awaits shorter than what the server asked for).
     """
 
+    trust_env: bool = False
+    """
+    Whether to respect the proxy-related environment variables and ``~/.netrc``.
+
+    If ``True``, the ``HTTP_PROXY``, ``HTTPS_PROXY``, ``NO_PROXY`` environment
+    variables and the ``~/.netrc`` file are used by the HTTP client session.
+
+    If ``False`` (default), the environment variables and the ``~/.netrc`` file
+    are ignored, and the HTTP client session connects directly to the server.
+    """
+
 
 @dataclasses.dataclass
 class PersistenceSettings:

--- a/kopf/_cogs/structs/credentials.py
+++ b/kopf/_cogs/structs/credentials.py
@@ -82,6 +82,7 @@ class ConnectionInfo(KubeContext):
     private_key_data: str | bytes | None = None
     default_namespace: str | None = None  # used for cluster objects' k8s-events.
     proxy_url: str | None = None
+    trust_env: bool = False
     priority: int = 0
     expiration: datetime.datetime | None = None  # TZ-aware or TZ-naive (implies UTC)
 

--- a/kopf/_core/intents/piggybacking.py
+++ b/kopf/_core/intents/piggybacking.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import yaml
 
+from kopf._cogs.configs import configuration
 from kopf._cogs.helpers import typedefs
 from kopf._cogs.structs import credentials
 
@@ -66,6 +67,7 @@ def has_pykube() -> bool:
 def login_via_client(
         *,
         logger: typedefs.Logger,
+        settings: configuration.OperatorSettings,
         **_: Any,
 ) -> credentials.ConnectionInfo | None:
 
@@ -114,6 +116,7 @@ def login_via_client(
         token=token,
         certificate_path=config.cert_file,  # can be a temporary file
         private_key_path=config.key_file,  # can be a temporary file
+        trust_env=settings.networking.trust_env,
         priority=PRIORITY_OF_CLIENT,
         # NB: no proxy_url: not parsed by the client, it only uses the env vars,
         # and we cannot respect the $NO_PROXY properly without trust_env=True.
@@ -125,6 +128,7 @@ def login_via_client(
 async def login_via_async_client(
         *,
         logger: typedefs.Logger,
+        settings: configuration.OperatorSettings,
         **_: Any,
 ) -> credentials.ConnectionInfo | None:
 
@@ -182,6 +186,7 @@ async def login_via_async_client(
         certificate_path=config.cert_file,  # can be a temporary file
         private_key_path=config.key_file,  # can be a temporary file
         proxy_url=config.proxy,
+        trust_env=settings.networking.trust_env,
         priority=PRIORITY_OF_ASYNC_CLIENT,
     )
 
@@ -189,6 +194,7 @@ async def login_via_async_client(
 def login_via_pykube(
         *,
         logger: typedefs.Logger,
+        settings: configuration.OperatorSettings,
         **_: Any,
 ) -> credentials.ConnectionInfo | None:
 
@@ -233,6 +239,7 @@ def login_via_pykube(
         private_key_path=pkey.filename() if pkey else None,  # can be a temporary file
         default_namespace=config.namespace,
         proxy_url=config.cluster.get('proxy-url'),
+        trust_env=settings.networking.trust_env,
         priority=PRIORITY_OF_PYKUBE,
     )
 
@@ -241,7 +248,11 @@ def has_service_account() -> bool:
     return os.path.exists('/var/run/secrets/kubernetes.io/serviceaccount/token')
 
 
-def login_with_service_account(**_: Any) -> credentials.ConnectionInfo | None:
+def login_with_service_account(
+        *,
+        settings: configuration.OperatorSettings,
+        **_: Any,
+) -> credentials.ConnectionInfo | None:
     """
     A minimalistic login handler that can get raw data from a service account.
 
@@ -271,6 +282,7 @@ def login_with_service_account(**_: Any) -> credentials.ConnectionInfo | None:
             ca_path=ca_path if os.path.exists(ca_path) else None,
             token=token or None,
             default_namespace=namespace or None,
+            trust_env=settings.networking.trust_env,
             priority=PRIORITY_OF_SERVICE_ACCOUNT,
         )
     else:
@@ -283,7 +295,11 @@ def has_kubeconfig() -> bool:
     return env_var_set or file_exists
 
 
-def login_with_kubeconfig(**_: Any) -> credentials.ConnectionInfo | None:
+def login_with_kubeconfig(
+        *,
+        settings: configuration.OperatorSettings,
+        **_: Any,
+) -> credentials.ConnectionInfo | None:
     """
     A minimalistic login handler that can get raw data from a kubeconfig file.
 
@@ -351,5 +367,6 @@ def login_with_kubeconfig(**_: Any) -> credentials.ConnectionInfo | None:
         token=user.get('token') or provider_token,
         default_namespace=context.get('namespace'),
         proxy_url=cluster.get('proxy-url'),
+        trust_env=settings.networking.trust_env,
         priority=PRIORITY_OF_KUBECONFIG,
     )

--- a/tests/authentication/test_credentials.py
+++ b/tests/authentication/test_credentials.py
@@ -236,6 +236,29 @@ async def test_custom_user_agent_preserved(vault):
         assert session.headers['User-Agent'] == 'myoperator/1.2.3'
 
 
+async def test_trust_env_is_disabled_by_default(vault):
+    await vault.populate({
+        'id': ConnectionInfo(
+            server='http://localhost',
+        ),
+    })
+    session = await fn()
+    async with session:
+        assert session.trust_env is False
+
+
+async def test_trust_env_is_enabled_via_connection_info(vault):
+    await vault.populate({
+        'id': ConnectionInfo(
+            server='http://localhost',
+            trust_env=True,
+        ),
+    })
+    session = await fn()
+    async with session:
+        assert session.trust_env is True
+
+
 @pytest_asyncio.fixture()
 async def proxy():
     server = ProxyServer()

--- a/tests/authentication/test_login_kubeconfig.py
+++ b/tests/authentication/test_login_kubeconfig.py
@@ -52,12 +52,12 @@ def test_has_kubeconfig_when_homedir_exists_but_no_envvar(mocker, envs):
 
 
 @pytest.mark.parametrize('envs', [{}, {'KUBECONFIG': ''}], ids=['absent', 'empty'])
-def test_homedir_is_used_if_it_exists(tmpdir, mocker, envs):
+def test_homedir_is_used_if_it_exists(tmpdir, mocker, settings, envs):
     exists_mock = mocker.patch('os.path.exists', return_value=True)
     open_mock = mocker.patch('kopf._core.intents.piggybacking.open')
     open_mock.return_value.__enter__.return_value.read.return_value = MINICONFIG
     mocker.patch.dict(os.environ, envs, clear=True)
-    credentials = login_with_kubeconfig()
+    credentials = login_with_kubeconfig(settings=settings)
     assert exists_mock.call_count == 1
     assert exists_mock.call_args_list[0].args[0].endswith('/.kube/config')
     assert open_mock.call_count == 1
@@ -66,48 +66,48 @@ def test_homedir_is_used_if_it_exists(tmpdir, mocker, envs):
 
 
 @pytest.mark.parametrize('envs', [{}, {'KUBECONFIG': ''}], ids=['absent', 'empty'])
-def test_homedir_is_ignored_if_it_is_absent(tmpdir, mocker, envs):
+def test_homedir_is_ignored_if_it_is_absent(tmpdir, mocker, settings, envs):
     exists_mock = mocker.patch('os.path.exists', return_value=False)
     open_mock = mocker.patch('kopf._core.intents.piggybacking.open')
     open_mock.return_value.__enter__.return_value.read.return_value = ''
     mocker.patch.dict(os.environ, envs, clear=True)
-    credentials = login_with_kubeconfig()
+    credentials = login_with_kubeconfig(settings=settings)
     assert exists_mock.call_count == 1
     assert exists_mock.call_args_list[0].args[0].endswith('/.kube/config')
     assert open_mock.call_count == 0
     assert credentials is None
 
 
-def test_absent_kubeconfig_fails(tmpdir, mocker):
+def test_absent_kubeconfig_fails(tmpdir, mocker, settings):
     kubeconfig = tmpdir.join('config')
     mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
     with pytest.raises(IOError):
-        login_with_kubeconfig()
+        login_with_kubeconfig(settings=settings)
 
 
-def test_corrupted_kubeconfig_fails(tmpdir, mocker):
+def test_corrupted_kubeconfig_fails(tmpdir, mocker, settings):
     kubeconfig = tmpdir.join('config')
     kubeconfig.write("""!!acb!.-//:""")  # invalid yaml
     mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
     with pytest.raises(yaml.YAMLError):
-        login_with_kubeconfig()
+        login_with_kubeconfig(settings=settings)
 
 
-def test_empty_kubeconfig_fails(tmpdir, mocker):
+def test_empty_kubeconfig_fails(tmpdir, mocker, settings):
     kubeconfig = tmpdir.join('config')
     kubeconfig.write('')
     mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
     with pytest.raises(LoginError) as err:
-        login_with_kubeconfig()
+        login_with_kubeconfig(settings=settings)
     assert "context is not set" in str(err.value)
 
 
-def test_mini_kubeconfig_reading(tmpdir, mocker):
+def test_mini_kubeconfig_reading(tmpdir, mocker, settings):
     kubeconfig = tmpdir.join('config')
     kubeconfig.write(MINICONFIG)
 
     mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
-    credentials = login_with_kubeconfig()
+    credentials = login_with_kubeconfig(settings=settings)
 
     assert credentials is not None
     assert credentials.server is None
@@ -123,9 +123,10 @@ def test_mini_kubeconfig_reading(tmpdir, mocker):
     assert credentials.password is None
     assert credentials.username is None
     assert credentials.default_namespace is None
+    assert credentials.trust_env is False
 
 
-def test_full_kubeconfig_reading_with_ssl_files(tmpdir, mocker):
+def test_full_kubeconfig_reading_with_ssl_files(tmpdir, mocker, settings):
     kubeconfig = tmpdir.join('config')
     kubeconfig.write('''
         kind: Config
@@ -157,7 +158,7 @@ def test_full_kubeconfig_reading_with_ssl_files(tmpdir, mocker):
     ''')
 
     mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
-    credentials = login_with_kubeconfig()
+    credentials = login_with_kubeconfig(settings=settings)
 
     assert credentials is not None
     assert credentials.server == 'https://hostname:1234/'
@@ -176,7 +177,7 @@ def test_full_kubeconfig_reading_with_ssl_files(tmpdir, mocker):
     assert credentials.default_namespace == 'ns'
 
 
-def test_full_kubeconfig_reading_with_ssl_data(tmpdir, mocker):
+def test_full_kubeconfig_reading_with_ssl_data(tmpdir, mocker, settings):
     kubeconfig = tmpdir.join('config')
     kubeconfig.write('''
         kind: Config
@@ -208,7 +209,7 @@ def test_full_kubeconfig_reading_with_ssl_data(tmpdir, mocker):
     ''')
 
     mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
-    credentials = login_with_kubeconfig()
+    credentials = login_with_kubeconfig(settings=settings)
 
     assert credentials is not None
     assert credentials.server == 'https://hostname:1234/'
@@ -227,7 +228,7 @@ def test_full_kubeconfig_reading_with_ssl_data(tmpdir, mocker):
     assert credentials.default_namespace == 'ns'
 
 
-def test_kubeconfig_with_provider_token(tmpdir, mocker):
+def test_kubeconfig_with_provider_token(tmpdir, mocker, settings):
     kubeconfig = tmpdir.join('config')
     kubeconfig.write('''
         kind: Config
@@ -248,13 +249,13 @@ def test_kubeconfig_with_provider_token(tmpdir, mocker):
     ''')
 
     mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
-    credentials = login_with_kubeconfig()
+    credentials = login_with_kubeconfig(settings=settings)
 
     assert credentials is not None
     assert credentials.token == 'provtkn'
 
 
-def test_merged_kubeconfigs_across_currentcontext(tmpdir, mocker):
+def test_merged_kubeconfigs_across_currentcontext(tmpdir, mocker, settings):
     kubeconfig1 = tmpdir.join('config1')
     kubeconfig1.write('''
         kind: Config
@@ -280,7 +281,7 @@ def test_merged_kubeconfigs_across_currentcontext(tmpdir, mocker):
     ''')
 
     mocker.patch.dict(os.environ, clear=True, KUBECONFIG=f'{kubeconfig1}{os.pathsep}{kubeconfig2}')
-    credentials = login_with_kubeconfig()
+    credentials = login_with_kubeconfig(settings=settings)
 
     assert credentials is not None
     assert credentials.default_namespace == 'ns'
@@ -288,7 +289,7 @@ def test_merged_kubeconfigs_across_currentcontext(tmpdir, mocker):
     assert credentials.token == 'tkn'
 
 
-def test_merged_kubeconfigs_across_contexts(tmpdir, mocker):
+def test_merged_kubeconfigs_across_contexts(tmpdir, mocker, settings):
     kubeconfig1 = tmpdir.join('config1')
     kubeconfig1.write('''
         kind: Config
@@ -314,7 +315,7 @@ def test_merged_kubeconfigs_across_contexts(tmpdir, mocker):
     ''')
 
     mocker.patch.dict(os.environ, clear=True, KUBECONFIG=f'{kubeconfig1}{os.pathsep}{kubeconfig2}')
-    credentials = login_with_kubeconfig()
+    credentials = login_with_kubeconfig(settings=settings)
 
     assert credentials is not None
     assert credentials.default_namespace == 'ns'
@@ -322,7 +323,7 @@ def test_merged_kubeconfigs_across_contexts(tmpdir, mocker):
     assert credentials.token == 'tkn'
 
 
-def test_merged_kubeconfigs_first_wins(tmpdir, mocker):
+def test_merged_kubeconfigs_first_wins(tmpdir, mocker, settings):
     kubeconfig1 = tmpdir.join('config1')
     kubeconfig1.write('''
         kind: Config
@@ -363,9 +364,21 @@ def test_merged_kubeconfigs_first_wins(tmpdir, mocker):
     ''')
 
     mocker.patch.dict(os.environ, clear=True, KUBECONFIG=f'{kubeconfig1}{os.pathsep}{kubeconfig2}')
-    credentials = login_with_kubeconfig()
+    credentials = login_with_kubeconfig(settings=settings)
 
     assert credentials is not None
     assert credentials.default_namespace == 'ns1'
     assert credentials.server == 'srv1'
     assert credentials.token == 'tkn1'
+
+
+def test_trust_env_is_propagated_from_settings(tmpdir, mocker, settings):
+    kubeconfig = tmpdir.join('config')
+    kubeconfig.write(MINICONFIG)
+
+    mocker.patch.dict(os.environ, clear=True, KUBECONFIG=str(kubeconfig))
+    settings.networking.trust_env = True
+    credentials = login_with_kubeconfig(settings=settings)
+
+    assert credentials is not None
+    assert credentials.trust_env is True

--- a/tests/authentication/test_login_serviceaccount.py
+++ b/tests/authentication/test_login_serviceaccount.py
@@ -22,27 +22,28 @@ def test_has_serviceaccount_when_special_file_exists(mocker):
     assert exists_mock.call_args_list[0].args[0] == SA_TOKEN_PATH
 
 
-def test_serviceaccount_with_all_absent_files(mocker):
+def test_serviceaccount_with_all_absent_files(mocker, settings):
     exists_mock = mocker.patch('os.path.exists', return_value=False)  # all 3 of them.
     open_mock = mocker.patch('kopf._core.intents.piggybacking.open')
     open_mock.return_value.__enter__.return_value.read.return_value = ''
-    credentials = login_with_service_account()
+    credentials = login_with_service_account(settings=settings)
     assert credentials is None
     assert exists_mock.call_count == 1
     assert exists_mock.call_args_list[0].args[0] == SA_TOKEN_PATH
     assert not open_mock.called
 
 
-def test_serviceaccount_with_all_present_files(mocker):
+def test_serviceaccount_with_all_present_files(mocker, settings):
     exists_mock = mocker.patch('os.path.exists', return_value=True)  # all 3 of them.
     open_mock = mocker.patch('kopf._core.intents.piggybacking.open')
     open_mock.return_value.__enter__.return_value.read.side_effect=[' tkn ', ' ns ', RuntimeError]
-    credentials = login_with_service_account()
+    credentials = login_with_service_account(settings=settings)
     assert credentials is not None
     assert credentials.server == 'https://kubernetes.default.svc'
     assert credentials.default_namespace == 'ns'
     assert credentials.token == 'tkn'
     assert credentials.ca_path == CA_PATH
+    assert credentials.trust_env is False
     assert exists_mock.call_count == 3
     assert exists_mock.call_args_list[0].args[0] == SA_TOKEN_PATH
     assert exists_mock.call_args_list[1].args[0] == NAMESPACE_PATH
@@ -53,12 +54,12 @@ def test_serviceaccount_with_all_present_files(mocker):
     # NB: the order is irrelevant and can be changed if needed.
 
 
-def test_serviceaccount_with_only_the_token_file(mocker):
+def test_serviceaccount_with_only_the_token_file(mocker, settings):
     # NB: the order is irrelevant and can be changed if needed.
     exists_mock = mocker.patch('os.path.exists', side_effect=[True, False, False])
     open_mock = mocker.patch('kopf._core.intents.piggybacking.open')
     open_mock.return_value.__enter__.return_value.read.side_effect=[' tkn ', RuntimeError]
-    credentials = login_with_service_account()
+    credentials = login_with_service_account(settings=settings)
     assert credentials is not None
     assert credentials.server == 'https://kubernetes.default.svc'
     assert credentials.default_namespace is None
@@ -70,3 +71,13 @@ def test_serviceaccount_with_only_the_token_file(mocker):
     assert exists_mock.call_args_list[2].args[0] == CA_PATH
     assert open_mock.call_count == 1
     assert open_mock.call_args_list[0].args[0] == SA_TOKEN_PATH
+
+
+def test_trust_env_is_propagated_from_settings(mocker, settings):
+    mocker.patch('os.path.exists', return_value=True)
+    open_mock = mocker.patch('kopf._core.intents.piggybacking.open')
+    open_mock.return_value.__enter__.return_value.read.side_effect=[' tkn ', ' ns ', RuntimeError]
+    settings.networking.trust_env = True
+    credentials = login_with_service_account(settings=settings)
+    assert credentials is not None
+    assert credentials.trust_env is True

--- a/tests/settings/test_defaults.py
+++ b/tests/settings/test_defaults.py
@@ -31,6 +31,7 @@ async def test_declared_public_interface_and_promised_defaults():
     assert settings.execution.max_workers is None
     assert settings.networking.request_timeout == 5 * 60
     assert settings.networking.connect_timeout is None
+    assert settings.networking.trust_env == False
     assert settings.persistence.consistency_timeout == 5.0
 
 


### PR DESCRIPTION
Allow operators to respect `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables and `~/.netrc` files by setting `settings.networking.trust_env = True`. The setting is propagated through the built-in login handlers to ConnectionInfo, and from there to the aiohttp client session. Custom login handlers can also set `trust_env` directly on `ConnectionInfo`.

Originated in #1277, improves the consequences of #1278.