### PR TITLE
Isolate KopfRunner's handlers from the caller's handlers or neighboring runners

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -42,6 +42,34 @@ exit code and output are available to the test (for additional assertions).
     the same as if it were executed with ``kopf run``.
 
 
+Handler isolation
+-----------------
+
+:class:`kopf.testing.KopfRunner` is isolated from the caller's environment
+by default: it creates its own registry and settings, so only the handlers
+from the specified files and modules are loaded --- the same as ``kopf run``
+would behave on the command line.
+
+This means that any ``@kopf.on.*`` handlers defined in the test file
+or elsewhere in the caller's code are not visible to the runner
+and do not affect the operator being tested.
+
+If the caller's handlers must be passed to the operator (not recommended), pass
+the caller's default registry explicitly from :func:`kopf.get_default_registry`
+--- this is where the handlers go to by default:
+
+.. code-block:: python
+
+    import kopf
+    from kopf.testing import KopfRunner
+
+    with KopfRunner(
+        ['run', '--verbose', 'example.py'],
+        registry=kopf.get_default_registry(),
+    ) as runner:
+        ...
+
+
 Mock server
 ===========
 

--- a/kopf/_kits/runner.py
+++ b/kopf/_kits/runner.py
@@ -74,8 +74,14 @@ class KopfRunner(_AbstractKopfRunner):
         self.kwargs = kwargs
         self.reraise = reraise
         self.timeout = timeout
-        self.registry = registry
+
+        # Separate the CLI-based runner from the environment. The CLI runner accepts files/modules
+        # and imports handlers from there, it should not inherit the caller's handlers.
+        # This pollutes the operator with unintended behaviour.
+        self.registry = registry if registry is not None else registries.SmartOperatorRegistry()
         self.settings = settings
+
+        # Internal synchronization of the runner (not the operator).
         self._stop = threading.Event()
         self._ready = threading.Event()  # NB: not asyncio.Event!
         self._thread = threading.Thread(target=self._target)

--- a/kopf/cli.py
+++ b/kopf/cli.py
@@ -89,12 +89,18 @@ def run(
         namespaces = tuple(namespaces) + (os.environ.get('KOPF_RUN_NAMESPACE', ''),)
     if namespaces and clusterwide:
         raise click.UsageError("Either --namespace or --all-namespaces can be used, not both.")
+
+    # Keep the default registry set only for the loading time (when we register handlers).
+    # This is for KopfRunner in tests, which needs isolation from the caller's environment.
+    # For the real CLI, this is a one-shot run and this trick makes no difference.
+    original_registry = registries.get_default_registry()
     if __controls.registry is not None:
         registries.set_default_registry(__controls.registry)
-    loaders.preload(
-        paths=paths,
-        modules=modules,
-    )
+    try:
+        loaders.preload(paths=paths, modules=modules)
+    finally:
+        registries.set_default_registry(original_registry)
+
     with loops.proper_loop(suggested_loop=__controls.loop) as actual_loop:
         return running.run(
             standalone=standalone,

--- a/tests/testing/test_runner.py
+++ b/tests/testing/test_runner.py
@@ -1,5 +1,8 @@
+import textwrap
+
 import pytest
 
+import kopf
 from kopf._cogs.configs.configuration import OperatorSettings
 from kopf._core.intents.registries import OperatorRegistry
 from kopf.testing import KopfRunner
@@ -35,6 +38,86 @@ def test_registry_and_settings_are_propagated(mocker):
     assert operator_mock.called
     assert operator_mock.call_args.kwargs['registry'] is registry
     assert operator_mock.call_args.kwargs['settings'] is settings
+
+
+def test_runner_is_isolated_from_caller(registry, mocker, tmp_path):
+    operator_mock = mocker.patch('kopf._core.reactor.running.operator')
+
+    # Enforce known ids instead of the default closures and nested functions.
+    @kopf.on.startup(registry=registry, id='caller_handler')
+    def caller_handler(**_):
+        pass
+
+    handler_file = tmp_path / "handlers.py"
+    handler_file.write_text(textwrap.dedent("""
+        import kopf
+
+        @kopf.on.startup(id='file_handler')
+        def file_handler(**_):
+            pass
+    """))
+
+    with KopfRunner(['run', str(handler_file), '--standalone']) as runner:
+        pass
+    assert runner.exit_code == 0
+    assert runner.exception is None
+
+    # The operator must be called with a fresh registry, not the caller's.
+    used_registry = operator_mock.call_args.kwargs['registry']
+    assert used_registry is not registry
+
+    # The file's handler must be in the operator's registry.
+    caller_handler_ids = [h.id for h in registry._activities.get_all_handlers()]
+    runner_handler_ids = [h.id for h in used_registry._activities.get_all_handlers()]
+    assert 'caller_handler' not in runner_handler_ids
+    assert 'file_handler' in runner_handler_ids
+    assert 'file_handler' not in caller_handler_ids
+    assert 'caller_handler' in caller_handler_ids
+
+
+def test_runner_is_isolated_from_sibling_runners(mocker, tmp_path):
+    operator_mock = mocker.patch('kopf._core.reactor.running.operator')
+
+    handler_file_a = tmp_path / "handlers_a.py"
+    handler_file_a.write_text(textwrap.dedent("""
+        import kopf
+
+        @kopf.on.startup(id='handler_a')
+        def handler_a(**_):
+            pass
+    """))
+
+    handler_file_b = tmp_path / "handlers_b.py"
+    handler_file_b.write_text(textwrap.dedent("""
+        import kopf
+
+        @kopf.on.startup(id='handler_b')
+        def handler_b(**_):
+            pass
+    """))
+
+    with KopfRunner(['run', str(handler_file_a), '--standalone']) as runner_a:
+        pass
+    assert runner_a.exit_code == 0
+    assert runner_a.exception is None
+
+    with KopfRunner(['run', str(handler_file_b), '--standalone']) as runner_b:
+        pass
+    assert runner_b.exit_code == 0
+    assert runner_b.exception is None
+
+    # Each runner must use its own fresh registry.
+    used_registry_a = operator_mock.call_args_list[0].kwargs['registry']
+    used_registry_b = operator_mock.call_args_list[1].kwargs['registry']
+    assert used_registry_a is not used_registry_b
+
+    # The first runner's handler must NOT be in the second runner's registry.
+    handler_ids_a = [h.id for h in used_registry_a._activities.get_all_handlers()]
+    handler_ids_b = [h.id for h in used_registry_b._activities.get_all_handlers()]
+    assert 'handler_a' in handler_ids_a
+    assert 'handler_b' not in handler_ids_a
+    assert 'handler_b' in handler_ids_b
+    assert 'handler_a' not in handler_ids_b
 
 
 def test_exception_from_runner_suppressed_with_no_reraise():


### PR DESCRIPTION
**BLOCKED, see below.**
**ABANDONED in faviour of KopfCLI, the true subprocess runner with full isolation. See #1292.**

That was the intended behaviour: the `KopfRunner` loads the handlers from the files and modules specified on the command line, the same as `kopf run` does. But the behaviour was broken: in addition to the specified files and modules, the handlers from the caller were leaked into the operator. Moreover, the handlers of different runners were accumulated in the same default registry over time, affecting each other.

That wasn't a big problem likely because (1) the test runners are rarely used; (2) they are loading the same handlers of the same operator anyway, differing only in the behavior of the runner's block.

Example:

```python
import kopf.testing

@kopf.on.event('pods')
def unintentional_handler(**_): ...

with kopf.testing.KopfRunner(['run', '--verbose', 'file1.py', '-m', 'module1']):
    # unintentional_handler will be in effect in addition to file1/module1 handlers
    ...

with kopf.testing.KopfRunner(['run', '--verbose', 'file2.py', '-m', 'module2']):
    # unintentional_handler will be in effect in addition to file2/module2 handlers
    # handlers from file1.py and module1 will also be here in the 2nd runner
    ...
```

This fix isolates the runner from the caller of the runner and from other runners, so that the runner runs in its own isolated environment (registry).

If the **old behaviour** is needed (not recommended), pass the default registry of the caller explicitly:

```python
import kopf.testing

@kopf.on.event('pods')
def desired_handler(**_): ...

with kopf.testing.KopfRunner(['run', '--verbose', 'file.py', '-m', 'module'],
                             registry=kopf.get_default_registry()):
    ...
```


--- 

**BLOCKER:** Works with files. Does not work with modules as `-m mod`: if the module was imported in the caller, it is NOT reloaded in the runner by Python, so the handler registration does not happen again, so the isolated registry remains empty.

The only solution seems to be running as a fair subprocess or to tweak the module loading (e.g. force reloading of specified modules one every run, potentially causing double-execution of the top-level code, double class declaration and invalidating the previous classes, and other unpleasant side effects).

Sub-processes seem to be the closest to the original intention — a fully isolated CLI runner as in `kopf run`. For non-isolated runners, the new `KopfTask` & `KopfThread` can replace the old behaviour of `KopfRunner`.

But this breaks the backwards compatibility.

**ANOTHER solution:** keep it as is, non-isolated, with all the side effects, but backwards compatible. Declare it as deprecated (issue a `DeprecationWarning` on creation). Replace it with a new runner `KopfProcess` to behave properly with all the file/module isolation — in line with `KopfTask` & `KopfThread`.

