### PR TITLE
Fix the transformation functions in timers/daemons patching

### DIFF
--- a/docs/daemons.rst
+++ b/docs/daemons.rst
@@ -333,23 +333,6 @@ will remember their value as it was at that moment in time,
 and will not be updated as the object changes.
 
 
-Results delivery
-================
-
-As with any other handlers, the daemons can return arbitrary JSON-serializable
-values to be put on the resource's status:
-
-.. code-block:: python
-
-    import asyncio
-    import kopf
-
-    @kopf.daemon('kopfexamples')
-    async def monitor_kex(stopped, **kwargs):
-        await asyncio.sleep(10.0)
-        return {'finished': True}
-
-
 Error handling
 ==============
 
@@ -370,6 +353,67 @@ The error handling is the same as for all other handlers: see :doc:`errors`:
 If a permanent error is raised, the daemon will never be restarted again.
 Same as when the daemon exits on its own (but this could be reconsidered
 in the future).
+
+
+Results delivery
+================
+
+As with any other handlers, the daemons can return arbitrary JSON-serializable
+values to be put on the resource's status:
+
+.. code-block:: python
+
+    import asyncio
+    import kopf
+
+    @kopf.daemon('kopfexamples')
+    async def monitor_kex(stopped, **kwargs):
+        await asyncio.sleep(10.0)
+        return {'finished': True}
+
+
+Patching
+========
+
+Daemons can modify the resource via the :kwarg:`patch` keyword argument,
+including both the merge-patch dictionary and the transformation functions
+(see :doc:`patches` for details).
+
+.. code-block:: python
+
+    import asyncio
+    import random
+    import kopf
+
+    # Transformation functions and JSON-patches are useful specifically for the lists.
+    def set_conditions(body: kopf.RawBody) -> None:
+        conditions = body.setdefault('status', {}).setdefault('conditions', [])
+        conditions[:] = [cond for cond in conditions if cond.get('type') != 'Whatever']
+        conditions.append({'type': 'Whatever', 'status': 'True', 'reason': 'SomeReason', 'message': 'Some message'})
+
+    @kopf.daemon('kopfexamples')
+    async def update_status(stopped, patch, **kwargs):
+        # This goes to the merge-patch.
+        patch.status['replicas'] = random.randint(1, 10)
+
+        # This goes to the JSON-patch.
+        patch.fns.append(set_conditions)
+
+        # Exit the daemon so that it restarts again (otherwise exits forever).
+        raise kopf.TemporaryError("retry a bit later", delay=5)
+
+The patch is applied after the handler exits on each iteration of the run loop.
+This includes when the handler raises :class:`kopf.TemporaryError` for retrying:
+all changes accumulated in the patch during that attempt are sent to
+the Kubernetes API before the next retry begins.
+After the patch is applied, it is cleared for the next iteration.
+
+If a transformation function's JSON Patch hits a ``resourceVersion`` mismatch
+(HTTP 422), the transformation functions are carried forward and retried
+on the next iteration --- not in the background. The handler can detect this
+by checking ``bool(patch)`` at the start: if it is true before the handler
+has made any changes, there are pending transformation functions from
+a previous iteration.
 
 
 Filtering

--- a/docs/patches.rst
+++ b/docs/patches.rst
@@ -106,10 +106,6 @@ The functions should therefore be safe to call repeatedly:
 they should check the current state before making changes
 rather than assuming a particular initial state.
 
-
-Arguments to transformation functions
---------------------------------------
-
 The transformation function takes a single positional argument
 for the body. If additional positional or keyword arguments are needed,
 use ``functools.partial``:
@@ -125,3 +121,27 @@ use ``functools.partial``:
     @kopf.on.create('kopfexamples')
     def create_fn(patch, **_):
         patch.fns.append(functools.partial(set_label, name='my-label', value='my-value'))
+
+
+Patch timing in daemons and timers
+==================================
+
+For :doc:`daemons <daemons>` and :doc:`timers <timers>`, the patch
+is applied after the handler exits on each iteration of the run loop ---
+including when the handler raises :class:`kopf.TemporaryError` for retrying.
+After the patch is applied, it is cleared for the next iteration.
+
+This means any changes accumulated in the patch dictionary
+and any transformation functions appended to ``patch.fns``
+during the handler's execution are sent to the Kubernetes API
+before the next invocation of the handler starts.
+
+If a transformation function's JSON Patch is rejected by the API server
+due to an optimistic concurrency conflict (HTTP 422), the transformation
+functions are carried forward to the next iteration, where they are
+retried against the newer state of the resource. The retry does not happen
+in the background --- it waits until the handler is invoked again on the next
+timer interval or daemon retry. Handlers can detect carried-forward
+transformation functions by checking ``bool(patch)`` at the start of the
+handler: if it is true before the handler has made any changes, it means
+there are pending transformation functions from a previous iteration.

--- a/docs/timers.rst
+++ b/docs/timers.rst
@@ -218,6 +218,47 @@ as a key.
     Use carefully with both idling & returned results.
 
 
+Patching
+========
+
+Timers can modify the resource via the :kwarg:`patch` keyword argument,
+including both the merge-patch dictionary and the transformation functions
+(see :doc:`patches` for details).
+
+.. code-block:: python
+
+    import asyncio
+    import random
+    import kopf
+
+    # Transformation functions and JSON-patches are useful specifically for the lists.
+    def set_conditions(body: kopf.RawBody) -> None:
+        conditions = body.setdefault('status', {}).setdefault('conditions', [])
+        conditions[:] = [cond for cond in conditions if cond.get('type') != 'Whatever']
+        conditions.append({'type': 'Whatever', 'status': 'True', 'reason': 'SomeReason', 'message': 'Some message'})
+
+    @kopf.timer('kopfexamples', interval=60)
+    async def update_status(patch, **kwargs):
+        # This goes to the merge-patch.
+        patch.status['replicas'] = random.randint(1, 10)
+
+        # This goes to the JSON-patch.
+        patch.fns.append(set_conditions)
+
+The patch is applied after the handler exits on each timer iteration.
+This includes when the handler raises :class:`kopf.TemporaryError` for retrying:
+all changes accumulated in the patch during that attempt are sent to
+the Kubernetes API before the next retry begins.
+After the patch is applied, it is cleared for the next iteration.
+
+If a transformation function's JSON Patch hits a ``resourceVersion`` mismatch
+(HTTP 422), the transformation functions are carried forward and retried
+on the next iteration --- not in the background. The handler can detect this
+by checking ``bool(patch)`` at the start: if it is true before the handler
+has made any changes, there are pending transformation functions from
+a previous iteration.
+
+
 Filtering
 =========
 

--- a/kopf/_cogs/clients/patching.py
+++ b/kopf/_cogs/clients/patching.py
@@ -75,7 +75,7 @@ async def patch_obj(
         # Use the latest known body for reference when calculating the item indexes in lists.
         # Note: we apply transformations for the whole body atomically, and in the future (not yet)
         # we want to get the ops from the functions, so we can only filter by path here.
-        fresh_body: bodies.RawBody | None = patched_body if patched_body else patch._original
+        fresh_body: bodies.Body | bodies.RawBody | None = patched_body or patch._original
         ops: patches.JSONPatch = remaining_patch.as_json_patch(fresh_body)
         body_ops: patches.JSONPatch
         status_ops: patches.JSONPatch

--- a/kopf/_cogs/structs/patches.py
+++ b/kopf/_cogs/structs/patches.py
@@ -90,6 +90,10 @@ class Patch(dict[str, Any]):
     def __bool__(self) -> bool:
         return len(self) > 0 or bool(self.fns)
 
+    def clear(self) -> None:
+        super().clear()
+        self._fns.clear()
+
     @property
     def fns(self) -> list[PatchFn]:
         return self._fns

--- a/kopf/_cogs/structs/patches.py
+++ b/kopf/_cogs/structs/patches.py
@@ -68,7 +68,7 @@ class Patch(dict[str, Any]):
         self,
         src: dict[str, Any] | None = None,
         /,
-        body: bodies.RawBody | None = None,
+        body: bodies.Body | None = None,
         fns: Iterable[PatchFn] = (),
     ) -> None:
         super().__init__(src or {})
@@ -110,7 +110,7 @@ class Patch(dict[str, Any]):
     def status(self) -> StatusPatch:
         return self._status
 
-    def as_json_patch(self, body: bodies.RawBody | None = None) -> JSONPatch:
+    def as_json_patch(self, body: bodies.Body | bodies.RawBody | None = None) -> JSONPatch:
         """
         Build a list of JSON-patch ops for the changes & transformations.
 
@@ -123,8 +123,9 @@ class Patch(dict[str, Any]):
         or setting the key to a value which is already in the resource body.
         """
         # Clone the original body to be mutated in memory before diffing.
-        body_as_is = body if body is not None else self._original
-        body_to_be = copy.deepcopy(body_as_is)
+        base: bodies.Body | bodies.RawBody | None = body if body is not None else self._original
+        body_as_is: bodies.RawBody | None = None if base is None else cast(bodies.RawBody, dict(base))
+        body_to_be: bodies.RawBody | None = copy.deepcopy(body_as_is)
         if not self:
             return []
         if body_as_is is None or body_to_be is None:

--- a/kopf/_core/engines/admission.py
+++ b/kopf/_core/engines/admission.py
@@ -135,7 +135,7 @@ async def serve_admission_request(
     old = bodies.Body(old_body) if old_body is not None else None
     new = bodies.Body(new_body) if new_body is not None else None
     diff = diffs.diff(old, new)
-    patch = patches.Patch(body=raw_body)
+    patch = patches.Patch(body=body)
     warnings: list[str] = []
     cause = causes.WebhookCause(
         resource=resource,

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -537,14 +537,14 @@ async def _daemon(
         )
         state = state.with_outcomes(outcomes)
         progression.deliver_results(outcomes=outcomes, patch=patch)
-        await application.patch_and_check(
+        _, remaining_patch = await application.patch_and_check(
             settings=settings,
             resource=resource,
             logger=logger,
             patch=patch,
             body=body,
         )
-        patch.clear()
+        patch = cause.patch = patches.Patch(remaining_patch, body=body)
 
         # The in-memory sleep does not react to resource changes, but only to stopping.
         if state.delay:
@@ -626,14 +626,14 @@ async def _timer(
         )
         state = state.with_outcomes(outcomes)
         progression.deliver_results(outcomes=outcomes, patch=patch)
-        await application.patch_and_check(
+        _, remaining_patch = await application.patch_and_check(
             settings=settings,
             resource=resource,
             logger=logger,
             patch=patch,
             body=body,
         )
-        patch.clear()
+        patch = cause.patch = patches.Patch(remaining_patch, body=body)
 
         # For temporary errors, override the schedule by the one provided by errors themselves.
         # It can be either a delay from TemporaryError, or a backoff for an arbitrary exception.

--- a/kopf/_core/engines/daemons.py
+++ b/kopf/_core/engines/daemons.py
@@ -89,13 +89,14 @@ async def spawn_daemons(
     for handler in handlers:
         if handler.id not in daemons:
             stopper = stoppers.DaemonStopper()
+            live_body = memory.live_fresh_body
             daemon_cause = causes.DaemonCause(
                 resource=cause.resource,
                 indices=cause.indices,
                 logger=cause.logger,
                 memo=cause.memo,
-                body=memory.live_fresh_body,
-                patch=patches.Patch(),  # not the same as the one-shot spawning patch!
+                body=live_body,
+                patch=patches.Patch(body=live_body),  # not the same as the one-shot spawning patch!
                 stopper=stopper,  # for checking (passed to kwargs)
             )
             daemon = Daemon(

--- a/kopf/_core/reactor/processing.py
+++ b/kopf/_core/reactor/processing.py
@@ -68,7 +68,7 @@ async def process_resource_event(
     # 4. Same as where a patch object of a similar wrapping semantics is created.
     live_fresh_body = memory.daemons_memory.live_fresh_body
     body = live_fresh_body if live_fresh_body is not None else bodies.Body(raw_body)
-    patch = patches.Patch(memory.remaining_patch, body=raw_body)
+    patch = patches.Patch(memory.remaining_patch, body=body)
 
     # Different loggers for different cases with different verbosity and exposure.
     local_logger = loggers.LocalObjectLogger(body=body, settings=settings)

--- a/tests/basic-structs/test_patch.py
+++ b/tests/basic-structs/test_patch.py
@@ -122,3 +122,15 @@ def test_patch_inherits_dict_and_fns():
     p2 = Patch(p1)
     assert p2['x'] == 'y'
     assert list(p2.fns) == [fn1]
+
+
+# === Patch.clear ===
+
+
+def test_patch_clear_clears_dict_and_fns():
+    fn = lambda body: None
+    patch = Patch({'a': 'b'}, fns=[fn])
+    patch.clear()
+    assert dict(patch) == {}
+    assert list(patch.fns) == []
+    assert not patch

--- a/tests/basic-structs/test_patch.py
+++ b/tests/basic-structs/test_patch.py
@@ -1,3 +1,4 @@
+from kopf._cogs.structs.bodies import Body
 from kopf._cogs.structs.patches import Patch
 
 # === Patch.__init__ ===
@@ -16,14 +17,14 @@ def test_patch_init_none_src():
 
 
 def test_patch_init_body_only():
-    body = {'metadata': {'name': 'obj'}}
+    body = Body({'metadata': {'name': 'obj'}})
     patch = Patch(body=body)
     assert dict(patch) == {}
     assert len(patch.fns) == 0
 
 
 def test_patch_init_body_stored_for_json_patch():
-    body = {'abc': 456}
+    body = Body({'abc': 456})
     patch = Patch(body=body)
     patch['abc'] = 789
     ops = patch.as_json_patch()

--- a/tests/basic-structs/test_patch_json.py
+++ b/tests/basic-structs/test_patch_json.py
@@ -2,7 +2,7 @@ import copy
 
 import pytest
 
-from kopf._cogs.structs.bodies import RawBody
+from kopf._cogs.structs.bodies import Body, RawBody
 from kopf._cogs.structs.patches import Patch
 
 
@@ -22,7 +22,7 @@ def test_no_error_when_no_body_is_needed():
 def test_body_argument_overrides_original():
     body1 = {'abc': 456}  # leads to ops=remove(abc) & op=add(xyz)
     body2 = {'xyz': 789}  # leads to op=replace(xyz) only
-    patch = Patch(body=body1)
+    patch = Patch(body=Body(body1))
     patch['abc'] = None
     patch['xyz'] = 123
     ops = patch.as_json_patch(body2)
@@ -33,14 +33,14 @@ def test_body_argument_overrides_original():
 
 def test_noop_empty_patch():
     body = {'abc': 456}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     ops = patch.as_json_patch()
     assert ops == []
 
 
 def test_noop_merge_of_empty_dict():
     body = {'xyz': {'abc': 456}}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = {}  # nothing to merge here
     ops = patch.as_json_patch()
     assert ops == []
@@ -48,7 +48,7 @@ def test_noop_merge_of_empty_dict():
 
 def test_noop_replacement_of_the_key():
     body = {'xyz': 123}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = 123
     ops = patch.as_json_patch()
     assert ops == []
@@ -56,7 +56,7 @@ def test_noop_replacement_of_the_key():
 
 def test_noop_removal_of_absent_key():
     body = {'abc': 456}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = None
     ops = patch.as_json_patch()
     assert ops == []
@@ -64,7 +64,7 @@ def test_noop_removal_of_absent_key():
 
 def test_addition_of_the_key():
     body = {'abc': 456}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = 123
     ops = patch.as_json_patch()
     assert ops == [
@@ -74,7 +74,7 @@ def test_addition_of_the_key():
 
 def test_replacement_of_the_key():
     body = {'xyz': 456}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = 123
     ops = patch.as_json_patch()
     assert ops == [
@@ -84,7 +84,7 @@ def test_replacement_of_the_key():
 
 def test_removal_of_the_key():
     body = {'xyz': 456}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = None
     ops = patch.as_json_patch()
     assert ops == [
@@ -94,7 +94,7 @@ def test_removal_of_the_key():
 
 def test_addition_of_the_subkey():
     body = {'xyz': {'def': 456}}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = {'abc': 123}
     ops = patch.as_json_patch()
     assert ops == [
@@ -104,7 +104,7 @@ def test_addition_of_the_subkey():
 
 def test_replacement_of_the_subkey():
     body = {'xyz': {'abc': 456}}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = {'abc': 123}
     ops = patch.as_json_patch()
     assert ops == [
@@ -114,7 +114,7 @@ def test_replacement_of_the_subkey():
 
 def test_addition_of_key_with_new_parent():
     body = {}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = {'abc': 123}
     ops = patch.as_json_patch()
     assert ops == [
@@ -124,7 +124,7 @@ def test_addition_of_key_with_new_parent():
 
 def test_addition_of_the_sub_subkey_with_existing_parent():
     body = {'xyz': {'uvw': 123}}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = {'abc': {'def': {'ghi': 456}}}
     ops = patch.as_json_patch()
     assert ops == [
@@ -134,7 +134,7 @@ def test_addition_of_the_sub_subkey_with_existing_parent():
 
 def test_removal_of_the_subkey_and_remaining_parent():
     body = {'xyz': {'abc': 456, 'other': '...'}}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = {'abc': None}
     ops = patch.as_json_patch()
     assert ops == [
@@ -144,7 +144,7 @@ def test_removal_of_the_subkey_and_remaining_parent():
 
 def test_removal_of_the_subkey_and_emptied_parent():
     body = {'xyz': {'abc': 456}}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = {'abc': None}
     ops = patch.as_json_patch()
     assert ops == [
@@ -154,7 +154,7 @@ def test_removal_of_the_subkey_and_emptied_parent():
 
 def test_addition_of_list_value():
     body = {'abc': 456}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = [1, 2, 3]
     ops = patch.as_json_patch()
     assert ops == [
@@ -164,7 +164,7 @@ def test_addition_of_list_value():
 
 def test_replacement_of_list_value():
     body = {'xyz': [1, 2, 3]}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['xyz'] = [4, 5]
     ops = patch.as_json_patch()
     # The jsonpatch library diffs lists element-by-element, not as a whole.
@@ -177,7 +177,7 @@ def test_replacement_of_list_value():
 
 def test_multiple_operations():
     body = {'existing': 1, 'toremove': 2}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['existing'] = 99
     patch['toremove'] = None
     patch['newkey'] = 'hello'
@@ -191,7 +191,7 @@ def test_multiple_operations():
 
 def test_fn_only():
     body = {'items': [1, 2]}
-    patch = Patch(body=body, fns=[lambda b: b['items'].append(3)])
+    patch = Patch(body=Body(body), fns=[lambda b: b['items'].append(3)])
     ops = patch.as_json_patch()
     assert ops == [
         {'op': 'add', 'path': '/items/2', 'value': 3},
@@ -200,7 +200,7 @@ def test_fn_only():
 
 def test_fn_combined_with_merge_patch():
     body = {'items': [1, 2], 'label': 'old'}
-    patch = Patch(body=body, fns=[lambda b: b['items'].append(3)])
+    patch = Patch(body=Body(body), fns=[lambda b: b['items'].append(3)])
     patch['label'] = 'new'
     ops = patch.as_json_patch()
     assert sorted(ops, key=lambda op: op['path']) == [
@@ -215,7 +215,7 @@ def test_fn_applied_strictly_after_merges():
         body['xyz'] += 1
 
     body = {'xyz': 100}
-    patch = Patch(body=body, fns=[increment])
+    patch = Patch(body=Body(body), fns=[increment])
     patch['xyz'] = 200
     ops = patch.as_json_patch()
     assert sorted(ops, key=lambda op: op['path']) == [
@@ -225,7 +225,7 @@ def test_fn_applied_strictly_after_merges():
 
 def test_escaping_of_key():
     body = {'~xyz/test': {'abc': '...', 'other': '...'}}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['~xyz/test'] = {'abc': None}
     ops = patch.as_json_patch()
     assert ops == [
@@ -235,7 +235,7 @@ def test_escaping_of_key():
 
 def test_recursive_escape_of_key():
     body = {'x/y/~z': {'a/b/~0c': '...', 'other': '...'}}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['x/y/~z'] = {'a/b/~0c': None}
     ops = patch.as_json_patch()
     assert ops == [
@@ -245,7 +245,7 @@ def test_recursive_escape_of_key():
 
 def test_does_not_mutate_original_body():
     body = {'spec': {'x': 'original'}}
-    patch = Patch(body=body)
+    patch = Patch(body=Body(body))
     patch['spec'] = {'x': 'modified'}
     body_before = copy.deepcopy(body)
     patch.as_json_patch()
@@ -254,7 +254,7 @@ def test_does_not_mutate_original_body():
 
 def test_does_not_mutate_original_body_with_fns():
     body = {'spec': {'x': 'original'}}
-    patch = Patch(body=body, fns=[lambda b: b.setdefault('extra', 'added')])
+    patch = Patch(body=Body(body), fns=[lambda b: b.setdefault('extra', 'added')])
     patch['spec'] = {'x': 'modified'}
     body_before = copy.deepcopy(body)
     patch.as_json_patch()

--- a/tests/handling/daemons/test_daemon_patching.py
+++ b/tests/handling/daemons/test_daemon_patching.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import kopf
+from kopf._core.actions.execution import TemporaryError
 
 
 async def test_daemon_patching_with_fns_only(
@@ -50,4 +51,40 @@ async def test_daemon_patching_with_merge_and_fns(
     assert payloads[1] == [
         {'op': 'test', 'path': '/metadata/resourceVersion', 'value': None},
         {'op': 'add', 'path': '/status', 'value': {'json-patch': 'hello'}},
+    ]
+
+
+async def test_daemon_fns_cleared_between_iterations(
+        settings, resource, dummy, assert_logs, k8s_mocked, simulate_cycle, looptime):
+    """Each daemon iteration must carry only its own fns, not accumulated from prior iterations."""
+    finished = asyncio.Event()
+
+    @kopf.daemon(*resource, id='fn', backoff=1.0)
+    async def fn(retry, patch: kopf.Patch, **kwargs):
+        dummy.mock(**kwargs, retry=retry, patch=patch)
+        n = dummy.mock.call_count
+        patch.fns.append(lambda body, n=n: body.setdefault('status', {}).update({f'iter{n}': True}))
+        if not retry:
+            raise TemporaryError("retry me!", delay=1.0)
+        finished.set()
+
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'resourceVersion': '123', 'finalizers': [finalizer]}}
+    await simulate_cycle(event_object)
+    await finished.wait()
+    await dummy.wait_for_daemon_done()
+
+    assert dummy.mock.call_count == 2
+
+    # If fns leak, the second retry's payload would contain operations from the first retry too.
+    payloads = [call.kwargs['payload'] for call in k8s_mocked.patch.call_args_list]
+    assert len(payloads) == 2
+    assert payloads[0] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
+        {'op': 'add', 'path': '/status', 'value': {f'iter1': True}},
+    ]
+    assert payloads[1] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
+        {'op': 'add', 'path': '/status', 'value': {f'iter2': True}},
+        # important: no "iter1" field here (as if when the fn would be preserved)!
     ]

--- a/tests/handling/daemons/test_daemon_patching.py
+++ b/tests/handling/daemons/test_daemon_patching.py
@@ -1,0 +1,53 @@
+import asyncio
+
+import kopf
+
+
+async def test_daemon_patching_with_fns_only(
+        settings, resource, dummy, k8s_mocked, simulate_cycle, looptime):
+    executed = asyncio.Event()
+
+    @kopf.daemon(*resource, id='fn')
+    async def fn(patch, **kwargs):
+        dummy.mock(**kwargs)
+        patch.fns.append(lambda body: body.setdefault('status', {}).update({'json-patch': 'hello'}))
+        executed.set()
+
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer], 'resourceVersion': '123'}}
+    await simulate_cycle(event_object)
+    await executed.wait()
+    await dummy.wait_for_daemon_done()
+
+    payloads = [call.kwargs['payload'] for call in k8s_mocked.patch.call_args_list]
+    assert len(payloads) == 1
+    assert payloads[0] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
+        {'op': 'add', 'path': '/status', 'value': {'json-patch': 'hello'}},
+    ]
+
+
+async def test_daemon_patching_with_merge_and_fns(
+        settings, resource, dummy, k8s_mocked, simulate_cycle, looptime):
+    executed = asyncio.Event()
+
+    @kopf.daemon(*resource, id='fn')
+    async def fn(patch, **kwargs):
+        dummy.mock(**kwargs)
+        patch.status['merge-patch'] = 'hello'
+        patch.fns.append(lambda body: body.setdefault('status', {}).update({'json-patch': 'hello'}))
+        executed.set()
+
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer], 'labels': {}}}
+    await simulate_cycle(event_object)
+    await executed.wait()
+    await dummy.wait_for_daemon_done()
+
+    payloads = [call.kwargs['payload'] for call in k8s_mocked.patch.call_args_list]
+    assert len(payloads) == 2
+    assert payloads[0] == {'status': {'merge-patch': 'hello'}}
+    assert payloads[1] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': None},
+        {'op': 'add', 'path': '/status', 'value': {'json-patch': 'hello'}},
+    ]

--- a/tests/handling/daemons/test_daemon_patching.py
+++ b/tests/handling/daemons/test_daemon_patching.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import kopf
+from kopf._cogs.clients.errors import APIUnprocessableEntityError
 from kopf._core.actions.execution import TemporaryError
 
 
@@ -87,4 +88,46 @@ async def test_daemon_fns_cleared_between_iterations(
         {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
         {'op': 'add', 'path': '/status', 'value': {f'iter2': True}},
         # important: no "iter1" field here (as if when the fn would be preserved)!
+    ]
+
+
+async def test_daemon_fns_carried_forward_on_conflict(
+        resource, settings, dummy, assert_logs, k8s_mocked, simulate_cycle, looptime):
+    """Patch fns must be retried on the next retry after a 422 conflict."""
+    finished = asyncio.Event()
+
+    @kopf.daemon(*resource, id='fn', backoff=1.0)
+    async def fn(retry, patch: kopf.Patch, **kwargs):
+        dummy.mock(**kwargs, patch=patch)
+        n = dummy.mock.call_count
+        patch.fns.append(lambda body, n=n: body.setdefault('status', {}).update({f'iter{n}': True}))
+        if not retry:
+            raise TemporaryError("retry me!", delay=1.0)
+        finished.set()
+
+    # Fail the first JSON-patch call with 422 (version conflict), succeed on 2nd and so on.
+    k8s_mocked.patch.side_effect = [
+        APIUnprocessableEntityError(status=422, headers={}),  # 1st json-patch
+        {'metadata': {'resourceVersion': '123'}},  # 2nd json-patch
+    ]
+
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'resourceVersion': '123', 'finalizers': [finalizer]}}
+    await simulate_cycle(event_object)
+    await finished.wait()
+    await dummy.wait_for_daemon_done()
+
+    assert dummy.mock.call_count == 2
+
+    # The fn was added on retry 0, JSON-patch failed with 422, fn was carried forward.
+    payloads = [call.kwargs['payload'] for call in k8s_mocked.patch.call_args_list]
+    assert len(payloads) == 2
+    assert payloads[0] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
+        {'op': 'add', 'path': '/status', 'value': {'iter1': True}},
+    ]
+    assert payloads[1] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
+        {'op': 'add', 'path': '/status', 'value': {'iter1': True, 'iter2': True}},
+        # important: "iter1" is carried forward, despite only "iter2" is added normally.
     ]

--- a/tests/handling/daemons/test_timer_patching.py
+++ b/tests/handling/daemons/test_timer_patching.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import kopf
+from kopf._cogs.clients.errors import APIUnprocessableEntityError
 
 
 async def test_timer_patching_with_fns_only(
@@ -92,4 +93,47 @@ async def test_timer_fns_cleared_between_iterations(
         {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
         {'op': 'add', 'path': '/status', 'value': {f'iter2': True}},
         # important: no "iter1" field here (as if when the fn would be preserved)!
+    ]
+
+
+async def test_timer_fns_carried_forward_on_conflict(
+        resource, settings, dummy, assert_logs, k8s_mocked, simulate_cycle, looptime):
+    """Patch fns must be retried on the next iteration after a 422 conflict."""
+    trigger = asyncio.Condition()
+
+    @kopf.timer(*resource, id='fn', interval=1.0)
+    async def fn(patch: kopf.Patch, **kwargs):
+        dummy.mock(**kwargs, patch=patch)
+        n = dummy.mock.call_count
+        patch.fns.append(lambda body, n=n: body.setdefault('status', {}).update({f'iter{n}': True}))
+        async with trigger:
+            trigger.notify_all()
+
+    # Fail the first JSON-patch call with 422 (version conflict), succeed on 2nd and so on.
+    k8s_mocked.patch.side_effect = [
+        APIUnprocessableEntityError(status=422, headers={}),  # 1st json-patch
+        {'metadata': {'resourceVersion': '123'}},  # 2nd json-patch
+    ]
+
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'resourceVersion': '123', 'finalizers': [finalizer]}}
+    await simulate_cycle(event_object)
+    async with trigger:
+        await trigger.wait()
+        await trigger.wait()
+    await asyncio.sleep(0.5)  # give it a half-cycle to patch after the last line of the handler
+
+    assert dummy.mock.call_count == 2
+
+    # The fn was added on iteration 1, JSON-patch failed with 422, fn was carried forward.
+    payloads = [call.kwargs['payload'] for call in k8s_mocked.patch.call_args_list]
+    assert len(payloads) == 2
+    assert payloads[0] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
+        {'op': 'add', 'path': '/status', 'value': {'iter1': True}},
+    ]
+    assert payloads[1] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
+        {'op': 'add', 'path': '/status', 'value': {'iter1': True, 'iter2': True}},
+        # important: "iter1" is carried forward, despite only "iter2" is added normally.
     ]

--- a/tests/handling/daemons/test_timer_patching.py
+++ b/tests/handling/daemons/test_timer_patching.py
@@ -55,3 +55,41 @@ async def test_timer_patching_with_merge_and_fns(
         {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
         {'op': 'add', 'path': '/status', 'value': {'json-patch': 'hello'}},
     ]
+
+
+async def test_timer_fns_cleared_between_iterations(
+        settings, resource, dummy, assert_logs, k8s_mocked, simulate_cycle, looptime):
+    """Each timer iteration must carry only its own fns, not accumulated from prior iterations."""
+    trigger = asyncio.Condition()
+
+    @kopf.timer(*resource, id='fn', interval=1.0)
+    async def fn(patch: kopf.Patch, **kwargs):
+        dummy.mock(**kwargs, patch=patch)
+        n = dummy.mock.call_count
+        patch.fns.append(lambda body, n=n: body.setdefault('status', {}).update({f'iter{n}': True}))
+        async with trigger:
+            trigger.notify_all()
+
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'resourceVersion': '123', 'finalizers': [finalizer]}}
+    await simulate_cycle(event_object)
+    initial_calls = len(k8s_mocked.patch.call_args_list)
+    async with trigger:
+        await trigger.wait()
+        await trigger.wait()
+    await asyncio.sleep(0.5)  # give it a half-cycle to patch after the last line of the handler
+
+    assert dummy.mock.call_count == 2
+
+    # If fns leak, the second retry's payload would contain operations from the first retry too.
+    payloads = [call.kwargs['payload'] for call in k8s_mocked.patch.call_args_list]
+    assert len(payloads) == 2
+    assert payloads[0] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
+        {'op': 'add', 'path': '/status', 'value': {f'iter1': True}},
+    ]
+    assert payloads[1] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
+        {'op': 'add', 'path': '/status', 'value': {f'iter2': True}},
+        # important: no "iter1" field here (as if when the fn would be preserved)!
+    ]

--- a/tests/handling/daemons/test_timer_patching.py
+++ b/tests/handling/daemons/test_timer_patching.py
@@ -1,0 +1,57 @@
+import asyncio
+
+import kopf
+
+
+async def test_timer_patching_with_fns_only(
+        settings, resource, dummy, k8s_mocked, simulate_cycle, looptime):
+    trigger = asyncio.Condition()
+
+    @kopf.timer(*resource, id='fn', interval=1.0)
+    async def fn(patch, **kwargs):
+        dummy.mock(**kwargs)
+        patch.fns.append(lambda body: body.setdefault('status', {}).update({'json-patch': 'hello'}))
+        async with trigger:
+            trigger.notify_all()
+
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer], 'resourceVersion': '123'}}
+    await simulate_cycle(event_object)
+    async with trigger:
+        await trigger.wait()
+    await asyncio.sleep(0.5)  # give it a half-cycle to patch after the last line of the handler
+
+    payloads = [call.kwargs['payload'] for call in k8s_mocked.patch.call_args_list]
+    assert len(payloads) == 1
+    assert payloads[0] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
+        {'op': 'add', 'path': '/status', 'value': {'json-patch': 'hello'}},
+    ]
+
+
+async def test_timer_patching_with_merge_and_fns(
+        settings, resource, dummy, k8s_mocked, simulate_cycle, looptime):
+    trigger = asyncio.Condition()
+
+    @kopf.timer(*resource, id='fn', interval=1.0)
+    async def fn(patch, **kwargs):
+        dummy.mock(**kwargs)
+        patch.status['merge-patch'] = 'hello'
+        patch.fns.append(lambda body: body.setdefault('status', {}).update({'json-patch': 'hello'}))
+        async with trigger:
+            trigger.notify_all()
+
+    finalizer = settings.persistence.finalizer
+    event_object = {'metadata': {'finalizers': [finalizer], 'resourceVersion': '123'}}
+    await simulate_cycle(event_object)
+    async with trigger:
+        await trigger.wait()
+    await asyncio.sleep(0.5)  # give it a half-cycle to patch after the last line of the handler
+
+    payloads = [call.kwargs['payload'] for call in k8s_mocked.patch.call_args_list]
+    assert len(payloads) == 2
+    assert payloads[0] == {'status': {'merge-patch': 'hello'}}
+    assert payloads[1] == [
+        {'op': 'test', 'path': '/metadata/resourceVersion', 'value': '123'},
+        {'op': 'add', 'path': '/status', 'value': {'json-patch': 'hello'}},
+    ]

--- a/tests/k8s/test_patching.py
+++ b/tests/k8s/test_patching.py
@@ -40,6 +40,7 @@ import pytest
 
 from kopf._cogs.clients.errors import APIError
 from kopf._cogs.clients.patching import patch_obj
+from kopf._cogs.structs.bodies import Body
 from kopf._cogs.structs.patches import Patch
 from kopf._cogs.structs.references import Resource
 
@@ -96,7 +97,7 @@ def _add_status_field(body):
 async def test_empty_or_noop_patch_makes_no_api_calls(
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
-    patch = Patch({}, body=original_body, fns=[_noop])
+    patch = Patch({}, body=Body(original_body), fns=[_noop])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -119,7 +120,7 @@ async def test_object_merge_alone(caplog,
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch({'spec': {'x': 'y'}}, body=original_body, fns=[])
+    patch = Patch({'spec': {'x': 'y'}}, body=Body(original_body), fns=[])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -142,7 +143,7 @@ async def test_status_merge_alone(
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch({'status': {'x': 'y'}}, body=original_body, fns=[])
+    patch = Patch({'status': {'x': 'y'}}, body=Body(original_body), fns=[])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -165,7 +166,7 @@ async def test_status_merge_after_object_merge(
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=original_body, fns=[])
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=Body(original_body), fns=[])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -190,7 +191,7 @@ async def test_object_jsonp_alone(
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch({}, body=original_body, fns=[_add_finalizer])
+    patch = Patch({}, body=Body(original_body), fns=[_add_finalizer])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -216,7 +217,7 @@ async def test_object_jsonp_after_object_merge(
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch({'spec': {'x': 'y'}}, body=original_body, fns=[_add_finalizer])
+    patch = Patch({'spec': {'x': 'y'}}, body=Body(original_body), fns=[_add_finalizer])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -244,7 +245,7 @@ async def test_object_jsonp_after_status_merge(
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch({'status': {'x': 'y'}}, body=original_body, fns=[_add_finalizer])
+    patch = Patch({'status': {'x': 'y'}}, body=Body(original_body), fns=[_add_finalizer])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -272,7 +273,7 @@ async def test_status_jsonp_alone(
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch({}, body=original_body, fns=[_add_status_field])
+    patch = Patch({}, body=Body(original_body), fns=[_add_status_field])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -298,7 +299,7 @@ async def test_status_jsonp_after_object_merge(
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch({'spec': {'x': 'y'}}, body=original_body, fns=[_add_status_field])
+    patch = Patch({'spec': {'x': 'y'}}, body=Body(original_body), fns=[_add_status_field])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -326,7 +327,7 @@ async def test_status_jsonp_after_status_merge(
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch({'status': {'x': 'y'}}, body=original_body, fns=[_add_status_field])
+    patch = Patch({'status': {'x': 'y'}}, body=Body(original_body), fns=[_add_status_field])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -354,7 +355,7 @@ async def test_status_jsonp_after_object_jsonp(
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch(body=original_body, fns=[_add_finalizer, _add_status_field])
+    patch = Patch(body=Body(original_body), fns=[_add_finalizer, _add_status_field])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -386,7 +387,7 @@ async def test_all_four_patches(
         kmock, settings, resource, namespace, logger, assert_logs):
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=original_body, fns=[_add_finalizer, _add_status_field])
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=Body(original_body), fns=[_add_finalizer, _add_status_field])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -424,7 +425,7 @@ async def test_no_subresource_skips_status_merge(
     resource = dataclasses.replace(resource, subresources=frozenset())
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=original_body)
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=Body(original_body))
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -448,7 +449,7 @@ async def test_no_subresource_skips_status_jsonp(
     resource = dataclasses.replace(resource, subresources=frozenset())
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
     kmock.objects[resource, namespace, 'name1'] = original_body
-    patch = Patch(body=original_body, fns=[_add_finalizer, _add_status_field])
+    patch = Patch(body=Body(original_body), fns=[_add_finalizer, _add_status_field])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -479,7 +480,7 @@ async def test_422_in_object_jsonp_returns_the_remaining_patch(
         kmock, settings, resource, namespace, logger, assert_logs):
     kmock[kmock.subresource(None), {'Content-Type': 'application/json-patch+json'}] ** 1 << 422
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
-    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=original_body, fns=[_add_finalizer, _add_status_field])
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=Body(original_body), fns=[_add_finalizer, _add_status_field])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -507,7 +508,7 @@ async def test_422_in_status_jsonp_returns_the_remaining_patch(
         kmock, settings, resource, namespace, logger, assert_logs):
     kmock[kmock.subresource('status'), {'Content-Type': 'application/json-patch+json'}] ** 1 << 422
     original_body = {'metadata': {'resourceVersion': 'rv0'}, 'status': {}}
-    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=original_body, fns=[_add_finalizer, _add_status_field])
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=Body(original_body), fns=[_add_finalizer, _add_status_field])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -544,7 +545,7 @@ async def test_404_ignores_absent_objects(
         kmock, settings, resource, namespace, logger, content_type, subresource,
         cluster_resource, namespaced_resource, assert_logs, exp_api_count):
     kmock[kmock.subresource(subresource), {'Content-Type': content_type}] ** 1 << 404
-    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body={}, fns=[_add_finalizer, _add_status_field])
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=Body({}), fns=[_add_finalizer, _add_status_field])
     result, remaining = await patch_obj(
         logger=logger, settings=settings, resource=resource,
         namespace=namespace, name='name1', patch=patch,
@@ -569,7 +570,7 @@ async def test_api_errors_raised(
         kmock, settings, status, resource, namespace, logger, content_type, subresource,
         cluster_resource, namespaced_resource, exp_api_count):
     kmock[kmock.subresource(subresource), {'Content-Type': content_type}] ** 1 << status
-    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body={}, fns=[_add_finalizer, _add_status_field])
+    patch = Patch({'spec': {'x': 'y'}, 'status': {'x': 'y'}}, body=Body({}), fns=[_add_finalizer, _add_status_field])
     with pytest.raises(APIError) as e:
         await patch_obj(
             logger=logger, settings=settings, resource=resource,


### PR DESCRIPTION
**Background:** A new functionality for json-patches with arbitrary resource transformations added in 1.44.0:

* #1253

That works in regular handling cycles and was tested there (unit-tests and manual tests).

**Problem:** However, in daemons & timers, it misbehaves: the fns are applied, but never cleared, so they are applied again and again and accumulate in the patch forever — assuming the user adds them at all.

Additionally, if the patching hits HTTP 422 on the "test" op failure, it returns the remaining patch with the unapplied fns, which is discarded instantly and does not go anywhere to the next cycles, as it does in the event-handling cycle. So, the scheduled fns are silently lost.

**Solution:**

- Clear the patch with fns, too, not just the dict.
- Preserve unapplied fns until the next timer/daemon cycle, and try applying again.

**Scope:** This is a new functinality and likely is not used in timers/daemons yet (adding `patch.fns`).  Otherwise, users would hit this issue and report it, and would avoid using it until fixed. Kopf does not populate this structure in timers/daemons.

**TODOs:**

- [x] Clearing the patch properly.
- [x] Re-applying in cycles.
- [x] Finding a right "reference body" if no merge-patch is available. (we have last-seen body in daemons)
- [x] Tiny docs specially for patches in timers/daemons.

**Debug:** An operator to manually explore the bug and the fixes:

```python
import functools
from typing import Any

import kopf


def fn(body: kopf.RawBody, f: str, v: Any) -> None:
    body.setdefault('spec')[f] = v


@kopf.timer('kopfexamples', interval=2)
def every_few_seconds_sync(patch, memo, **_: Any) -> None:
    n = memo.get('counter', 0) + 1
    memo['counter'] = n
    patch.fns.append(functools.partial(fn, f=f'f{n}', v=n))
```

1) In the main branch, the timer stops running, because it raises the `ValueError` on trying to calculate the json-diff from the None body (impossible), and therefore moves to `memory.forever_stopped` and does not trigger anymore.

2) Then, the non-clearing of the functions can be seen by removing or altering some earlier f-fields manually and seeing them re-added on the next iteration — because the fns were not cleared.

3) Then, the non-retrying (loss of functions) can be seen on the very 1st iteration after the finalizer is added, which changes the resourceVerson, and the patch initially fails the "test" op. Not seen on 2nd and further iterations, unless there is a manual patch of the resource from outside (kubectl or so).