### PR TITLE
Add Kubernetes watch-list selectors

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -315,6 +315,41 @@ __ https://github.com/kubernetes/kubernetes/blob/c20e0bc54189aef73a6a1498b4eab28
         settings.watching.server_timeout = 10 * 60
 
 
+Server-side watch selectors
+===========================
+
+``settings.watching.server_side_selectors`` maps a concrete resource identity
+``(group, version, plural)`` to raw Kubernetes ``labelSelector`` and
+``fieldSelector`` query parameters. Kopf passes these selectors to Kubernetes
+for both the initial LIST request and the following WATCH requests.
+
+This setting is explicit and opt-in. Kopf does not infer these query parameters
+from handler filters such as ``labels=``, ``annotations=``, ``field=``,
+``value=``, or ``when=``. Those filters still run on the client side and keep
+their existing behavior.
+
+.. code-block:: python
+
+    import kopf
+    from typing import Any
+
+    @kopf.on.startup()
+    def configure(settings: kopf.OperatorSettings, **_: Any) -> None:
+        settings.watching.server_side_selectors[("", "v1", "pods")] = (
+            kopf.WatchListSelector(
+                label_selector="prefect.io/flow-run-id",
+                field_selector="status.phase!=Succeeded,status.phase!=Failed",
+            )
+        )
+        settings.watching.server_side_selectors[("batch", "v1", "jobs")] = (
+            kopf.WatchListSelector(label_selector="prefect.io/flow-run-id")
+        )
+
+Kubernetes supports ``labelSelector`` for LIST/WATCH requests, and supports
+``fieldSelector`` only for selected fields on each resource type. Kubernetes
+rejects invalid selectors.
+
+
 Proxy and environment trust
 ---------------------------
 

--- a/kopf/__init__.py
+++ b/kopf/__init__.py
@@ -19,6 +19,7 @@ from kopf.on import (
 )
 from kopf._cogs.configs.configuration import (
     OperatorSettings,
+    WatchListSelector,
 )
 from kopf._cogs.configs.diffbase import (
     DiffBaseStorage,
@@ -232,6 +233,7 @@ __all__ = [
     'set_default_registry',
     'PRESENT', 'ABSENT',
     'OperatorSettings',
+    'WatchListSelector',
     'DiffBaseStorage',
     'AnnotationsDiffBaseStorage',
     'StatusDiffBaseStorage',

--- a/kopf/_cogs/clients/fetching.py
+++ b/kopf/_cogs/clients/fetching.py
@@ -12,6 +12,7 @@ async def list_objs(
         resource: references.Resource,
         namespace: references.Namespace,
         logger: typedefs.Logger,
+        server_side_selector: configuration.WatchListSelector | None = None,
 ) -> tuple[Collection[bodies.RawBody], str]:
     """
     List the objects of specific resource type.
@@ -25,8 +26,10 @@ async def list_objs(
 
     * The resource is namespace-scoped AND operator is namespaced-restricted.
     """
+    params = server_side_selector.as_url_params() if server_side_selector is not None else None
+
     rsp = await api.get(
-        url=resource.get_url(namespace=namespace),
+        url=resource.get_url(namespace=namespace, params=params),
         logger=logger,
         settings=settings,
     )

--- a/kopf/_cogs/clients/watching.py
+++ b/kopf/_cogs/clients/watching.py
@@ -54,6 +54,7 @@ async def infinite_watch(
         settings: configuration.OperatorSettings,
         resource: references.Resource,
         namespace: references.Namespace,
+        server_side_selector: configuration.WatchListSelector | None = None,
         operator_paused: aiotoggles.ToggleSet | None = None,  # None for tests & observation
         _iterations: int | None = None,  # used in tests/mocks/fixtures
 ) -> AsyncIterator[Bookmark | bodies.RawEvent]:
@@ -82,6 +83,7 @@ async def infinite_watch(
                     settings=settings,
                     resource=resource,
                     namespace=namespace,
+                    server_side_selector=server_side_selector,
                     operator_pause_waiter=operator_pause_waiter,
                 )
                 try:
@@ -160,6 +162,7 @@ async def continuous_watch(
         settings: configuration.OperatorSettings,
         resource: references.Resource,
         namespace: references.Namespace,
+        server_side_selector: configuration.WatchListSelector | None = None,
         operator_pause_waiter: aiotasks.Future,
 ) -> AsyncIterator[Bookmark | bodies.RawEvent]:
 
@@ -171,6 +174,7 @@ async def continuous_watch(
             settings=settings,
             resource=resource,
             namespace=namespace,
+            server_side_selector=server_side_selector,
         )
         for obj in objs:
             yield {'type': None, 'object': obj}
@@ -191,6 +195,7 @@ async def continuous_watch(
             resource=resource,
             namespace=namespace,
             since=resource_version,
+            server_side_selector=server_side_selector,
             operator_pause_waiter=operator_pause_waiter,
         )
         async for raw_input in stream:
@@ -228,6 +233,7 @@ async def watch_objs(
         resource: references.Resource,
         namespace: references.Namespace,
         since: str | None = None,
+        server_side_selector: configuration.WatchListSelector | None = None,
         operator_pause_waiter: aiotasks.Future,
 ) -> AsyncIterator[bodies.RawInput]:
     """
@@ -249,6 +255,8 @@ async def watch_objs(
         params['resourceVersion'] = since
     if settings.watching.server_timeout is not None:
         params['timeoutSeconds'] = str(settings.watching.server_timeout)
+    if server_side_selector is not None:
+        params.update(server_side_selector.as_url_params())
 
     connect_timeout = (
         settings.watching.connect_timeout if settings.watching.connect_timeout is not None else

--- a/kopf/_cogs/configs/configuration.py
+++ b/kopf/_cogs/configs/configuration.py
@@ -32,7 +32,38 @@ import warnings
 from collections.abc import Iterable
 
 from kopf._cogs.configs import diffbase, progress
-from kopf._cogs.structs import reviews
+from kopf._cogs.structs import references, reviews
+
+ResourceIdentity = tuple[str, str, str]
+
+
+@dataclasses.dataclass(frozen=True)
+class WatchListSelector:
+    """
+    Raw Kubernetes selectors for resource LIST/WATCH requests.
+
+    Kopf passes these selectors to Kubernetes as ``labelSelector`` and
+    ``fieldSelector`` query parameters. Kopf does not infer them from its
+    handler filters.
+    """
+
+    label_selector: str | None = None
+    """
+    A raw Kubernetes ``labelSelector`` query parameter.
+    """
+
+    field_selector: str | None = None
+    """
+    A raw Kubernetes ``fieldSelector`` query parameter.
+    """
+
+    def as_url_params(self) -> dict[str, str]:
+        params: dict[str, str] = {}
+        if self.label_selector is not None:
+            params['labelSelector'] = self.label_selector
+        if self.field_selector is not None:
+            params['fieldSelector'] = self.field_selector
+        return params
 
 
 @dataclasses.dataclass
@@ -208,6 +239,24 @@ class WatchingSettings:
     so the default of 70 seconds allows for reasonable jitter while still
     detecting dead streams and reconnecting while the events are in memory.
     """
+
+    server_side_selectors: dict[ResourceIdentity, WatchListSelector] = dataclasses.field(
+        default_factory=dict)
+    """
+    Raw Kubernetes selectors for resource LIST/WATCH requests.
+
+    The mapping uses resource identity keys: ``(group, version, plural)``.
+    For example, core v1 Pods use ``("", "v1", "pods")``.
+    """
+
+    def resolve_server_side_selector(
+            self,
+            resource: references.Resource,
+    ) -> WatchListSelector | None:
+        """
+        Resolve the configured server-side selector for a concrete resource.
+        """
+        return self.server_side_selectors.get((resource.group, resource.version, resource.plural))
 
 
 @dataclasses.dataclass

--- a/kopf/_core/reactor/orchestration.py
+++ b/kopf/_core/reactor/orchestration.py
@@ -249,6 +249,7 @@ async def spawn_missing_watchers(
             resource_indexed: aiotoggles.Toggle | None = None
             if resource in indexed_resources:
                 resource_indexed = await ensemble.operator_indexed.make_toggle(name=what)
+            server_side_selector = settings.watching.resolve_server_side_selector(resource)
             ensemble.watcher_tasks[dkey] = aiotasks.create_guarded_task(
                 name=f"watcher for {what}", logger=logger, cancellable=True,
                 coro=queueing.watcher(
@@ -258,6 +259,7 @@ async def spawn_missing_watchers(
                     settings=settings,
                     resource=resource,
                     namespace=namespace,
+                    server_side_selector=server_side_selector,
                     processor=functools.partial(processor, resource=resource)))
 
     # Unblock globally, let the specialised per-resource-kind blockers hold the readiness.

--- a/kopf/_core/reactor/queueing.py
+++ b/kopf/_core/reactor/queueing.py
@@ -130,6 +130,7 @@ async def watcher(
         namespace: references.Namespace,
         settings: configuration.OperatorSettings,
         resource: references.Resource,
+        server_side_selector: configuration.WatchListSelector | None = None,
         processor: WatchStreamProcessor,
         operator_paused: aiotoggles.ToggleSet | None = None,  # None for tests & observation
         operator_indexed: aiotoggles.ToggleSet | None = None,  # None for tests & observation
@@ -178,6 +179,7 @@ async def watcher(
         stream = watching.infinite_watch(
             settings=settings,
             resource=resource, namespace=namespace,
+            server_side_selector=server_side_selector,
             operator_paused=operator_paused,
         )
         async for raw_event in stream:

--- a/tests/k8s/test_list_objs.py
+++ b/tests/k8s/test_list_objs.py
@@ -1,10 +1,21 @@
+from typing import Any
+
 import pytest
 
 from kopf._cogs.clients.errors import APIError
 from kopf._cogs.clients.fetching import list_objs
+from kopf._cogs.configs.configuration import OperatorSettings, WatchListSelector
+from kopf._cogs.helpers import typedefs
+from kopf._cogs.structs import references
 
 
-async def test_listing_works(kmock, settings, logger, resource, namespace):
+async def test_listing_works(
+        kmock: Any,
+        settings: OperatorSettings,
+        logger: typedefs.Logger,
+        resource: references.Resource,
+        namespace: references.Namespace,
+) -> None:
     kmock[resource, kmock.namespace(namespace)] << {'items': [{}, {}]}
     items, resource_version = await list_objs(
         logger=logger,
@@ -16,11 +27,64 @@ async def test_listing_works(kmock, settings, logger, resource, namespace):
     assert len(kmock['list']) == 1
 
 
+async def test_listing_omits_server_side_selectors_by_default(
+        kmock: Any,
+        settings: OperatorSettings,
+        logger: typedefs.Logger,
+        resource: references.Resource,
+        namespace: references.Namespace,
+) -> None:
+    kmock[resource, kmock.namespace(namespace)] << {'items': []}
+
+    await list_objs(
+        logger=logger,
+        settings=settings,
+        resource=resource,
+        namespace=namespace,
+    )
+
+    assert 'labelSelector' not in kmock[0].url.query
+    assert 'fieldSelector' not in kmock[0].url.query
+
+
+async def test_listing_passes_server_side_selectors(
+        kmock: Any,
+        settings: OperatorSettings,
+        logger: typedefs.Logger,
+        resource: references.Resource,
+        namespace: references.Namespace,
+) -> None:
+    label_selector = 'prefect.io/flow-run-id'
+    field_selector = 'status.phase!=Succeeded,status.phase!=Failed'
+    kmock[resource, kmock.namespace(namespace)] << {'items': []}
+
+    await list_objs(
+        logger=logger,
+        settings=settings,
+        resource=resource,
+        namespace=namespace,
+        server_side_selector=WatchListSelector(
+            label_selector=label_selector,
+            field_selector=field_selector,
+        ),
+    )
+
+    assert kmock[0].url.query['labelSelector'] == label_selector
+    assert kmock[0].url.query['fieldSelector'] == field_selector
+
+
 # Note: 401 is wrapped into a LoginError and is tested elsewhere.
 @pytest.mark.parametrize('status', [400, 403, 500, 666])
 async def test_raises_direct_api_errors(
-        kmock, settings, logger, status, resource, namespace,
-        cluster_resource, namespaced_resource):
+        kmock: Any,
+        settings: OperatorSettings,
+        logger: typedefs.Logger,
+        status: int,
+        resource: references.Resource,
+        namespace: references.Namespace,
+        cluster_resource: references.Resource,
+        namespaced_resource: references.Resource,
+) -> None:
     kmock[cluster_resource, kmock.namespace(None)] << status
     kmock[namespaced_resource, kmock.namespace('ns')] << status
 

--- a/tests/k8s/test_watching_selectors.py
+++ b/tests/k8s/test_watching_selectors.py
@@ -1,0 +1,97 @@
+import asyncio
+from typing import Any
+
+from kopf._cogs.clients.watching import Bookmark, continuous_watch, watch_objs
+from kopf._cogs.configs.configuration import OperatorSettings, WatchListSelector
+from kopf._cogs.structs import references
+
+
+async def test_watch_omits_server_side_selectors_by_default(
+        kmock: Any,
+        settings: OperatorSettings,
+        resource: references.Resource,
+        namespace: references.Namespace,
+) -> None:
+    kmock['watch', resource, kmock.namespace(namespace)] << ()
+
+    async for _ in watch_objs(
+            settings=settings,
+            resource=resource,
+            namespace=namespace,
+            since='123',
+            operator_pause_waiter=asyncio.Future()):
+        pass
+
+    assert kmock[0].url.query['watch'] == 'true'
+    assert kmock[0].url.query['allowWatchBookmarks'] == 'true'
+    assert kmock[0].url.query['resourceVersion'] == '123'
+    assert 'labelSelector' not in kmock[0].url.query
+    assert 'fieldSelector' not in kmock[0].url.query
+
+
+async def test_watch_passes_server_side_selectors_with_watch_params(
+        kmock: Any,
+        settings: OperatorSettings,
+        resource: references.Resource,
+        namespace: references.Namespace,
+) -> None:
+    settings.watching.server_timeout = 42
+    label_selector = 'prefect.io/flow-run-id'
+    field_selector = 'status.phase!=Succeeded,status.phase!=Failed'
+    kmock['watch', resource, kmock.namespace(namespace)] << ()
+
+    async for _ in watch_objs(
+            settings=settings,
+            resource=resource,
+            namespace=namespace,
+            since='123',
+            server_side_selector=WatchListSelector(
+                label_selector=label_selector,
+                field_selector=field_selector,
+            ),
+            operator_pause_waiter=asyncio.Future()):
+        pass
+
+    assert kmock[0].url.query['watch'] == 'true'
+    assert kmock[0].url.query['allowWatchBookmarks'] == 'true'
+    assert kmock[0].url.query['resourceVersion'] == '123'
+    assert kmock[0].url.query['timeoutSeconds'] == '42'
+    assert kmock[0].url.query['labelSelector'] == label_selector
+    assert kmock[0].url.query['fieldSelector'] == field_selector
+
+
+async def test_continuous_watch_uses_same_selectors_for_list_and_watch(
+        kmock: Any,
+        settings: OperatorSettings,
+        resource: references.Resource,
+        namespace: references.Namespace,
+) -> None:
+    label_selector = 'prefect.io/flow-run-id'
+    field_selector = 'status.phase!=Succeeded,status.phase!=Failed'
+    selector = WatchListSelector(
+        label_selector=label_selector,
+        field_selector=field_selector,
+    )
+    kmock['list', resource, kmock.namespace(namespace)] << {
+        'metadata': {'resourceVersion': '100'},
+        'items': [],
+    }
+    kmock['watch', resource, kmock.namespace(namespace)] << (
+        {'type': 'ERROR', 'object': {'code': 410}},
+    )
+
+    events = []
+    async for event in continuous_watch(
+            settings=settings,
+            resource=resource,
+            namespace=namespace,
+            server_side_selector=selector,
+            operator_pause_waiter=asyncio.Future()):
+        events.append(event)
+
+    assert events == [Bookmark.LISTED]
+    assert kmock[0].url.query['labelSelector'] == label_selector
+    assert kmock[0].url.query['fieldSelector'] == field_selector
+    assert kmock[1].url.query['labelSelector'] == label_selector
+    assert kmock[1].url.query['fieldSelector'] == field_selector
+    assert kmock[1].url.query['resourceVersion'] == '100'

--- a/tests/reactor/test_queueing.py
+++ b/tests/reactor/test_queueing.py
@@ -18,9 +18,12 @@ import asyncio
 import contextlib
 import gc
 import weakref
+from typing import Any
 
 import pytest
 
+from kopf._cogs.configs.configuration import WatchListSelector
+from kopf._cogs.structs import references
 from kopf._core.reactor.queueing import EOS, ObjectUid, Stream, watcher, worker
 
 
@@ -126,6 +129,40 @@ async def test_bookmarks_are_ignored(worker_mock, looptime, resource, processor,
     while not streams[key].backlog.empty():
         queue_events.append(streams[key].backlog.get_nowait())
     assert all(e is EOS.token or e['type'] != 'BOOKMARK' for e in queue_events)
+
+
+@pytest.mark.usefixtures('watcher_limited')
+async def test_server_side_selectors_are_used_by_watcher(
+        settings: Any,
+        kmock: Any,
+        resource: references.Resource,
+        namespace: references.Namespace,
+        processor: Any,
+) -> None:
+    label_selector = 'prefect.io/flow-run-id'
+    field_selector = 'status.phase!=Succeeded,status.phase!=Failed'
+    selector = WatchListSelector(
+        label_selector=label_selector,
+        field_selector=field_selector,
+    )
+    kmock['list', resource, kmock.namespace(namespace)] << {
+        'metadata': {'resourceVersion': '100'},
+        'items': [],
+    }
+
+    await watcher(
+        namespace=namespace,
+        resource=resource,
+        settings=settings,
+        processor=processor,
+        server_side_selector=selector,
+    )
+
+    assert kmock[0].url.query['labelSelector'] == label_selector
+    assert kmock[0].url.query['fieldSelector'] == field_selector
+    assert kmock[1].url.query['labelSelector'] == label_selector
+    assert kmock[1].url.query['fieldSelector'] == field_selector
+    assert kmock[1].url.query['resourceVersion'] == '100'
 
 
 @pytest.mark.parametrize('unique, events', [

--- a/tests/settings/test_defaults.py
+++ b/tests/settings/test_defaults.py
@@ -20,6 +20,7 @@ async def test_declared_public_interface_and_promised_defaults():
     assert settings.watching.connect_timeout is None
     assert settings.watching.server_timeout is None
     assert settings.watching.client_timeout is None
+    assert settings.watching.server_side_selectors == {}
     assert settings.queueing.worker_limit is None
     assert settings.queueing.idle_timeout == 5.0
     assert settings.queueing.exit_timeout == 2.0

--- a/tests/settings/test_server_side_watch_selectors.py
+++ b/tests/settings/test_server_side_watch_selectors.py
@@ -1,0 +1,33 @@
+import kopf
+from kopf._cogs.structs.references import Resource
+
+
+def test_server_side_selectors_resolve_by_concrete_resource_identity() -> None:
+    settings = kopf.OperatorSettings()
+    pods_selector = kopf.WatchListSelector(
+        label_selector='prefect.io/flow-run-id',
+        field_selector='status.phase!=Succeeded,status.phase!=Failed',
+    )
+    jobs_selector = kopf.WatchListSelector(
+        label_selector='prefect.io/flow-run-id',
+    )
+
+    settings.watching.server_side_selectors[('', 'v1', 'pods')] = pods_selector
+    settings.watching.server_side_selectors[('batch', 'v1', 'jobs')] = jobs_selector
+
+    assert settings.watching.resolve_server_side_selector(
+        Resource('', 'v1', 'pods', namespaced=True)) is pods_selector
+    assert settings.watching.resolve_server_side_selector(
+        Resource('batch', 'v1', 'jobs', namespaced=True)) is jobs_selector
+
+
+def test_server_side_selectors_ignore_unknown_resources() -> None:
+    settings = kopf.OperatorSettings()
+    settings.watching.server_side_selectors[('', 'v1', 'pods')] = kopf.WatchListSelector(
+        label_selector='prefect.io/flow-run-id',
+    )
+
+    assert settings.watching.resolve_server_side_selector(
+        Resource('', 'v1', 'services', namespaced=True)) is None
+    assert settings.watching.resolve_server_side_selector(
+        Resource('batch', 'v1', 'jobs', namespaced=True)) is None


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping maintainers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Hi! I work on Prefect, where we use Kopf in our Kubernetes worker to watch resources associated with flow runs.

One place this has become important for us is watching pods and jobs. Our handlers are already scoped with Kopf filters, but the initial Kubernetes LIST still returns every object in scope before those filters run inside the process. In larger or multi-tenant clusters, that can mean the worker has to receive and hold many more objects than it actually needs.

This PR adds an explicit, opt-in way to pass Kubernetes `labelSelector` and `fieldSelector` parameters to LIST/WATCH requests for specific resources. That gives operators a way to ask Kubernetes to do the coarse filtering before objects are sent back to Kopf.

The setting is intentionally explicit. Kopf does not try to translate handler filters into Kubernetes selectors, since those are different contracts and Kubernetes field-selector support varies by resource. Existing handler filters such as `labels=`, `annotations=`, `field=`, `value=`, and `when=` continue to work exactly as they do today.

When no selectors are configured, LIST/WATCH behavior stays unchanged.

This came up while investigating Prefect Kubernetes worker observer OOMs: https://github.com/PrefectHQ/prefect/issues/22208
