### PR TITLE
Speed up KopfRunner by skipping the 1-second sleep on aiohttp 3.12.4+

### DIFF
--- a/kopf/_kits/runner.py
+++ b/kopf/_kits/runner.py
@@ -1,15 +1,39 @@
 import asyncio
 import concurrent.futures
 import contextlib
+import re
 import threading
 import types
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+import aiohttp
 import click.testing
 
 from kopf import cli
 from kopf._cogs.configs import configuration
 from kopf._core.intents import registries
+
+
+def _parse_version(version_string: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for part in version_string.split('.')[:3]:
+        m = re.match(r'\d+', part)
+        if m is None:
+            raise ValueError(f"Cannot parse version part: {part!r}")
+        parts.append(int(m.group()))
+    return tuple(parts)
+
+
+try:
+    _aiohttp_version = _parse_version(aiohttp.__version__)
+    _AIOHTTP_HAS_GRACEFUL_SHUTDOWN = _aiohttp_version >= (3, 12, 4)
+except (AttributeError, ValueError):  # if aiohttp.__version__ is gone
+    try:
+        import importlib.metadata
+        _aiohttp_version = _parse_version(importlib.metadata.version('aiohttp'))
+        _AIOHTTP_HAS_GRACEFUL_SHUTDOWN = _aiohttp_version >= (3, 12, 4)
+    except (AttributeError, ValueError):
+        _AIOHTTP_HAS_GRACEFUL_SHUTDOWN = True  # optimistically assume it works
 
 _ExcType = BaseException
 _ExcInfo = tuple[type[_ExcType], _ExcType, types.TracebackType]
@@ -147,8 +171,9 @@ class KopfRunner(_AbstractKopfRunner):
 
             # Shut down the transports and prevent ResourceWarning: unclosed transport.
             # See: https://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown
-            # TODO: Try a hack: https://github.com/aio-libs/aiohttp/issues/1925#issuecomment-575754386
-            loop.run_until_complete(asyncio.sleep(1.0))
+            # Fixed in aiohttp 3.12.4; the sleep is only needed for older versions.
+            if not _AIOHTTP_HAS_GRACEFUL_SHUTDOWN:
+                loop.run_until_complete(asyncio.sleep(1.0))
 
             loop.close()
 


### PR DESCRIPTION
The sleep was a workaround for aiohttp not closing SSL transports gracefully on shutdown, causing ResourceWarning. This is fixed in aiohttp 3.12.4, so the sleep is now conditional — only applied for older versions. If the version cannot be determined, the sleep is optimistically skipped.

* https://github.com/aio-libs/aiohttp/blob/master/CHANGES.rst#3124-2025-05-28
* https://github.com/aio-libs/aiohttp/issues/1925#issuecomment-3260157915

The previous official recommendation to sleep:

* https://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown