### PR TITLE
Support kubernetes_asyncio as the first-class 3rd-party library

### DIFF
--- a/kopf/_cogs/helpers/thirdparty.py
+++ b/kopf/_cogs/helpers/thirdparty.py
@@ -5,8 +5,16 @@ This utility does all the trickery needed to import the libraries if possible,
 or to skip them and make typing/runtime dummies for the rest of the codebase.
 """
 import abc
-from typing import Any, Protocol, TypeAlias
+from typing import Any, Protocol
 
+# MyPy is very picky on what we re-export, so let's give it what it want.
+# The implicit logic in imports does not work, since we have two similar libraries
+# with same-named classes, but have to distinguish them.
+__all__ = [
+    'V1ObjectMetaSync', 'V1OwnerReferenceSync',
+    'V1ObjectMetaAsync', 'V1OwnerReferenceAsync',
+    'KubernetesModelSync', 'KubernetesModelAsync',
+]
 
 # Since client libraries are optional, support their objects only if they are installed.
 # If not installed, use a dummy class to miss all isinstance() checks for that library.
@@ -22,9 +30,18 @@ except ImportError:
     PykubeObject = _dummy
 
 try:
-    from kubernetes.client import V1ObjectMeta as V1ObjectMeta, V1OwnerReference as V1OwnerReference
+    from kubernetes.client import V1ObjectMeta as V1ObjectMetaSync, \
+                                  V1OwnerReference as V1OwnerReferenceSync
 except ImportError:
-    V1ObjectMeta = V1OwnerReference = None
+    V1ObjectMetaSync = V1OwnerReferenceSync = None
+
+
+# Beware: `kubernetes_asyncio` is type-annotated, unlike `kubernetes`, so more picky.
+try:
+    from kubernetes_asyncio.client import V1ObjectMeta as V1ObjectMetaAsync, \
+                                          V1OwnerReference as V1OwnerReferenceAsync
+except ImportError:
+    V1ObjectMetaAsync = V1OwnerReferenceAsync = None  # type: ignore[misc,assignment]
 
 
 class V1OwnerReferenceProtocol(Protocol):
@@ -46,10 +63,10 @@ class V1ObjectMetaProtocol(Protocol):
 
 # Kubernetes client does not have any common base classes, its code is fully generated.
 # Only recognise classes from a specific module. Ignore all API/HTTP/auth-related tools.
-class KubernetesModel(abc.ABC):
+class KubernetesModelSync(abc.ABC):
     @classmethod
     def __subclasshook__(cls, subcls: Any) -> Any:  # suppress types in this hack
-        if cls is KubernetesModel:
+        if cls is KubernetesModelSync:
             if any(C.__module__.startswith('kubernetes.client.models.') for C in subcls.__mro__):
                 return True
         return NotImplemented
@@ -60,4 +77,22 @@ class KubernetesModel(abc.ABC):
 
     @metadata.setter
     def metadata(self, _: V1ObjectMetaProtocol | None) -> None:
+        raise NotImplementedError
+
+
+# Same-same, but different: when we populate the metadata or inner fields, we use proper classes.
+class KubernetesModelAsync(abc.ABC):
+    @classmethod
+    def __subclasshook__(cls, subcls: Any) -> Any:  # suppress types in this hack
+        if cls is KubernetesModelAsync:
+            if any(C.__module__.startswith('kubernetes_asyncio.client.models.') for C in subcls.__mro__):
+                return True
+        return NotImplemented
+
+    @property
+    def metadata(self) -> V1ObjectMetaAsync | None:
+        raise NotImplementedError
+
+    @metadata.setter
+    def metadata(self, _: V1ObjectMetaAsync | None) -> None:
         raise NotImplementedError

--- a/kopf/_cogs/structs/dicts.py
+++ b/kopf/_cogs/structs/dicts.py
@@ -45,7 +45,7 @@ def parse_field(
 
 
 def resolve_obj(
-        d: thirdparty.KubernetesModel | Mapping[Any, Any] | None,
+        d: thirdparty.KubernetesModelSync | thirdparty.KubernetesModelAsync | Mapping[Any, Any] | None,
         field: FieldSpec,
         default: _T | _UNSET = _UNSET.token,
 ) -> Any | _T:
@@ -63,7 +63,7 @@ def resolve_obj(
             match result:
                 case collections.abc.Mapping():
                     result = result[key]
-                case thirdparty.KubernetesModel():
+                case thirdparty.KubernetesModelSync() | thirdparty.KubernetesModelAsync():
                     attrmap: dict[str, str] = getattr(result, 'attribute_map', {})
                     attrs = [attr for attr, schema_key in attrmap.items() if schema_key == key]
                     key = attrs[0] if attrs else key
@@ -242,7 +242,7 @@ def walk(
         case thirdparty.PykubeObject():
             # Pykube is yielded as an underlying dict, never as its own class.
             yield from walk(objs.obj, nested=nested)
-        case thirdparty.KubernetesModel():
+        case thirdparty.KubernetesModelSync() | thirdparty.KubernetesModelAsync():
             yield objs
             for subfield in (nested if nested is not None else []):
                 try:

--- a/kopf/_kits/hierarchies.py
+++ b/kopf/_kits/hierarchies.py
@@ -12,7 +12,7 @@ from kopf._cogs.structs import bodies, dicts
 from kopf._core.actions import execution
 from kopf._core.intents import causes
 
-K8sObject: TypeAlias = MutableMapping[Any, Any] | thirdparty.PykubeObject | thirdparty.KubernetesModel
+K8sObject: TypeAlias = MutableMapping[Any, Any] | thirdparty.PykubeObject | thirdparty.KubernetesModelSync | thirdparty.KubernetesModelAsync
 K8sObjects: TypeAlias = K8sObject | Iterable[K8sObject]
 
 
@@ -44,14 +44,29 @@ def append_owner_reference(
                 refs = obj.setdefault('metadata', {}).setdefault('ownerReferences', [])
                 if not any(ref.get('uid') == owner_ref['uid'] for ref in refs):
                     refs.append(owner_ref)
-            case thirdparty.KubernetesModel():
+            case thirdparty.KubernetesModelSync():
                 if obj.metadata is None:
-                    obj.metadata = thirdparty.V1ObjectMeta()
+                    obj.metadata = thirdparty.V1ObjectMetaSync()
                 if obj.metadata.owner_references is None:
                     obj.metadata.owner_references = []
                 refs = obj.metadata.owner_references
                 if not any(ref.uid == owner_ref['uid'] for ref in refs):
-                    refs.append(thirdparty.V1OwnerReference(
+                    refs.append(thirdparty.V1OwnerReferenceSync(
+                        api_version=owner_ref['apiVersion'],
+                        kind=owner_ref['kind'],
+                        name=owner_ref['name'],
+                        uid=owner_ref['uid'],
+                        controller=owner_ref['controller'],
+                        block_owner_deletion=owner_ref['blockOwnerDeletion'],
+                    ))
+            case thirdparty.KubernetesModelAsync():
+                if obj.metadata is None:
+                    obj.metadata = thirdparty.V1ObjectMetaAsync()
+                if obj.metadata.owner_references is None:
+                    obj.metadata.owner_references = []
+                refs = obj.metadata.owner_references
+                if not any(ref.uid == owner_ref['uid'] for ref in refs):
+                    refs.append(thirdparty.V1OwnerReferenceAsync(
                         api_version=owner_ref['apiVersion'],
                         kind=owner_ref['kind'],
                         name=owner_ref['name'],
@@ -82,9 +97,17 @@ def remove_owner_reference(
                 refs = obj.setdefault('metadata', {}).setdefault('ownerReferences', [])
                 if any(ref.get('uid') == owner_ref['uid'] for ref in refs):
                     refs[:] = [ref for ref in refs if ref.get('uid') != owner_ref['uid']]
-            case thirdparty.KubernetesModel():
+            case thirdparty.KubernetesModelSync():
                 if obj.metadata is None:
-                    obj.metadata = thirdparty.V1ObjectMeta()
+                    obj.metadata = thirdparty.V1ObjectMetaSync()
+                if obj.metadata.owner_references is None:
+                    obj.metadata.owner_references = []
+                refs = obj.metadata.owner_references
+                if any(ref.uid == owner_ref['uid'] for ref in refs):
+                    refs[:] = [ref for ref in refs if ref.uid != owner_ref['uid']]
+            case thirdparty.KubernetesModelAsync():
+                if obj.metadata is None:
+                    obj.metadata = thirdparty.V1ObjectMetaAsync()
                 if obj.metadata.owner_references is None:
                     obj.metadata.owner_references = []
                 refs = obj.metadata.owner_references
@@ -123,9 +146,15 @@ def label(
         match obj:
             case collections.abc.MutableMapping():
                 obj_labels = obj.setdefault('metadata', {}).setdefault('labels', {})
-            case thirdparty.KubernetesModel():
+            case thirdparty.KubernetesModelSync():
                 if obj.metadata is None:
-                    obj.metadata = thirdparty.V1ObjectMeta()
+                    obj.metadata = thirdparty.V1ObjectMetaSync()
+                if obj.metadata.labels is None:
+                    obj.metadata.labels = {}
+                obj_labels = obj.metadata.labels
+            case thirdparty.KubernetesModelAsync():
+                if obj.metadata is None:
+                    obj.metadata = thirdparty.V1ObjectMetaAsync()
                 if obj.metadata.labels is None:
                     obj.metadata.labels = {}
                 obj_labels = obj.metadata.labels
@@ -185,9 +214,9 @@ def harmonize_naming(
                         obj.setdefault('metadata', {})['generateName'] = f'{name}-'
                         if 'name' in obj['metadata']:
                             del obj['metadata']['name']
-            case thirdparty.KubernetesModel():
+            case thirdparty.KubernetesModelSync():
                 if obj.metadata is None:
-                    obj.metadata = thirdparty.V1ObjectMeta()
+                    obj.metadata = thirdparty.V1ObjectMetaSync()
                 noname = obj.metadata.name is None and obj.metadata.generate_name is None
                 if forced or noname:
                     if strict:
@@ -198,6 +227,21 @@ def harmonize_naming(
                         obj.metadata.generate_name = f'{name}-'
                         if obj.metadata.name is not None:
                             obj.metadata.name = None
+            case thirdparty.KubernetesModelAsync():
+                if obj.metadata is None:
+                    obj.metadata = thirdparty.V1ObjectMetaAsync()
+                noname = obj.metadata.name is None and obj.metadata.generate_name is None
+                if forced or noname:
+                    # Types: we are right, kubernetes_asyncio is wrong: it declares names as str,
+                    # while the initial values are None, and there is no way to reset the names.
+                    if strict:
+                        obj.metadata.name = name
+                        if obj.metadata.generate_name is not None:
+                            obj.metadata.generate_name = None  # type: ignore[assignment]
+                    else:
+                        obj.metadata.generate_name = f'{name}-'
+                        if obj.metadata.name is not None:
+                            obj.metadata.name = None  # type: ignore[assignment]
             case _:
                 raise TypeError(f"K8s object class is not supported: {type(obj)}")
 
@@ -231,11 +275,18 @@ def adjust_namespace(
             case collections.abc.MutableMapping():
                 if forced or obj.get('metadata', {}).get('namespace') is None:
                     obj.setdefault('metadata', {})['namespace'] = namespace
-            case thirdparty.KubernetesModel():
+            case thirdparty.KubernetesModelSync():
                 if obj.metadata is None:
-                    obj.metadata = thirdparty.V1ObjectMeta()
+                    obj.metadata = thirdparty.V1ObjectMetaSync()
                 if forced or obj.metadata.namespace is None:
                     obj.metadata.namespace = namespace
+            case thirdparty.KubernetesModelAsync():
+                if obj.metadata is None:
+                    obj.metadata = thirdparty.V1ObjectMetaAsync()
+                if forced or obj.metadata.namespace is None:
+                    # Types: we are right, kubernetes_asyncio is wrong: it declares names as str,
+                    # while the initial values are None, and there is no way to reset the names.
+                    obj.metadata.namespace = namespace  # type: ignore[assignment]
             case _:
                 raise TypeError(f"K8s object class is not supported: {type(obj)}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -399,6 +399,16 @@ def _with_module_absent(name: str):
         assert mod_after is mod_before
 
 
+@pytest.fixture(params=[True], ids=['with-async-client'])  # for hinting suffixes
+def kubernetes_asyncio():
+    yield from _with_module_present('kubernetes_asyncio')
+
+
+@pytest.fixture(params=[True], ids=['no-async-client'])  # for hinting suffixes
+def no_kubernetes_asyncio():
+    yield from _with_module_absent('kubernetes_asyncio')
+
+
 @pytest.fixture(params=[True], ids=['with-client'])  # for hinting suffixes
 def kubernetes():
     yield from _with_module_present('kubernetes')

--- a/tests/hierarchies/conftest.py
+++ b/tests/hierarchies/conftest.py
@@ -39,3 +39,16 @@ def kubernetes_model(kubernetes):
         ),
     )
     return obj
+
+
+@pytest.fixture()
+def kubernetes_asyncio_model(kubernetes_asyncio):
+    # The most tricky class -- with attribute-to-key mapping (jobTemplate).
+    obj = kubernetes_asyncio.client.V1CronJob(
+        metadata=kubernetes_asyncio.client.V1ObjectMeta(),
+        spec=kubernetes_asyncio.client.V1CronJobSpec(
+            schedule='* * * * *',
+            job_template=kubernetes_asyncio.client.V1JobTemplateSpec(),
+        ),
+    )
+    return obj

--- a/tests/hierarchies/test_labelling.py
+++ b/tests/hierarchies/test_labelling.py
@@ -56,6 +56,16 @@ def test_adding_to_kubernetes_model(kubernetes_model):
     assert kubernetes_model.metadata.labels['label-2'] == 'value-2'
 
 
+def test_adding_to_kubernetes_asyncio_model(kubernetes_asyncio_model):
+    kubernetes_asyncio_model.metadata = None
+    kopf.label(kubernetes_asyncio_model, {'label-1': 'value-1', 'label-2': 'value-2'})
+    assert len(kubernetes_asyncio_model.metadata.labels) == 2
+    assert 'label-1' in kubernetes_asyncio_model.metadata.labels
+    assert 'label-2' in kubernetes_asyncio_model.metadata.labels
+    assert kubernetes_asyncio_model.metadata.labels['label-1'] == 'value-1'
+    assert kubernetes_asyncio_model.metadata.labels['label-2'] == 'value-2'
+
+
 def test_forcing_true_warns_on_deprecated_option():
     obj = {'metadata': {'labels': {'label': 'old-value'}}}
     with pytest.deprecated_call(match=r"use forced="):
@@ -124,6 +134,24 @@ def test_forcing_default_to_kubernetes_model(kubernetes_model):
     assert kubernetes_model.metadata.labels['label'] == 'old-value'
 
 
+def test_forcing_true_to_kubernetes_asyncio_model(kubernetes_asyncio_model):
+    kubernetes_asyncio_model.metadata.labels = {'label': 'old-value'}
+    kopf.label(kubernetes_asyncio_model, {'label': 'new-value'}, forced=True)
+    assert kubernetes_asyncio_model.metadata.labels['label'] == 'new-value'
+
+
+def test_forcing_false_to_kubernetes_asyncio_model(kubernetes_asyncio_model):
+    kubernetes_asyncio_model.metadata.labels = {'label': 'old-value'}
+    kopf.label(kubernetes_asyncio_model, {'label': 'new-value'}, forced=False)
+    assert kubernetes_asyncio_model.metadata.labels['label'] == 'old-value'
+
+
+def test_forcing_default_to_kubernetes_asyncio_model(kubernetes_asyncio_model):
+    kubernetes_asyncio_model.metadata.labels = {'label': 'old-value'}
+    kopf.label(kubernetes_asyncio_model, {'label': 'new-value'})
+    assert kubernetes_asyncio_model.metadata.labels['label'] == 'old-value'
+
+
 @pytest.mark.parametrize('nested', [
     pytest.param(('spec.jobTemplate', 'spec.unexistent'), id='tuple'),
     pytest.param(['spec.jobTemplate', 'spec.unexistent'], id='list'),
@@ -168,6 +196,21 @@ def test_nested_with_forced_true_to_kubernetes_model(nested, kubernetes_model):
     assert not hasattr(kubernetes_model.spec, 'unexistent')
 
 
+
+@pytest.mark.parametrize('nested', [
+    pytest.param(('spec.jobTemplate', 'spec.unexistent'), id='tuple'),
+    pytest.param(['spec.jobTemplate', 'spec.unexistent'], id='list'),
+    pytest.param({'spec.jobTemplate', 'spec.unexistent'}, id='set'),
+    pytest.param('spec.jobTemplate', id='string'),
+])
+def test_nested_with_forced_true_to_kubernetes_asyncio_model(nested, kubernetes_asyncio_model):
+    kubernetes_asyncio_model.metadata.labels = {'label': 'old-value'}
+    kopf.label(kubernetes_asyncio_model, {'label': 'new-value'}, nested=nested, forced=True)
+    assert kubernetes_asyncio_model.metadata.labels['label'] == 'new-value'
+    assert kubernetes_asyncio_model.spec.job_template.metadata.labels['label'] == 'new-value'
+    assert not hasattr(kubernetes_asyncio_model.spec, 'unexistent')
+
+
 @pytest.mark.parametrize('nested', [
     pytest.param(('spec.jobTemplate', 'spec.unexistent'), id='tuple'),
     pytest.param(['spec.jobTemplate', 'spec.unexistent'], id='list'),
@@ -210,3 +253,17 @@ def test_nested_with_forced_false_to_kubernetes_model(nested, kubernetes_model):
     assert kubernetes_model.metadata.labels['label'] == 'old-value'
     assert kubernetes_model.spec.job_template.metadata.labels['label'] == 'new-value'
     assert not hasattr(kubernetes_model.spec, 'unexistent')
+
+
+@pytest.mark.parametrize('nested', [
+    pytest.param(('spec.jobTemplate', 'spec.unexistent'), id='tuple'),
+    pytest.param(['spec.jobTemplate', 'spec.unexistent'], id='list'),
+    pytest.param({'spec.jobTemplate', 'spec.unexistent'}, id='set'),
+    pytest.param('spec.jobTemplate', id='string'),
+])
+def test_nested_with_forced_false_to_kubernetes_asyncio_model(nested, kubernetes_asyncio_model):
+    kubernetes_asyncio_model.metadata.labels = {'label': 'old-value'}
+    kopf.label(kubernetes_asyncio_model, {'label': 'new-value'}, nested=nested, forced=False)
+    assert kubernetes_asyncio_model.metadata.labels['label'] == 'old-value'
+    assert kubernetes_asyncio_model.spec.job_template.metadata.labels['label'] == 'new-value'
+    assert not hasattr(kubernetes_asyncio_model.spec, 'unexistent')

--- a/tests/hierarchies/test_name_harmonizing.py
+++ b/tests/hierarchies/test_name_harmonizing.py
@@ -97,6 +97,17 @@ def test_preserved_names_of_kubernetes_model(forcedness, strictness, kubernetes_
     assert kubernetes_model.metadata.generate_name != 'provided-name'
 
 
+@obj1_with_names
+@any_strict_mode
+@non_forced_mode
+def test_preserved_names_of_kubernetes_asyncio_model(forcedness, strictness, kubernetes_asyncio_model, obj1):
+    kubernetes_asyncio_model.metadata.name = obj1.get('metadata', {}).get('name')
+    kubernetes_asyncio_model.metadata.generate_name = obj1.get('metadata', {}).get('generateName')
+    kopf.harmonize_naming(kubernetes_asyncio_model, name='provided-name', **forcedness, **strictness)
+    assert kubernetes_asyncio_model.metadata.name != 'provided-name'
+    assert kubernetes_asyncio_model.metadata.generate_name != 'provided-name'
+
+
 # In the FORCED mode, the EXISTING names are overwritten.
 # It only depends which of the names -- regular or generated -- is left.
 @obj1_with_names
@@ -148,6 +159,17 @@ def test_overwriting_of_strict_name_of_kubernetes_model(forcedness, strictness, 
 
 
 @obj1_with_names
+@strict_mode
+@forced_mode
+def test_overwriting_of_strict_name_of_kubernetes_asyncio_model(forcedness, strictness, kubernetes_asyncio_model, obj1):
+    kubernetes_asyncio_model.metadata.name = obj1.get('metadata', {}).get('name')
+    kubernetes_asyncio_model.metadata.generate_name = obj1.get('metadata', {}).get('generateName')
+    kopf.harmonize_naming(kubernetes_asyncio_model, name='provided-name', **forcedness, **strictness)
+    assert kubernetes_asyncio_model.metadata.name == 'provided-name'
+    assert kubernetes_asyncio_model.metadata.generate_name is None
+
+
+@obj1_with_names
 @non_strict_mode
 @forced_mode
 def test_overwriting_of_relaxed_name_of_dict(forcedness, strictness, obj1):
@@ -193,6 +215,17 @@ def test_overwriting_of_relaxed_name_of_kubernetes_model(forcedness, strictness,
     kopf.harmonize_naming(kubernetes_model, name='provided-name', **forcedness, **strictness)
     assert kubernetes_model.metadata.name is None
     assert kubernetes_model.metadata.generate_name == 'provided-name-'
+
+
+@obj1_with_names
+@non_strict_mode
+@forced_mode
+def test_overwriting_of_relaxed_name_of_kubernetes_asyncio_model(forcedness, strictness, kubernetes_asyncio_model, obj1):
+    kubernetes_asyncio_model.metadata.name = obj1.get('metadata', {}).get('name')
+    kubernetes_asyncio_model.metadata.generate_name = obj1.get('metadata', {}).get('generateName')
+    kopf.harmonize_naming(kubernetes_asyncio_model, name='provided-name', **forcedness, **strictness)
+    assert kubernetes_asyncio_model.metadata.name is None
+    assert kubernetes_asyncio_model.metadata.generate_name == 'provided-name-'
 
 
 # When names are ABSENT, they are added regardless of the forced mode.
@@ -243,6 +276,15 @@ def test_assignment_of_strict_name_of_kubernetes_model(forcedness, strictness, k
     assert kubernetes_model.metadata.generate_name is None
 
 
+@strict_mode
+@any_forced_mode
+def test_assignment_of_strict_name_of_kubernetes_asyncio_model(forcedness, strictness, kubernetes_asyncio_model):
+    kubernetes_asyncio_model.metadata = None
+    kopf.harmonize_naming(kubernetes_asyncio_model, name='provided-name', **forcedness, **strictness)
+    assert kubernetes_asyncio_model.metadata.name == 'provided-name'
+    assert kubernetes_asyncio_model.metadata.generate_name is None
+
+
 @obj1_without_names
 @non_strict_mode
 @any_forced_mode
@@ -287,3 +329,12 @@ def test_assignment_of_nonstrict_name_of_kubernetes_model(forcedness, strictness
     kopf.harmonize_naming(kubernetes_model, name='provided-name', **forcedness, **strictness)
     assert kubernetes_model.metadata.name is None
     assert kubernetes_model.metadata.generate_name == 'provided-name-'
+
+
+@non_strict_mode
+@any_forced_mode
+def test_assignment_of_nonstrict_name_of_kubernetes_asyncio_model(forcedness, strictness, kubernetes_asyncio_model):
+    kubernetes_asyncio_model.metadata = None
+    kopf.harmonize_naming(kubernetes_asyncio_model, name='provided-name', **forcedness, **strictness)
+    assert kubernetes_asyncio_model.metadata.name is None
+    assert kubernetes_asyncio_model.metadata.generate_name == 'provided-name-'

--- a/tests/hierarchies/test_namespace_adjusting.py
+++ b/tests/hierarchies/test_namespace_adjusting.py
@@ -72,6 +72,14 @@ def test_preserved_namespace_of_kubernetes_model(forcedness, kubernetes_model, o
     assert kubernetes_model.metadata.namespace != 'provided-namespace'
 
 
+@obj1_with_namespace
+@non_forced_mode
+def test_preserved_namespace_of_kubernetes_asyncio_model(forcedness, kubernetes_asyncio_model, obj1):
+    kubernetes_asyncio_model.metadata.namespace = obj1.get('metadata', {}).get('namespace')
+    kopf.adjust_namespace(kubernetes_asyncio_model, namespace='provided-namespace', **forcedness)
+    assert kubernetes_asyncio_model.metadata.namespace != 'provided-namespace'
+
+
 #
 # In the FORCED mode, the EXISTING namespaces are overwritten.
 #
@@ -113,6 +121,14 @@ def test_overwriting_namespace_of_kubernetes_model(forcedness, kubernetes_model,
     assert kubernetes_model.metadata.namespace == 'provided-namespace'
 
 
+@obj1_with_namespace
+@forced_mode
+def test_overwriting_namespace_of_kubernetes_asyncio_model(forcedness, kubernetes_asyncio_model, obj1):
+    kubernetes_asyncio_model.metadata.namespace = obj1.get('metadata', {}).get('namespace')
+    kopf.adjust_namespace(kubernetes_asyncio_model, namespace='provided-namespace', **forcedness)
+    assert kubernetes_asyncio_model.metadata.namespace == 'provided-namespace'
+
+
 #
 # When namespaces are ABSENT, they are added regardless of the forced mode.
 #
@@ -151,3 +167,10 @@ def test_assignment_namespace_of_kubernetes_model(forcedness, kubernetes_model):
     kubernetes_model.metadata = None
     kopf.adjust_namespace(kubernetes_model, namespace='provided-namespace', **forcedness)
     assert kubernetes_model.metadata.namespace == 'provided-namespace'
+
+
+@any_forced_mode
+def test_assignment_namespace_of_kubernetes_asyncio_model(forcedness, kubernetes_asyncio_model):
+    kubernetes_asyncio_model.metadata = None
+    kopf.adjust_namespace(kubernetes_asyncio_model, namespace='provided-namespace', **forcedness)
+    assert kubernetes_asyncio_model.metadata.namespace == 'provided-namespace'

--- a/tests/hierarchies/test_owner_referencing.py
+++ b/tests/hierarchies/test_owner_referencing.py
@@ -93,6 +93,19 @@ def test_appending_to_kubernetes_model(kubernetes_model):
     assert kubernetes_model.metadata.owner_references[0].uid == OWNER_UID
 
 
+def test_appending_to_kubernetes_asyncio_model(kubernetes_asyncio_model):
+    kubernetes_asyncio_model.metadata = None
+    kopf.append_owner_reference(kubernetes_asyncio_model, owner=Body(OWNER))
+    assert kubernetes_asyncio_model.metadata is not None
+    assert kubernetes_asyncio_model.metadata.owner_references is not None
+    assert isinstance(kubernetes_asyncio_model.metadata.owner_references, list)
+    assert len(kubernetes_asyncio_model.metadata.owner_references) == 1
+    assert kubernetes_asyncio_model.metadata.owner_references[0].api_version == OWNER_API_VERSION
+    assert kubernetes_asyncio_model.metadata.owner_references[0].kind == OWNER_KIND
+    assert kubernetes_asyncio_model.metadata.owner_references[0].name == OWNER_NAME
+    assert kubernetes_asyncio_model.metadata.owner_references[0].uid == OWNER_UID
+
+
 def test_appending_deduplicates_by_uid():
     """
     The uid is the only necessary criterion to identify same objects.
@@ -187,6 +200,16 @@ def test_removal_from_kubernetes_model(kubernetes_model):
     assert kubernetes_model.metadata.owner_references is not None
     assert isinstance(kubernetes_model.metadata.owner_references, list)
     assert len(kubernetes_model.metadata.owner_references) == 0
+
+
+def test_removal_from_kubernetes_asyncio_model(kubernetes_asyncio_model):
+    kubernetes_asyncio_model.metadata = None
+    kopf.append_owner_reference(kubernetes_asyncio_model, owner=Body(OWNER))
+    kopf.remove_owner_reference(kubernetes_asyncio_model, owner=Body(OWNER))
+    assert kubernetes_asyncio_model.metadata is not None
+    assert kubernetes_asyncio_model.metadata.owner_references is not None
+    assert isinstance(kubernetes_asyncio_model.metadata.owner_references, list)
+    assert len(kubernetes_asyncio_model.metadata.owner_references) == 0
 
 
 def test_removal_identifies_by_uid():

--- a/tests/test_absent_modules.py
+++ b/tests/test_absent_modules.py
@@ -5,6 +5,12 @@ Otherwise, the tests are useless or can show false-positives.
 import pytest
 
 
+@pytest.mark.usefixtures('no_kubernetes_asyncio')
+def test_client_asyncio_uninstalled_has_effect():
+    with pytest.raises(ImportError):
+        import kubernetes_asyncio
+
+
 @pytest.mark.usefixtures('no_kubernetes')
 def test_client_uninstalled_has_effect():
     with pytest.raises(ImportError):

--- a/tests/test_thirdparty.py
+++ b/tests/test_thirdparty.py
@@ -2,21 +2,21 @@ import types
 
 import pytest
 
-from kopf._cogs.helpers.thirdparty import KubernetesModel
+from kopf._cogs.helpers.thirdparty import KubernetesModelSync
 
 
 @pytest.mark.parametrize('name', ['V1Pod', 'V1ObjectMeta', 'V1PodSpec', 'V1PodTemplateSpec'])
 def test_kubernetes_model_classes_detection(kubernetes, name):
     cls = getattr(kubernetes.client, name)
-    assert issubclass(cls, KubernetesModel)
+    assert issubclass(cls, KubernetesModelSync)
 
 
 @pytest.mark.parametrize('name', ['CoreV1Api', 'ApiClient', 'Configuration'])
 def test_kubernetes_other_classes_detection(kubernetes, name):
     cls = getattr(kubernetes.client, name)
-    assert not issubclass(cls, KubernetesModel)
+    assert not issubclass(cls, KubernetesModelSync)
 
 
 @pytest.mark.parametrize('cls', [object, types.SimpleNamespace])
 def test_non_kubernetes_classes_detection(kubernetes, cls):
-    assert not issubclass(cls, KubernetesModel)
+    assert not issubclass(cls, KubernetesModelSync)


### PR DESCRIPTION
Authentication piggybacking was implemented some time ago. Now, it is time to properly support all its models for hierarchy management.

* #1010 

Closes #809 (supersedes it), closes #806 (properly).
