### PR TITLE
Terminate operator tasks sequentially in groups

### DIFF
--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -5,6 +5,7 @@ import signal
 import threading
 import warnings
 from collections.abc import Collection, Coroutine, MutableSequence, Sequence
+from typing import Any
 
 from kopf._cogs.aiokits import aioadapters, aiobindings, aiotasks, aiotoggles, aiovalues
 from kopf._cogs.clients import auth
@@ -158,6 +159,7 @@ async def spawn_tasks(
         ready_flag: aioadapters.Flag | None = None,
         vault: credentials.Vault | None = None,
         memo: object | None = None,
+        flat: bool = False,  # for backwards compatibility, just in case
         _command: Coroutine[None, None, None] | None = None,
 ) -> Collection[aiotasks.Task]:
     """
@@ -196,7 +198,9 @@ async def spawn_tasks(
     signal_flag: aiotasks.Future = asyncio.Future()
     started_flag: asyncio.Event = asyncio.Event()
     operator_paused = aiotoggles.ToggleSet(any)
-    tasks: MutableSequence[aiotasks.Task] = []
+    inner_tasks: list[aiotasks.Task] = []
+    authn_tasks: list[aiotasks.Task] = []
+    outer_tasks: list[aiotasks.Task] = []
 
     # Map kwargs into the settings object.
     settings.peering.clusterwide = clusterwide
@@ -219,20 +223,19 @@ async def spawn_tasks(
     posting.settings_var.set(settings)
 
     # A few common background forever-running infrastructural tasks (irregular root tasks).
-    tasks.append(asyncio.create_task(
+    inner_tasks.append(asyncio.create_task(
         name="stop-flag checker",
         coro=_stop_flag_checker(
             signal_flag=signal_flag,
             stop_flag=stop_flag)))
-    tasks.append(asyncio.create_task(
+    inner_tasks.append(asyncio.create_task(
         name="ultimate termination",
         coro=_ultimate_termination(
             settings=settings,
             stop_flag=stop_flag)))
-    tasks.append(asyncio.create_task(
+    outer_tasks.append(asyncio.create_task(
         name="startup/cleanup activities",
         coro=_startup_cleanup_activities(
-            root_tasks=tasks,  # used as a "live" view, populated later.
             ready_flag=ready_flag,
             started_flag=started_flag,
             registry=registry,
@@ -242,7 +245,7 @@ async def spawn_tasks(
             memo=memo)))  # to purge & finalize the caches in the end.
 
     # Kill all the daemons gracefully when the operator exits (so that they are not "hung").
-    tasks.append(aiotasks.create_guarded_task(
+    outer_tasks.append(aiotasks.create_guarded_task(
         name="daemon killer", flag=started_flag, logger=logger,
         coro=daemons.daemon_killer(
             settings=settings,
@@ -250,7 +253,7 @@ async def spawn_tasks(
             operator_paused=operator_paused)))
 
     # Keeping the credentials fresh and valid via the authentication handlers on demand.
-    tasks.append(aiotasks.create_guarded_task(
+    authn_tasks.append(aiotasks.create_guarded_task(
         name="credentials retriever", flag=started_flag, logger=logger,
         coro=activities.authenticator(
             registry=registry,
@@ -261,7 +264,7 @@ async def spawn_tasks(
 
     # K8s-event posting. Events are queued in-memory and posted in the background.
     # NB: currently, it is a global task, but can be made per-resource or per-object.
-    tasks.append(aiotasks.create_guarded_task(
+    inner_tasks.append(aiotasks.create_guarded_task(
         name="poster of events", flag=started_flag, logger=logger,
         coro=posting.poster(
             settings=settings,
@@ -270,7 +273,7 @@ async def spawn_tasks(
 
     # Liveness probing -- so that Kubernetes would know that the operator is alive.
     if liveness_endpoint:
-        tasks.append(aiotasks.create_guarded_task(
+        inner_tasks.append(aiotasks.create_guarded_task(
             name="health reporter", flag=started_flag, logger=logger,
             coro=probing.health_reporter(
                 registry=registry,
@@ -282,19 +285,19 @@ async def spawn_tasks(
     # Admission webhooks run as either a server or a tunnel or a fixed config.
     # The webhook manager automatically adjusts the cluster configuration at runtime.
     container: aiovalues.Container[reviews.WebhookClientConfig] = aiovalues.Container()
-    tasks.append(aiotasks.create_guarded_task(
+    inner_tasks.append(aiotasks.create_guarded_task(
         name="admission insights chain", flag=started_flag, logger=logger,
         coro=aiobindings.condition_chain(
             source=insights.revised, target=container.changed)))
-    tasks.append(aiotasks.create_guarded_task(
+    inner_tasks.append(aiotasks.create_guarded_task(
         name="admission validating configuration manager", flag=started_flag, logger=logger,
         coro=admission.validating_configuration_manager(
             container=container, settings=settings, registry=registry, insights=insights)))
-    tasks.append(aiotasks.create_guarded_task(
+    inner_tasks.append(aiotasks.create_guarded_task(
         name="admission mutating configuration manager", flag=started_flag, logger=logger,
         coro=admission.mutating_configuration_manager(
             container=container, settings=settings, registry=registry, insights=insights)))
-    tasks.append(aiotasks.create_guarded_task(
+    inner_tasks.append(aiotasks.create_guarded_task(
         name="admission webhook server", flag=started_flag, logger=logger,
         coro=admission.admission_webhook_server(
             container=container, settings=settings, registry=registry, insights=insights,
@@ -305,13 +308,13 @@ async def spawn_tasks(
 
     # Permanent observation of what resource kinds and namespaces are available in the cluster.
     # Spawn and cancel dimensional tasks as they come and go; dimensions = resources x namespaces.
-    tasks.append(aiotasks.create_guarded_task(
+    inner_tasks.append(aiotasks.create_guarded_task(
         name="resource observer", flag=started_flag, logger=logger,
         coro=observation.resource_observer(
             insights=insights,
             registry=registry,
             settings=settings)))
-    tasks.append(aiotasks.create_guarded_task(
+    inner_tasks.append(aiotasks.create_guarded_task(
         name="namespace observer", flag=started_flag, logger=logger,
         coro=observation.namespace_observer(
             clusterwide=clusterwide,
@@ -322,11 +325,11 @@ async def spawn_tasks(
     # Explicit command is a hack for the CLI to run coroutines in an operator-like environment.
     # If not specified, then use the normal resource processing. It is not exposed publicly (yet).
     if _command is not None:
-        tasks.append(aiotasks.create_guarded_task(
+        inner_tasks.append(aiotasks.create_guarded_task(
             name="the command", flag=started_flag, logger=logger, finishable=True,
             coro=_command))
     else:
-        tasks.append(aiotasks.create_guarded_task(
+        inner_tasks.append(aiotasks.create_guarded_task(
             name="multidimensional multitasker", flag=started_flag, logger=logger,
             coro=orchestration.orchestrator(
                 settings=settings,
@@ -342,6 +345,27 @@ async def spawn_tasks(
                                             memobase=memo,
                                             operator_paused=operator_paused,
                                             event_queue=event_queue))))
+
+    # It is a list of one task now by default. But a legacy flat list of tasks can be requested
+    # for backwards compatibility; the trade-off: losing the extra safety on termination.
+    # TODO: give them better names.
+    # TODO: maybe wrap the outer_tasks to one final task, too? (but return as [task] for back-compat)
+    tasks: MutableSequence[aiotasks.Task] = []
+    if flat:
+        tasks = outer_tasks + authn_tasks + inner_tasks
+    else:
+        authn_tasks.append(aiotasks.create_guarded_task(
+            name="inner task group", logger=logger, finishable=True,
+            coro=run_group(inner_tasks, name='inner'),
+        ))
+        outer_tasks.append(aiotasks.create_guarded_task(
+            name="client task group", logger=logger, finishable=True,
+            coro=run_group(authn_tasks, name='client'),
+        ))
+        tasks.append(aiotasks.create_guarded_task(
+            name="outer task group", logger=logger, finishable=True,
+            coro=run_group(outer_tasks, name='outer'),
+        ))
 
     # Ensure that all guarded tasks got control for a moment to enter the guard.
     await asyncio.sleep(0)
@@ -361,63 +385,93 @@ async def spawn_tasks(
     return tasks
 
 
+async def run_group(
+        tasks: Collection[aiotasks.Task],
+        *,
+        name: str,
+        return_when: Any = asyncio.FIRST_COMPLETED,
+        timeout: float | None = None,
+        cancel_interval: float | None = 10,
+        exit_interval: float | None = None,
+) -> None:
+    """
+    Orchestrate the tasks and terminate them gracefully when needed.
+
+    The nested tasks are expected to run forever. Their number is limited.
+    Once any of them exits, the whole group and all tasks of the group exit.
+
+    The nested tasks, in turn, can spawn multiple sub-tasks of various purposes.
+    They can be awaited, monitored, or fired-and-forgot.
+
+    The group can be wrapped into its own task and be a part of a bigger group.
+    When the nested group exits, the parent group begins its own termination.
+    This way, we form task termination sequences. But all tasks start at once,
+    unless there is explicit orchestration via the readiness/starting flags.
+    """
+    logger.info(f"🔥 entering {name!r}")
+    # Run the infinite tasks until one of them fails/exits (they never exit normally).
+    # If the operator is cancelled, propagate the cancellation to all the sub-tasks.
+    # There is no graceful period: cancel as soon as possible, but allow them to finish.
+    try:
+        done, pending = await aiotasks.wait(tasks, timeout=timeout, return_when=return_when)
+    except asyncio.CancelledError:
+        logger.info(f"🔥 cancelling {name!r}")
+        await aiotasks.stop(tasks, title=name, logger=logger, cancelled=True, interval=cancel_interval)
+        logger.info(f"🔥 cancelled {name!r}")
+        raise
+
+    # If the operator is intact, but one of the root tasks has exited (successfully or not),
+    # cancel all the remaining root tasks, and gracefully exit other spawned sub-tasks.
+    logger.info(f"🔥 stopping {name!r}")
+    if pending:
+        cancelled, _ = await aiotasks.stop(pending, title=name, logger=logger, interval=exit_interval)
+    else:
+        cancelled = set()
+    logger.info(f"🔥 stopped {name!r}")
+
+    # If succeeded or if cancellation is silenced, re-raise from failed tasks (if any).
+    await aiotasks.reraise(done | cancelled)
+
+
 async def run_tasks(
         root_tasks: Collection[aiotasks.Task],
         *,
         ignored: Collection[aiotasks.Task] = frozenset(),
 ) -> None:
     """
-    Orchestrate the tasks and terminate them gracefully when needed.
+    Orchestrate the operator tasks and terminate them gracefully when needed.
 
     The root tasks are expected to run forever. Their number is limited. Once
     any of them exits, the whole operator and all other root tasks should exit.
 
-    The root tasks, in turn, can spawn multiple sub-tasks of various purposes.
-    They can be awaited, monitored, or fired-and-forgot.
-
     The hung tasks are those that were spawned during the operator runtime,
-    and were not cancelled/exited on the root tasks termination. They are given
-    some extra time to finish, after which they are forcibly terminated too.
+    and were not canceled/exited on the root tasks termination. They are given
+    some extra time to finish, after which they are forcefully terminated too.
 
     .. note::
         Due to implementation details, every task created after the operator's
-        startup is assumed to be a task or a sub-task of the operator.
-        In the end, all tasks are forcibly cancelled. Even if those tasks were
+        startup is deemed to be a task or a sub-task of the operator.
+        In the end, all tasks are forcefully canceled. Even if those tasks were
         created by other means. There is no way to trace who spawned what.
         Only the tasks that existed before the operator startup are ignored
         (for example, those that spawned the operator itself).
     """
 
-    # Run the infinite tasks until one of them fails/exits (they never exit normally).
-    # If the operator is cancelled, propagate the cancellation to all the sub-tasks.
-    # There is no graceful period: cancel as soon as possible, but allow them to finish.
     try:
-        root_done, root_pending = await aiotasks.wait(root_tasks, return_when=asyncio.FIRST_COMPLETED)
+        await run_group(root_tasks, name="Root")
     except asyncio.CancelledError:
-        await aiotasks.stop(root_tasks, title="Root", logger=logger, cancelled=True, interval=10)
         hung_tasks = await aiotasks.all_tasks(ignored=ignored)
         await aiotasks.stop(hung_tasks, title="Hung", logger=logger, cancelled=True, interval=1)
         raise
-
-    # If the operator is intact, but one of the root tasks has exited (successfully or not),
-    # cancel all the remaining root tasks, and gracefully exit other spawned sub-tasks.
-    root_cancelled, _ = await aiotasks.stop(root_pending, title="Root", logger=logger)
+    except Exception:
+        # TODO: terminate properly! (but how did it terminate before?)
+        raise
 
     # After the root tasks are all gone, cancel any spawned sub-tasks (e.g. handlers).
     # If the operator is cancelled, propagate the cancellation to all the sub-tasks.
     # TODO: an assumption! the loop is not fully ours! find a way to cancel only our spawned tasks.
     hung_tasks = await aiotasks.all_tasks(ignored=ignored)
-    try:
-        hung_done, hung_pending = await aiotasks.wait(hung_tasks, timeout=5)
-    except asyncio.CancelledError:
-        await aiotasks.stop(hung_tasks, title="Hung", logger=logger, cancelled=True, interval=1)
-        raise
-
-    # If the operator is intact, but the timeout is reached, forcely cancel the sub-tasks.
-    hung_cancelled, _ = await aiotasks.stop(hung_pending, title="Hung", logger=logger, interval=1)
-
-    # If succeeded or if cancellation is silenced, re-raise from failed tasks (if any).
-    await aiotasks.reraise(root_done | root_cancelled | hung_done | hung_cancelled)
+    await run_group(hung_tasks, name="Hung", timeout=5, return_when=asyncio.ALL_COMPLETED, cancel_interval=1, exit_interval=1)
 
 
 async def _stop_flag_checker(
@@ -478,7 +532,6 @@ async def _ultimate_termination(
 
 
 async def _startup_cleanup_activities(
-        root_tasks: Sequence[aiotasks.Task],  # mutated externally!
         ready_flag: aioadapters.Flag | None,
         started_flag: asyncio.Event,
         registry: registries.OperatorRegistry,
@@ -524,16 +577,6 @@ async def _startup_cleanup_activities(
         await asyncio.Event().wait()
     except asyncio.CancelledError:
         pass
-
-    # Wait for all other root tasks to exit before cleaning up.
-    # Beware: on explicit operator cancellation, there is no graceful period at all.
-    try:
-        current_task = asyncio.current_task()
-        awaited_tasks = {task for task in root_tasks if task is not current_task}
-        await aiotasks.wait(awaited_tasks)
-    except asyncio.CancelledError:
-        logger.warning("Cleanup activity is not executed at all due to cancellation.")
-        raise
 
     # Execute the cleanup activity after all other root tasks are presumably done.
     try:


### PR DESCRIPTION
**Problem:** We now cancel all tasks at once (as soon as any task exits, e.g. an exit-flag waiter). However, some tasks require other tasks to properly terminate. For instance, the peering shutdown in the orchestrator requires the authenticator to continue working. With the current approach, the authenticator exits soon, and the peering cannot shut down and de-register itself properly.

**Solution:** With the new approach, tasks are nested in groups, each group being a task itself. The termination usually starts from the most nested group, and unfolds inside out, terminating the inner groups, then middle groups, then outer groups.

**Limitation:** By this, we break the existing interface where all tasks are returned flat. We replace it with a list of one and only one task — the outermost group. This keeps the public interface intact, assuming the users did what we expected them to do: `spawn_tasks()`, and then pass that list down to `run_tasks()` unmodified. Alternatively, the users could orchestrate tasks their own way — this will work, too (with a list of a single root task). The exposure to the tasks structure will disappear though.

The legacy flat list can be requested (I hope no one needs it, but it is there just in case): `spawn_tasks(…, flat=True)`.

Fixes #1033. Supersedes #1110. Replaced by #1286.

TODOs:

- [ ] Revise the termination in edge cases: regular errors, hung tasks, etc. I have lost it for a moment.
- [ ] Review the timeouts (cancellation, exit) and intervals — to be the same as before the change.
- [ ] Give task groups better names — for log readability (I will have to debug it from logs one day).
- [ ] Maybe: adjust the docs to reflect the proper termination sequence (do we doc it at all?).
- [ ] Adjust tests and add new ones.
- [ ] Remove debug logs (🔥).
