### PR TITLE
Configure the default backoff for unexpected errors as an operator-wide setting

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -29,11 +29,15 @@ which can happen either immediately, or after some delay:
     @kopf.on.create('kopfexamples')
     def create_fn(spec: kopf.Spec, **_: Any) -> None:
         if not is_data_ready():
-            raise kopf.TemporaryError("The data is not yet ready.", delay=60)
+            raise kopf.TemporaryError("The data is not yet ready.", delay=30)
 
 In that case, there is no need to sleep in the handler explicitly, thus blocking
 any other events, causes, and generally any other handlers on the same object
 from being handled (such as deletion or parallel handlers/sub-handlers).
+
+The default delay for temporary errors is hard-coded to 60 seconds and cannot
+be configured globally for the operator (unlike ``settings.execution.default_backoff``
+for arbitrary errors). Override the default explicitly in code if needed.
 
 .. note::
     The multiple handlers and the sub-handlers are implemented via this
@@ -157,7 +161,17 @@ can be configured:
     def create_fn(spec: kopf.Spec, **_: Any) -> None:
         raise Exception()
 
-The default is 60 seconds.
+The default is 60 seconds, which you can configure globally for the operator
+with ``settings.execution.default_backoff``:
+
+.. code-block:: python
+
+    import kopf
+    from typing import Any
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
+        settings.execution.default_backoff = 30
 
 .. note::
 

--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -329,6 +329,16 @@ class ExecutionSettings:
     Settings for synchronous handlers execution (e.g. thread-/process-pools).
     """
 
+    default_backoff: float = 60
+    """
+    The duration to postpone the retry of arbitrary errors (except Kopf's ones).
+
+    Each handler can set its own backoff with the ``backoff`` parameter.
+
+    :class:`kopf.TemporaryError` has its own hard-coded default of 60 seconds,
+    which can be overridden explicitly with ``kopf.TemporaryError(…, delay=…)``.
+    """
+
     executor: concurrent.futures.Executor = dataclasses.field(
         default_factory=concurrent.futures.ThreadPoolExecutor)
     """

--- a/kopf/_core/actions/execution.py
+++ b/kopf/_core/actions/execution.py
@@ -21,9 +21,6 @@ from kopf._cogs.helpers import typedefs
 from kopf._cogs.structs import ids
 from kopf._core.actions import invocation
 
-# The default delay duration for the regular exception in retry-mode.
-DEFAULT_RETRY_DELAY = 1 * 60
-
 
 class PermanentError(Exception):
     """ A fatal handler error, the retries are useless. """
@@ -34,7 +31,7 @@ class TemporaryError(Exception):
     def __init__(
             self,
             __msg: str | None = None,
-            delay: float | None = DEFAULT_RETRY_DELAY,
+            delay: float | None = 60,
     ) -> None:
         super().__init__(__msg)
         self.delay = delay
@@ -233,7 +230,7 @@ async def execute_handler_once(
     exceptions mean the failure of execution itself.
     """
     errors_mode = handler.errors if handler.errors is not None else default_errors
-    backoff = handler.backoff if handler.backoff is not None else DEFAULT_RETRY_DELAY
+    backoff = handler.backoff if handler.backoff is not None else settings.execution.default_backoff
     logger = cause.logger
 
     # Mutable accumulator for all the sub-handlers of any level deep; populated in `kopf.execute`.

--- a/tests/e2e/test_examples.py
+++ b/tests/e2e/test_examples.py
@@ -25,7 +25,7 @@ def test_all_examples_are_runnable(mocker, settings, with_crd, exampledir, caplo
         pytest.importorskip('kubernetes')
 
     # To prevent lengthy sleeps on the simulated retries.
-    mocker.patch('kopf._core.actions.execution.DEFAULT_RETRY_DELAY', 1)
+    settings.execution.default_backoff = 1
 
     # To prevent lengthy threads in the loop executor when the process exits.
     settings.watching.server_timeout = 10
@@ -33,7 +33,7 @@ def test_all_examples_are_runnable(mocker, settings, with_crd, exampledir, caplo
     # Run an operator and simulate some activity with the operated resource.
     with KopfRunner(
         ['run', '--all-namespaces', '--standalone', '--verbose', str(example_py)],
-        timeout=60,
+        timeout=60, settings=settings,
     ) as runner:
 
         # Give it some time to start.

--- a/tests/handling/test_error_handling.py
+++ b/tests/handling/test_error_handling.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 
+import freezegun
 import pytest
 
 import kopf
@@ -104,12 +105,20 @@ async def test_retry_error_delays_handler(
 
 
 # The extrahandlers are needed to prevent the cycle ending and status purging.
+@freezegun.freeze_time('2020-12-31T00:00:00')
+@pytest.mark.parametrize('backoff_setting, expected_delayed, expected_log_seconds', [
+    (0, '2020-12-31T00:00:00.000000+00:00', 0),
+    (30, '2020-12-31T00:00:30.000000+00:00', 30),
+    (60, '2020-12-31T00:01:00.000000+00:00', 60),
+])
 @pytest.mark.parametrize('cause_type', HANDLER_REASONS)
 async def test_arbitrary_error_delays_handler(
         registry, settings, handlers, extrahandlers, resource, cause_mock, cause_type,
-        assert_logs, k8s_mocked, looptime):
+        assert_logs, k8s_mocked, looptime,
+        backoff_setting, expected_delayed, expected_log_seconds):
     name1 = f'{cause_type}_fn'
 
+    settings.execution.default_backoff = backoff_setting
     event_type = None if cause_type == Reason.RESUME else 'irrelevant'
     cause_mock.reason = cause_type
     handlers.create_mock.side_effect = Exception("oops")
@@ -142,8 +151,8 @@ async def test_arbitrary_error_delays_handler(
     progress = json.loads(patch['metadata']['annotations'][f"kopf.zalando.org/{name1}"])
     assert progress['failure'] is False
     assert progress['success'] is False
-    assert progress['delayed']
+    assert progress['delayed'] == expected_delayed
 
     assert_logs([
-        "Handler .+ failed with an exception and will try again in 60 seconds: oops",
+        rf"Handler .+ failed with an exception and will try again in {expected_log_seconds} seconds: oops",
     ])

--- a/tests/settings/test_defaults.py
+++ b/tests/settings/test_defaults.py
@@ -27,6 +27,7 @@ async def test_declared_public_interface_and_promised_defaults():
     assert settings.scanning.disabled == False
     assert settings.admission.server is None
     assert settings.admission.managed is None
+    assert settings.execution.default_backoff == 60
     assert settings.execution.executor is not None
     assert settings.execution.max_workers is None
     assert settings.networking.request_timeout == 5 * 60


### PR DESCRIPTION
Operator authors can now tune the default retry delay for arbitrary handler exceptions once per operator, instead of setting ``backoff=`` on every decorator or relying on a hard-coded internal constant. The per-handler ``backoff=`` override still takes precedence, and ``kopf.TemporaryError(delay=…)`` keeps its independent hard-coded default.

This was necessary mainly for our own e2e tests, where this constant was previosuly monkey-patched for speedup. Now, it is configured properly. Monkey-patching is generally bad.