### PR TITLE
Postpone the cancellation of authenticator to the very last moment

### DIFF
--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -197,6 +197,7 @@ async def spawn_tasks(
     started_flag: asyncio.Event = asyncio.Event()
     operator_paused = aiotoggles.ToggleSet(any)
     tasks: MutableSequence[aiotasks.Task] = []
+    core_tasks: MutableSequence[aiotasks.Task] = []
 
     # Map kwargs into the settings object.
     settings.peering.clusterwide = clusterwide
@@ -233,6 +234,7 @@ async def spawn_tasks(
         name="startup/cleanup activities",
         coro=startup_cleanup_activities(
             root_tasks=tasks,  # used as a "live" view, populated later.
+            core_tasks=core_tasks,
             ready_flag=ready_flag,
             started_flag=started_flag,
             registry=registry,
@@ -250,7 +252,7 @@ async def spawn_tasks(
             operator_paused=operator_paused)))
 
     # Keeping the credentials fresh and valid via the authentication handlers on demand.
-    tasks.append(aiotasks.create_guarded_task(
+    core_tasks.append(aiotasks.create_guarded_task(
         name="credentials retriever", flag=started_flag, logger=logger,
         coro=activities.authenticator(
             registry=registry,
@@ -479,6 +481,7 @@ async def ultimate_termination(
 
 async def startup_cleanup_activities(
         root_tasks: Sequence[aiotasks.Task],  # mutated externally!
+        core_tasks: Sequence[aiotasks.Task],  # mutated externally!
         ready_flag: aioadapters.Flag | None,
         started_flag: asyncio.Event,
         registry: registries.OperatorRegistry,
@@ -501,39 +504,51 @@ async def startup_cleanup_activities(
     """
     logger.debug(f"Starting Kopf {versions.version or '(unknown version)'}.")
 
-    # Execute the startup activity before any root task starts running (due to readiness flag).
     try:
-        await activities.run_activity(
-            lifecycle=lifecycles.all_at_once,
-            registry=registry,
-            settings=settings,
-            activity=causes.Activity.STARTUP,
-            indices=indices,
-            memo=memo,
-        )
-    except asyncio.CancelledError:
-        logger.warning("Startup activity is only partially executed due to cancellation.")
-        raise
+        # Execute the startup activity before any root task starts running (due to readiness flag).
+        try:
+            await activities.run_activity(
+                lifecycle=lifecycles.all_at_once,
+                registry=registry,
+                settings=settings,
+                activity=causes.Activity.STARTUP,
+                indices=indices,
+                memo=memo,
+            )
+        except asyncio.CancelledError:
+            logger.warning("Startup activity is only partially executed due to cancellation.")
+            raise
 
-    # Notify the caller that we are ready to be executed. This unfreezes all the root tasks.
-    started_flag.set()
-    await aioadapters.raise_flag(ready_flag)
+        # Notify the caller that we are ready to be executed. This unfreezes all the root tasks.
+        started_flag.set()
+        await aioadapters.raise_flag(ready_flag)
 
-    # Sleep forever, or until cancelled, which happens when the operator begins its shutdown.
-    try:
-        await asyncio.Event().wait()
-    except asyncio.CancelledError:
-        pass
+        # Sleep forever, or until cancelled, which happens when the operator begins its shutdown.
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            pass
 
-    # Wait for all other root tasks to exit before cleaning up.
-    # Beware: on explicit operator cancellation, there is no graceful period at all.
-    try:
-        current_task = asyncio.current_task()
-        awaited_tasks = {task for task in root_tasks if task is not current_task}
-        await aiotasks.wait(awaited_tasks)
-    except asyncio.CancelledError:
-        logger.warning("Cleanup activity is not executed at all due to cancellation.")
-        raise
+        # Wait for all other root tasks to exit before cleaning up.
+        # Beware: on explicit operator cancellation, there is no graceful period at all.
+        try:
+            current_task = asyncio.current_task()
+            awaited_tasks = {task for task in root_tasks if task is not current_task}
+            await aiotasks.wait(awaited_tasks)
+        except asyncio.CancelledError:
+            logger.warning("Cleanup activity is not executed at all due to cancellation.")
+            raise
+    finally:
+        # Cancel the special "core" tasks after all "root" tasks are gone (happy path)
+        # or when the startup/cleanup activities are cancelled (operator termination case).
+        # The "core" tasks are excluded from "root" tasks, so not canceled with them.
+        # We own and manage "core" tasks, we cannot let them remain unattended or orphaned.
+        try:
+            core_done, _ = await aiotasks.stop(core_tasks, title="Core", logger=logger, interval=10)
+            await aiotasks.reraise(core_done)
+        except asyncio.CancelledError:
+            logger.warning("Cleanup activity is not executed at all due to cancellation.")
+            raise
 
     # Execute the cleanup activity after all other root tasks are presumably done.
     try:

--- a/tests/running/test_spawn_tasks.py
+++ b/tests/running/test_spawn_tasks.py
@@ -127,19 +127,20 @@ async def test_always_present_tasks(registry, settings):
     )
     task_names = {t.get_name() for t in tasks}
 
-    assert "stop-flag checker" in task_names
-    assert "ultimate termination" in task_names
-    assert "startup/cleanup activities" in task_names
-    assert "daemon killer" in task_names
-    assert "credentials retriever" in task_names
-    assert "poster of events" in task_names
-    assert "admission insights chain" in task_names
-    assert "admission validating configuration manager" in task_names
-    assert "admission mutating configuration manager" in task_names
-    assert "admission webhook server" in task_names
-    assert "resource observer" in task_names
-    assert "namespace observer" in task_names
-    assert "multidimensional multitasker" in task_names
+    assert task_names == {
+        "stop-flag checker",
+        "ultimate termination",
+        "startup/cleanup activities",
+        "daemon killer",
+        "poster of events",
+        "admission insights chain",
+        "admission validating configuration manager",
+        "admission mutating configuration manager",
+        "admission webhook server",
+        "resource observer",
+        "namespace observer",
+        "multidimensional multitasker",
+    }
     assert "health reporter" not in task_names
 
     await _cancel_all(tasks)
@@ -155,6 +156,21 @@ async def test_liveness_endpoint_adds_health_reporter(registry, settings):
     task_names = {t.get_name() for t in tasks}
     assert "health reporter" in task_names
     await _cancel_all(tasks)
+
+
+# The cancellation of "core" tasks is tested elsewhere. We just test that it is passed, not lost.
+async def test_core_tasks_passed_to_activities(registry, settings, mocker):
+    mock = mocker.patch('kopf._core.reactor.running.startup_cleanup_activities')
+    tasks = await spawn_tasks(
+        registry=registry,
+        settings=settings,
+        clusterwide=True,
+    )
+    core_tasks = mock.call_args.kwargs['core_tasks']
+    core_task_names = {t.get_name() for t in core_tasks}
+    assert core_task_names == {"credentials retriever"}
+    await _cancel_all(tasks)
+    await _cancel_all(core_tasks)  # because not awaited and not stopped in the mock
 
 
 async def test_command_replaces_orchestrator(registry, settings):

--- a/tests/running/test_startup_cleanup_activities.py
+++ b/tests/running/test_startup_cleanup_activities.py
@@ -15,9 +15,11 @@ async def test_startup_sets_flags(registry, settings, looptime):
     started_flag = asyncio.Event()
     ready_flag = asyncio.Event()
     root_tasks: list[aiotasks.Task] = []
+    core_task = asyncio.create_task(asyncio.sleep(10), name="dummy_core")
 
     task = asyncio.create_task(startup_cleanup_activities(
         root_tasks=root_tasks,
+        core_tasks=[core_task],
         ready_flag=ready_flag,
         started_flag=started_flag,
         registry=registry,
@@ -35,6 +37,7 @@ async def test_startup_sets_flags(registry, settings, looptime):
     with contextlib.suppress(asyncio.CancelledError):
         await task
 
+    assert core_task.done()
     assert looptime == 0
 
 
@@ -42,6 +45,7 @@ async def test_cleanup_runs_only_after_root_tasks_exit(registry, settings, loopt
     started_flag = asyncio.Event()
     root_tasks: list[aiotasks.Task] = []
     cleanup_result: dict[str, object] = {}
+    core_task = asyncio.create_task(asyncio.sleep(10), name="dummy_core")
 
     @kopf.on.cleanup(registry=registry)
     async def cleanup_handler(**_):
@@ -55,6 +59,7 @@ async def test_cleanup_runs_only_after_root_tasks_exit(registry, settings, loopt
 
     task = asyncio.create_task(startup_cleanup_activities(
         root_tasks=root_tasks,
+        core_tasks=[core_task],
         ready_flag=None,
         started_flag=started_flag,
         registry=registry,
@@ -76,12 +81,14 @@ async def test_cleanup_runs_only_after_root_tasks_exit(registry, settings, loopt
     with contextlib.suppress(asyncio.CancelledError):
         await task
 
+    assert core_task.done()
     assert cleanup_result == {'called': True}
     assert looptime == 3
 
 
 async def test_cancellation_during_startup(registry, settings, assert_logs, looptime):
     started_flag = asyncio.Event()
+    core_task = asyncio.create_task(asyncio.sleep(10), name="dummy_core")
 
     @kopf.on.startup(registry=registry)
     async def blocking_startup(**_):
@@ -89,6 +96,7 @@ async def test_cancellation_during_startup(registry, settings, assert_logs, loop
 
     task = asyncio.create_task(startup_cleanup_activities(
         root_tasks=[],
+        core_tasks=[core_task],
         ready_flag=None,
         started_flag=started_flag,
         registry=registry,
@@ -104,6 +112,7 @@ async def test_cancellation_during_startup(registry, settings, assert_logs, loop
     with pytest.raises(asyncio.CancelledError):
         await task
 
+    assert core_task.done()
     assert not started_flag.is_set()
     assert_logs(["Startup activity is only partially executed due to cancellation."])
     assert looptime == 3
@@ -112,6 +121,7 @@ async def test_cancellation_during_startup(registry, settings, assert_logs, loop
 async def test_cancellation_during_root_task_wait(registry, settings, assert_logs, looptime):
     started_flag = asyncio.Event()
     root_tasks: list[aiotasks.Task] = []
+    core_task = asyncio.create_task(asyncio.sleep(10), name="dummy_core")
 
     async def dummy_task():
         await asyncio.sleep(10)
@@ -121,6 +131,7 @@ async def test_cancellation_during_root_task_wait(registry, settings, assert_log
 
     task = asyncio.create_task(startup_cleanup_activities(
         root_tasks=root_tasks,
+        core_tasks=[core_task],
         ready_flag=None,
         started_flag=started_flag,
         registry=registry,
@@ -144,6 +155,7 @@ async def test_cancellation_during_root_task_wait(registry, settings, assert_log
     with pytest.raises(asyncio.CancelledError):
         await task
 
+    assert core_task.done()
     assert_logs(["Cleanup activity is not executed at all due to cancellation."])
     assert looptime == 3
 
@@ -155,6 +167,7 @@ async def test_cancellation_during_root_task_wait(registry, settings, assert_log
 async def test_cancellation_during_cleanup(registry, settings, assert_logs, looptime):
     started_flag = asyncio.Event()
     root_tasks: list[aiotasks.Task] = []
+    core_task = asyncio.create_task(asyncio.sleep(10), name="dummy_core")
 
     @kopf.on.cleanup(registry=registry)
     async def blocking_cleanup(**_):
@@ -168,6 +181,7 @@ async def test_cancellation_during_cleanup(registry, settings, assert_logs, loop
 
     task = asyncio.create_task(startup_cleanup_activities(
         root_tasks=root_tasks,
+        core_tasks=[core_task],
         ready_flag=None,
         started_flag=started_flag,
         registry=registry,
@@ -192,5 +206,104 @@ async def test_cancellation_during_cleanup(registry, settings, assert_logs, loop
     with pytest.raises(asyncio.CancelledError):
         await task
 
+    assert core_task.done()
     assert_logs(["Cleanup activity is only partially executed due to cancellation."])
     assert looptime == 6
+
+
+async def test_cancellation_during_core_task_stop(registry, settings, assert_logs, looptime):
+    started_flag = asyncio.Event()
+    root_tasks: list[aiotasks.Task] = []
+
+    async def dummy_root_task():
+        await asyncio.sleep(3)
+
+    async def stubborn_core_task():
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            await asyncio.sleep(10)
+
+    dummy = asyncio.create_task(dummy_root_task(), name="dummy_root")
+    root_tasks.append(dummy)
+
+    core_tasks = [asyncio.create_task(stubborn_core_task(), name="stubborn_core")]
+
+    task = asyncio.create_task(startup_cleanup_activities(
+        root_tasks=root_tasks,
+        core_tasks=core_tasks,
+        ready_flag=None,
+        started_flag=started_flag,
+        registry=registry,
+        settings=settings,
+        indices=OperatorIndexers().indices,
+        vault=Vault(),
+        memo=AnyMemo(Memo()),
+    ))
+    root_tasks.append(task)
+
+    await started_flag.wait()
+
+    # First cancel wakes from sleep; the task then waits for root tasks.
+    task.cancel()
+    await asyncio.sleep(0)
+
+    # The root task finishes after 3 seconds, then core task stopping begins.
+    # Wait a bit more, then cancel during the core task stopping phase.
+    await asyncio.sleep(5)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert looptime == 5
+    assert_logs(["Cleanup activity is not executed at all due to cancellation."])
+
+    # Clean up the stubborn core task.
+    core_tasks[0].cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await core_tasks[0]
+
+
+async def test_core_tasks_are_stopped_after_root_tasks(settings, registry, looptime):
+    timestamps: dict[str, float] = {}
+
+    async def sample_task(duration: float, key: str) -> None:
+        nonlocal timestamps
+        try:
+            await asyncio.sleep(duration)
+        finally:
+            timestamps[key] = float(looptime)
+
+    root_tasks = [
+        asyncio.create_task(sample_task(2, 'root1')),
+        asyncio.create_task(sample_task(5, 'root2')),
+    ]
+    core_tasks = [
+        asyncio.create_task(sample_task(9, 'core1')),
+        asyncio.create_task(sample_task(9, 'core2')),
+    ]
+
+    started_flag = asyncio.Event()
+    activities_task = asyncio.create_task(startup_cleanup_activities(
+        root_tasks=root_tasks,
+        core_tasks=core_tasks,
+        ready_flag=None,
+        started_flag=started_flag,
+        registry=registry,
+        settings=settings,
+        indices=OperatorIndexers().indices,
+        vault=Vault(),
+        memo=Memo(),
+    ))
+    root_tasks.append(activities_task)
+
+    # Simulate the behavior of the guarded task (briefly).
+    await started_flag.wait()
+    activities_task.cancel()  # interrupt its eternal sleep
+    await activities_task
+
+    assert timestamps['root1'] == 2
+    assert timestamps['root2'] == 5
+    assert timestamps['core1'] == 5  # the latest of root tasks, not 9
+    assert timestamps['core2'] == 5  # the latest of root tasks, not 9


### PR DESCRIPTION
**Problem:** We now cancel all tasks at once (as soon as any task exits, e.g. the exit-flag waiter). However, some tasks require other tasks to properly terminate. For instance, the peering shutdown in the orchestrator requires the authenticator to continue working. With the current approach, the authenticator exits soon, and the peering cannot shut down and de-register itself properly.

**Solution:** With the new approach, some tasks are made special —the "core" tasks— and we postpone their cancellation to the very last moment, which happens strictly after all the regular ("root") tasks exit, but before the cleanup activities as before.

**Backwards compatibility:** This way, we keep all the interfaces intact: `spawn_tasks` and `run_tasks()` are a part of the public interface (though I regret this move), their change would require semantic v2, which is not planned. Only the internal relations between tasks change, and one task —the authenticator— disappears from the returned list, though remains controlled internally.

**Extensibility:** When and if needed, some other tasks can be grouped into several layers (exiting priorities) the same way — all hidden from the public interface.

**Benefit:** a plain and elegant solution to a very specific problem, no over-engineering or over-generalisation (as in the superseded PRs).

Fixes #1033. Supersedes #1110. Supersedes #1282.