### PR TITLE
Extend the docs with "ask ai" links to templated queries

### DIFF
--- a/docs/_templates/sidebar/ask-ai.html
+++ b/docs/_templates/sidebar/ask-ai.html
@@ -1,0 +1,11 @@
+<style>
+    .sidebar-ask-ai-container {
+        margin-top:0;
+    }
+</style>
+<div class="sidebar-ask-ai-container sidebar-tree">
+<p class="caption">
+Ask <a target="_blank" href="https://claude.ai/new?q={{ ('Read from ' + (pathurl or '') + ' and be ready to answer questions.') | urlencode }}">Claude</a>
+or  <a target="_blank" href="https://chat.openai.com/?hints=search&q={{ ('Read from ' + (pathurl or '') + ' and be ready to answer questions.') | urlencode }}">ChatGPT</a>
+</p>
+</div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,20 @@ templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 html_static_path = ['_static']
 html_theme = 'furo'
+html_sidebars = {
+   '**': [
+       # The defaults from furo/theme/furo/theme.conf, plus ask-ai.html.
+       'sidebar/brand.html',
+       'sidebar/search.html',
+       'sidebar/ask-ai.html',
+       'sidebar/scroll-start.html',
+       'sidebar/navigation.html',
+       'sidebar/ethical-ads.html',
+       'sidebar/scroll-end.html',
+       'sidebar/variant-selector.html',
+    ],
+}
+
 
 default_role = 'py:obj'
 


### PR DESCRIPTION
<img width="574" height="311" alt="image" src="https://github.com/user-attachments/assets/d6aecda8-e40a-47a7-9302-a40542c113d5" />

TODOs:

- [x] Check if `pageurl` is populated in ReadTheDocs (empty locally).
  - Nope, it is empty too (in the PR build).
- [ ] ❗️ Find a variable for the absolute page URL, including the stable/latest version split.
- [ ] Reduce the margins of the following ToC.
- [ ] Try moving this to the top-right buttons bar (where dark/light mode is; but Furo (theme) has no such blocks).