### PR TITLE
Type-check the examples in strict mode, add type annotations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
           do
             echo "Checking ${d}"
-            uv run mypy --config-file= --ignore-missing-imports $d
+            uv run mypy $d
             exit_codes=$[${exit_codes} + $?]
           done
           exit ${exit_codes}

--- a/.github/workflows/thorough.yaml
+++ b/.github/workflows/thorough.yaml
@@ -33,7 +33,7 @@ jobs:
           for d in $(find examples -maxdepth 1 -mindepth 1 -type d)
           do
             echo "Checking ${d}"
-            uv run mypy --config-file= --ignore-missing-imports $d
+            uv run mypy $d
             exit_codes=$[${exit_codes} + $?]
           done
           exit ${exit_codes}

--- a/examples/01-minimal/example.py
+++ b/examples/01-minimal/example.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 import kopf
 
 
 @kopf.on.create('kopfexamples')
-def create_fn(spec, **kwargs):
+def create_fn(spec: kopf.Spec, **_: Any) -> Any:
     print(f"And here we are! Creating: {spec}")
     return {'message': 'hello world'}  # will be the new status

--- a/examples/02-children/example.py
+++ b/examples/02-children/example.py
@@ -1,10 +1,12 @@
+from typing import Any
+
 import kopf
 import pykube
 import yaml
 
 
 @kopf.on.create('kopfexamples')
-def create_fn(spec, **kwargs):
+def create_fn(spec: kopf.Spec, **_: Any) -> Any:
 
     # Render the pod yaml with some spec fields used in the template.
     doc = yaml.safe_load(f"""

--- a/examples/03-exceptions/example.py
+++ b/examples/03-exceptions/example.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import kopf
 
 
@@ -6,23 +8,23 @@ class MyException(Exception):
 
 
 @kopf.on.create('kopfexamples')
-def instant_failure_with_only_a_message(**kwargs):
+def instant_failure_with_only_a_message(**_: Any) -> None:
     raise kopf.PermanentError("Fail once and for all.")
 
 
 @kopf.on.create('kopfexamples')
-def eventual_success_with_a_few_messages(retry, **kwargs):
+def eventual_success_with_a_few_messages(retry: int, **_: Any) -> None:
     if retry < 3:  # 0, 1, 2, 3
         raise kopf.TemporaryError("Expected recoverable error.", delay=1.0)
 
 
 @kopf.on.create('kopfexamples', retries=3, backoff=1.0)
-def eventual_failure_with_tracebacks(**kwargs):
+def eventual_failure_with_tracebacks(**_: Any) -> None:
     raise MyException("An error that is supposed to be recoverable.")
 
 
 @kopf.on.create('kopfexamples', errors=kopf.ErrorsMode.PERMANENT, backoff=1.0)
-def instant_failure_with_traceback(**kwargs):
+def instant_failure_with_traceback(**_: Any) -> None:
     raise MyException("An error that is supposed to be recoverable.")
 
 

--- a/examples/04-events/example.py
+++ b/examples/04-events/example.py
@@ -1,11 +1,13 @@
 """
 Send the custom events for the handled or other objects.
 """
+from typing import Any
+
 import kopf
 
 
 @kopf.on.create('kopfexamples')
-def create_fn(body, **kwargs):
+def create_fn(body: kopf.Body, **_: Any) -> None:
 
     # The all-purpose function for the event creation.
     kopf.event(body, type="SomeType", reason="SomeReason", message="Some message")

--- a/examples/05-handlers/example.py
+++ b/examples/05-handlers/example.py
@@ -1,41 +1,43 @@
+from typing import Any
+
 import kopf
 
 
 @kopf.on.resume('kopfexamples')
-def resume_fn_1(**kwargs):
+def resume_fn_1(**_: Any) -> None:
     print(f'RESUMED 1st')
 
 
 @kopf.on.create('kopfexamples')
-def create_fn_1(**kwargs):
+def create_fn_1(**_: Any) -> None:
     print('CREATED 1st')
 
 
 @kopf.on.resume('kopfexamples')
-def resume_fn_2(**kwargs):
+def resume_fn_2(**_: Any) -> None:
     print(f'RESUMED 2nd')
 
 
 @kopf.on.create('kopfexamples')
-def create_fn_2(**kwargs):
+def create_fn_2(**_: Any) -> None:
     print('CREATED 2nd')
 
 
 @kopf.on.update('kopfexamples')
-def update_fn(old, new, diff, **kwargs):
+def update_fn(old: Any, new: Any, diff: kopf.Diff, **_: Any) -> None:
     print('UPDATED')
 
 
 @kopf.on.delete('kopfexamples')
-def delete_fn_1(**kwargs):
+def delete_fn_1(**_: Any) -> None:
     print('DELETED 1st')
 
 
 @kopf.on.delete('kopfexamples')
-def delete_fn_2(**kwargs):
+def delete_fn_2(**_: Any) -> None:
     print('DELETED 2nd')
 
 
 @kopf.on.field('kopfexamples', field='spec.field')
-def field_fn(old, new, **kwargs):
+def field_fn(old: Any, new: Any, **_: Any) -> None:
     print(f'FIELD CHANGED: {old} -> {new}')

--- a/examples/06-peering/example.py
+++ b/examples/06-peering/example.py
@@ -1,6 +1,8 @@
+from typing import Any
+
 import kopf
 
 
 @kopf.on.create('kopfexamples')
-def create_fn(**kwargs):
+def create_fn(**_: Any) -> None:
     pass

--- a/examples/07-subhandlers/example.py
+++ b/examples/07-subhandlers/example.py
@@ -1,11 +1,13 @@
+from typing import Any
+
 import kopf
 
 
 @kopf.on.create('kopfexamples')
-def create_fn(spec, **kwargs):
+def create_fn(spec: kopf.Spec, **_: Any) -> None:
 
     for item in spec.get('items', []):
 
         @kopf.subhandler(id=item)
-        async def create_item_fn(item=item, **kwargs):
+        async def create_item_fn(item: str = item, **_: Any) -> None:
             print(f"=== Handling creation for {item}. ===")

--- a/examples/08-events/example.py
+++ b/examples/08-events/example.py
@@ -1,13 +1,15 @@
+from typing import Any
+
 import kopf
 
 
 @kopf.on.event('kopfexamples')
-def event_fn_with_error(**kwargs):
+def event_fn_with_error(**_: Any) -> None:
     raise Exception("Oops!")
 
 
 @kopf.on.event('kopfexamples')
-def normal_event_fn(event, **kwargs):
+def normal_event_fn(event: kopf.RawEvent, **_: Any) -> None:
     print(f"Event received: {event!r}")
 
 

--- a/examples/09-testing/example.py
+++ b/examples/09-testing/example.py
@@ -1,6 +1,8 @@
+from typing import Any
+
 import kopf
 
 
 @kopf.on.create('kopfexamples')
-def create_fn(logger, **kwargs):
+def create_fn(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Something was logged here.")

--- a/examples/10-builtins/example.py
+++ b/examples/10-builtins/example.py
@@ -1,14 +1,16 @@
 import asyncio
+from typing import Any
 
 import kopf
 import pykube
 
-tasks: dict[str, dict[str, asyncio.Task]] = {}  # dict{namespace: dict{name: asyncio.Task}}
+tasks: dict[str, dict[str, asyncio.Task[None]]] = {}  # dict{namespace: dict{name: asyncio.Task}}
 
 
 @kopf.on.resume('pods')
 @kopf.on.create('pods')
-async def pod_in_sight(namespace, name, logger, **kwargs):
+async def pod_in_sight(namespace: str | None, name: str | None, logger: kopf.Logger, **_: Any) -> None:
+    assert namespace is not None and name is not None  # for type-checkers
     if namespace.startswith('kube-'):
         return
     else:
@@ -18,13 +20,13 @@ async def pod_in_sight(namespace, name, logger, **kwargs):
 
 
 @kopf.on.delete('pods')
-async def pod_deleted(namespace, name, **kwargs):
+async def pod_deleted(namespace: str | None, name: str | None, **_: Any) -> None:
     if namespace in tasks and name in tasks[namespace]:
         task = tasks[namespace][name]
         task.cancel()  # it will also remove from `tasks`
 
 
-async def pod_killer(namespace, name, logger, timeout=30):
+async def pod_killer(namespace: str | None, name: str | None, logger: kopf.Logger, timeout: float = 30) -> None:
     try:
         logger.info(f"=== Pod killing happens in {timeout}s.")
         await asyncio.sleep(timeout)

--- a/examples/11-filtering-handlers/example.py
+++ b/examples/11-filtering-handlers/example.py
@@ -1,92 +1,94 @@
+from typing import Any
+
 import kopf
 
 
-def say_yes(value, spec, **_) -> bool:
+def say_yes(value: Any, spec: kopf.Spec, **_: Any) -> bool:
     return value == 'somevalue' and spec.get('field') is not None
 
 
-def say_no(value, spec, **_) -> bool:
+def say_no(value: Any, spec: kopf.Spec, **_: Any) -> bool:
     return value == 'somevalue' and spec.get('field') == 'not-this-value-for-sure'
 
 
 @kopf.on.create('kopfexamples', labels={'somelabel': 'somevalue'})
-def create_with_labels_matching(logger, **kwargs):
+def create_with_labels_matching(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Label is matching.")
 
 
 @kopf.on.create('kopfexamples', labels={'somelabel': kopf.PRESENT})
-def create_with_labels_present(logger, **kwargs):
+def create_with_labels_present(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Label is present.")
 
 
 @kopf.on.create('kopfexamples', labels={'nonexistent': kopf.ABSENT})
-def create_with_labels_absent(logger, **kwargs):
+def create_with_labels_absent(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Label is absent.")
 
 
 @kopf.on.create('kopfexamples', labels={'somelabel': say_yes})
-def create_with_labels_callback_matching(logger, **kwargs):
+def create_with_labels_callback_matching(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Label callback matching.")
 
 
 @kopf.on.create('kopfexamples', annotations={'someannotation': 'somevalue'})
-def create_with_annotations_matching(logger, **kwargs):
+def create_with_annotations_matching(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Annotation is matching.")
 
 
 @kopf.on.create('kopfexamples', annotations={'someannotation': kopf.PRESENT})
-def create_with_annotations_present(logger, **kwargs):
+def create_with_annotations_present(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Annotation is present.")
 
 
 @kopf.on.create('kopfexamples', annotations={'nonexistent': kopf.ABSENT})
-def create_with_annotations_absent(logger, **kwargs):
+def create_with_annotations_absent(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Annotation is absent.")
 
 
 @kopf.on.create('kopfexamples', annotations={'someannotation': say_no})
-def create_with_annotations_callback_matching(logger, **kwargs):
+def create_with_annotations_callback_matching(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Annotation callback mismatch.")
 
 
 @kopf.on.create('kopfexamples', when=lambda body, **_: True)
-def create_with_filter_satisfied(logger, **kwargs):
+def create_with_filter_satisfied(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Filter satisfied.")
 
 
 @kopf.on.create('kopfexamples', when=lambda body, **_: False)
-def create_with_filter_not_satisfied(logger, **kwargs):
+def create_with_filter_not_satisfied(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Filter not satisfied.")
 
 
 @kopf.on.create('kopfexamples', field='spec.field', value='value')
-def create_with_field_value_satisfied(logger, **kwargs):
+def create_with_field_value_satisfied(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Field value is satisfied.")
 
 
 @kopf.on.create('kopfexamples', field='spec.field', value='something-else')
-def create_with_field_value_not_satisfied(logger, **kwargs):
+def create_with_field_value_not_satisfied(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Field value is not satisfied.")
 
 
 @kopf.on.create('kopfexamples', field='spec.field', value=kopf.PRESENT)
-def create_with_field_presence_satisfied(logger, **kwargs):
+def create_with_field_presence_satisfied(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Field presence is satisfied.")
 
 
 @kopf.on.create('kopfexamples', field='spec.inexistent', value=kopf.PRESENT)
-def create_with_field_presence_not_satisfied(logger, **kwargs):
+def create_with_field_presence_not_satisfied(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Field presence is not satisfied.")
 
 
 @kopf.on.update('kopfexamples',
                 field='spec.field', old='value', new='changed')
-def update_with_field_change_satisfied(logger, **kwargs):
+def update_with_field_change_satisfied(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Field change is satisfied.")
 
 
 @kopf.daemon('kopfexamples', field='spec.field', value='value')
-def daemon_with_field(stopped: kopf.DaemonStopped, logger, **kwargs):
+def daemon_with_field(stopped: kopf.DaemonStopped, logger: kopf.Logger, **_: Any) -> None:
     while not stopped:
         logger.info("Field daemon is satisfied.")
         stopped.wait(1)

--- a/examples/12-embedded/example.py
+++ b/examples/12-embedded/example.py
@@ -2,25 +2,26 @@ import asyncio
 import contextlib
 import threading
 import time
+from typing import Any
 
 import kopf
-import pykube
+import pykube.objects
 
 
 @kopf.on.create('kopfexamples')
-def create_fn(memo: kopf.Memo, **kwargs):
-    print(memo.create_tpl.format(**kwargs))  # type: ignore
+def create_fn(memo: kopf.Memo, **kwargs: Any) -> None:
+    print(memo.create_tpl.format(**kwargs))
 
 
 @kopf.on.delete('kopfexamples')
-def delete_fn(memo: kopf.Memo, **kwargs):
-    print(memo.delete_tpl.format(**kwargs))  # type: ignore
+def delete_fn(memo: kopf.Memo, **kwargs: Any) -> None:
+    print(memo.delete_tpl.format(**kwargs))
 
 
 def kopf_thread(
         ready_flag: threading.Event,
         stop_flag: threading.Event,
-):
+) -> None:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     with contextlib.closing(loop):
@@ -37,7 +38,7 @@ def kopf_thread(
         ))
 
 
-def main(steps=3):
+def main(steps: int = 3) -> None:
 
     # Start the operator and let it initialise.
     print(f"Starting the main app.")
@@ -64,13 +65,13 @@ def main(steps=3):
     thread.join()
 
 
-class KopfExample(pykube.objects.NamespacedAPIObject):
+class KopfExample(pykube.objects.NamespacedAPIObject):  # type: ignore[misc]
     version = "kopf.dev/v1"
     endpoint = "kopfexamples"
     kind = "KopfExample"
 
 
-def _create_object(step):
+def _create_object(step: int) -> None:
     try:
         api = pykube.HTTPClient(pykube.KubeConfig.from_env())
         kex = KopfExample(api, dict(
@@ -89,7 +90,7 @@ def _create_object(step):
             raise
 
 
-def _delete_object(step):
+def _delete_object(step: int) -> None:
     try:
         api = pykube.HTTPClient(pykube.KubeConfig.from_env())
         kex = KopfExample.objects(api, namespace='default').get_by_name(f'kopf-example-{step}')

--- a/examples/13-hooks/example.py
+++ b/examples/13-hooks/example.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import random
+from typing import Any
 
 import kopf
 import pykube
@@ -10,14 +11,14 @@ STOPPERS: dict[str, dict[str, asyncio.Event]] = {}  # [namespace][name]
 
 
 @kopf.on.startup()
-async def startup_fn_simple(logger, **kwargs):
+async def startup_fn_simple(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Initialising the task-lock...")
     global LOCK
     LOCK = asyncio.Lock()  # in the current asyncio loop
 
 
 @kopf.on.startup()
-async def startup_fn_retried(retry, logger, **kwargs):
+async def startup_fn_retried(retry: int, logger: kopf.Logger, **_: Any) -> None:
     if retry < 3:
         raise kopf.TemporaryError(f"Going to succeed in {3-retry}s", delay=1)
     else:
@@ -26,7 +27,7 @@ async def startup_fn_retried(retry, logger, **kwargs):
 
 
 @kopf.on.cleanup()
-async def cleanup_fn(logger, **kwargs):
+async def cleanup_fn(logger: kopf.Logger, **_: Any) -> None:
     logger.info("Cleaning up...")
     for namespace in STOPPERS.keys():
         for name, flag in STOPPERS[namespace].items():
@@ -35,7 +36,7 @@ async def cleanup_fn(logger, **kwargs):
 
 
 @kopf.on.login(errors=kopf.ErrorsMode.PERMANENT)
-async def login_fn(**kwargs):
+async def login_fn(**_: Any) -> kopf.ConnectionInfo:
     print('Logging in in 2s...')
     await asyncio.sleep(2.0)
 
@@ -59,17 +60,18 @@ async def login_fn(**kwargs):
 
 
 @kopf.on.probe()
-async def tasks_count(**kwargs):
+async def tasks_count(**_: Any) -> int:
     return sum(len(flags) for flags in STOPPERS.values())
 
 
 @kopf.on.probe()
-async def monitored_objects(**kwargs):
+async def monitored_objects(**_: Any) -> dict[str, list[str]]:
     return {namespace: sorted(name for name in STOPPERS[namespace]) for namespace in STOPPERS}
 
 
 @kopf.on.event('pods')
-async def pod_task(namespace, name, logger, **_):
+async def pod_task(namespace: str | None, name: str | None, logger: kopf.Logger, **_: Any) -> None:
+    assert namespace is not None and name is not None  # for type-checkers
     async with LOCK:
         if namespace not in STOPPERS or name not in STOPPERS[namespace]:
             flag = asyncio.Event()
@@ -77,7 +79,7 @@ async def pod_task(namespace, name, logger, **_):
             asyncio.create_task(_task_fn(logger, shouldstop=flag))
 
 
-async def _task_fn(logger, shouldstop: asyncio.Event):
+async def _task_fn(logger: kopf.Logger, shouldstop: asyncio.Event) -> None:
     while not shouldstop.is_set():
         await asyncio.sleep(random.randint(1, 10))
         logger.info("Served by the background task.")

--- a/examples/14-daemons/example.py
+++ b/examples/14-daemons/example.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from typing import Any
 
 import kopf
 
@@ -7,7 +8,8 @@ import kopf
 # Sync daemons in threads are non-interruptable, they must check for the `stopped` flag.
 # This daemon exits after 3 attempts and then 30 seconds of running (unless stopped).
 @kopf.daemon('kopfexamples', backoff=3)
-def background_sync(stopped: kopf.DaemonStopped, spec, logger, retry, patch, **_):
+def background_sync(stopped: kopf.DaemonStopped, spec: kopf.Spec, logger: kopf.Logger,
+                    retry: int, patch: kopf.Patch, **_: Any) -> None:
     if retry < 3:
         patch.status['message'] = f"Failed {retry+1} times."
         raise kopf.TemporaryError("Simulated failure.", delay=1)
@@ -24,7 +26,7 @@ def background_sync(stopped: kopf.DaemonStopped, spec, logger, retry, patch, **_
 # This daemon runs forever (until stopped, i.e. cancelled). Yet fails to start for 3 first times.
 @kopf.daemon('kopfexamples', backoff=3, cancellation_backoff=1.0, cancellation_timeout=0.5,
              annotations={'someannotation': 'somevalue'})
-async def background_async(spec, logger, retry, **_):
+async def background_async(spec: kopf.Spec, logger: kopf.Logger, retry: int, **_: Any) -> None:
     if retry < 3:
         raise kopf.TemporaryError("Simulated failure.", delay=1)
 

--- a/examples/15-timers/example.py
+++ b/examples/15-timers/example.py
@@ -1,11 +1,13 @@
+from typing import Any
+
 import kopf
 
 
 @kopf.timer('kopfexamples', idle=5, interval=2)
-def every_few_seconds_sync(spec, logger, **_):
+def every_few_seconds_sync(spec: kopf.Spec, logger: kopf.Logger, **_: Any) -> None:
     logger.info(f"Ping from a sync timer: field={spec['field']!r}")
 
 
 @kopf.timer('kopfexamples', idle=10, interval=4)
-async def every_few_seconds_async(spec, logger, **_):
+async def every_few_seconds_async(spec: kopf.Spec, logger: kopf.Logger, **_: Any) -> None:
     logger.info(f"Ping from an async timer: field={spec['field']!r}")

--- a/examples/16-indexing/example.py
+++ b/examples/16-indexing/example.py
@@ -1,10 +1,11 @@
 import pprint
+from typing import Any
 
 import kopf
 
 
 @kopf.index('pods')
-def is_running(namespace, name, status, **_):
+def is_running(*, namespace: str | None, name: str | None, status: kopf.Status, **_: Any) -> Any:
     return {(namespace, name): status.get('phase') == 'Running'}
     # {('kube-system', 'traefik-...-...'): [True],
     #  ('kube-system', 'helm-install-traefik-...'): [False],
@@ -12,7 +13,7 @@ def is_running(namespace, name, status, **_):
 
 
 @kopf.index('pods')
-def by_label(labels, name, **_):
+def by_label(labels: kopf.Labels, name: str | None, **_: Any) -> Any:
     return {(label, value): name for label, value in labels.items()}
     # {('app', 'traefik'): ['traefik-...-...'],
     #  ('job-name', 'helm-install-traefik'): ['helm-install-traefik-...'],
@@ -21,17 +22,19 @@ def by_label(labels, name, **_):
 
 
 @kopf.on.probe()  # type: ignore
-def pod_count(is_running: kopf.Index, **_):
+def pod_count(is_running: kopf.Index[tuple[str, str], list[bool]], **_: Any) -> int:
     return len(is_running)
 
 
 @kopf.on.probe()  # type: ignore
-def pod_names(is_running: kopf.Index, **_):
+def pod_names(is_running: kopf.Index[tuple[str, str], list[bool]], **_: Any) -> list[str]:
     return [name for _, name in is_running]
 
 
 @kopf.timer('kex', interval=5)  # type: ignore
-def intervalled(is_running: kopf.Index, by_label: kopf.Index, patch: kopf.Patch, **_):
+def intervalled(is_running: kopf.Index[tuple[str, str], list[bool]],
+                by_label: kopf.Index[tuple[str, str], list[str]],
+                patch: kopf.Patch, **_: Any) -> None:
     pprint.pprint(dict(by_label))
     patch.status['running-pods'] = [
         f"{ns}::{name}"

--- a/examples/17-admission/example.py
+++ b/examples/17-admission/example.py
@@ -1,4 +1,5 @@
 import pathlib
+from typing import Any
 
 import kopf
 
@@ -6,7 +7,7 @@ ROOT = (pathlib.Path.cwd() / pathlib.Path(__file__)).parent.parent.parent
 
 
 @kopf.on.startup()
-def config(settings: kopf.OperatorSettings, **_):
+def config(settings: kopf.OperatorSettings, **_: Any) -> None:
 
     # Plain and simple local endpoint with an auto-generated certificate:
     settings.admission.server = kopf.WebhookServer()
@@ -47,7 +48,7 @@ def config(settings: kopf.OperatorSettings, **_):
 
 
 @kopf.on.validate('kex')
-def authhook(headers: kopf.Headers, sslpeer: kopf.SSLPeer, warnings: list[str], **_):
+def authhook(headers: kopf.Headers, sslpeer: kopf.SSLPeer, warnings: list[str], **_: Any) -> None:
     user_agent = headers.get('User-Agent', '(unidentified)')
     warnings.append(f"Accessing as user-agent: {user_agent}")
     if not sslpeer.get('subject'):
@@ -61,18 +62,18 @@ def authhook(headers: kopf.Headers, sslpeer: kopf.SSLPeer, warnings: list[str], 
 
 
 @kopf.on.validate('kex')
-def validate1(spec, dryrun, **_):
+def validate1(spec: kopf.Spec, dryrun: bool, **_: Any) -> None:
     if not dryrun and spec.get('field') == 'wrong':
         raise kopf.AdmissionError("Meh! I don't like it. Change the field.")
 
 
 @kopf.on.validate('kex', field='spec.field', value='not-allowed')
-def validate2(**_):
+def validate2(**_: Any) -> None:
     raise kopf.AdmissionError("I'm too lazy anyway. Go away!", code=555)
 
 
 @kopf.on.validate('kex', subresource='*')
-def validate_subresources(spec, subresource, status, warnings: list[str], **_):
+def validate_subresources(spec: kopf.Spec, subresource: str | None, status: kopf.Status, warnings: list[str], **_: Any) -> None:
     if subresource == 'status' and status.get('field') != spec.get('field'):
         raise kopf.AdmissionError("status.field MUST be equal to spec.field!")
     elif subresource is None and status.get('field') != spec.get('field'):
@@ -81,7 +82,7 @@ def validate_subresources(spec, subresource, status, warnings: list[str], **_):
 
 
 @kopf.on.mutate('kex', labels={'somelabel': 'somevalue'})
-def mutate1(patch: kopf.Patch, **_):
+def mutate1(patch: kopf.Patch, **_: Any) -> None:
     patch.spec['injected'] = 123
 
 

--- a/examples/99-all-at-once/example.py
+++ b/examples/99-all-at-once/example.py
@@ -1,6 +1,7 @@
 import asyncio
 import pprint
 import time
+from typing import Any
 
 import kopf
 import pykube
@@ -8,13 +9,13 @@ import yaml
 
 
 @kopf.on.startup()
-async def startup_fn_simple(logger, **kwargs):
+async def startup_fn_simple(logger: kopf.Logger, **_: Any) -> None:
     logger.info('Starting in 1s...')
     await asyncio.sleep(1)
 
 
 @kopf.on.startup()
-async def startup_fn_retried(retry, logger, **kwargs):
+async def startup_fn_retried(retry: int, logger: kopf.Logger, **_: Any) -> None:
     if retry < 3:
         raise kopf.TemporaryError(f"Going to succeed in {3-retry}s", delay=1)
     else:
@@ -23,13 +24,13 @@ async def startup_fn_retried(retry, logger, **kwargs):
 
 
 @kopf.on.cleanup()
-async def cleanup_fn(logger, **kwargs):
+async def cleanup_fn(logger: kopf.Logger, **_: Any) -> None:
     logger.info('Cleaning up in 3s...')
     await asyncio.sleep(3)
 
 
 @kopf.on.create('kopfexamples')
-def create_1(body, meta, spec, status, **kwargs):
+def create_1(body: kopf.Body, **_: Any) -> Any:
     children = _create_children(owner=body)
 
     kopf.info(body, reason='AnyReason')
@@ -40,7 +41,7 @@ def create_1(body, meta, spec, status, **kwargs):
 
 
 @kopf.on.create('kopfexamples')
-def create_2(body, meta, spec, status, retry=None, **kwargs):
+def create_2(retry: int, **_: Any) -> Any:
     wait_for_something()  # specific for job2, e.g. an external API poller
 
     if not retry:
@@ -51,32 +52,32 @@ def create_2(body, meta, spec, status, retry=None, **kwargs):
 
 
 @kopf.on.update('kopfexamples')
-def update(body, meta, spec, status, old, new, diff, **kwargs):
+def update(diff: kopf.Diff, **_: Any) -> None:
     print('Handling the diff')
     pprint.pprint(list(diff))
 
 
 @kopf.on.field('kopfexamples', field='spec.lst')
-def update_lst(body, meta, spec, status, old, new, **kwargs):
+def update_lst(old: Any, new: Any, **_: Any) -> None:
     print(f'Handling the FIELD = {old} -> {new}')
 
 
 @kopf.on.delete('kopfexamples')
-def delete(body, meta, spec, status, **kwargs):
+def delete(**_: Any) -> None:
     pass
 
 
-def _create_children(owner):
+def _create_children(owner: kopf.Body) -> list[kopf.Body]:
     return []
 
 
-def wait_for_something():
+def wait_for_something() -> None:
     # Note: intentionally blocking from the asyncio point of view.
     time.sleep(1)
 
 
 @kopf.on.create('kopfexamples')
-def create_pod(**kwargs):
+def create_pod(**_: Any) -> None:
 
     # Render the pod yaml with some spec fields used in the template.
     pod_data = yaml.safe_load(f"""
@@ -101,7 +102,7 @@ def create_pod(**kwargs):
 
 
 @kopf.on.event('pods', labels={'application': 'kopf-example-10'})
-def example_pod_change(logger, **kwargs):
+def example_pod_change(logger: kopf.Logger, **_: Any) -> None:
     logger.info("This pod is special for us.")
 
 

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -186,7 +186,7 @@ from kopf._kits.webhooks import (
 )
 
 __all__ = [
-    'on', 'lifecycles', 'register', 'execute', 'daemon', 'timer', 'index',
+    'on', 'lifecycles', 'subhandler', 'register', 'execute', 'daemon', 'timer', 'index',
     'configure', 'LogFormat',
     'login_via_pykube',
     'login_via_client',
@@ -219,6 +219,7 @@ __all__ = [
     'WebhookServer',
     'WebhookK3dServer',
     'WebhookMinikubeServer',
+    'WebhookDockerDesktopServer',
     'WebhookNgrokTunnel',
     'WebhookAutoServer',
     'WebhookAutoTunnel',

--- a/kopf/_cogs/structs/ephemera.py
+++ b/kopf/_cogs/structs/ephemera.py
@@ -91,5 +91,5 @@ class Index(Mapping[_K, Store[_V]], Generic[_K, _V]):
     """
 
 
-# Only an abstract interface. Implementated in `~indexing.Indices`.
+# Only an abstract interface. Implemented in `~indexing.Indices`.
 Indices = Mapping[str, Index[Any, Any]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ version_file = "kopf/_cogs/helpers/versions.py"
 [tool.mypy]
 strict = true
 packages = ["kopf"]
+exclude = ['(^|/)test_.*\.py$']
 python_version = "3.10"
 exclude_gitignore = true
 warn_unused_configs = true


### PR DESCRIPTION
As a preparation for the restoration of callback protocols in #1254, enable the strict-mode type checking in examples. Ensure that it works before that PR and after.

There are still some weird unresolved issues (in `examples/16-indexing/example.py`), but those can be suppressed for now.