### PR TITLE
Improve thread safety in debug mode of event loops

### DIFF
--- a/kopf/_core/engines/posting.py
+++ b/kopf/_core/engines/posting.py
@@ -85,13 +85,7 @@ def enqueue(
         # No event-loop or another event-loop - assume another thread.
         # Use the cross-thread thread-safe methods. Do not block or wait.
         # Beware of #1212: `run_coroutine_threadsafe(queue.put(…), loop=loop)` is flawed.
-        queue.put_nowait(event)
-        loop.call_soon_threadsafe(_no_op_event_loop_awakener)
-
-
-# The same as `lambda: None`, but with no closure data attached & better for JIT in PyPy.
-def _no_op_event_loop_awakener() -> None:
-    pass
+        loop.call_soon_threadsafe(queue.put_nowait, event)
 
 
 def event(

--- a/tests/posting/test_threadsafety.py
+++ b/tests/posting/test_threadsafety.py
@@ -95,6 +95,7 @@ async def test_nonthreadsafe_indeed_fails(chronometer, threader, event_queue):
         threader(0.2, thread_fn)
         await event_queue.get()
 
+    # We wake up on the wakeup call (0.5) instead of the proper queue.put (0.2).
     assert 0.5 <= chronometer.seconds < 0.6
     assert 0.5 <= loopometer.seconds < 0.6
     assert thread_was_called.is_set()
@@ -114,6 +115,7 @@ async def test_threadsafe_indeed_works(chronometer, threader, event_queue):
         threader(0.2, thread_fn)
         await event_queue.get()
 
+    # We wake up on time of the queue.put (0.2), not on the wakeup call (0.5).
     assert 0.2 <= chronometer.seconds < 0.3
     assert 0.2 <= loopometer.seconds < 0.3
     assert thread_was_called.is_set()
@@ -121,9 +123,15 @@ async def test_threadsafe_indeed_works(chronometer, threader, event_queue):
 
 @pytest.mark.looptime(False)
 @pytest.mark.usefixtures('event_queue_loop', 'settings_via_contextvar')
-async def test_queueing_is_threadsafe(chronometer, threader, event_queue):
+@pytest.mark.parametrize('debug', [False, True], ids=['regular', 'paranoid'])
+async def test_queueing_is_threadsafe(chronometer, threader, event_queue, debug):
     loop = asyncio.get_running_loop()
     thread_was_called = threading.Event()
+
+    # Setup the worst case to catch inconsistencies in cross-thread coordination.
+    # Debug mode makes event loops extra paranoid about thread safety, like this:
+    # RuntimeError("Non-thread-safe operation invoked on an event loop other than the current one")
+    loop.set_debug(debug)
 
     def thread_fn():
         thread_was_called.set()
@@ -134,6 +142,7 @@ async def test_queueing_is_threadsafe(chronometer, threader, event_queue):
         threader(0.2, thread_fn)
         await event_queue.get()
 
+    # We wake up on time of the queue.put (0.2), not on the wakeup call (0.5).
     assert 0.2 <= chronometer.seconds < 0.3
     assert 0.2 <= loopometer.seconds < 0.3
     assert thread_was_called.is_set()


### PR DESCRIPTION
Event loops are extra paranoid about thread safety, so they raise an error when the `kopf.event()` is called from the thread pool, i.e. sync handlers:

```python
RuntimeError("Non-thread-safe operation invoked on an event loop other than the current one")
```

This only happens if the debug mode is enabled — either explicitly via `loop.set_debug(True)` or `asyncio.run(…, debug=True)`, or implicitly with the env var `PYTHONASYNCIODEBUG=1` (as it was in my IDE).

And so, this way is wrong when called from a thread-pool executor:

```python
        queue.put_nowait(event)
        loop.call_soon_threadsafe(_no_op_event_loop_awakener)
```

This way is correct:

```python
        loop.call_soon_threadsafe(queue.put_nowait, event)
```

Commit 81e6a33e3163d0d036c00f0e326c4524313328bc introduced this issue, with a note that the choice between these two methods was unclear and they were the same. Turns out, they are not precisely the same.

**Scope:** limited; no one runs production in debug-mode event loops.