### PR TITLE
Extract the aiohttp capability checkers from runners to a module

### DIFF
--- a/kopf/_cogs/helpers/aiohttpcaps.py
+++ b/kopf/_cogs/helpers/aiohttpcaps.py
@@ -1,0 +1,31 @@
+import importlib.metadata
+import re
+
+import aiohttp
+
+
+def _parse_version(version_string: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for part in version_string.split('.')[:3]:
+        m = re.match(r'\d+', part)
+        if m is None:
+            raise ValueError(f"Cannot parse version part: {part!r}")
+        parts.append(int(m.group()))
+    return tuple(parts)
+
+
+def _check_aiohttp_has_graceful_shutdown() -> bool:
+    try:
+        version = _parse_version(aiohttp.__version__)
+        return version >= (3, 12, 4)
+    except (AttributeError, ValueError):  # if aiohttp.__version__ is gone
+        pass
+    try:
+        version = _parse_version(importlib.metadata.version('aiohttp'))
+        return version >= (3, 12, 4)
+    except (AttributeError, ValueError):
+        pass
+    return True  # optimistically assume it works
+
+
+AIOHTTP_HAS_GRACEFUL_SHUTDOWN = _check_aiohttp_has_graceful_shutdown()

--- a/kopf/_kits/runner.py
+++ b/kopf/_kits/runner.py
@@ -1,39 +1,16 @@
 import asyncio
 import concurrent.futures
 import contextlib
-import re
 import threading
 import types
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-import aiohttp
 import click.testing
 
 from kopf import cli
 from kopf._cogs.configs import configuration
+from kopf._cogs.helpers import aiohttpcaps
 from kopf._core.intents import registries
-
-
-def _parse_version(version_string: str) -> tuple[int, ...]:
-    parts: list[int] = []
-    for part in version_string.split('.')[:3]:
-        m = re.match(r'\d+', part)
-        if m is None:
-            raise ValueError(f"Cannot parse version part: {part!r}")
-        parts.append(int(m.group()))
-    return tuple(parts)
-
-
-try:
-    _aiohttp_version = _parse_version(aiohttp.__version__)
-    _AIOHTTP_HAS_GRACEFUL_SHUTDOWN = _aiohttp_version >= (3, 12, 4)
-except (AttributeError, ValueError):  # if aiohttp.__version__ is gone
-    try:
-        import importlib.metadata
-        _aiohttp_version = _parse_version(importlib.metadata.version('aiohttp'))
-        _AIOHTTP_HAS_GRACEFUL_SHUTDOWN = _aiohttp_version >= (3, 12, 4)
-    except (AttributeError, ValueError):
-        _AIOHTTP_HAS_GRACEFUL_SHUTDOWN = True  # optimistically assume it works
 
 _ExcType = BaseException
 _ExcInfo = tuple[type[_ExcType], _ExcType, types.TracebackType]
@@ -172,7 +149,7 @@ class KopfRunner(_AbstractKopfRunner):
             # Shut down the transports and prevent ResourceWarning: unclosed transport.
             # See: https://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown
             # Fixed in aiohttp 3.12.4; the sleep is only needed for older versions.
-            if not _AIOHTTP_HAS_GRACEFUL_SHUTDOWN:
+            if not aiohttpcaps.AIOHTTP_HAS_GRACEFUL_SHUTDOWN:
                 loop.run_until_complete(asyncio.sleep(1.0))
 
             loop.close()

--- a/tests/test_aiohttp_capabilities.py
+++ b/tests/test_aiohttp_capabilities.py
@@ -1,0 +1,50 @@
+import pytest
+
+from kopf._cogs.helpers.aiohttpcaps import _check_aiohttp_has_graceful_shutdown, _parse_version
+
+
+def test_parse_version_simple():
+    assert _parse_version('3.12.4') == (3, 12, 4)
+
+
+def test_parse_version_pre_release_suffix():
+    assert _parse_version('3.12.4rc1') == (3, 12, 4)
+
+
+def test_parse_version_dev_suffix():
+    assert _parse_version('3.12.4.dev0') == (3, 12, 4)
+
+
+def test_parse_version_non_numeric():
+    with pytest.raises(ValueError):
+        _parse_version('abc.def.ghi')
+
+
+def test_graceful_shutdown_with_capability(mocker):
+    mock_aiohttp = mocker.patch('kopf._cogs.helpers.aiohttpcaps.aiohttp')
+    mock_aiohttp.__version__ = '3.12.4'
+    assert _check_aiohttp_has_graceful_shutdown() is True
+
+
+def test_graceful_shutdown_without_capability(mocker):
+    mock_aiohttp = mocker.patch('kopf._cogs.helpers.aiohttpcaps.aiohttp')
+    mock_aiohttp.__version__ = '3.12.3'
+    assert _check_aiohttp_has_graceful_shutdown() is False
+
+
+def test_graceful_shutdown_fallback_with_capability(mocker):
+    mocker.patch('kopf._cogs.helpers.aiohttpcaps.aiohttp', spec=[])
+    mocker.patch('importlib.metadata.version', return_value='3.12.4')
+    assert _check_aiohttp_has_graceful_shutdown() is True
+
+
+def test_graceful_shutdown_fallback_without_capability(mocker):
+    mocker.patch('kopf._cogs.helpers.aiohttpcaps.aiohttp', spec=[])
+    mocker.patch('importlib.metadata.version', return_value='3.12.3')
+    assert _check_aiohttp_has_graceful_shutdown() is False
+
+
+def test_graceful_shutdown_all_methods_fail_returns_true(mocker):
+    mocker.patch('kopf._cogs.helpers.aiohttpcaps.aiohttp', spec=[])
+    mocker.patch('importlib.metadata.version', side_effect=ValueError)
+    assert _check_aiohttp_has_graceful_shutdown() is True


### PR DESCRIPTION
A stability-improving follow-up for

* #1291 