### PR TITLE
Annotate types in all code examples in the documentation

### DIFF
--- a/docs/admission.rst
+++ b/docs/admission.rst
@@ -46,18 +46,19 @@ Validation handlers
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.validate('kopfexamples')
-    def say_hello(warnings: list[str], **_):
+    def say_hello(warnings: list[str], **_: Any) -> None:
         warnings.append("Verified with the operator's hook.")
 
     @kopf.on.validate('kopfexamples')
-    def check_numbers(spec, **_):
+    def check_numbers(spec: kopf.Spec, **_: Any) -> None:
         if not isinstance(spec.get('numbers', []), list):
             raise kopf.AdmissionError("Numbers must be a list if present.")
 
     @kopf.on.validate('kopfexamples')
-    def convertible_numbers(spec, warnings, **_):
+    def convertible_numbers(spec: kopf.Spec, warnings: list[str], **_: Any) -> None:
         if isinstance(spec.get('numbers', []), list):
             for val in spec.get('numbers', []):
                 if not isinstance(val, float):
@@ -69,7 +70,7 @@ Validation handlers
                         warnings.append(f"{val!r} is not a number but can be converted.")
 
     @kopf.on.validate('kopfexamples')
-    def numbers_range(spec, **_):
+    def numbers_range(spec: kopf.Spec, **_: Any) -> None:
         if isinstance(spec.get('numbers', []), list):
             if not all(0 <= float(val) <= 100 for val in spec.get('numbers', [])):
                 raise kopf.AdmissionError("Numbers must be below 0..100.", code=499)
@@ -89,18 +90,19 @@ To mutate the object, modify the :kwarg:`patch`. Changes to :kwarg:`body`,
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.mutate('kopfexamples')
-    def ensure_default_numbers(spec, patch, **_):
+    def ensure_default_numbers(spec: kopf.Spec, patch: kopf.Patch, **_: Any) -> None:
         if 'numbers' not in spec:
             patch.spec['numbers'] = [1, 2, 3]
 
     @kopf.on.mutate('kopfexamples')
-    def convert_numbers_if_possible(spec, patch, **_):
+    def convert_numbers_if_possible(spec: kopf.Spec, patch: kopf.Patch, **_: Any) -> None:
         if 'numbers' in spec and isinstance(spec.get('numbers'), list):
             patch.spec['numbers'] = [_maybe_number(v) for v in spec['numbers']]
 
-    def _maybe_number(v):
+    def _maybe_number(v: Any) -> Any:
         try:
             return float(v)
         except ValueError:
@@ -197,9 +199,10 @@ and add strings to it:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.validate('kopfexamples')
-    def ensure_default_numbers(spec, warnings: list[str], **_):
+    def ensure_default_numbers(spec: kopf.Spec, warnings: list[str], **_: Any) -> None:
         if spec.get('field') == 'value':
             warnings.append("The default value is used. It is okay but worth changing.")
 
@@ -252,7 +255,7 @@ to select the single error to report in the admission review response.
 .. code-block:: python
 
     @kopf.on.validate('kopfexamples')
-    def validate1(spec, **_):
+    def validate1(spec: kopf.Spec, **_: Any) -> None:
         if spec.get('field') == 'value':
             raise kopf.AdmissionError("Meh! I do not like it. Change the field.", code=400)
 
@@ -298,7 +301,7 @@ To enable, set the name of the managed configuration objects:
 .. code-block:: python
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.admission.managed = 'auto.kopf.dev'
 
 Multiple records for webhooks will be added or removed for multiple resources
@@ -341,7 +344,7 @@ so it must be set by the developer:
 .. code-block:: python
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         if os.environ.get('ENVIRONMENT') is None:
             # Only as an example:
             settings.admission.server = kopf.WebhookK3dServer(port=54321)
@@ -468,14 +471,15 @@ explaining this topic is beyond the scope of this framework's documentation):
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def config(settings: kopf.OperatorSettings, **_):
+    def config(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.admission.managed = 'auto.kopf.dev'
         settings.admission.server = kopf.WebhookServer(cafile='client-cert.pem')
 
     @kopf.on.validate('kex')
-    def show_auth(headers, sslpeer, **_):
+    def show_auth(headers: kopf.Headers, sslpeer: kopf.SSLPeer, **_: Any) -> None:
         print(f'{headers=}')
         print(f'{sslpeer=}')
 
@@ -536,7 +540,7 @@ a self-signed certificate is generated at startup, and only HTTPS is served.
 .. code-block:: python
 
     @kopf.on.startup()
-    def config(settings: kopf.OperatorSettings, **_):
+    def config(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.admission.server = kopf.WebhookServer()
 
 That endpoint can be accessed directly with ``curl``:
@@ -550,7 +554,7 @@ It is possible to store the generated certificate and use it as a CA:
 .. code-block:: python
 
     @kopf.on.startup()
-    def config(settings: kopf.OperatorSettings, **_):
+    def config(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.admission.server = kopf.WebhookServer(cadump='selfsigned.pem')
 
 .. code-block:: bash
@@ -565,7 +569,7 @@ This applies to all servers:
 .. code-block:: python
 
     @kopf.on.startup()
-    def config(settings: kopf.OperatorSettings, **_):
+    def config(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.admission.server = kopf.WebhookServer(
             cafile='/secrets/ca.pem',       # or cadata, or capath.
             certfile='/secrets/cert.pem',
@@ -592,7 +596,7 @@ do not support HTTPS tunnelling (or that require paid subscriptions):
 .. code-block:: python
 
     @kopf.on.startup()
-    def config(settings: kopf.OperatorSettings, **_):
+    def config(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.admission.server = kopf.WebhookServer(insecure=True)
 
 
@@ -613,7 +617,7 @@ One is a simple but non-configurable coroutine function:
         await asyncio.Event().wait()
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.admission.server = mytunnel  # no arguments!
 
 Another one is a slightly more complex but configurable class:
@@ -627,7 +631,7 @@ Another one is a slightly more complex but configurable class:
             await asyncio.Event().wait()
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.admission.server = MyTunnel()  # arguments are possible.
 
 The iterator MUST accept a positional argument of type :class:`kopf.WebhookFn`
@@ -720,7 +724,7 @@ the asynchronous context manager protocol:
 .. code-block:: python
 
     class MyServer:
-        def __init__(self):
+        def __init__(self) -> None:
             super().__init__()
             self._resource = None
 
@@ -728,7 +732,7 @@ the asynchronous context manager protocol:
             self._resource = PotentiallyLeakableResource()
             return self
 
-        async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+        async def __aexit__(self, exc_type: type | None, exc_val: BaseException | None, exc_tb: object) -> bool:
             self._resource.cleanup()
             self._resource = None
 

--- a/docs/async.rst
+++ b/docs/async.rst
@@ -10,9 +10,10 @@ Kopf supports asynchronous handler functions:
 
     import asyncio
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    async def create_fn(spec, **_):
+    async def create_fn(spec: kopf.Spec, **_: Any) -> None:
         await asyncio.sleep(1.0)
 
 Async functions have an additional benefit over non-async ones:

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -37,9 +37,10 @@ or an instance of :class:`kopf.ConnectionInfo`:
 
     import datetime
     import kopf
+    from typing import Any
 
     @kopf.on.login()
-    def login_fn(**kwargs):
+    def login_fn(**_: Any) -> kopf.ConnectionInfo | None:
         return kopf.ConnectionInfo(
             server='https://localhost',
             proxy_url='http://localhost:8080',
@@ -67,9 +68,10 @@ communication is needed and async mode is supported:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.login()
-    async def login_fn(**kwargs):
+    async def login_fn(**_: Any) -> kopf.ConnectionInfo | None:
         pass
 
 A :class:`kopf.ConnectionInfo` is a container to bring the parameters necessary
@@ -160,9 +162,10 @@ Kopf will own and manage the provided session and will close it when needed.
 
     import aiohttp
     import kopf
+    from typing import Any
 
     @kopf.on.login()
-    async def login_fn(**kwargs) -> kopf.AiohttpSession:
+    async def login_fn(**_: Any) -> kopf.AiohttpSession:
         credentials = kopf.login_with_kubeconfig()  # or any other available method
         headers = {
             'X-Custom-Header': 'helloworld',
@@ -227,9 +230,10 @@ by calling one of the piggybacking functions:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.login()
-    def login_fn(**kwargs):
+    def login_fn(**kwargs: Any) -> kopf.ConnectionInfo | None:
         return kopf.login_via_pykube(**kwargs)
 
 Or:
@@ -237,9 +241,10 @@ Or:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.login()
-    def login_fn(**kwargs):
+    def login_fn(**kwargs: Any) -> kopf.ConnectionInfo | None:
         return kopf.login_via_client(**kwargs)
 
 The same trick is also useful to limit the authentication attempts
@@ -249,9 +254,10 @@ until it succeeds, returns nothing, or explicitly fails):
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.login(retries=3)
-    def login_fn(**kwargs):
+    def login_fn(**kwargs: Any) -> kopf.ConnectionInfo | None:
         return kopf.login_via_pykube(**kwargs)
 
 Similarly, if the libraries are installed and needed, but their credentials
@@ -260,9 +266,10 @@ are not desired, the rudimentary login functions can be used directly:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.login()
-    def login_fn(**kwargs):
+    def login_fn(**kwargs: Any) -> kopf.ConnectionInfo | None:
         return kopf.login_with_service_account(**kwargs) or kopf.login_with_kubeconfig(**kwargs)
 
 .. seealso::
@@ -306,10 +313,11 @@ a good idea or not is for you to decide based on the specifics of your system):
 
 .. code-block:: python
 
-    import logging
     import kopf
+    import logging
+    from typing import Any
 
     @kopf.on.startup()
-    def disable_auth_logs(**_):
+    def disable_auth_logs(**_: Any) -> None:
         logging.getLogger('kopf.activities.authentication').disabled = True
         logging.getLogger('kopf._core.engines.activities').disabled = True

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -20,9 +20,10 @@ The settings can be modified in the startup handlers (see :doc:`startup`):
 
     import kopf
     import logging
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.posting.level = logging.WARNING
         settings.watching.connect_timeout = 1 * 60
         settings.watching.server_timeout = 10 * 60
@@ -127,11 +128,12 @@ The default is ``logging.INFO``.
 
 .. code-block:: python
 
-    import logging
     import kopf
+    import logging
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.posting.level = logging.ERROR
 
 The event-posting can be disabled completely (the default is to be enabled):
@@ -139,9 +141,10 @@ The event-posting can be disabled completely (the default is to be enabled):
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.posting.enabled = False
 
 These two settings also affect :func:`kopf.event` and related functions:
@@ -156,9 +159,10 @@ calls are posted:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.posting.loggers = False
 
 
@@ -174,9 +178,10 @@ with another one:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.execution.max_workers = 20
 
 
@@ -191,9 +196,10 @@ handler itself. To avoid this, make the on-startup handler asynchronous:
 
     import concurrent.futures
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    async def configure(settings: kopf.OperatorSettings, **_):
+    async def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.execution.executor = concurrent.futures.ThreadPoolExecutor()
 
 The same executor is used both for regular sync handlers and for sync daemons.
@@ -204,9 +210,10 @@ make sure to pre-scale the executor accordingly
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    async def configure(settings: kopf.OperatorSettings, **kwargs):
+    async def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.execution.max_workers = 1000
 
 
@@ -300,9 +307,10 @@ __ https://github.com/kubernetes/kubernetes/blob/c20e0bc54189aef73a6a1498b4eab28
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.networking.connect_timeout = 10
         settings.networking.request_timeout = 60
         settings.watching.server_timeout = 10 * 60
@@ -329,9 +337,10 @@ see :doc:`authentication`.
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.networking.trust_env = True
 
 
@@ -372,9 +381,10 @@ version did not arrive within the specified time, it will never arrive.
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.consistency_timeout = 10
 
 The default value (5 seconds) aims for the safest scenario out of the box.
@@ -407,9 +417,10 @@ The name of the finalizer can be configured:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.finalizer = 'my-operator.example.com/kopf-finalizer'
 
 The default is the one that was hard-coded before:
@@ -430,9 +441,10 @@ To store the state only in the annotations with a preferred prefix:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.progress_storage = kopf.AnnotationsProgressStorage(prefix='my-op.example.com')
 
 To store the state only in the status or any other field:
@@ -440,9 +452,10 @@ To store the state only in the status or any other field:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.progress_storage = kopf.StatusProgressStorage(field='status.my-operator')
 
 To store in multiple places (all are written to in sync, but the first found
@@ -451,9 +464,10 @@ state will be used when reading, i.e. the first storage has precedence):
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.progress_storage = kopf.MultiProgressStorage([
             kopf.AnnotationsProgressStorage(prefix='my-op.example.com'),
             kopf.StatusProgressStorage(field='status.my-operator'),
@@ -469,9 +483,10 @@ It is an equivalent of:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.progress_storage = kopf.SmartProgressStorage()
 
 It is also possible to implement custom state storage instead of storing
@@ -544,9 +559,10 @@ The default is an equivalent of:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.diffbase_storage = kopf.AnnotationsDiffBaseStorage(
             prefix='kopf.zalando.org',
             key='last-handled-configuration',
@@ -582,9 +598,10 @@ for diff-base storage, apply this configuration:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.persistence.diffbase_storage = kopf.MultiDiffBaseStorage([
             kopf.StatusDiffBaseStorage(field='status.diff-base'),
             kopf.AnnotationsDiffBaseStorage(prefix='kopf.zalando.org', key='last-handled-configuration'),
@@ -623,7 +640,7 @@ If you have very restrictive cluster permissions, disable the cluster discovery:
 .. code-block:: python
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.scanning.disabled = True
 
 
@@ -649,9 +666,10 @@ It is a sequence of back-offs between attempts (in seconds):
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.networking.error_backoffs = [10, 20, 30]
 
 Note that the number of attempts is one more than the number of backoff
@@ -677,14 +695,16 @@ are required; however, make sure that it is re-iterable for multiple uses:
 
     import kopf
     import random
+    from collections.abc import Iterator
+    from typing import Any
 
     class InfiniteBackoffsWithJitter:
-        def __iter__(self):
+        def __iter__(self) -> Iterator[int]:
             while True:
                 yield 10 + random.randint(-5, +5)
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.networking.error_backoffs = InfiniteBackoffsWithJitter()
 
 
@@ -735,9 +755,10 @@ flooding, it is possible to throttle activity on a per-resource basis:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.queueing.error_delays = [10, 20, 30]
 
 In that case, all unhandled errors in the framework or in the Kubernetes API
@@ -771,24 +792,26 @@ For example, to disable the access logs of the probing server:
 .. code-block:: python
 
     import logging
+    from typing import Any
 
     @kopf.on.startup()
-    async def configure(**_):
+    async def configure(**_: Any) -> None:
         logging.getLogger('aiohttp.access').propagate = False
 
 To selectively filter only some log messages but not the others:
 
 .. code-block:: python
 
-    import logging
     import kopf
+    import logging
+    from typing import Any
 
     class ExcludeProbesFilter(logging.Filter):
         def filter(self, record: logging.LogRecord) -> bool:
             return 'GET /healthz ' not in record.getMessage()
 
     @kopf.on.startup()
-    async def configure_access_logs(**_):
+    async def configure_access_logs(**_: Any) -> None:
         logging.getLogger('aiohttp.access').addFilter(ExcludeProbesFilter())
 
 For more information on the logging configuration, see:
@@ -800,15 +823,16 @@ Kopf's internals, which are then posted as Kubernetes events (``v1/events``):
 
 .. code-block:: python
 
-    import logging
     import kopf
+    import logging
+    from typing import Any
 
     class ExcludeKopfInternals(logging.Filter):
         def filter(self, record: logging.LogRecord) -> bool:
             return '/kopf/' not in record.pathname
 
     @kopf.on.startup()
-    async def configure_kopf_logs(**_):
+    async def configure_kopf_logs(**_: Any) -> None:
         logging.getLogger('kopf.objects').addFilter(ExcludeKopfInternals())
 
 .. warning::

--- a/docs/daemons.rst
+++ b/docs/daemons.rst
@@ -23,17 +23,18 @@ with ``@kopf.daemon`` and make it run for a long time or forever:
 .. code-block:: python
 
     import asyncio
-    import time
     import kopf
+    import time
+    from typing import Any
 
     @kopf.daemon('kopfexamples')
-    async def monitor_kex_async(**kwargs):
+    async def monitor_kex_async(**_: Any) -> None:
         while True:
             ...  # check something
             await asyncio.sleep(10)
 
     @kopf.daemon('kopfexamples')
-    def monitor_kex_sync(stopped, **kwargs):
+    def monitor_kex_sync(stopped: kopf.DaemonStopped, **_: Any) -> None:
         while not stopped:
             ...  # check something
             time.sleep(10)
@@ -62,9 +63,10 @@ daemons SHOULD_ check for the value of this flag as often as possible:
 
     import asyncio
     import kopf
+    from typing import Any
 
     @kopf.daemon('kopfexamples')
-    def monitor_kex(stopped, **kwargs):
+    def monitor_kex(stopped: kopf.DaemonStopped, **_: Any) -> None:
         while not stopped:
             time.sleep(1.0)
         print("We are done. Bye.")
@@ -77,9 +79,10 @@ raised at any point of their code (specifically, at any ``await`` clause):
 
     import asyncio
     import kopf
+    from typing import Any
 
     @kopf.daemon('kopfexamples', cancellation_timeout=1.0)
-    async def monitor_kex(**kwargs):
+    async def monitor_kex(**_: Any) -> None:
         try:
             while True:
                 await asyncio.sleep(10)
@@ -111,10 +114,11 @@ The termination sequence parameters can be controlled when declaring a daemon:
 
     import asyncio
     import kopf
+    from typing import Any
 
     @kopf.daemon('kopfexamples',
                  cancellation_backoff=1.0, cancellation_timeout=3.0)
-    async def monitor_kex(stopped, **kwargs):
+    async def monitor_kex(stopped: kopf.DaemonStopped, **_: Any) -> None:
         while not stopped:
             await asyncio.sleep(1)
 
@@ -179,9 +183,10 @@ instead of ``time.sleep()``: the wait will end when either the time is reached
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.daemon('kopfexamples')
-    def monitor_kex(stopped, **kwargs):
+    def monitor_kex(stopped: kopf.DaemonStopped, **_: Any) -> None:
         while not stopped:
             stopped.wait(10)
 
@@ -193,9 +198,10 @@ is neither configured nor desired, ``stopped.wait()`` can be used too
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.daemon('kopfexamples')
-    async def monitor_kex(stopped, **kwargs):
+    async def monitor_kex(stopped: kopf.DaemonStopped, **_: Any) -> None:
         while not stopped:
             await stopped.wait(10)
 
@@ -222,9 +228,10 @@ It is possible to postpone the daemon spawning:
 
     import asyncio
     import kopf
+    from typing import Any
 
     @kopf.daemon('kopfexamples', initial_delay=30)
-    async def monitor_kex(stopped, **kwargs):
+    async def monitor_kex(stopped: kopf.DaemonStopped, **_: Any) -> None:
         while True:
             await asyncio.sleep(1.0)
 
@@ -238,17 +245,18 @@ as the handler itself, and returns the delay in seconds:
 
 .. code-block:: python
 
-    import random
     import kopf
+    import random
+    from typing import Any
 
-    def get_delay(body, **kwargs):
+    def get_delay(body: kopf.Body, **_: Any) -> int:
         return random.randint(
             body.get('spec', {}).get('minDelay', 0),
             body.get('spec', {}).get('maxDelay', 60),
         )
 
     @kopf.daemon('kopfexamples', initial_delay=get_delay)
-    async def monitor_kex(stopped, **kwargs):
+    async def monitor_kex(stopped: kopf.DaemonStopped, **_: Any) -> None:
         ...
 
 This is primarily intended for load balancing during operator restarts (e.g. by
@@ -274,9 +282,10 @@ To simulate restarting, raise :class:`kopf.TemporaryError` with a delay set.
 
     import asyncio
     import kopf
+    from typing import Any
 
     @kopf.daemon('kopfexamples')
-    async def monitor_kex(stopped, **kwargs):
+    async def monitor_kex(stopped: kopf.DaemonStopped, **_: Any) -> None:
         await asyncio.sleep(10.0)
         raise kopf.TemporaryError("Need to restart.", delay=10)
 
@@ -312,18 +321,19 @@ modified during its lifecycle (not frozen as in the event-driven handlers):
 
 .. code-block:: python
 
+    import kopf
     import random
     import time
-    import kopf
+    from typing import Any
 
     @kopf.daemon('kopfexamples')
-    def monitor_kex(stopped, logger, body, spec, **kwargs):
+    def monitor_kex(stopped: kopf.DaemonStopped, logger: kopf.Logger, body: kopf.Body, spec: kopf.Spec, **_: Any) -> None:
         while not stopped:
             logger.info(f"FIELD={spec['field']}")
             time.sleep(1)
 
     @kopf.timer('kopfexamples', interval=2.5)
-    def modify_kex_sometimes(patch, **kwargs):
+    def modify_kex_sometimes(patch: kopf.Patch, **_: Any) -> None:
         patch.spec['field'] = random.randint(0, 100)
 
 Always access the fields through the provided kwargs, and do not store
@@ -342,7 +352,7 @@ The error handling is the same as for all other handlers: see :doc:`errors`:
 
     @kopf.daemon('kopfexamples',
                  errors=kopf.ErrorsMode.TEMPORARY, backoff=1, retries=10)
-    def monitor_kex(retry, **_):
+    def monitor_kex(retry: int, **_: Any) -> None:
         if retry < 3:
             raise kopf.TemporaryError("I'll be back!", delay=1)
         elif retry < 5:
@@ -365,9 +375,10 @@ values to be put on the resource's status:
 
     import asyncio
     import kopf
+    from typing import Any
 
     @kopf.daemon('kopfexamples')
-    async def monitor_kex(stopped, **kwargs):
+    async def monitor_kex(stopped: kopf.DaemonStopped, **_: Any) -> dict[str, bool]:
         await asyncio.sleep(10.0)
         return {'finished': True}
 
@@ -382,8 +393,9 @@ including both the merge-patch dictionary and the transformation functions
 .. code-block:: python
 
     import asyncio
-    import random
     import kopf
+    import random
+    from typing import Any
 
     # Transformation functions and JSON-patches are useful specifically for the lists.
     def set_conditions(body: kopf.RawBody) -> None:
@@ -392,7 +404,7 @@ including both the merge-patch dictionary and the transformation functions
         conditions.append({'type': 'Whatever', 'status': 'True', 'reason': 'SomeReason', 'message': 'Some message'})
 
     @kopf.daemon('kopfexamples')
-    async def update_status(stopped, patch, **kwargs):
+    async def update_status(stopped: kopf.DaemonStopped, patch: kopf.Patch, **_: Any) -> None:
         # This goes to the merge-patch.
         patch.status['replicas'] = random.randint(1, 10)
 
@@ -424,14 +436,15 @@ to only spawn daemons for specific resources:
 
 .. code-block:: python
 
-    import time
     import kopf
+    import time
+    from typing import Any
 
     @kopf.daemon('kopfexamples',
                  annotations={'some-annotation': 'some-value'},
                  labels={'some-label': 'some-value'},
                  when=lambda name, **_: 'some' in name)
-    def monitor_selected_kexes(stopped, **kwargs):
+    def monitor_selected_kexes(stopped: kopf.DaemonStopped, **_: Any) -> None:
         while not stopped:
             time.sleep(1)
 

--- a/docs/embedding.rst
+++ b/docs/embedding.rst
@@ -19,18 +19,18 @@ while running the main application in the main thread:
 .. code-block:: python
 
     import asyncio
-    import threading
-
     import kopf
+    import threading
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         pass
 
-    def kopf_thread():
+    def kopf_thread() -> None:
         asyncio.run(kopf.operator())
 
-    def main():
+    def main() -> None:
         thread = threading.Thread(target=kopf_thread)
         thread.start()
         # ...
@@ -53,7 +53,7 @@ themselves. The example above is equivalent to the following:
 
 .. code-block:: python
 
-    def kopf_thread():
+    def kopf_thread() -> None:
         loop = asyncio.get_event_loop_policy().get_event_loop()
         tasks = loop.run_until_complete(kopf.spawn_tasks())
         loop.run_until_complete(kopf.run_tasks(tasks, return_when=asyncio.FIRST_COMPLETED))
@@ -62,7 +62,7 @@ Or, if proper cancellation and termination are not required, of the following:
 
 .. code-block:: python
 
-    def kopf_thread():
+    def kopf_thread() -> None:
         loop = asyncio.get_event_loop_policy().get_event_loop()
         tasks = loop.run_until_complete(kopf.spawn_tasks())
         loop.run_until_complete(asyncio.wait(tasks))
@@ -91,7 +91,7 @@ __ http://magic.io/blog/uvloop-blazing-fast-python-networking/
     import kopf
     import uvloop
 
-    def main():
+    def main() -> None:
         loop = uvloop.EventLoopPolicy().get_event_loop()
         loop.run(kopf.operator())
 
@@ -102,7 +102,7 @@ Or this way:
     import kopf
     import uvloop
 
-    def main():
+    def main() -> None:
         kopf.run(loop=uvloop.EventLoopPolicy().new_event_loop())
 
 Or this way:
@@ -112,7 +112,7 @@ Or this way:
     import kopf
     import uvloop
 
-    def main():
+    def main() -> None:
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
         kopf.run()
 
@@ -139,22 +139,22 @@ in :mod:`contextvars` containers with values isolated per-loop and per-task.
 .. code-block:: python
 
     import asyncio
-    import threading
-
     import kopf
+    import threading
+    from typing import Any
 
     registry = kopf.OperatorRegistry()
 
     @kopf.on.create('kopfexamples', registry=registry)
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         pass
 
-    def kopf_thread():
+    def kopf_thread() -> None:
         asyncio.run(kopf.operator(
             registry=registry,
         ))
 
-    def main():
+    def main() -> None:
         thread = threading.Thread(target=kopf_thread)
         thread.start()
         # ...

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -24,9 +24,10 @@ which can happen either immediately, or after some delay:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def create_fn(spec, **_):
+    def create_fn(spec: kopf.Spec, **_: Any) -> None:
         if not is_data_ready():
             raise kopf.TemporaryError("The data is not yet ready.", delay=60)
 
@@ -56,9 +57,10 @@ is no need to retry over time, as it will not become better:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def create_fn(spec, **_):
+    def create_fn(spec: kopf.Spec, **_: Any) -> None:
         valid_until = datetime.datetime.fromisoformat(spec['validUntil'])
         if valid_until <= datetime.datetime.now(datetime.timezone.utc):
             raise kopf.PermanentError("The object is not valid anymore.")
@@ -83,9 +85,10 @@ The reaction to the arbitrary errors can be configured:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples', errors=kopf.ErrorsMode.PERMANENT)
-    def create_fn(spec, **_):
+    def create_fn(spec: kopf.Spec, **_: Any) -> None:
         raise Exception()
 
 Possible values of ``errors`` are:
@@ -103,9 +106,10 @@ The overall runtime of the handler can be limited:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples', timeout=60*60)
-    def create_fn(spec, **_):
+    def create_fn(spec: kopf.Spec, **_: Any) -> None:
         raise kopf.TemporaryError(delay=60)
 
 If the handler has not succeeded within this time, it is considered
@@ -126,9 +130,10 @@ The number of retries can be limited too:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples', retries=3)
-    def create_fn(spec, **_):
+    def create_fn(spec: kopf.Spec, **_: Any) -> None:
         raise Exception()
 
 Once the number of retries is reached, the handler fails permanently.
@@ -146,9 +151,10 @@ can be configured:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples', backoff=30)
-    def create_fn(spec, **_):
+    def create_fn(spec: kopf.Spec, **_: Any) -> None:
         raise Exception()
 
 The default is 60 seconds.

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -22,9 +22,10 @@ for the handled objects as Kubernetes events:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def create_fn(body, **_):
+    def create_fn(body: kopf.Body, **_: Any) -> None:
         kopf.event(body,
                    type='SomeType',
                    reason='SomeReason',
@@ -41,9 +42,10 @@ For convenience, a few shortcuts are provided to mimic Python's ``logging``:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def create_fn(body, **_):
+    def create_fn(body: kopf.Body, **_: Any) -> None:
         kopf.warn(body, reason='SomeReason', message='Some message')
         kopf.info(body, reason='SomeReason', message='Some message')
         try:
@@ -83,9 +85,10 @@ handled (and not necessarily even their children):
 
     import kopf
     import kubernetes
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def create_fn(name, namespace, uid, **_):
+    def create_fn(name: str, namespace: str | None, uid: str, **_: Any) -> None:
 
         pod = kubernetes.client.V1Pod()
         api = kubernetes.client.CoreV1Api()

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -33,7 +33,7 @@ Match only when the resource's label or annotation has a specific value:
     @kopf.on.create('kopfexamples',
                     labels={'some-label': 'somevalue'},
                     annotations={'some-annotation': 'somevalue'})
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 Match only when the resource has a label or an annotation with any value:
@@ -43,7 +43,7 @@ Match only when the resource has a label or an annotation with any value:
     @kopf.on.create('kopfexamples',
                     labels={'some-label': kopf.PRESENT},
                     annotations={'some-annotation': kopf.PRESENT})
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 Match only when the resource has no label or annotation with that name:
@@ -53,7 +53,7 @@ Match only when the resource has no label or annotation with that name:
     @kopf.on.create('kopfexamples',
                     labels={'some-label': kopf.ABSENT},
                     annotations={'some-annotation': kopf.ABSENT})
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 Note that empty strings in labels and annotations are treated as regular values,
@@ -69,15 +69,15 @@ similar to the metadata filters:
 .. code-block:: python
 
     @kopf.on.create('kopfexamples', field='spec.field', value='world')
-    def created_with_world_in_field(**_):
+    def created_with_world_in_field(**_: Any) -> None:
         pass
 
     @kopf.on.create('kopfexamples', field='spec.field', value=kopf.PRESENT)
-    def created_with_field(**_):
+    def created_with_field(**_: Any) -> None:
         pass
 
     @kopf.on.create('kopfexamples', field='spec.no-field', value=kopf.ABSENT)
-    def created_without_field(**_):
+    def created_without_field(**_: Any) -> None:
         pass
 
 When the ``value=`` filter is not specified, but the ``field=`` filter is,
@@ -87,11 +87,11 @@ with any value (for update handlers: present before or after the change).
 .. code-block:: python
 
     @kopf.on.create('kopfexamples', field='spec.field')
-    def created_with_field(**_):
+    def created_with_field(**_: Any) -> None:
         pass
 
     @kopf.on.update('kopfexamples', field='spec.field')
-    def field_is_affected(old, new, **_):
+    def field_is_affected(old: Any, new: Any, **_: Any) -> None:
         pass
 
 
@@ -104,7 +104,7 @@ relevant to the specified fields, as well as different values of :kwarg:`param`:
 
     @kopf.on.update('kopfexamples', field='spec.field', param='fld')
     @kopf.on.update('kopfexamples', field='spec.items', param='itm')
-    def one_of_the_fields_is_affected(old, new, **_):
+    def one_of_the_fields_is_affected(old: Any, new: Any, **_: Any) -> None:
         pass
 
 However, different causes ---mostly resuming combined with one of creation/update/deletion---
@@ -169,15 +169,15 @@ using the same filtering methods/markers as all other filters.
 .. code-block:: python
 
     @kopf.on.update('kopfexamples', field='spec.field', old='x', new='y')
-    def field_is_edited(**_):
+    def field_is_edited(**_: Any) -> None:
         pass
 
     @kopf.on.update('kopfexamples', field='spec.field', old=kopf.ABSENT, new=kopf.PRESENT)
-    def field_is_added(**_):
+    def field_is_added(**_: Any) -> None:
         pass
 
     @kopf.on.update('kopfexamples', field='spec.field', old=kopf.PRESENT, new=kopf.ABSENT)
-    def field_is_removed(**_):
+    def field_is_removed(**_: Any) -> None:
         pass
 
 If one of ``old=`` or ``new=`` is not specified (or set to ``None``),
@@ -189,7 +189,7 @@ to it or by adding it to the resource (i.e. regardless of the old value):*
 .. code-block:: python
 
     @kopf.on.update('kopfexamples', field='spec.field', new='world')
-    def hello_world(**_):
+    def hello_world(**_: Any) -> None:
         pass
 
 *Match when the field loses a specific value either by being edited/patched
@@ -198,7 +198,7 @@ to something else, or by removing the field from the resource:*
 .. code-block:: python
 
     @kopf.on.update('kopfexamples', field='spec.field', old='world')
-    def goodbye_world(**_):
+    def goodbye_world(**_: Any) -> None:
         pass
 
 Generally, the update handlers with ``old=/new=`` filters are invoked only when
@@ -231,13 +231,13 @@ The passed value will be ``None`` if the value is absent in the resource.
 
 .. code-block:: python
 
-    def check_value(value, spec, **_):
+    def check_value(value: str | None, /, spec: kopf.Spec, **_: Any) -> bool:
         return value == 'some-value' and spec.get('field') is not None
 
     @kopf.on.create('kopfexamples',
                     labels={'some-label': check_value},
                     annotations={'some-annotation': check_value})
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 
@@ -249,15 +249,15 @@ as the respective handlers (with ``**kwargs/**_`` for forward compatibility).
 
 .. code-block:: python
 
-    def is_good_enough(spec, **_):
+    def is_good_enough(spec: kopf.Spec, **_: Any) -> bool:
         return spec.get('field') in spec.get('items', [])
 
     @kopf.on.create('kopfexamples', when=is_good_enough)
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
     @kopf.on.create('kopfexamples', when=lambda spec, **_: spec.get('field') in spec.get('items', []))
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 Callback filters are not limited to checking the resource's content.
@@ -282,22 +282,23 @@ Kopf provides several helpers to combine multiple callbacks into one
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
-    def whole_fn1(name, **_): return name.startswith('kopf-')
-    def whole_fn2(spec, **_): return spec.get('field') == 'value'
-    def value_fn1(value, **_): return value.startswith('some')
-    def value_fn2(value, **_): return value.endswith('label')
+    def whole_fn1(name: str, **_: Any) -> bool: return name.startswith('kopf-')
+    def whole_fn2(spec: kopf.Spec, **_: Any) -> bool: return spec.get('field') == 'value'
+    def value_fn1(value: str | None, **_: Any) -> bool: return value and value.startswith('some')
+    def value_fn2(value: str | None, **_: Any) -> bool: return value and value.endswith('label')
 
     @kopf.on.create('kopfexamples',
                     when=kopf.all_([whole_fn1, whole_fn2]),
                     labels={'somelabel': kopf.all_([value_fn1, value_fn2])})
-    def create_fn1(**_):
+    def create_fn1(**_: Any) -> None:
         pass
 
     @kopf.on.create('kopfexamples',
                     when=kopf.any_([whole_fn1, whole_fn2]),
                     labels={'somelabel': kopf.any_([value_fn1, value_fn2])})
-    def create_fn2(**_):
+    def create_fn2(**_: Any) -> None:
         pass
 
 The following wrappers are available:

--- a/docs/handlers.rst
+++ b/docs/handlers.rst
@@ -44,9 +44,10 @@ To register a handler for an event, use the ``@kopf.on`` decorator:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 All available decorators are described below.
@@ -66,9 +67,10 @@ thus resolving the mentioned ambiguity and giving meaning to ``self``/``cls``:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     class MyCls:
-        def my_handler(self, spec, **kwargs):
+        def my_handler(self, spec: kopf.Spec, **_: Any) -> None:
             print(repr(self))
 
     instance = MyCls()
@@ -89,9 +91,10 @@ The following event-handler is available:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event('kopfexamples')
-    def my_handler(event: kopf.RawEvent, **_):
+    def my_handler(event: kopf.RawEvent, **_: Any) -> None:
         pass
 
 The event has the following structure:
@@ -145,17 +148,18 @@ The following three core cause-handlers are available:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
     @kopf.on.update('kopfexamples')
-    def my_handler(spec, old, new, diff, **_):
+    def my_handler(spec: kopf.Spec, old: Any, new: Any, diff: kopf.Diff, **_: Any) -> None:
         pass
 
     @kopf.on.delete('kopfexamples')
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 Despite the handlers seeing the full body of the resource object, they react
@@ -170,9 +174,10 @@ For example, to react to changes in the status of ``kind: Job``:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.update('batch/v1', 'jobs', field='status')
-    def job_status_changes(**_):
+    def job_status_changes(**_: Any) -> None:
         pass
 
 .. note::
@@ -194,9 +199,10 @@ and detects an object that existed before:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.resume('kopfexamples')
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 This handler can be used to start threads or asyncio tasks or to update
@@ -218,10 +224,11 @@ when the operator starts while the object already exists:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.resume('kopfexamples')
     @kopf.on.create('kopfexamples')
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 However, the resuming handlers are **not** called if the object has been deleted
@@ -236,19 +243,21 @@ For example:
 
 .. code-block:: python
 
+    import asyncio
     import kopf
+    from typing import Any
 
-    TASKS = {}
+    TASKS: dict[str, asyncio.Task[None]] = {}
 
     @kopf.on.delete('kopfexamples')
-    async def my_handler(spec, name, **_):
-        if name in TASKS:
+    async def my_handler(spec: kopf.Spec, name: str, **_: Any) -> None:
+        if name and name in TASKS:
             TASKS[name].cancel()
 
     @kopf.on.resume('kopfexamples')
     @kopf.on.create('kopfexamples')
-    def my_handler(spec, **_):
-        if name not in TASKS:
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
+        if name and name not in TASKS:
             TASKS[name] = asyncio.create_task(some_coroutine(spec))
 
 In this example, if the operator starts and notices an object that has been
@@ -263,9 +272,10 @@ with ``deleted=True`` option:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.resume('kopfexamples', deleted=True)
-    def my_handler(spec, **_):
+    def my_handler(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 In that case, both the deletion and resuming handlers will be invoked. It is
@@ -280,9 +290,10 @@ Specific fields can be handled instead of the whole object:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.field('kopfexamples', field='spec.somefield')
-    def somefield_changed(old, new, **_):
+    def somefield_changed(old: Any, new: Any, **_: Any) -> None:
         pass
 
 There is no special detection of the causes for the fields,
@@ -321,9 +332,10 @@ Sub-handlers can be implemented either imperatively
 
     import functools
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    async def create_fn(spec, **_):
+    async def create_fn(spec: kopf.Spec, **_: Any) -> None:
         fns = {}
 
         for item in spec.get('items', []):
@@ -331,7 +343,7 @@ Sub-handlers can be implemented either imperatively
 
        await kopf.execute(fns=fns)
 
-    def handle_item(item, *, spec, **_):
+    def handle_item(item: Any, *, spec: kopf.Spec, **_: Any) -> None:
         pass
 
 Or declaratively with decorators:
@@ -339,14 +351,15 @@ Or declaratively with decorators:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def create_fn(spec, **_):
+    def create_fn(spec: kopf.Spec, **_: Any) -> None:
 
         for item in spec.get('items', []):
 
             @kopf.subhandler(id=item)
-            def handle_item(item=item, **_):
+            def handle_item(item: Any = item, **_: Any) -> None:
                 pass
 
 Both of these ways are equivalent.

--- a/docs/hierarchies.rst
+++ b/docs/hierarchies.rst
@@ -31,7 +31,7 @@ To label the resources to be created, use :func:`kopf.label`:
 .. code-block:: python
 
     @kopf.on.create('KopfExample')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
         kopf.label(objs, {'label1': 'value1', 'label2': 'value2'})
         print(objs)
@@ -48,7 +48,7 @@ not the same as an empty dict ``{}`` --- which is equivalent to doing nothing):
 .. code-block:: python
 
     @kopf.on.create('KopfExample')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
         kopf.label(objs)
         print(objs)
@@ -64,7 +64,7 @@ be overwritten. To overwrite labels, use ``forced=True``:
 .. code-block:: python
 
     @kopf.on.create('KopfExample')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
         kopf.label(objs, {'label1': 'value1', 'somelabel': 'not-this'}, forced=True)
         kopf.label(objs, forced=True)
@@ -90,7 +90,7 @@ and no labels are added. Labels are added only to pre-existing structures:
 .. code-block:: python
 
     @kopf.on.create('KopfExample')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         objs = [{'kind': 'Job'}, {'kind': 'Deployment', 'spec': {'template': {}}}]
         kopf.label(objs, {'label1': 'value1'}, nested='spec.template')
         kopf.label(objs, nested='spec.template')
@@ -137,7 +137,7 @@ being processed, omit the explicit owner argument or set it to ``None``:
 .. code-block:: python
 
     @kopf.on.create('KopfExample')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
         kopf.append_owner_reference(objs)
         print(objs)
@@ -201,7 +201,7 @@ currently being processed, omit the name or set it to ``None``
 .. code-block:: python
 
     @kopf.on.create('KopfExample')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
         kopf.harmonize_naming(objs, forced=True, strict=True)
         print(objs)
@@ -215,7 +215,7 @@ The actual name will only be known after the resource is created:
 .. code-block:: python
 
     @kopf.on.create('KopfExample')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
         kopf.harmonize_naming(objs)
         print(objs)
@@ -251,7 +251,7 @@ of the resource currently being processed, omit the namespace or set it to ``Non
 .. code-block:: python
 
     @kopf.on.create('KopfExample')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
         kopf.adjust_namespace(objs, forced=True)
         print(objs)
@@ -268,7 +268,7 @@ All of the above can be done in a single call with :func:`kopf.adopt`; the ``for
 .. code-block:: python
 
     @kopf.on.create('KopfExample')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         objs = [{'kind': 'Job'}, {'kind': 'Deployment'}]
         kopf.adopt(objs, strict=True, forced=True, nested='spec.template')
         print(objs)
@@ -306,9 +306,10 @@ and `kubernetes client`_ (resource models from ``kubernetes.client.models``).
 
     import kopf
     import pykube
+    from typing import Any
 
     @kopf.on.create('KopfExample')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         api = pykube.HTTPClient(pykube.KubeConfig.from_env())
         pod = pykube.objects.Pod(api, {})
         kopf.adopt(pod)
@@ -317,9 +318,10 @@ and `kubernetes client`_ (resource models from ``kubernetes.client.models``).
 
     import kopf
     import kubernetes.client
+    from typing import Any
 
     @kopf.on.create('KopfExample')
-    def create_fn(**_):
+    def create_fn(**_: Any) -> None:
         pod = kubernetes.client.V1Pod()
         kopf.adopt(pod)
         print(pod)

--- a/docs/idempotence.rst
+++ b/docs/idempotence.rst
@@ -17,9 +17,10 @@ twice within one handling cycle.
 
     import functools
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    async def create(spec, namespace, **kwargs):
+    async def create(spec: kopf.Spec, namespace: str | None, **_: Any) -> None:
         print("Entering create()!")  # executed ~7 times.
         await kopf.execute(fns={
             'a': create_a,
@@ -27,11 +28,11 @@ twice within one handling cycle.
         })
         print("Leaving create()!")  # executed 1 time only.
 
-    async def create_a(retry, **kwargs):
+    async def create_a(retry: int, **_: Any) -> None:
         if retry < 2:
             raise kopf.TemporaryError("Not ready yet.", delay=10)
 
-    async def create_b(retry, **kwargs):
+    async def create_b(retry: int, **_: Any) -> None:
         if retry < 6:
             raise kopf.TemporaryError("Not ready yet.", delay=10)
 

--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -21,9 +21,10 @@ Indices are declared with a ``@kopf.index`` decorator on an indexing function
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods')
-    async def my_idx(**_):
+    async def my_idx(**_: Any) -> Any:
         ...
 
 The name of the function or its ``id=`` option is the index's name.
@@ -34,14 +35,15 @@ as direct kwargs named the same as the index (type hints are optional):
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     # ... continued from previous examples:
     @kopf.timer('KopfExample', interval=5)
-    def tick(my_idx: kopf.Index, **_):
+    def tick(my_idx: kopf.Index, **_: Any) -> None:
         ...
 
     @kopf.on.probe()
-    def metric(my_idx: kopf.Index, **_):
+    def metric(my_idx: kopf.Index, **_: Any) -> Any:
         ...
 
 When a resource is created or starts matching the filters, it is processed
@@ -98,9 +100,10 @@ it is merged into the index under the key taken from the result:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods')
-    async def string_keys(namespace, name, **_):
+    async def string_keys(namespace: str | None, name: str, **_: Any) -> Any:
         return {namespace: name}
         # {'namespace1': ['pod1a', 'pod1b', ...],
         #  'namespace2': ['pod2a', 'pod2b', ...],
@@ -111,9 +114,10 @@ Multi-value keys are possible using tuples or other hashable types:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods')
-    async def tuple_keys(namespace, name, **_):
+    async def tuple_keys(namespace: str | None, name: str, **_: Any) -> Any:
         return {(namespace, name): 'hello'}
         # {('namespace1', 'pod1a'): ['hello'],
         #  ('namespace1', 'pod1b'): ['hello'],
@@ -127,9 +131,10 @@ and they are all merged into their respective places in the index:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods')
-    async def by_label(labels, name, **_):
+    async def by_label(labels: kopf.Labels, name: str, **_: Any) -> Any:
         return {(label, value): name for label, value in labels.items()}
         # {('label1', 'value1a'): ['pod1', 'pod2', ...],
         #  ('label1', 'value1b'): ['pod3', 'pod4', ...],
@@ -138,7 +143,7 @@ and they are all merged into their respective places in the index:
         #   ...}
 
     @kopf.timer('kex', interval=5)
-    def tick(by_label: kopf.Index, **_):
+    def tick(by_label: kopf.Index, **_: Any) -> None:
         print(list(by_label.get(('label2', 'value2b'), [])))
         # ['pod1', 'pod3']
         for podname in by_label.get(('label2', 'value2b'), []):
@@ -165,9 +170,10 @@ The resources are not indexed by key, but rather collected under the same key
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods')
-    async def pod_names(name: str, **_):
+    async def pod_names(name: str, **_: Any) -> Any:
         return name
         # {None: ['pod1', 'pod2', ...]}
 
@@ -177,9 +183,10 @@ as-is (i.e. with no special treatment):
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods')
-    async def container_names(spec: kopf.Spec, **_):
+    async def container_names(spec: kopf.Spec, **_: Any) -> Any:
         return {container['name'] for container in spec.get('containers', [])}
         # {None: [{'main1', 'sidecar2'}, {'main2'}, ...]}
 
@@ -196,9 +203,10 @@ you mostly need to iterate over all of them without key lookups:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods')
-    async def pods_list(namespace, name, **_):
+    async def pods_list(namespace: str | None, name: str, **_: Any) -> Any:
         return namespace, name
         # {None: [('namespace1', 'pod1a'),
         #         ('namespace1', 'pod1b'),
@@ -207,7 +215,7 @@ you mostly need to iterate over all of them without key lookups:
         #           ...]}
 
     @kopf.timer('kopfexamples', interval=5)
-    def tick_list(pods_list: kopf.Index, **_):
+    def tick_list(pods_list: kopf.Index, **_: Any) -> None:
         for ns, name in pods_list.get(None, []):
             print(f"{ns}::{name}")
 
@@ -217,9 +225,10 @@ more often than full iterations:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods')
-    async def pods_dict(namespace, name, **_):
+    async def pods_dict(namespace: str | None, name: str, **_: Any) -> Any:
         return {(namespace, name): None}
         # {('namespace1', 'pod1a'): [None],
         #  ('namespace1', 'pod1b'): [None],
@@ -228,7 +237,7 @@ more often than full iterations:
         #   ...}
 
     @kopf.timer('kopfexamples', interval=5)
-    def tick_dict(pods_dict: kopf.Index, spec: kopf.Spec, namespace: str, **_):
+    def tick_dict(pods_dict: kopf.Index, spec: kopf.Spec, namespace: str | None, **_: Any) -> None:
         monitored_namespace = spec.get('monitoredNamespace', namespace)
         for ns, name in pods_dict:
             if ns == monitored_namespace:
@@ -243,13 +252,14 @@ To store the entire resource or its essential parts, return them explicitly:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('deployments')
-    async def whole_deployments(name: str, namespace: str, body: kopf.Body, **_):
+    async def whole_deployments(name: str, namespace: str | None, body: kopf.Body, **_: Any) -> Any:
         return {(namespace, name): body}
 
     @kopf.timer('kopfexamples', interval=5)
-    def tick(whole_deployments: kopf.Index, **_):
+    def tick(whole_deployments: kopf.Index, **_: Any) -> None:
         deployment, *_ = whole_deployments[('kube-system', 'coredns')]
         actual = deployment.status.get('replicas')
         desired = deployment.spec.get('replicas')
@@ -284,9 +294,10 @@ while the secondary index indexes pod names by namespace only:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods')
-    async def primary(namespace, name, spec, **_):
+    async def primary(namespace: str | None, name: str, spec: kopf.Spec, **_: Any) -> Any:
         container_names = {container['name'] for container in spec['containers']}
         return {(namespace, name): container_names}
         # {('namespace1', 'pod1a'): [{'main'}],
@@ -296,15 +307,15 @@ while the secondary index indexes pod names by namespace only:
         #   ...}
 
     @kopf.index('pods')
-    async def secondary(namespace, name, **_):
+    async def secondary(namespace: str | None, name: str, **_: Any) -> Any:
         return {namespace: name}
         # {'namespace1': ['pod1a', 'pod1b'],
         #  'namespace2': ['pod2a', 'pod2b'],
         #   ...}
 
     @kopf.timer('kopfexamples', interval=5)
-    def tick(primary: kopf.Index, secondary: kopf.Index, spec: kopf.Spec, **_):
-        namespace_containers = set()
+    def tick(primary: kopf.Index, secondary: kopf.Index, spec: kopf.Spec, **_: Any) -> None:
+        namespace_containers: set[str] = set()
         monitored_namespace = spec.get('monitoredNamespace', 'default')
         for pod_name in secondary.get(monitored_namespace, []):
             reconstructed_key = (monitored_namespace, pod_name)
@@ -333,9 +344,10 @@ occur in the indexing function with the errors mode set to ``IGNORED``):
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods')
-    async def empty_index(**_):
+    async def empty_index(**_: Any) -> Any:
         pass
         # {}
 
@@ -347,9 +359,10 @@ indices and collections that have no values left in them are removed from the in
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods')
-    async def index_of_nones(**_):
+    async def index_of_nones(**_: Any) -> Any:
         return {'key': None}
         # {'key': [None, None, ...]}
 
@@ -370,9 +383,10 @@ as returning ``None``, except that the exception's stack trace is also logged:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods', errors=kopf.ErrorsMode.IGNORED)  # the default
-    async def fn1(**_):
+    async def fn1(**_: Any) -> Any:
         raise Exception("Keep the stale values, if any.")
 
 :class:`kopf.PermanentError` and arbitrary exceptions with ``errors=PERMANENT``
@@ -383,13 +397,14 @@ and exclude the failed resource from future indexing by this index
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods', errors=kopf.ErrorsMode.PERMANENT)
-    async def fn1(**_):
+    async def fn1(**_: Any) -> Any:
         raise Exception("Excluded forever.")
 
     @kopf.index('pods')
-    async def fn2(**_):
+    async def fn2(**_: Any) -> Any:
         raise kopf.PermamentError("Excluded forever.")
 
 :class:`kopf.TemporaryError` and arbitrary exceptions with ``errors=TEMPORARY``
@@ -402,13 +417,14 @@ but current problems are preventing that from happening:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.index('pods', errors=kopf.ErrorsMode.TEMPORARY)
-    async def fn1(**_):
+    async def fn1(**_: Any) -> Any:
         raise Exception("Excluded for 60s.")
 
     @kopf.index('pods')
-    async def fn2(**_):
+    async def fn2(**_: Any) -> Any:
         raise kopf.TemporaryError("Excluded for 30s.", delay=30)
 
 In the "temporary" mode, the decorator's error-handling options are used:

--- a/docs/kwargs.rst
+++ b/docs/kwargs.rst
@@ -50,17 +50,18 @@ possibly with different selectors and filters, for one handler function:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('KopfExample', param=1000)
     @kopf.on.resume('KopfExample', param=100)
     @kopf.on.update('KopfExample', param=10, field='spec.field')
     @kopf.on.update('KopfExample', param=1, field='spec.items')
-    def count_updates(param, patch, **_):
+    def count_updates(param: Any, patch: kopf.Patch, **_: Any) -> None:
         patch.status['counter'] = body.status.get('counter', 0) + param
 
     @kopf.on.update('Child1', param='first', field='status.done', new=True)
     @kopf.on.update('Child2', param='second', field='status.done', new=True)
-    def child_updated(param, patch, **_):
+    def child_updated(param: Any, patch: kopf.Patch, **_: Any) -> None:
         patch_parent({'status': {param: {'done': True}}})
 
 Note that Kopf deduplicates the handlers to execute on a single occasion by
@@ -74,10 +75,11 @@ each time with the appropriate values of old/new/diff/param kwargs for those fie
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.update('KopfExample', param=10, field='spec.field')
     @kopf.on.update('KopfExample', param=1, field='spec')
-    def fn(param, **_):
+    def fn(param: Any, **_: Any) -> None:
         pass
 
 

--- a/docs/memos.rst
+++ b/docs/memos.rst
@@ -21,13 +21,14 @@ the memo is also re-created (technically, it is a new resource).
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event('KopfExample')
-    def pinged(memo: kopf.Memo, **_):
+    def pinged(memo: kopf.Memo, **_: Any) -> None:
         memo.counter = memo.get('counter', 0) + 1
 
     @kopf.timer('KopfExample', interval=10)
-    def tick(memo: kopf.Memo, logger, **_):
+    def tick(memo: kopf.Memo, logger: kopf.Logger, **_: Any) -> None:
         logger.info(f"{memo.counter} events have been received in 10 seconds.")
         memo.counter = 0
 
@@ -47,19 +48,20 @@ passed from outside the operator when :doc:`embedding` is used, or both:
     import kopf
     import queue
     import threading
+    from typing import Any
 
     @kopf.on.startup()
-    def start_background_worker(memo: kopf.Memo, **_):
+    def start_background_worker(memo: kopf.Memo, **_: Any) -> None:
         memo.my_queue = queue.Queue()
         memo.my_thread = threading.Thread(target=background, args=(memo.my_queue,))
         memo.my_thread.start()
 
     @kopf.on.cleanup()
-    def stop_background_worker(memo: kopf.Memo, **_):
+    def stop_background_worker(memo: kopf.Memo, **_: Any) -> None:
         memo['my_queue'].put(None)
         memo['my_thread'].join()
 
-    def background(queue: queue.Queue):
+    def background(queue: queue.Queue) -> None:
         while True:
             item = queue.get()
             if item is None:
@@ -81,7 +83,7 @@ where they can be mixed with per-resource values:
 
     # ... continued from the previous example.
     @kopf.on.event('KopfExample')
-    def pinged(memo: kopf.Memo, namespace: str, name: str, **_):
+    def pinged(memo: kopf.Memo, namespace: str | None, name: str, **_: Any) -> None:
         if not memo.get('is_seen'):
             memo.my_queue.put(f"{namespace}/{name}")
             memo.is_seen = True
@@ -116,6 +118,7 @@ to return ``self`` when asked to make a copy, as shown below:
     import asyncio
     import dataclasses
     import kopf
+    from typing import Any
 
     @dataclasses.dataclass()
     class CustomContext:
@@ -126,11 +129,11 @@ to return ``self`` when asked to make a copy, as shown below:
             return self
 
     @kopf.on.create('kopfexamples')
-    def create_fn(memo: CustomContext, **kwargs):
+    def create_fn(memo: CustomContext, **kwargs: Any) -> None:
         print(memo.create_tpl.format(**kwargs))
 
     @kopf.on.delete('kopfexamples')
-    def delete_fn(memo: CustomContext, **kwargs):
+    def delete_fn(memo: CustomContext, **kwargs: Any) -> None:
         print(memo.delete_tpl.format(**kwargs))
 
     if __name__ == '__main__':

--- a/docs/patches.rst
+++ b/docs/patches.rst
@@ -34,9 +34,10 @@ after the handler finishes:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def ensure_defaults(spec, patch, **_):
+    def ensure_defaults(spec: kopf.Spec, patch: kopf.Patch, **_: Any) -> None:
         if 'greeting' not in spec:
             patch.spec['greeting'] = 'hello'
         patch.status['state'] = 'initialized'
@@ -48,9 +49,10 @@ Other values overwrite the existing ones:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.update('kopfexamples')
-    def cleanup_obsolete_fields(patch, **_):
+    def cleanup_obsolete_fields(patch: kopf.Patch, **_: Any) -> None:
         patch.spec['obsoleteField'] = None  # deletes the field
         patch.status['phase'] = 'updated'   # overwrites the value
 
@@ -75,14 +77,15 @@ so there is no need to worry:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
-    def add_finalizer(body):
+    def add_finalizer(body: kopf.RawBody, /) -> None:
         finalizers = body.setdefault('metadata', {}).setdefault('finalizers', [])
         if 'my-operator/cleanup' not in finalizers:
             finalizers.append('my-operator/cleanup')
 
     @kopf.on.create('kopfexamples')
-    def create_fn(patch, **_):
+    def create_fn(patch: kopf.Patch, **_: Any) -> None:
         patch.fns.append(add_finalizer)
 
 The framework calls the transformation functions against the freshest seen
@@ -114,12 +117,13 @@ use ``functools.partial``:
 
     import functools
     import kopf
+    from typing import Any
 
-    def set_label(body, name, value):
+    def set_label(body: kopf.RawBody, /, name: str, value: str) -> None:
         body.setdefault('metadata', {}).setdefault('labels', {})[name] = value
 
     @kopf.on.create('kopfexamples')
-    def create_fn(patch, **_):
+    def create_fn(patch: kopf.Patch, **_: Any) -> None:
         patch.fns.append(functools.partial(set_label, name='my-label', value='my-value'))
 
 

--- a/docs/peering.rst
+++ b/docs/peering.rst
@@ -28,9 +28,10 @@ Or:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.peering.priority = 100
 
 As a shortcut, there is a :option:`--dev` option, which sets
@@ -100,9 +101,10 @@ Or:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.peering.name = "example"
         settings.peering.mandatory = True
 
@@ -138,9 +140,10 @@ Or:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.peering.standalone = True
 
 In that case, the operator will not pause if other operators with
@@ -183,11 +186,12 @@ Or:
 
 .. code-block:: python
 
-    import random
     import kopf
+    import random
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.peering.priority = random.randint(0, 32767)
 
 ``$RANDOM`` is a bash feature
@@ -210,11 +214,12 @@ The operator also logs keep-alive activity. This can be distracting. To disable 
 
 .. code-block:: python
 
-    import random
     import kopf
+    import random
+    from typing import Any
 
     @kopf.on.startup()
-    def configure(settings: kopf.OperatorSettings, **_):
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
         settings.peering.stealth = True
 
 There is no equivalent CLI option for that.

--- a/docs/probing.rst
+++ b/docs/probing.rst
@@ -73,13 +73,14 @@ probing handlers:
     import datetime
     import kopf
     import random
+    from typing import Any
 
     @kopf.on.probe(id='now')
-    def get_current_timestamp(**kwargs):
+    def get_current_timestamp(**_: Any) -> str:
         return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
     @kopf.on.probe(id='random')
-    def get_random_value(**kwargs):
+    def get_random_value(**_: Any) -> int:
         return random.randint(0, 1_000_000)
 
 The probe handlers will be executed on requests to the liveness URL,

--- a/docs/reconciliation.rst
+++ b/docs/reconciliation.rst
@@ -105,25 +105,26 @@ but you can get the overall idea:
 
 .. code-block:: python
 
-    import random
     import kopf
+    import random
+    from typing import Any
 
     # Keep in-memory index of children resources, so that we avoid API calls doing the same.
     @kopf.index('pods', labels={'parent-kex': kopf.PRESENT})
-    def kex_pods(body, name, **_):
+    def kex_pods(body: kopf.Body, name: str, **_: Any) -> Any:
         parent_name = body.metadata.labels['parent-kex']
         return {parent_name: name}
 
     # Regularly calculate and save the *actual state* from an in-memory index.
     # If an in-memory index is absent, redesign this to make API calls to get the same data.
     @kopf.timer('kopfexamples', interval=10)
-    def calculate_actual_state(name, kex_pods, patch, **_):
+    def calculate_actual_state(name: str, kex_pods: kopf.Index, patch: kopf.Patch, **_: Any) -> None:
         actual_pods = kex_pods.get(name, [])
         patch.status['replicas'] = len(actual_pods)
 
     # React to changes in either the *desired* or *actual* states, and reconcile them.
     @kopf.on.event('kopfexamples')
-    def react_on_state_changes(body, name, **_):
+    def react_on_state_changes(body: kopf.Body, name: str, **_: Any) -> None:
         actual_replicas = body.status.get('replicas', 0)
         desired_replicas = body.spec.get('replicas', 1)
         delta = desired_replicas - actual_replicas

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -17,13 +17,14 @@ separated by a slash:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event('kopf.dev', 'v1', 'kopfexamples')
     @kopf.on.event('kopf.dev/v1', 'kopfexamples')
     @kopf.on.event('apps', 'v1', 'deployments')
     @kopf.on.event('apps/v1', 'deployments')
     @kopf.on.event('', 'v1', 'pods')
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 If only one API specification is given (except for ``v1``), it is treated
@@ -32,10 +33,11 @@ as an API group, and the preferred API version of that API group is used:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event('kopf.dev', 'kopfexamples')
     @kopf.on.event('apps', 'deployments')
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 It is also possible to specify the resources with ``kubectl``'s semantics:
@@ -43,10 +45,11 @@ It is also possible to specify the resources with ``kubectl``'s semantics:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event('kopfexamples.kopf.dev')
     @kopf.on.event('deployments.apps')
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 One exceptional case is ``v1`` as the API specification: it corresponds
@@ -56,10 +59,11 @@ to an empty API group name. The following specifications are equivalent:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event('v1', 'pods')
     @kopf.on.event('', 'v1', 'pods')
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 If neither the API group nor the API version is specified,
@@ -69,11 +73,12 @@ However, it is reasonable to expect only one:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event('kopfexamples')
     @kopf.on.event('deployments')
     @kopf.on.event('pods')
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 In all examples above, where a resource identifier is expected, it can be
@@ -84,6 +89,7 @@ possible names of the specific resource once it is discovered:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event('kopfexamples')
     @kopf.on.event('kopfexample')
@@ -92,7 +98,7 @@ possible names of the specific resource once it is discovered:
     @kopf.on.event('StatefulSet')
     @kopf.on.event('deployments')
     @kopf.on.event('pod')
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 The resource specification can be more specific on which name to match
@@ -101,6 +107,7 @@ by using the keyword arguments:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event(kind='KopfExample')
     @kopf.on.event(plural='kopfexamples')
@@ -108,7 +115,7 @@ by using the keyword arguments:
     @kopf.on.event(shortcut='kex')
     @kopf.on.event(group='kopf.dev', plural='kopfexamples')
     @kopf.on.event(group='kopf.dev', version='v1', plural='kopfexamples')
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 
@@ -121,9 +128,10 @@ specified to avoid unintended consequences:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event(category='all')
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 Note that the conventional category ``all`` does not actually mean all resources,
@@ -140,11 +148,12 @@ of the mandatory resource name:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event('kopf.dev', 'v1', kopf.EVERYTHING)
     @kopf.on.event('kopf.dev/v1', kopf.EVERYTHING)
     @kopf.on.event('kopf.dev', kopf.EVERYTHING)
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 As a consequence of the above, to handle every resource in the cluster
@@ -154,9 +163,10 @@ omit the API group/version and use the marker only:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event(kopf.EVERYTHING)
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 Serving everything is better when it is used with filters:
@@ -164,9 +174,10 @@ Serving everything is better when it is used with filters:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event(kopf.EVERYTHING, labels={'only-this': kopf.PRESENT})
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 
@@ -181,12 +192,13 @@ and return a boolean indicating whether to handle the resource:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     def kex_selector(resource: kopf.Resource) -> bool:
         return resource.plural == 'kopfexamples' and resource.preferred
 
     @kopf.on.event(kex_selector)
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 You can combine the callable resource selectors with other keyword selectors
@@ -195,12 +207,13 @@ You can combine the callable resource selectors with other keyword selectors
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     def kex_selector(resource: kopf.Resource) -> bool:
         return resource.plural == 'kopfexamples' and resource.preferred
 
     @kopf.on.event(kex_selector, group='kopf.dev')
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 There is a subtle difference between callable resource selectors and filters
@@ -230,13 +243,14 @@ To handle core v1 events, name them directly and explicitly:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     def all_core_v1(resource: kopf.Resource) -> bool:
         return resource.group == '' and resource.preferred
 
     @kopf.on.event(all_core_v1)
     @kopf.on.event('v1', 'events')
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 
@@ -254,10 +268,11 @@ even if there are accidental overlaps in the specifications.
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.event('kopfexamples')
     @kopf.on.event('v1', 'pods')
-    def fn(**_):
+    def fn(**_: Any) -> None:
         pass
 
 
@@ -291,13 +306,14 @@ Ambiguous resource selectors
     .. code-block:: python
 
         import kopf
+        from typing import Any
 
         @kopf.on.event('pods')  # NOT SO GOOD, ambiguous, though works
         @kopf.on.event('pods.v1')  # GOOD, specific
         @kopf.on.event('v1', 'pods')  # GOOD, specific
         @kopf.on.event('pods.metrics.k8s.io')  # GOOD, specific
         @kopf.on.event('metrics.k8s.io', 'pods')  # GOOD, specific
-        def fn(**_):
+        def fn(**_: Any) -> None:
             pass
 
     Reserve short forms for prototyping and experimentation,

--- a/docs/results.rst
+++ b/docs/results.rst
@@ -8,13 +8,14 @@ Kopf then stores these values in the resource status under the name of the handl
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def create_kex_1(**_):
+    def create_kex_1(**_: Any) -> int:
         return 100
 
     @kopf.on.create('kopfexamples')
-    def create_kex_2(uid, **_):
+    def create_kex_2(uid: str, **_: Any) -> dict[str, int]:
         return {'r1': random.randint(0, 100), 'r2': random.randint(100, 999)}
 
 These results are visible in the object's content:
@@ -41,9 +42,10 @@ recovery in case of operator failures and restarts:
 
     import kopf
     import pykube
+    from typing import Any
 
     @kopf.on.create('kopfexamples')
-    def create_job(status, **_):
+    def create_job(status: kopf.Status, **_: Any) -> dict[str, str]:
         if not status.get('create_pvc', {}):
             raise kopf.TemporaryError("PVC is not created yet.", delay=10)
 
@@ -55,7 +57,7 @@ recovery in case of operator failures and restarts:
         return {'name': obj.name}
 
     @kopf.on.create('kopfexamples')
-    def create_pvc(**_):
+    def create_pvc(**_: Any) -> dict[str, str]:
         api = pykube.HTTPClient(pykube.KubeConfig.from_env())
         obj = pykube.PersistentVolumeClaim(api, {...})
         obj.create()

--- a/docs/shutdown.rst
+++ b/docs/shutdown.rst
@@ -10,9 +10,10 @@ by raising the stop-flag, or by cancelling the operator's task
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.cleanup()
-    async def cleanup_fn(logger, **kwargs):
+    async def cleanup_fn(logger: kopf.Logger, **_: Any) -> None:
         pass
 
 The cleanup handlers are not guaranteed to execute fully if they take

--- a/docs/startup.rst
+++ b/docs/startup.rst
@@ -13,11 +13,12 @@ the loop-bound variables --- which is impossible in the module-level code:
 
     import asyncio
     import kopf
+    from typing import Any
 
     LOCK: asyncio.Lock
 
     @kopf.on.startup()
-    async def startup_fn(logger, **kwargs):
+    async def startup_fn(logger: kopf.Logger, **_: Any) -> None:
         global LOCK
         LOCK = asyncio.Lock()  # uses the running asyncio loop by default
 

--- a/docs/timers.rst
+++ b/docs/timers.rst
@@ -15,11 +15,12 @@ The interval defines how often to trigger the handler (in seconds):
 .. code-block:: python
 
     import asyncio
-    import time
     import kopf
+    import time
+    from typing import Any
 
     @kopf.timer('kopfexamples', interval=1.0)
-    def ping_kex(spec, **kwargs):
+    def ping_kex(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 
@@ -34,11 +35,12 @@ every number of seconds sharp, no matter how long it takes to execute it:
 .. code-block:: python
 
     import asyncio
-    import time
     import kopf
+    import time
+    from typing import Any
 
     @kopf.timer('kopfexamples', interval=1.0, sharp=True)
-    def ping_kex(spec, **kwargs):
+    def ping_kex(spec: kopf.Spec, **_: Any) -> None:
         time.sleep(0.3)
 
 In this example, the timer takes 0.3 seconds to execute. The actual interval
@@ -56,9 +58,10 @@ be invoked when it is stable for some time:
 
     import asyncio
     import kopf
+    from typing import Any
 
     @kopf.timer('kopfexamples', idle=10)
-    def ping_kex(spec, **kwargs):
+    def ping_kex(spec: kopf.Spec, **_: Any) -> None:
         print(f"FIELD={spec['field']}")
 
 The creation of a resource is considered as a change, so idling also shifts
@@ -76,9 +79,10 @@ Once changed, the timer will stop and wait for the new idling time:
 
     import asyncio
     import kopf
+    from typing import Any
 
     @kopf.timer('kopfexamples', idle=10, interval=1)
-    def ping_kex(spec, **kwargs):
+    def ping_kex(spec: kopf.Spec, **_: Any) -> None:
         print(f"FIELD={spec['field']}")
 
 
@@ -93,11 +97,12 @@ It is possible to postpone the invocations:
 .. code-block:: python
 
     import asyncio
-    import time
     import kopf
+    import time
+    from typing import Any
 
     @kopf.timer('kopfexamples', interval=1, initial_delay=5)
-    def ping_kex(spec, **kwargs):
+    def ping_kex(spec: kopf.Spec, **_: Any) -> None:
         print(f"FIELD={spec['field']}")
 
 This is similar to idling, except that it is applied only once per
@@ -108,17 +113,18 @@ as the handler itself, and returns the delay in seconds:
 
 .. code-block:: python
 
-    import random
     import kopf
+    import random
+    from typing import Any
 
-    def get_delay(body, **kwargs):
+    def get_delay(body: kopf.Body, **_: Any) -> int:
         return random.randint(
             body.get('spec', {}).get('minDelay', 0),
             body.get('spec', {}).get('maxDelay', 60),
         )
 
     @kopf.timer('kopfexamples', interval=1, initial_delay=get_delay)
-    def ping_kex(spec, **kwargs):
+    def ping_kex(spec: kopf.Spec, **_: Any) -> None:
         ...
 
 This is primarily intended for load balancing during operator restarts (e.g. by
@@ -136,10 +142,11 @@ the resources every 10 seconds if they are unmodified for 10 minutes:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.timer('kopfexamples',
                 initial_delay=60, interval=10, idle=600)
-    def ping_kex(spec, **kwargs):
+    def ping_kex(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 
@@ -169,10 +176,11 @@ from the first execution to the end of the retrying cycle:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.timer('kopfexamples',
                 errors=kopf.ErrorsMode.TEMPORARY, interval=10, backoff=5)
-    def monitor_kex_by_time(name, retry, **kwargs):
+    def monitor_kex_by_time(name: str, retry: int, **_: Any) -> None:
         if retry < 3:
             raise Exception()
 
@@ -204,11 +212,12 @@ as a key.
 
 .. code-block:: python
 
-    import random
     import kopf
+    import random
+    from typing import Any
 
     @kopf.timer('kopfexamples', interval=10)
-    def ping_kex(spec, **kwargs):
+    def ping_kex(spec: kopf.Spec, **_: Any) -> int:
         return random.randint(0, 100)
 
 .. note::
@@ -228,8 +237,9 @@ including both the merge-patch dictionary and the transformation functions
 .. code-block:: python
 
     import asyncio
-    import random
     import kopf
+    import random
+    from typing import Any
 
     # Transformation functions and JSON-patches are useful specifically for the lists.
     def set_conditions(body: kopf.RawBody) -> None:
@@ -238,7 +248,7 @@ including both the merge-patch dictionary and the transformation functions
         conditions.append({'type': 'Whatever', 'status': 'True', 'reason': 'SomeReason', 'message': 'Some message'})
 
     @kopf.timer('kopfexamples', interval=60)
-    async def update_status(patch, **kwargs):
+    async def update_status(patch: kopf.Patch, **_: Any) -> None:
         # This goes to the merge-patch.
         patch.status['replicas'] = random.randint(1, 10)
 
@@ -267,12 +277,13 @@ It is also possible to use the existing :doc:`filters`:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.timer('kopfexamples', interval=10,
                 annotations={'some-annotation': 'some-value'},
                 labels={'some-label': 'some-value'},
                 when=lambda name, **_: 'some' in name)
-    def ping_kex(spec, **kwargs):
+    def ping_kex(spec: kopf.Spec, **_: Any) -> None:
         pass
 
 

--- a/docs/tips-and-tricks.rst
+++ b/docs/tips-and-tricks.rst
@@ -24,14 +24,15 @@ ever again, even after the operator restarts, use annotation filters
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.update('kopfexamples', annotations={'update-fn-never-again': kopf.ABSENT})
-    def update_fn(patch, **_):
+    def update_fn(patch: kopf.Patch, **_: Any) -> None:
         patch.metadata.annotations['update-fn-never-again'] = 'yes'
         raise kopf.PermanentError("Never call update-fn again.")
 
     @kopf.daemon('kopfexamples', annotations={'monitor-never-again': kopf.ABSENT})
-    async def monitor_kex(patch, **kwargs):
+    async def monitor_kex(patch: kopf.Patch, **_: Any) -> None:
         patch.metadata.annotations['monitor-never-again'] = 'yes'
 
 Such a never-again exclusion may be implemented as a built-in Kopf feature one day,

--- a/docs/walkthrough/creation.rst
+++ b/docs/walkthrough/creation.rst
@@ -52,13 +52,14 @@ We will use the official Kubernetes client library (``pip install kubernetes``):
     :name: creation
     :caption: ephemeral.py
 
-    import os
     import kopf
     import kubernetes
+    import os
     import yaml
+    from typing import Any
 
     @kopf.on.create('ephemeralvolumeclaims')
-    def create_fn(spec, name, namespace, logger, **kwargs):
+    def create_fn(spec: kopf.Spec, name: str, namespace: str | None, logger: kopf.Logger, **_: Any) -> None:
 
         size = spec.get('size')
         if not size:

--- a/docs/walkthrough/deletion.rst
+++ b/docs/walkthrough/deletion.rst
@@ -34,13 +34,14 @@ Let us extend the creation handler:
     :caption: ephemeral.py
     :emphasize-lines: 18
 
-    import os
     import kopf
     import kubernetes
+    import os
     import yaml
+    from typing import Any
 
     @kopf.on.create('ephemeralvolumeclaims')
-    def create_fn(spec, name, namespace, logger, body, **kwargs):
+    def create_fn(spec: kopf.Spec, name: str, namespace: str | None, logger: kopf.Logger, body: kopf.Body, **_: Any) -> dict[str, str]:
 
         size = spec.get('size')
         if not size:

--- a/docs/walkthrough/diffs.rst
+++ b/docs/walkthrough/diffs.rst
@@ -31,7 +31,7 @@ but we will use another feature of Kopf to track one specific field only:
     :emphasize-lines: 1, 5
 
     @kopf.on.field('ephemeralvolumeclaims', field='metadata.labels')
-    def relabel(old, new, status, namespace, **kwargs):
+    def relabel(old: Any, new: Any, status: kopf.Status, namespace: str | None, **_: Any) -> None:
 
         pvc_name = status['create_fn']['pvc-name']
         pvc_patch = {'metadata': {'labels': new}}
@@ -103,7 +103,7 @@ which is exactly what the patch object needs to delete that field:
     :emphasize-lines: 4
 
     @kopf.on.field('ephemeralvolumeclaims', field='metadata.labels')
-    def relabel(diff, status, namespace, **kwargs):
+    def relabel(diff: kopf.Diff, status: kopf.Status, namespace: str | None, **_: Any) -> None:
 
         labels_patch = {field[0]: new for op, field, old, new in diff}
         pvc_name = status['create_fn']['pvc-name']

--- a/docs/walkthrough/starting.rst
+++ b/docs/walkthrough/starting.rst
@@ -16,9 +16,10 @@ just to see how it can be started.
 
     import kopf
     import logging
+    from typing import Any
 
     @kopf.on.create('ephemeralvolumeclaims')
-    def create_fn(body, **kwargs):
+    def create_fn(body: kopf.Body, **_: Any) -> None:
         logging.info(f"A handler is called with body: {body}")
 
 .. note::

--- a/docs/walkthrough/updates.rst
+++ b/docs/walkthrough/updates.rst
@@ -25,7 +25,7 @@ with one additional line:
     :emphasize-lines: 21
 
     @kopf.on.create('ephemeralvolumeclaims')
-    def create_fn(spec, name, namespace, logger, **kwargs):
+    def create_fn(spec: kopf.Spec, name: str, namespace: str | None, logger: kopf.Logger, **_: Any) -> dict[str, str]:
 
         size = spec.get('size')
         if not size:
@@ -81,9 +81,10 @@ and patches the PVC with the new size from the EVC:
 .. code-block:: python
 
     import kopf
+    from typing import Any
 
     @kopf.on.update('ephemeralvolumeclaims')
-    def update_fn(spec, status, namespace, logger, **kwargs):
+    def update_fn(spec: kopf.Spec, status: kopf.Status, namespace: str | None, logger: kopf.Logger, **_: Any) -> None:
 
         size = spec.get('size', None)
         if not size:

--- a/kopf/_cogs/clients/patching.py
+++ b/kopf/_cogs/clients/patching.py
@@ -9,7 +9,7 @@ async def patch_obj(
         settings: configuration.OperatorSettings,
         resource: references.Resource,
         namespace: references.Namespace,
-        name: str | None,
+        name: str,
         patch: patches.Patch,
         logger: typedefs.Logger,
         silent: bool = False,


### PR DESCRIPTION
A wider follow-up for

* #1280

The age of non-typed code is gone. It is time to have type hints everywhere, including the docs.