### PR TITLE
Test the operator's top-level routines

### DIFF
--- a/kopf/_core/reactor/running.py
+++ b/kopf/_core/reactor/running.py
@@ -221,17 +221,17 @@ async def spawn_tasks(
     # A few common background forever-running infrastructural tasks (irregular root tasks).
     tasks.append(asyncio.create_task(
         name="stop-flag checker",
-        coro=_stop_flag_checker(
+        coro=stop_flag_checker(
             signal_flag=signal_flag,
             stop_flag=stop_flag)))
     tasks.append(asyncio.create_task(
         name="ultimate termination",
-        coro=_ultimate_termination(
+        coro=ultimate_termination(
             settings=settings,
             stop_flag=stop_flag)))
     tasks.append(asyncio.create_task(
         name="startup/cleanup activities",
-        coro=_startup_cleanup_activities(
+        coro=startup_cleanup_activities(
             root_tasks=tasks,  # used as a "live" view, populated later.
             ready_flag=ready_flag,
             started_flag=started_flag,
@@ -420,7 +420,7 @@ async def run_tasks(
     await aiotasks.reraise(root_done | root_cancelled | hung_done | hung_cancelled)
 
 
-async def _stop_flag_checker(
+async def stop_flag_checker(
         signal_flag: aiotasks.Future,
         stop_flag: aioadapters.Flag | None,
 ) -> None:
@@ -452,7 +452,7 @@ async def _stop_flag_checker(
             logger.info(f"Stop-flag is set to {result!r}. Operator is stopping.")
 
 
-async def _ultimate_termination(
+async def ultimate_termination(
         *,
         settings: configuration.OperatorSettings,
         stop_flag: aioadapters.Flag | None,
@@ -477,7 +477,7 @@ async def _ultimate_termination(
                                 signal.pthread_kill, threading.get_ident(), signal.SIGKILL)
 
 
-async def _startup_cleanup_activities(
+async def startup_cleanup_activities(
         root_tasks: Sequence[aiotasks.Task],  # mutated externally!
         ready_flag: aioadapters.Flag | None,
         started_flag: asyncio.Event,

--- a/tests/running/test_operator.py
+++ b/tests/running/test_operator.py
@@ -1,0 +1,44 @@
+from kopf._core.reactor.running import operator
+
+
+async def test_spawn_tasks_result_passed_to_run_tasks(mocker):
+    sentinel = object()
+    spawn = mocker.patch('kopf._core.reactor.running.spawn_tasks', return_value=sentinel)
+    run = mocker.patch('kopf._core.reactor.running.run_tasks')
+
+    await operator(clusterwide=True)
+
+    assert spawn.await_count == 1
+    assert run.await_count == 1
+    assert run.call_args.args[0] is sentinel
+
+
+async def test_existing_tasks_passed_as_ignored(mocker):
+    existing = frozenset()
+    mocker.patch('kopf._cogs.aiokits.aiotasks.all_tasks', return_value=existing)
+    mocker.patch('kopf._core.reactor.running.spawn_tasks', return_value=[])
+    run = mocker.patch('kopf._core.reactor.running.run_tasks')
+
+    await operator(clusterwide=True)
+
+    assert run.call_args.kwargs['ignored'] is existing
+
+
+async def test_kwargs_forwarded_to_spawn_tasks(mocker):
+    spawn = mocker.patch('kopf._core.reactor.running.spawn_tasks', return_value=[])
+    mocker.patch('kopf._core.reactor.running.run_tasks')
+
+    await operator(
+        clusterwide=True,
+        priority=100,
+        peering_name='my-peering',
+        standalone=True,
+        liveness_endpoint="/health",
+    )
+
+    kwargs = spawn.call_args.kwargs
+    assert kwargs['clusterwide'] is True
+    assert kwargs['priority'] == 100
+    assert kwargs['peering_name'] == 'my-peering'
+    assert kwargs['standalone'] is True
+    assert kwargs['liveness_endpoint'] == "/health"

--- a/tests/running/test_run_tasks.py
+++ b/tests/running/test_run_tasks.py
@@ -1,0 +1,159 @@
+import asyncio
+
+import pytest
+
+from kopf._cogs.aiokits import aiotasks
+from kopf._core.reactor.running import run_tasks
+
+
+async def test_root_task_exit_cancels_remaining(assert_logs, looptime):
+    async def finishes_soon():
+        await asyncio.sleep(3)
+
+    async def runs_forever():
+        await asyncio.sleep(10)
+
+    ignored = asyncio.all_tasks()
+    task_a = asyncio.create_task(finishes_soon(), name="finishes_soon")
+    task_b = asyncio.create_task(runs_forever(), name="runs_forever")
+    await run_tasks([task_a, task_b], ignored=ignored)
+
+    assert task_a.done()
+    assert task_b.done()
+    assert task_b.cancelled()
+    assert looptime == 3
+    assert_logs([
+        r"Root tasks are stopped: finishing normally",
+        r"Hung tasks stopping is skipped: no tasks given",
+    ])
+
+
+async def test_root_task_exception_is_reraised(assert_logs, looptime):
+    async def fails_soon():
+        await asyncio.sleep(3)
+        raise RuntimeError("boom")
+
+    async def runs_forever():
+        await asyncio.sleep(10)
+
+    ignored = asyncio.all_tasks()
+    task_a = asyncio.create_task(fails_soon(), name="fails_soon")
+    task_b = asyncio.create_task(runs_forever(), name="runs_forever")
+    with pytest.raises(RuntimeError, match="boom"):
+        await run_tasks([task_a, task_b], ignored=ignored)
+
+    assert task_a.done()
+    assert task_b.done()
+    assert looptime == 3
+    assert_logs([
+        r"Root tasks are stopped: finishing normally",
+    ])
+
+
+async def test_cancellation_during_root_wait(assert_logs, looptime):
+    async def runs_forever():
+        await asyncio.sleep(10)
+
+    ignored = asyncio.all_tasks()
+    task_a = asyncio.create_task(runs_forever(), name="root_a")
+    task_b = asyncio.create_task(runs_forever(), name="root_b")
+    runner = asyncio.create_task(run_tasks([task_a, task_b], ignored=ignored))
+
+    await asyncio.sleep(3)
+    runner.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner
+
+    assert task_a.done()
+    assert task_b.done()
+    assert looptime == 3
+    assert_logs([
+        r"Root tasks are stopped: cancelling normally",
+        r"Hung tasks stopping is skipped: no tasks given",
+    ])
+
+
+async def test_hung_subtask_cancelled_after_grace_period(assert_logs, looptime):
+    hung_task: aiotasks.Task | None = None
+
+    async def spawns_and_exits():
+        nonlocal hung_task
+        hung_task = asyncio.create_task(asyncio.sleep(10), name="hung_subtask")
+        await asyncio.sleep(3)
+
+    async def runs_forever():
+        await asyncio.sleep(10)
+
+    ignored = asyncio.all_tasks()
+    task_a = asyncio.create_task(spawns_and_exits(), name="spawns_and_exits")
+    task_b = asyncio.create_task(runs_forever(), name="runs_forever")
+    await run_tasks([task_a, task_b], ignored=ignored)
+
+    assert hung_task is not None
+    assert hung_task.done()
+    assert hung_task.cancelled()
+    # 3s for root exit + 5s grace period for hung task timeout.
+    assert looptime == 8
+    assert_logs([
+        r"Root tasks are stopped: finishing normally",
+        r"Hung tasks are stopped: finishing normally",
+    ])
+
+
+async def test_hung_subtask_finishes_within_grace_period(assert_logs, looptime):
+    hung_task: aiotasks.Task | None = None
+
+    async def spawns_and_exits():
+        nonlocal hung_task
+        hung_task = asyncio.create_task(asyncio.sleep(2), name="hung_subtask")
+
+    async def runs_forever():
+        await asyncio.sleep(10)
+
+    ignored = asyncio.all_tasks()
+    task_a = asyncio.create_task(spawns_and_exits(), name="spawns_and_exits")
+    task_b = asyncio.create_task(runs_forever(), name="runs_forever")
+    await run_tasks([task_a, task_b], ignored=ignored)
+
+    assert hung_task is not None
+    assert hung_task.done()
+    assert not hung_task.cancelled()
+    # 0s for root exit + 2s for hung task finishing within grace period.
+    assert looptime == 2
+    assert_logs([
+        r"Root tasks are stopped: finishing normally",
+        r"Hung tasks stopping is skipped: no tasks given",
+    ])
+
+
+async def test_cancellation_during_hung_task_wait(assert_logs, looptime):
+    hung_task: aiotasks.Task | None = None
+
+    async def spawns_and_exits():
+        nonlocal hung_task
+        hung_task = asyncio.create_task(asyncio.sleep(10), name="hung_subtask")
+        await asyncio.sleep(3)
+
+    async def runs_forever():
+        await asyncio.sleep(10)
+
+    ignored = asyncio.all_tasks()
+    task_a = asyncio.create_task(spawns_and_exits(), name="spawns_and_exits")
+    task_b = asyncio.create_task(runs_forever(), name="runs_forever")
+    runner = asyncio.create_task(run_tasks([task_a, task_b], ignored=ignored))
+
+    # 3s for root exit, then cancel during the 5s hung-task grace period.
+    await asyncio.sleep(5)
+    runner.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner
+
+    assert hung_task is not None
+    assert hung_task.done()
+    assert looptime == 5
+    assert_logs([
+        r"Root tasks are stopped: finishing normally",
+        r"Hung tasks are stopped: cancelling normally",
+    ])

--- a/tests/running/test_spawn_tasks.py
+++ b/tests/running/test_spawn_tasks.py
@@ -1,0 +1,173 @@
+import asyncio
+
+import pytest
+
+import kopf
+from kopf._core.reactor.running import spawn_tasks
+
+
+@pytest.fixture(autouse=True)
+def _safe_tasks(registry, settings):
+    """Block startup to keep guarded tasks idle; disable SIGKILL scheduling."""
+    settings.process.ultimate_exiting_timeout = None
+
+    @kopf.on.startup(registry=registry)
+    async def block_startup(**_):
+        await asyncio.sleep(10)
+
+
+async def _cancel_all(tasks):
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+# --- Argument validation ---
+
+
+async def test_namespace_and_namespaces_cannot_coexist(registry, settings):
+    with pytest.raises(TypeError, match="Either namespaces= or namespace= can be passed"):
+        await spawn_tasks(
+            registry=registry,
+            settings=settings,
+            namespaces=['ns1'],
+            namespace='ns2',
+        )
+
+
+async def test_clusterwide_and_namespaces_cannot_coexist(registry, settings):
+    with pytest.raises(TypeError, match="cluster-wide or namespaced, not both"):
+        await spawn_tasks(
+            registry=registry,
+            settings=settings,
+            clusterwide=True,
+            namespaces=['ns1'],
+        )
+
+
+async def test_deprecated_namespace_kwarg(registry, settings):
+    with pytest.warns(DeprecationWarning, match="namespace= is deprecated"):
+        tasks = await spawn_tasks(
+            registry=registry,
+            settings=settings,
+            namespace='ns1',
+        )
+    await _cancel_all(tasks)
+
+
+async def test_missing_scope_defaults_to_clusterwide(registry, settings):
+    with pytest.warns(FutureWarning, match="Absence of either namespaces or cluster-wide"):
+        tasks = await spawn_tasks(
+            registry=registry,
+            settings=settings,
+        )
+    assert settings.peering.clusterwide is True
+    await _cancel_all(tasks)
+
+
+# --- Settings mapping ---
+
+
+async def test_clusterwide_mapped_to_settings(registry, settings):
+    assert settings.peering.clusterwide is False
+    tasks = await spawn_tasks(
+        registry=registry,
+        settings=settings,
+        clusterwide=True,
+    )
+    assert settings.peering.clusterwide is True
+    await _cancel_all(tasks)
+
+
+async def test_peering_name_mapped_to_settings(registry, settings):
+    assert settings.peering.mandatory is False
+    tasks = await spawn_tasks(
+        registry=registry,
+        settings=settings,
+        clusterwide=True,
+        peering_name='my-peering',
+    )
+    assert settings.peering.mandatory is True
+    assert settings.peering.name == 'my-peering'
+    await _cancel_all(tasks)
+
+
+async def test_standalone_mapped_to_settings(registry, settings):
+    assert settings.peering.standalone is False
+    tasks = await spawn_tasks(
+        registry=registry,
+        settings=settings,
+        clusterwide=True,
+        standalone=True,
+    )
+    assert settings.peering.standalone is True
+    await _cancel_all(tasks)
+
+
+async def test_priority_mapped_to_settings(registry, settings):
+    assert settings.peering.priority == 0
+    tasks = await spawn_tasks(
+        registry=registry,
+        settings=settings,
+        clusterwide=True,
+        priority=100,
+    )
+    assert settings.peering.priority == 100
+    await _cancel_all(tasks)
+
+
+# --- Task composition ---
+
+
+async def test_always_present_tasks(registry, settings):
+    tasks = await spawn_tasks(
+        registry=registry,
+        settings=settings,
+        clusterwide=True,
+    )
+    task_names = {t.get_name() for t in tasks}
+
+    assert "stop-flag checker" in task_names
+    assert "ultimate termination" in task_names
+    assert "startup/cleanup activities" in task_names
+    assert "daemon killer" in task_names
+    assert "credentials retriever" in task_names
+    assert "poster of events" in task_names
+    assert "admission insights chain" in task_names
+    assert "admission validating configuration manager" in task_names
+    assert "admission mutating configuration manager" in task_names
+    assert "admission webhook server" in task_names
+    assert "resource observer" in task_names
+    assert "namespace observer" in task_names
+    assert "multidimensional multitasker" in task_names
+    assert "health reporter" not in task_names
+
+    await _cancel_all(tasks)
+
+
+async def test_liveness_endpoint_adds_health_reporter(registry, settings):
+    tasks = await spawn_tasks(
+        registry=registry,
+        settings=settings,
+        clusterwide=True,
+        liveness_endpoint="/health",
+    )
+    task_names = {t.get_name() for t in tasks}
+    assert "health reporter" in task_names
+    await _cancel_all(tasks)
+
+
+async def test_command_replaces_orchestrator(registry, settings):
+    async def my_command():
+        await asyncio.Event().wait()
+
+    tasks = await spawn_tasks(
+        registry=registry,
+        settings=settings,
+        clusterwide=True,
+        _command=my_command(),
+    )
+    task_names = {t.get_name() for t in tasks}
+    assert "the command" in task_names
+    assert "multidimensional multitasker" not in task_names
+    await _cancel_all(tasks)

--- a/tests/running/test_startup_cleanup_activities.py
+++ b/tests/running/test_startup_cleanup_activities.py
@@ -1,0 +1,196 @@
+import asyncio
+import contextlib
+
+import pytest
+
+import kopf
+from kopf._cogs.aiokits import aiotasks
+from kopf._cogs.structs.credentials import Vault
+from kopf._cogs.structs.ephemera import AnyMemo, Memo
+from kopf._core.engines.indexing import OperatorIndexers
+from kopf._core.reactor.running import startup_cleanup_activities
+
+
+async def test_startup_sets_flags(registry, settings, looptime):
+    started_flag = asyncio.Event()
+    ready_flag = asyncio.Event()
+    root_tasks: list[aiotasks.Task] = []
+
+    task = asyncio.create_task(startup_cleanup_activities(
+        root_tasks=root_tasks,
+        ready_flag=ready_flag,
+        started_flag=started_flag,
+        registry=registry,
+        settings=settings,
+        indices=OperatorIndexers().indices,
+        vault=Vault(),
+        memo=AnyMemo(Memo()),
+    ))
+    root_tasks.append(task)
+
+    await started_flag.wait()
+    assert ready_flag.is_set()
+
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert looptime == 0
+
+
+async def test_cleanup_runs_only_after_root_tasks_exit(registry, settings, looptime):
+    started_flag = asyncio.Event()
+    root_tasks: list[aiotasks.Task] = []
+    cleanup_result: dict[str, object] = {}
+
+    @kopf.on.cleanup(registry=registry)
+    async def cleanup_handler(**_):
+        cleanup_result['called'] = True
+
+    async def dummy_task():
+        await asyncio.sleep(3)
+
+    dummy = asyncio.create_task(dummy_task(), name="dummy_task")
+    root_tasks.append(dummy)
+
+    task = asyncio.create_task(startup_cleanup_activities(
+        root_tasks=root_tasks,
+        ready_flag=None,
+        started_flag=started_flag,
+        registry=registry,
+        settings=settings,
+        indices=OperatorIndexers().indices,
+        vault=Vault(),
+        memo=AnyMemo(Memo()),
+    ))
+    root_tasks.append(task)
+
+    await started_flag.wait()
+
+    # Simulate operator shutdown: cancel the activities task (wakes it from sleep).
+    task.cancel()
+    await asyncio.sleep(0)
+
+    # The activities task is now waiting for other root tasks to exit.
+    # The dummy task sleeps for 3 seconds, then exits.
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert cleanup_result == {'called': True}
+    assert looptime == 3
+
+
+async def test_cancellation_during_startup(registry, settings, assert_logs, looptime):
+    started_flag = asyncio.Event()
+
+    @kopf.on.startup(registry=registry)
+    async def blocking_startup(**_):
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(startup_cleanup_activities(
+        root_tasks=[],
+        ready_flag=None,
+        started_flag=started_flag,
+        registry=registry,
+        settings=settings,
+        indices=OperatorIndexers().indices,
+        vault=Vault(),
+        memo=AnyMemo(Memo()),
+    ))
+
+    await asyncio.sleep(3)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not started_flag.is_set()
+    assert_logs(["Startup activity is only partially executed due to cancellation."])
+    assert looptime == 3
+
+
+async def test_cancellation_during_root_task_wait(registry, settings, assert_logs, looptime):
+    started_flag = asyncio.Event()
+    root_tasks: list[aiotasks.Task] = []
+
+    async def dummy_task():
+        await asyncio.sleep(10)
+
+    dummy = asyncio.create_task(dummy_task(), name="dummy_task")
+    root_tasks.append(dummy)
+
+    task = asyncio.create_task(startup_cleanup_activities(
+        root_tasks=root_tasks,
+        ready_flag=None,
+        started_flag=started_flag,
+        registry=registry,
+        settings=settings,
+        indices=OperatorIndexers().indices,
+        vault=Vault(),
+        memo=AnyMemo(Memo()),
+    ))
+    root_tasks.append(task)
+
+    await started_flag.wait()
+
+    # First cancel wakes from sleep; the task then waits for root tasks.
+    task.cancel()
+    await asyncio.sleep(0)
+
+    # Wait a bit, then cancel again while it is waiting for the dummy task.
+    await asyncio.sleep(3)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert_logs(["Cleanup activity is not executed at all due to cancellation."])
+    assert looptime == 3
+
+    dummy.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await dummy
+
+
+async def test_cancellation_during_cleanup(registry, settings, assert_logs, looptime):
+    started_flag = asyncio.Event()
+    root_tasks: list[aiotasks.Task] = []
+
+    @kopf.on.cleanup(registry=registry)
+    async def blocking_cleanup(**_):
+        await asyncio.sleep(10)
+
+    async def dummy_task():
+        await asyncio.sleep(3)
+
+    dummy = asyncio.create_task(dummy_task(), name="dummy_task")
+    root_tasks.append(dummy)
+
+    task = asyncio.create_task(startup_cleanup_activities(
+        root_tasks=root_tasks,
+        ready_flag=None,
+        started_flag=started_flag,
+        registry=registry,
+        settings=settings,
+        indices=OperatorIndexers().indices,
+        vault=Vault(),
+        memo=AnyMemo(Memo()),
+    ))
+    root_tasks.append(task)
+
+    await started_flag.wait()
+
+    # First cancel wakes from sleep; the task then waits for root tasks.
+    task.cancel()
+    await asyncio.sleep(0)
+
+    # The dummy task finishes after 3 seconds, so the cleanup handler starts.
+    # Wait a bit more, then cancel during the cleanup handler.
+    await asyncio.sleep(6)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert_logs(["Cleanup activity is only partially executed due to cancellation."])
+    assert looptime == 6

--- a/tests/running/test_stop_flag_checker.py
+++ b/tests/running/test_stop_flag_checker.py
@@ -1,0 +1,89 @@
+import asyncio
+import contextlib
+import signal
+
+from kopf._core.reactor.running import stop_flag_checker
+
+
+async def test_stop_via_stop_flag_with_none_result(assert_logs, looptime):
+    signal_flag: asyncio.Future[object] = asyncio.Future()
+    stop_flag: asyncio.Future[object] = asyncio.Future()
+
+    task = asyncio.create_task(stop_flag_checker(
+        signal_flag=signal_flag,
+        stop_flag=stop_flag,
+    ))
+
+    await asyncio.sleep(3)
+    stop_flag.set_result(None)
+    await task
+
+    assert_logs(["Stop-flag is raised. Operator is stopping."])
+    assert looptime == 3
+
+
+async def test_stop_via_stop_flag_with_custom_value(assert_logs, looptime):
+    signal_flag: asyncio.Future[object] = asyncio.Future()
+    stop_flag: asyncio.Future[object] = asyncio.Future()
+
+    task = asyncio.create_task(stop_flag_checker(
+        signal_flag=signal_flag,
+        stop_flag=stop_flag,
+    ))
+
+    await asyncio.sleep(3)
+    stop_flag.set_result('custom-reason')
+    await task
+
+    assert_logs(["Stop-flag is set to 'custom-reason'. Operator is stopping."])
+    assert looptime == 3
+
+
+async def test_stop_via_asyncio_event(assert_logs, looptime):
+    signal_flag: asyncio.Future[object] = asyncio.Future()
+    stop_flag = asyncio.Event()
+
+    task = asyncio.create_task(stop_flag_checker(
+        signal_flag=signal_flag,
+        stop_flag=stop_flag,
+    ))
+
+    await asyncio.sleep(3)
+    stop_flag.set()
+    await task
+
+    assert_logs(["Stop-flag is set to True. Operator is stopping."])
+    assert looptime == 3
+
+
+async def test_stop_via_signal_flag(assert_logs, looptime):
+    signal_flag: asyncio.Future[object] = asyncio.Future()
+
+    task = asyncio.create_task(stop_flag_checker(
+        signal_flag=signal_flag,
+        stop_flag=None,
+    ))
+
+    await asyncio.sleep(3)
+    signal_flag.set_result(signal.SIGINT)
+    await task
+
+    assert_logs(["Signal SIGINT is received. Operator is stopping."])
+    assert looptime == 3
+
+
+async def test_cancellation_exits_silently(assert_logs, looptime):
+    signal_flag: asyncio.Future[object] = asyncio.Future()
+
+    task = asyncio.create_task(stop_flag_checker(
+        signal_flag=signal_flag,
+        stop_flag=None,
+    ))
+
+    await asyncio.sleep(3)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert_logs(prohibited=["Operator is stopping"])
+    assert looptime == 3

--- a/tests/running/test_ultimate_termination.py
+++ b/tests/running/test_ultimate_termination.py
@@ -1,0 +1,71 @@
+import asyncio
+import signal
+import threading
+
+from kopf._core.reactor.running import ultimate_termination
+
+
+async def test_no_kill_scheduled_when_stop_flag_is_set(settings, mocker, looptime):
+    pthread_kill = mocker.patch.object(signal, 'pthread_kill')
+    stop_flag = asyncio.Event()
+    stop_flag.set()
+
+    task = asyncio.create_task(ultimate_termination(
+        settings=settings,
+        stop_flag=stop_flag,
+    ))
+
+    await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.sleep(0)
+
+    assert task.done()
+    assert not pthread_kill.called
+    assert looptime == 0
+
+
+async def test_no_kill_scheduled_when_timeout_is_none(settings, mocker, looptime):
+    pthread_kill = mocker.patch.object(signal, 'pthread_kill')
+    settings.process.ultimate_exiting_timeout = None
+
+    task = asyncio.create_task(ultimate_termination(
+        settings=settings,
+        stop_flag=None,
+    ))
+
+    await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.sleep(0)
+
+    assert task.done()
+
+    # Even after waiting, no kill should be scheduled.
+    await asyncio.sleep(10)
+
+    assert not pthread_kill.called
+    assert looptime == 10
+
+
+async def test_kill_scheduled_when_stop_flag_is_not_set(settings, mocker, looptime):
+    pthread_kill = mocker.patch.object(signal, 'pthread_kill')
+    mocker.patch.object(threading, 'get_ident', return_value=12345)
+    settings.process.ultimate_exiting_timeout = 10
+
+    task = asyncio.create_task(ultimate_termination(
+        settings=settings,
+        stop_flag=None,
+    ))
+
+    await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.sleep(0)
+
+    assert task.done()
+    assert not pthread_kill.called
+
+    # Fast-forward past the scheduled call_later timeout.
+    await asyncio.sleep(10)
+
+    assert pthread_kill.call_count == 1
+    assert pthread_kill.call_args.args == (12345, signal.SIGKILL)
+    assert looptime == 10


### PR DESCRIPTION
The previously untested functions of the running module are now covered: startup/cleanup activities (startup flag setting, cleanup after root tasks, cancellation at each phase), ultimate termination (SIGKILL scheduling with and without stop flag and timeout), stop flag checker (all flag types and cancellation), and run_tasks orchestration (root task exit/failure, hung sub-task grace period, cancellation at each phase). The underscore prefix is removed from the tested functions to make them importable by the tests.
