### PR TITLE
Switch all bundled storages from merge-patches to json-patches

### DIFF
--- a/kopf/_cogs/configs/conventions.py
+++ b/kopf/_cogs/configs/conventions.py
@@ -31,12 +31,13 @@ in most cases, they will be used as the annotation names with special symbols
 replaced; in some cases, they will be cut and hash-suffixed.
 """
 import base64
+import functools
 import hashlib
 import warnings
 from collections.abc import Collection, Iterable
 from typing import Any
 
-from kopf._cogs.structs import bodies, patches
+from kopf._cogs.structs import bodies, dicts, patches
 
 
 class CollisionEvadingConvention:
@@ -254,8 +255,8 @@ class StorageKeyMarkingConvention:
         value = 'yes'
         if prefix and not prefix.startswith('kopf.'):
             marker = f'{prefix}/kopf-managed'
-            if marker not in body.metadata.annotations and marker not in patch.metadata.annotations:
-                patch.metadata.annotations[marker] = value
+            key_field = ['metadata', 'annotations', marker]
+            patch.fns.append(functools.partial(dicts.ensure, field=key_field, value=value))
 
 
 class StorageStanzaCleaner:

--- a/kopf/_cogs/configs/diffbase.py
+++ b/kopf/_cogs/configs/diffbase.py
@@ -1,5 +1,6 @@
 import abc
 import copy
+import functools
 import json
 from collections.abc import Collection, Iterable
 from typing import Any, cast
@@ -163,7 +164,8 @@ class AnnotationsDiffBaseStorage(conventions.StorageKeyFormingConvention, DiffBa
         encoded: str = json.dumps(essence, separators=(',', ':'))  # NB: no spaces
         encoded += '\n'  # for better kubectl presentation without wrapping (same as kubectl's one)
         for full_key in self.make_keys(self.key, body=body):
-            patch.metadata.annotations[full_key] = encoded
+            field = ['metadata', 'annotations', full_key]
+            patch.fns.append(functools.partial(dicts.ensure, field=field, value=encoded))
         self._store_marker(prefix=self.prefix, patch=patch, body=body)
 
 
@@ -222,7 +224,7 @@ class StatusDiffBaseStorage(DiffBaseStorage):
     ) -> None:
         # Store as a single string instead of full dict -- to avoid merges and unexpected data.
         encoded: str = json.dumps(essence, separators=(',', ':'))  # NB: no spaces
-        dicts.ensure(patch, self.field, encoded)
+        patch.fns.append(functools.partial(dicts.ensure, field=self.field, value=encoded))
 
 
 class MultiDiffBaseStorage(DiffBaseStorage):

--- a/kopf/_cogs/configs/progress.py
+++ b/kopf/_cogs/configs/progress.py
@@ -40,6 +40,7 @@ All timestamps are strings in ISO8601 format in UTC (no explicit ``Z`` suffix).
 """
 import abc
 import copy
+import functools
 import json
 from collections.abc import Collection
 from typing import Any, TypedDict, cast
@@ -199,7 +200,7 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
         encoded = json.dumps(decoded, separators=(',', ':'))  # NB: no spaces
         for full_key in self.make_keys(key, body=body):
             key_field = ['metadata', 'annotations', full_key]
-            dicts.ensure(patch, key_field, encoded)
+            patch.fns.append(functools.partial(dicts.ensure, field=key_field, value=encoded))
         self._store_marker(prefix=self.prefix, patch=patch, body=body)
 
     def purge(
@@ -209,15 +210,9 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
             body: bodies.Body,
             patch: patches.Patch,
     ) -> None:
-        absent = object()
         for full_key in self.make_keys(key, body=body):
             key_field = ['metadata', 'annotations', full_key]
-            body_value = dicts.resolve(body, key_field, absent)
-            patch_value = dicts.resolve(patch, key_field, absent)
-            if body_value is not absent:
-                dicts.ensure(patch, key_field, None)
-            elif patch_value is not absent:
-                dicts.remove(patch, key_field)
+            patch.fns.append(functools.partial(dicts.remove, field=key_field))
 
     def touch(
             self,
@@ -228,10 +223,8 @@ class AnnotationsProgressStorage(conventions.StorageKeyFormingConvention,
     ) -> None:
         for full_key in self.make_keys(self.touch_key, body=body):
             key_field = ['metadata', 'annotations', full_key]
-            body_value = dicts.resolve(body, key_field, None)
-            if body_value != value:  # also covers absent-vs-None cases.
-                dicts.ensure(patch, key_field, value)
-                self._store_marker(prefix=self.prefix, patch=patch, body=body)
+            patch.fns.append(functools.partial(dicts.ensure, field=key_field, value=value))
+        self._store_marker(prefix=self.prefix, patch=patch, body=body)
 
     def clear(self, *, essence: bodies.BodyEssence) -> bodies.BodyEssence:
         essence = super().clear(essence=essence)
@@ -329,7 +322,7 @@ class StatusProgressStorage(ProgressStorage):
             patch: patches.Patch,
     ) -> None:
         # Nones are cleaned by K8s API itself.
-        dicts.ensure(patch, self.field + (key,), record)
+        patch.fns.append(functools.partial(dicts.ensure, field=self.field + (key,), value=record))
 
     def purge(
             self,
@@ -338,14 +331,7 @@ class StatusProgressStorage(ProgressStorage):
             body: bodies.Body,
             patch: patches.Patch,
     ) -> None:
-        absent = object()
-        key_field = self.field + (key,)
-        body_value = dicts.resolve(body, key_field, absent)
-        patch_value = dicts.resolve(patch, key_field, absent)
-        if body_value is not absent:
-            dicts.ensure(patch, key_field, None)
-        elif patch_value is not absent:
-            dicts.remove(patch, key_field)
+        patch.fns.append(functools.partial(dicts.remove, field=self.field + (key,)))
 
     def touch(
             self,
@@ -354,10 +340,7 @@ class StatusProgressStorage(ProgressStorage):
             patch: patches.Patch,
             value: str | None,
     ) -> None:
-        key_field = self.touch_field
-        body_value = dicts.resolve(body, key_field, None)
-        if body_value != value:  # also covers absent-vs-None cases.
-            dicts.ensure(patch, key_field, value)
+        patch.fns.append(functools.partial(dicts.ensure, field=self.touch_field, value=value))
 
     def clear(self, *, essence: bodies.BodyEssence) -> bodies.BodyEssence:
         essence = super().clear(essence=essence)


### PR DESCRIPTION
**NOTE: Not for merging!** I'm opening and keeping it here just for history (I can easily lose a branch). It is a proposal to convert all remaining internal patches from merge-patches to json-patches. Not merged because the benefits are unclear and insignificant (see the counter-argument below). But for the finalization of the idea, it is how it could look like — if I return to this topic in the future. Prerequisites:

* #1253
* #1252 

---

Since we are already doing the JSON-patches for some operations (finalizers management), there is no reason to keep merge-patches in place. They only increase the number of PATCH API calls, leading to the same results in the end.

The downside is that we get somewhat chaotic code with callbacks (partials or closures), and wordy logs with remaining patches consisting of bound methods (reprs). Yet the k8s clusters should feel the ease in terms of the reduced API load.

**The counter-argument:** the json-patches for finalizers were really a minor overhead happening twice per the object lifecycle (at creation and deletion). The users likely use the merge-patches, so they are unavoidable. At best, this change can improve the "out of the box" behaviour on very heavy clusters. But such advanced users can implement their storage with json-patches, or move the storage to external systems (not annotations/status at all). All in all, the gain is insignificant.

TODOs:

- [ ] Adjust tests.