### PR TITLE
Fix a test failure specifically in PyPy 3.11.15+

### DIFF
--- a/tests/utilities/aiotasks/test_coro_cancellation.py
+++ b/tests/utilities/aiotasks/test_coro_cancellation.py
@@ -67,11 +67,15 @@ async def test_coro_is_awaited_via_a_task_with_no_warning(coromock_task_factory)
         warnings.simplefilter('default')
         mock = Mock()
         coro = f(mock)
-        coromock = AsyncMock(wraps=coro, spec=coro)
+
+        # NB: `spec=coro` could help with a proper set of methods and the removal of close(),
+        #     but fails in PyPy 3.11.15+ on accessing `coro.cr_frame` while enumerating it.
+        coromock = AsyncMock(wraps=coro)
         del coromock.close
         await cancel_coro(coromock)
 
         # The warnings come only from the garbage collection, so dereference it.
+        del coromock  # also refers coro internally
         del coro
         gc.collect()
 


### PR DESCRIPTION
It works in CPython (all versions). It works in PyPy 3.11.13. Only PyPy 3.11.15 has this problem.

The coro cancellation test fails with an existing warning while no warnings are expected. The warning is:

```
{message : RuntimeWarning("coroutine 'f' was never awaited"), category : 'RuntimeWarning', filename : '/Users/nolar/.pyenv/versions/pypy3.11-7.3.22/lib/pypy3.11/unittest/mock.py', lineno : 457, line : None}
```

When converted to errors:

```
    def _mock_add_spec(self, spec, spec_set, _spec_as_instance=False,
                       _eat_self=False):
        ………
        for attr in dir(spec):
>           if iscoroutinefunction(getattr(spec, attr, None)):
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^
E           RuntimeWarning: coroutine 'f' was never awaited
```

As found manually, it fails on accessing the `coro.cr_frame` attribute while enumerating it — just accessing, not doing anything with it.

Removing the spec part of the async mock helps. It was only needed to ensure that `coro.close()` does not exist. Alternative: enumerate ourselves (`fields = dir(coro)`) and exclude the `cr_…` attributes in addition to `close()`, but also some other unsupported magic methods as per Mock/AsyncMock docs — I do not know which ones.

An artificial test to ensure the test fails when the bug is reproduced: in `cancel_coro()`, comment out the task creation and awaiting, in which case the `coro` remains unawaited and therefore issues a warning on garbage collection.

The extra line also fixes an issue when `coro` was still referenced by the mock and not garbage-collected (a pre-existing bug in the test).
