### PR TITLE
Paginate the initial list with limit/continue

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,3 +21,4 @@ and [Historic GitHub Contributors](https://github.com/zalando-incubator/kopf/gra
 - [Vennamaneni Sai Narasimha](https://github.com/thevennamaneni)
 - [Cliff Burdick](https://github.com/cliffburdick)
 - [CJ Baar](https://github.com/cjbaar)
+- [Gerard Casas Saez](https://github.com/casassg)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -314,6 +314,23 @@ __ https://github.com/kubernetes/kubernetes/blob/c20e0bc54189aef73a6a1498b4eab28
         settings.networking.request_timeout = 60
         settings.watching.server_timeout = 10 * 60
 
+``settings.watching.batch_size`` (integer) is the page size (the ``limit=``
+query parameter) for the initial listing that precedes every watch. When set,
+the list is fetched in chunks via the Kubernetes API's ``limit``/``continue``
+pagination instead of a single request, which caps the peak memory footprint
+of the bootstrap listing for large collections (the whole list would otherwise
+be loaded and parsed into memory at once). The default is ``None`` --- the whole
+collection is fetched in a single request, preserving the original behaviour.
+
+.. code-block:: python
+
+    import kopf
+    from typing import Any
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
+        settings.watching.batch_size = 500
+
 
 Proxy and environment trust
 ---------------------------

--- a/kopf/_cogs/clients/fetching.py
+++ b/kopf/_cogs/clients/fetching.py
@@ -24,20 +24,45 @@ async def list_objs(
     Otherwise, the namespace-scoped call is used:
 
     * The resource is namespace-scoped AND operator is namespaced-restricted.
-    """
-    rsp = await api.get(
-        url=resource.get_url(namespace=namespace),
-        logger=logger,
-        settings=settings,
-    )
 
+    When ``settings.watching.batch_size`` is set, the collection is fetched in
+    chunks via the Kubernetes API's ``limit``/``continue`` pagination, which
+    keeps the peak memory footprint low for large collections. Otherwise, the
+    whole collection is fetched in a single request (the default behaviour).
+    """
     items: list[bodies.RawBody] = []
-    resource_version = rsp.get('metadata', {}).get('resourceVersion', None)
-    for item in rsp.get('items', []):
-        if 'kind' in rsp:
-            item.setdefault('kind', rsp['kind'].removesuffix('List'))
-        if 'apiVersion' in rsp:
-            item.setdefault('apiVersion', rsp['apiVersion'])
-        items.append(item)
+    resource_version: str | None = None
+    continue_token: str | None = None
+    while True:
+
+        params: dict[str, str] = {}
+        if settings.watching.batch_size is not None:
+            params['limit'] = str(settings.watching.batch_size)
+        if continue_token:
+            params['continue'] = continue_token
+
+        rsp = await api.get(
+            url=resource.get_url(namespace=namespace, params=params or None),
+            logger=logger,
+            settings=settings,
+        )
+
+        # All chunks of a paginated list share one consistent snapshot, so the
+        # resource version is the same on every page; keep the first non-empty
+        # one to continue the watch-stream from the fully listed state.
+        if resource_version is None:
+            resource_version = rsp.get('metadata', {}).get('resourceVersion', None)
+
+        for item in rsp.get('items', []):
+            if 'kind' in rsp:
+                item.setdefault('kind', rsp['kind'].removesuffix('List'))
+            if 'apiVersion' in rsp:
+                item.setdefault('apiVersion', rsp['apiVersion'])
+            items.append(item)
+
+        # Keep fetching while the server reports more chunks of the collection.
+        continue_token = rsp.get('metadata', {}).get('continue', None)
+        if not continue_token:
+            break
 
     return items, resource_version

--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -209,6 +209,20 @@ class WatchingSettings:
     detecting dead streams and reconnecting while the events are in memory.
     """
 
+    batch_size: int | None = None
+    """
+    The page size (the ``limit=`` query parameter) for the initial listing
+    that precedes every watch.
+
+    When set, the initial list is fetched in chunks using the Kubernetes API's
+    ``limit``/``continue`` pagination instead of a single request. This caps the
+    peak memory footprint of the bootstrap listing for large collections, where
+    the whole list would otherwise be loaded and parsed into memory at once.
+
+    If ``None`` (the default), the whole list is fetched in a single request,
+    which preserves the original behaviour.
+    """
+
 
 @dataclasses.dataclass
 class QueueingSettings:

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -1,13 +1,7 @@
-import urllib.parse
-
 import pytest
 
 from kopf._cogs.clients.errors import APIError
 from kopf._cogs.clients.fetching import list_objs
-
-
-def _query(url):
-    return dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(url).query))
 
 
 async def test_listing_works(kmock, settings, logger, resource, namespace):
@@ -20,40 +14,23 @@ async def test_listing_works(kmock, settings, logger, resource, namespace):
     )
     assert items == [{}, {}]
     assert len(kmock['list']) == 1
-
-
-async def test_listing_is_a_single_unpaginated_request_by_default(
-        mocker, settings, logger, resource, namespace):
-    get = mocker.patch('kopf._cogs.clients.api.get', return_value={
-        'metadata': {'resourceVersion': '123'},
-        'items': [{'spec': 1}, {'spec': 2}],
-    })
-    items, resource_version = await list_objs(
-        logger=logger,
-        settings=settings,
-        resource=resource,
-        namespace=namespace,
-    )
-    assert [item['spec'] for item in items] == [1, 2]
-    assert resource_version == '123'
-    assert get.call_count == 1
-    query = _query(get.call_args.kwargs['url'])
-    assert 'limit' not in query
-    assert 'continue' not in query
+    assert kmock['list'][0].params == {}
 
 
 async def test_listing_is_paginated_when_batch_size_is_set(
-        mocker, settings, logger, resource, namespace):
+        kmock, settings, logger, resource, namespace):
     settings.watching.batch_size = 2
-    pages = [
-        {'metadata': {'resourceVersion': '100', 'continue': 'TOKEN1'},
-         'items': [{'spec': 1}, {'spec': 2}]},
-        {'metadata': {'resourceVersion': '100', 'continue': 'TOKEN2'},
-         'items': [{'spec': 3}, {'spec': 4}]},
-        {'metadata': {'resourceVersion': '100'},
-         'items': [{'spec': 5}]},
-    ]
-    get = mocker.patch('kopf._cogs.clients.api.get', side_effect=pages)
+    ns = kmock.namespace(namespace)
+    kmock[resource, ns] << {
+        'metadata': {'resourceVersion': '100', 'continue': 'TOKEN1'},
+        'items': [{'spec': 1}, {'spec': 2}]}
+    kmock[resource, ns, kmock.params({'continue': 'TOKEN1'})].override << {
+        'metadata': {'resourceVersion': '100', 'continue': 'TOKEN2'},
+        'items': [{'spec': 3}, {'spec': 4}]}
+    kmock[resource, ns, kmock.params({'continue': 'TOKEN2'})].override << {
+        'metadata': {'resourceVersion': '100', 'continue': ''},
+        'items': [{'spec': 5}]}
+
     items, resource_version = await list_objs(
         logger=logger,
         settings=settings,
@@ -61,55 +38,32 @@ async def test_listing_is_paginated_when_batch_size_is_set(
         namespace=namespace,
     )
 
-    # All chunks are aggregated into a single collection.
     assert [item['spec'] for item in items] == [1, 2, 3, 4, 5]
-
-    # The snapshot resource version (the same across all chunks) is returned.
     assert resource_version == '100'
-
-    # Each chunk carries the page size; the follow-ups carry the continue token.
-    assert get.call_count == 3
-    assert _query(get.call_args_list[0].kwargs['url']) == {'limit': '2'}
-    assert _query(get.call_args_list[1].kwargs['url']) == {'limit': '2', 'continue': 'TOKEN1'}
-    assert _query(get.call_args_list[2].kwargs['url']) == {'limit': '2', 'continue': 'TOKEN2'}
-
-
-async def test_listing_stops_at_an_empty_continue_token(
-        mocker, settings, logger, resource, namespace):
-    settings.watching.batch_size = 100
-    get = mocker.patch('kopf._cogs.clients.api.get', side_effect=[
-        {'metadata': {'resourceVersion': '7', 'continue': ''},
-         'items': [{'spec': 1}]},
-    ])
-    items, resource_version = await list_objs(
-        logger=logger,
-        settings=settings,
-        resource=resource,
-        namespace=namespace,
-    )
-    assert [item['spec'] for item in items] == [1]
-    assert resource_version == '7'
-    assert get.call_count == 1
+    assert len(kmock['list']) == 3
+    assert kmock['list'][0].params == {'limit': '2'}
+    assert kmock['list'][1].params == {'limit': '2', 'continue': 'TOKEN1'}
+    assert kmock['list'][2].params == {'limit': '2', 'continue': 'TOKEN2'}
 
 
 async def test_listing_defaults_kind_and_version_across_pages(
-        mocker, settings, logger, resource, namespace):
+        kmock, settings, logger, resource, namespace):
     settings.watching.batch_size = 1
-    pages = [
-        {'apiVersion': 'v1', 'kind': 'PodList', 'metadata': {'continue': 'NEXT'},
-         'items': [{'metadata': {'name': 'a'}}]},
-        {'apiVersion': 'v1', 'kind': 'PodList', 'metadata': {},
-         'items': [{'metadata': {'name': 'b'}}]},
-    ]
-    mocker.patch('kopf._cogs.clients.api.get', side_effect=pages)
+    ns = kmock.namespace(namespace)
+    kmock[resource, ns] << {
+        'apiVersion': 'v1', 'kind': 'PodList', 'metadata': {'continue': 'NEXT'},
+        'items': [{}]}
+    kmock[resource, ns, kmock.params({'continue': 'NEXT'})].override << {
+        'apiVersion': 'v1', 'kind': 'PodList', 'metadata': {},
+        'items': [{}]}
     items, _ = await list_objs(
         logger=logger,
         settings=settings,
         resource=resource,
         namespace=namespace,
     )
+    assert len(items) == 2
     assert all(item['kind'] == 'Pod' and item['apiVersion'] == 'v1' for item in items)
-    assert [item['metadata']['name'] for item in items] == ['a', 'b']
 
 
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -1,7 +1,13 @@
+import urllib.parse
+
 import pytest
 
 from kopf._cogs.clients.errors import APIError
 from kopf._cogs.clients.fetching import list_objs
+
+
+def _query(url):
+    return dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(url).query))
 
 
 async def test_listing_works(kmock, settings, logger, resource, namespace):
@@ -14,6 +20,96 @@ async def test_listing_works(kmock, settings, logger, resource, namespace):
     )
     assert items == [{}, {}]
     assert len(kmock['list']) == 1
+
+
+async def test_listing_is_a_single_unpaginated_request_by_default(
+        mocker, settings, logger, resource, namespace):
+    get = mocker.patch('kopf._cogs.clients.api.get', return_value={
+        'metadata': {'resourceVersion': '123'},
+        'items': [{'spec': 1}, {'spec': 2}],
+    })
+    items, resource_version = await list_objs(
+        logger=logger,
+        settings=settings,
+        resource=resource,
+        namespace=namespace,
+    )
+    assert [item['spec'] for item in items] == [1, 2]
+    assert resource_version == '123'
+    assert get.call_count == 1
+    query = _query(get.call_args.kwargs['url'])
+    assert 'limit' not in query
+    assert 'continue' not in query
+
+
+async def test_listing_is_paginated_when_batch_size_is_set(
+        mocker, settings, logger, resource, namespace):
+    settings.watching.batch_size = 2
+    pages = [
+        {'metadata': {'resourceVersion': '100', 'continue': 'TOKEN1'},
+         'items': [{'spec': 1}, {'spec': 2}]},
+        {'metadata': {'resourceVersion': '100', 'continue': 'TOKEN2'},
+         'items': [{'spec': 3}, {'spec': 4}]},
+        {'metadata': {'resourceVersion': '100'},
+         'items': [{'spec': 5}]},
+    ]
+    get = mocker.patch('kopf._cogs.clients.api.get', side_effect=pages)
+    items, resource_version = await list_objs(
+        logger=logger,
+        settings=settings,
+        resource=resource,
+        namespace=namespace,
+    )
+
+    # All chunks are aggregated into a single collection.
+    assert [item['spec'] for item in items] == [1, 2, 3, 4, 5]
+
+    # The snapshot resource version (the same across all chunks) is returned.
+    assert resource_version == '100'
+
+    # Each chunk carries the page size; the follow-ups carry the continue token.
+    assert get.call_count == 3
+    assert _query(get.call_args_list[0].kwargs['url']) == {'limit': '2'}
+    assert _query(get.call_args_list[1].kwargs['url']) == {'limit': '2', 'continue': 'TOKEN1'}
+    assert _query(get.call_args_list[2].kwargs['url']) == {'limit': '2', 'continue': 'TOKEN2'}
+
+
+async def test_listing_stops_at_an_empty_continue_token(
+        mocker, settings, logger, resource, namespace):
+    settings.watching.batch_size = 100
+    get = mocker.patch('kopf._cogs.clients.api.get', side_effect=[
+        {'metadata': {'resourceVersion': '7', 'continue': ''},
+         'items': [{'spec': 1}]},
+    ])
+    items, resource_version = await list_objs(
+        logger=logger,
+        settings=settings,
+        resource=resource,
+        namespace=namespace,
+    )
+    assert [item['spec'] for item in items] == [1]
+    assert resource_version == '7'
+    assert get.call_count == 1
+
+
+async def test_listing_defaults_kind_and_version_across_pages(
+        mocker, settings, logger, resource, namespace):
+    settings.watching.batch_size = 1
+    pages = [
+        {'apiVersion': 'v1', 'kind': 'PodList', 'metadata': {'continue': 'NEXT'},
+         'items': [{'metadata': {'name': 'a'}}]},
+        {'apiVersion': 'v1', 'kind': 'PodList', 'metadata': {},
+         'items': [{'metadata': {'name': 'b'}}]},
+    ]
+    mocker.patch('kopf._cogs.clients.api.get', side_effect=pages)
+    items, _ = await list_objs(
+        logger=logger,
+        settings=settings,
+        resource=resource,
+        namespace=namespace,
+    )
+    assert all(item['kind'] == 'Pod' and item['apiVersion'] == 'v1' for item in items)
+    assert [item['metadata']['name'] for item in items] == ['a', 'b']
 
 
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.


### PR DESCRIPTION
Add an opt-in `settings.watching.batch_size` to fetch the **initial listing** (the list preceding every watch) in `limit`/`continue` pages instead of one large request, capping the cold-start peak-memory spike for high-cardinality cluster-wide watches (e.g. Pods/Jobs).

- `list_objs()` paginates via `limit`/`continue` when `batch_size` is set, aggregating items across pages.
- Keeps the snapshot `resourceVersion` (consistent across chunks) to start the watch from the fully-listed state.
- Fully backward compatible: `batch_size` defaults to `None` → single unpaginated request, unchanged URL/params.
- `tests/k8s/test_list_objs.py` (kmock-based) covers the default single request, multi-page aggregation + query params, empty-continue stop, and `kind`/`apiVersion` defaulting across pages.

## Why

`list_objs()` issues one unpaginated `GET` and parses the entire collection into memory at once before the watch begins. For operators/observers watching high-cardinality built-in resources cluster-wide, the cold-start list materializes every object simultaneously — a peak-memory spike scaling with total object count.

We hit this with a Prefect Kubernetes worker, which embeds a `kopf` observer watching all Pods/Jobs cluster-wide ([`prefect_kubernetes/observer.py`](https://github.com/PrefectHQ/prefect/blob/dd7dda66ba0f7fc085a86c1cdcc24f5451cefbe6/src/integrations/prefect-kubernetes/prefect_kubernetes/observer.py#L14)): after a restart, the cold-start list of thousands of objects pushed the container past its memory limit and it crash-looped (OOMKilled). The Kubernetes API already supports chunked retrieval for exactly this ([Retrieving large results in chunks](https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-in-chunks)), and `client-go`'s reflector paginates its list by default — `kopf` just wasn't using it.

## Example usage

```python
@kopf.on.startup()
def configure(settings: kopf.OperatorSettings, **_):
    settings.watching.batch_size = 500   # page size; None (default) = single request
```
