### PR TITLE
Reduce supply chain attacks in CI by using 7-day old dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,9 @@ include = ["kopf", "kopf.*"]
 [tool.setuptools_scm]
 version_file = "kopf/_cogs/helpers/versions.py"
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.mypy]
 strict = true
 packages = ["kopf"]


### PR DESCRIPTION
An easy hack to prevent obvious attacks on the supply chain, i.e. Kopf's runtime and testing/linting dependencies in CI — and only in CI. Limiting the runtime dependencies of Kopf-based operators is the responsibility and policy of the operator developers, not of Kopf — this is skipped.

Context: a recent supply chain attack via LiteLLM's package injection. The injection was noticed and fixed within hours, but during that time, all who installed the newer versions were exposed, their credentials exfiltrated.

With other packages used by Kopf, this could be Kopf's tokens and credentials. There are not many left; mainly, OIDC is used everywhere; but there are some nevertheless. At least, the very fresh packages are of no benefit to our CI, so 7 days is good enough time to wait until somebody else notices the vulnerability. If it remains unnoticed, then we roll back to the original scenario without this hack.

Kopf intentionally does not lock dependencies in CI, so that the scheduled daily/weekly runs would fail with newer dependencies and indicate an error — without the noisy dependabot-style PRs.

---
Tested by extending the horizon to 30 days and checking which packages are picked in `rm -f uv.lock` and `uv sync --dry-run`