### PR TITLE
fix: avoid TypeError when kubernetes_asyncio is unavailable

### DIFF
--- a/kopf/_cogs/helpers/thirdparty.py
+++ b/kopf/_cogs/helpers/thirdparty.py
@@ -4,6 +4,8 @@ Type definitions from optional 3rd-party libraries, e.g. pykube-ng & kubernetes.
 This utility does all the trickery needed to import the libraries if possible,
 or to skip them and make typing/runtime dummies for the rest of the codebase.
 """
+from __future__ import annotations
+
 import abc
 from typing import Any, Protocol
 


### PR DESCRIPTION
Fixes #1288

When `kubernetes_asyncio` is missing, `V1ObjectMetaAsync` is set to `None`. At runtime, `V1ObjectMetaAsync | None` then evaluates immediately and raises a `TypeError`.

Deferring annotation evaluation in this module keeps those optional type hints from being executed at import time.

Greetings, saschabuehrle